### PR TITLE
Spinner when the ajax requests are running (when security image feature is enabled)

### DIFF
--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -69,6 +69,10 @@ define([
           });
         }
         this.model.save();
+        this.options.appState.trigger('loading', true);
+      });
+      this.listenTo(this.model, 'error', function () {
+        this.options.appState.trigger('loading', false);
       });
       if (this.settings.get('features.preventBrowserFromSavingOktaPassword')) {
         this.add(PasswordJammer);


### PR DESCRIPTION
OKTA-78589
screencast - https://okta.box.com/s/iexcl6lqeyyxa3ozaa9gjcrom5biqrq5
Note - This PR is only for the spinner when security image is enabled. I will file another ticket for showing spinner when there is no security image enabled and handle it next week.

@nbories-okta As discussed on Tuesday, the spinner only shows up on Primary Auth to MFA verify screen and not on all requests.

Reviewers - @nbories-okta @rchild-okta @alexma-okta 
