### PR TITLE
Fix the bug where the user is taken to the push screen from MFA enroll manual push/passcode form

### DIFF
--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -88,6 +88,7 @@ function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm
         throw new Error('Unrecognized factor/provider');
       }
 
+      this.addListeners();
       this.add(new View(this.toJSON()));
 
       // Okta Push is different from the other factors - it has a backup

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -140,6 +140,8 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
 
       BaseLoginController.apply(this, arguments);
 
+      this.addListeners();
+
       // Add SocialAuth view only when the idps are configured. If configured, 'socialAuthPositionTop'
       // will determine the order in which the social auth and primary auth are shown on the screen.
       if (options.settings.get('socialAuthConfigured')) {

--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -49,11 +49,11 @@ function (Okta, Q) {
       var self = this;
       return fn.call(this, this.appState.get('transaction'))
       .then(function(trans) {
-        self.appState.set('transaction', trans);
+        self.trigger('setTransaction', trans);
         return trans;
       })
       .fail(function(err) {
-        self.appState.set('transactionError', err);
+        self.trigger('setTransactionError', err);
         self.trigger('error', self, err.xhr);
         if (rethrow) {
           throw err;
@@ -68,7 +68,7 @@ function (Okta, Q) {
       // If it's a promise, listen for failures
       if (Q.isPromise(res)) {
         res.fail(function(err) {
-          self.appState.set('transactionError', err);
+          self.trigger('setTransactionError', err);
           self.trigger('error', self, err.xhr);
         });
       }
@@ -83,11 +83,11 @@ function (Okta, Q) {
       // If it's a promise, then chain to it
       if (Q.isPromise(res)) {
         return res.then(function(trans) {
-          self.appState.set('transaction', trans);
+          self.trigger('setTransaction', trans);
           return trans;
         })
         .fail(function(err) {
-          self.appState.set('transactionError', err);
+          self.trigger('setTransactionError', err);
           self.trigger('error', self, err.xhr);
           throw err;
         });

--- a/src/util/FormController.js
+++ b/src/util/FormController.js
@@ -113,6 +113,7 @@ function (Okta, FormType, Toolbar, FormUtil, BaseLoginController, BaseLoginModel
         this.add(this.footer);
       }
 
+      this.addListeners();
       initialize.apply(this, arguments);
     },
 

--- a/test/spec/MfaVerify_spec.js
+++ b/test/spec/MfaVerify_spec.js
@@ -284,6 +284,7 @@ function (Q, _, $, Duo, OktaAuth, LoginUtil, Util, MfaVerifyForm, Beacon, Expect
         });
         itp('disables the "verify button" when clicked', function () {
           return setupSecurityQuestion().then(function (test) {
+            Q.stopUnhandledRejectionTracking();
             $.ajax.calls.reset();
             test.form.setAnswer('who cares');
             test.setNextResponse(resInvalid);
@@ -383,6 +384,7 @@ function (Q, _, $, Duo, OktaAuth, LoginUtil, Util, MfaVerifyForm, Beacon, Expect
         });
         itp('disables the "verify button" when clicked', function () {
           return setupGoogleTOTP().then(function (test) {
+            Q.stopUnhandledRejectionTracking();
             $.ajax.calls.reset();
             test.form.setAnswer('who cares');
             test.setNextResponse(resInvalid);
@@ -437,6 +439,7 @@ function (Q, _, $, Duo, OktaAuth, LoginUtil, Util, MfaVerifyForm, Beacon, Expect
         });
         itp('disables the "verify button" when clicked', function () {
           return setupYubikey().then(function (test) {
+            Q.stopUnhandledRejectionTracking();
             $.ajax.calls.reset();
             test.form.setAnswer('who cares');
             test.setNextResponse(resInvalid);

--- a/test/spec/PrimaryAuth_spec.js
+++ b/test/spec/PrimaryAuth_spec.js
@@ -659,6 +659,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, PrimaryAuthForm, Beacon,
       });
       itp('reenables the button after a CORS error', function () {
         return setup().then(function (test) {
+          Q.stopUnhandledRejectionTracking();
           $.ajax.calls.reset();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -674,6 +675,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, PrimaryAuthForm, Beacon,
       });
       itp('disables the "sign in" button when clicked', function () {
         return setup().then(function (test) {
+          Q.stopUnhandledRejectionTracking();
           $.ajax.calls.reset();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');


### PR DESCRIPTION
bacon:test
resolves:OKTA-82997

Also fixes the missing cases for disabling the form's primary button.

Not sure how we would add a unit test for this, since this is caused by a delayed poll, but here are the tests that test this already (Selenium test caught this) -
- JSUnit test - EnrollTotpController_spec#Manual Setup#renders pass code form on "Next" button click when Manual is selected and sends activation request with correct params on pass code submit
- Selenium test - NewLoginPageTotpTest#testOktaIphoneTokenSetupAndChallengeWithoutRemember
