### PR TITLE
Prevent jumping of the widget when security image is not enabled.

### DIFF
--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -87,6 +87,14 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       <div class="auth-content"><div class="auth-content-inner"></div></div>\
     ',
 
+    // Attach a 'no-beacon' class if the security image feature
+    // is not passed in to prevent the beacon from jumping.
+    initialize: function (options) {
+      if (!options.settings.get('features.securityImage')) {
+        this.$el.addClass('no-beacon');
+      }
+    },
+
     /* jshint maxcomplexity:false */
     setBeacon: function (NextBeacon, options) {
       var selector = '[data-type="beacon-container"]',


### PR DESCRIPTION
resolves:OKTA-80058

Screencasts before the fix (current version) - 
![securityimage1](https://cloud.githubusercontent.com/assets/12504056/13185268/0cb7ac0e-d6f5-11e5-8830-25d04d2d2149.gif)
![securityimage2](https://cloud.githubusercontent.com/assets/12504056/13185273/14aeec74-d6f5-11e5-9e2c-da1c1df43567.gif)
![nosecurityimage1](https://cloud.githubusercontent.com/assets/12504056/13185276/18c33284-d6f5-11e5-967e-62e61c1506ff.gif)

Screencasts after fix -
![securityimage1_fix](https://cloud.githubusercontent.com/assets/12504056/13185295/2dfbaad2-d6f5-11e5-861a-5decd776800b.gif)
![securityimage2_fix](https://cloud.githubusercontent.com/assets/12504056/13185298/31b0592a-d6f5-11e5-8ed1-2b7843380717.gif)
![nosecurityimage_fix](https://cloud.githubusercontent.com/assets/12504056/13185301/35016e2a-d6f5-11e5-8bba-54345a8dbcf5.gif)
