### PR TITLE
Fix the JS unit tests that are failing after the exponential backoff implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Includes @lboyette-okta Auth SDK changes for exponential backoff and fixed the tests that were failing as a result of this change.

bacon:test
resolves: OKTA-80961

Reviewers: @lboyette-okta @rchild-okta 
