### PR TITLE
Changed poll interval to prevent keep-alive errors in Safari/IE

### DIFF
--- a/src/BarcodePushController.js
+++ b/src/BarcodePushController.js
@@ -47,7 +47,9 @@ define([
 ],
 function (Okta, FactorUtil, FormController, FormType, RouterUtil, BarcodeView, Footer) {
 
-  var PUSH_INTERVAL = 5000;
+  // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
+  // in network connection lost errors in Safari and IE.
+  var PUSH_INTERVAL = 6000;
 
   return FormController.extend({
     className: 'barcode-push',

--- a/src/EnrollmentLinkSentController.js
+++ b/src/EnrollmentLinkSentController.js
@@ -45,7 +45,9 @@ define([
 ],
 function (Okta, CountryUtil, FormController, FormType, RouterUtil) {
 
-  var PUSH_INTERVAL = 5000;
+  // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
+  // in network connection lost errors in Safari and IE.
+  var PUSH_INTERVAL = 6000;
 
   var Footer = Okta.View.extend({
     template: '\

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -45,7 +45,10 @@ function (Okta, factorUtil) {
   var _ = Okta._;
   var $ = Okta.$;
   var LAST_USERNAME_COOKIE_NAME = 'ln';
-  var PUSH_INTERVAL = 5000;
+
+  // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
+  // in network connection lost errors in Safari and IE.
+  var PUSH_INTERVAL = 6000;
 
   var Factor = Okta.Model.extend({
     extraProperties: true,


### PR DESCRIPTION
Server keepalive is set to 5 seconds - polling at that frequency increases
the chance of getting network connection lost errors in Safari and IE.

RESOLVES OKTA-80926
Bacon: test
