### PR TITLE
Adding a build property to be used internally by our Storage manager

### DIFF
--- a/buildtools/getcifullversion/ci-fullversion.js
+++ b/buildtools/getcifullversion/ci-fullversion.js
@@ -1,0 +1,30 @@
+/*
+ * ci-fullversion
+ *
+ * A task for printing to stdout the fullversion of the package including git commit id for reference.
+ *
+ * Internal full version is defined as:
+ *   <semver>-<datetime>-<short git sha>
+ * where datetime is equivalent to cmd output:
+ *   date +"%Y%m%d%H%M"
+ *
+ * Example:
+ *   node ci-fullversion.js
+ *   > 1.1.1-201603151046-d117b77
+*/
+
+/*jshint -W024 */
+/*global console*/
+
+var appRoot = require('app-root-path'),
+    PACKAGE_JSON = require(appRoot + '/package.json'),
+    git = require('git-rev-sync'),
+    moment = require('moment');
+
+function getFullVersion() {
+    var currentDate = moment().format('YYYYMMDDHHss');
+    return PACKAGE_JSON.version + '-' + currentDate + '-' + git.short();
+}
+
+console.log(getFullVersion());
+

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,11 +4,11 @@
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
-      "from": "abbrev@>=1.0.0 <2.0.0"
+      "from": "abbrev@1.0.7"
     },
     "accepts": {
       "version": "1.2.13",
-      "from": "accepts@>=1.2.13 <1.3.0"
+      "from": "accepts@1.2.13"
     },
     "adm-zip": {
       "version": "0.4.4",
@@ -16,11 +16,11 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0"
+      "from": "align-text@0.1.4"
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "amdefine@>=0.0.4"
+      "from": "amdefine@1.0.0"
     },
     "ansi-regex": {
       "version": "0.2.1",
@@ -30,13 +30,17 @@
       "version": "1.1.0",
       "from": "ansi-styles@1.1.0"
     },
+    "app-root-path": {
+      "version": "1.0.0",
+      "from": "app-root-path@1.0.0"
+    },
     "argparse": {
       "version": "0.1.16",
-      "from": "argparse@>=0.1.11 <0.2.0",
+      "from": "argparse@0.1.16",
       "dependencies": {
         "underscore.string": {
           "version": "2.4.0",
-          "from": "underscore.string@>=2.4.0 <2.5.0"
+          "from": "underscore.string@2.4.0"
         }
       }
     },
@@ -50,7 +54,7 @@
     },
     "asap": {
       "version": "2.0.3",
-      "from": "asap@>=2.0.0 <3.0.0"
+      "from": "asap@2.0.3"
     },
     "asn1": {
       "version": "0.1.11",
@@ -58,23 +62,23 @@
     },
     "assert-plus": {
       "version": "0.1.5",
-      "from": "assert-plus@>=0.1.5 <0.2.0"
+      "from": "assert-plus@0.1.5"
     },
     "async": {
       "version": "0.1.22",
-      "from": "async@>=0.1.22 <0.2.0"
+      "from": "async@0.1.22"
     },
     "aws-sign2": {
       "version": "0.5.0",
-      "from": "aws-sign2@>=0.5.0 <0.6.0"
+      "from": "aws-sign2@0.5.0"
     },
     "balanced-match": {
       "version": "0.3.0",
-      "from": "balanced-match@>=0.3.0 <0.4.0"
+      "from": "balanced-match@0.3.0"
     },
     "basic-auth": {
       "version": "1.0.3",
-      "from": "basic-auth@>=1.0.3 <1.1.0"
+      "from": "basic-auth@1.0.3"
     },
     "batch": {
       "version": "0.5.3",
@@ -96,15 +100,15 @@
     },
     "bl": {
       "version": "0.9.5",
-      "from": "bl@>=0.9.0 <0.10.0"
+      "from": "bl@0.9.5"
     },
     "bluebird": {
       "version": "2.10.2",
-      "from": "bluebird@>=2.3.0 <3.0.0"
+      "from": "bluebird@2.10.2"
     },
     "boom": {
       "version": "0.4.2",
-      "from": "boom@>=0.4.0 <0.5.0"
+      "from": "boom@0.4.2"
     },
     "brace-expansion": {
       "version": "1.1.3",
@@ -124,11 +128,11 @@
     },
     "caseless": {
       "version": "0.6.0",
-      "from": "caseless@>=0.6.0 <0.7.0"
+      "from": "caseless@0.6.0"
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0"
+      "from": "center-align@0.1.3"
     },
     "chalk": {
       "version": "0.5.1",
@@ -136,25 +140,25 @@
     },
     "charenc": {
       "version": "0.0.1",
-      "from": "charenc@>=0.0.1 <0.1.0"
+      "from": "charenc@0.0.1"
     },
     "cli": {
       "version": "0.6.6",
-      "from": "cli@>=0.6.0 <0.7.0",
+      "from": "cli@0.6.6",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.1 <3.3.0"
+          "from": "glob@3.2.11"
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0"
+          "from": "minimatch@0.3.0"
         }
       }
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
+      "from": "cliui@2.1.0",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -164,7 +168,7 @@
     },
     "coffee-script": {
       "version": "1.3.3",
-      "from": "coffee-script@>=1.3.3 <1.4.0"
+      "from": "coffee-script@1.3.3"
     },
     "color-convert": {
       "version": "1.0.0",
@@ -172,15 +176,15 @@
     },
     "colors": {
       "version": "0.6.2",
-      "from": "colors@>=0.6.2 <0.7.0"
+      "from": "colors@0.6.2"
     },
     "combined-stream": {
       "version": "0.0.7",
-      "from": "combined-stream@>=0.0.4 <0.1.0"
+      "from": "combined-stream@0.0.7"
     },
     "commander": {
       "version": "2.9.0",
-      "from": "commander@>=2.9.0 <3.0.0"
+      "from": "commander@2.9.0"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -188,31 +192,31 @@
     },
     "config-chain": {
       "version": "1.1.10",
-      "from": "config-chain@>=1.1.8 <1.2.0"
+      "from": "config-chain@1.1.10"
     },
     "connect": {
       "version": "3.4.1",
-      "from": "connect@>=3.4.0 <4.0.0"
+      "from": "connect@3.4.1"
     },
     "connect-livereload": {
       "version": "0.5.4",
-      "from": "connect-livereload@>=0.5.0 <0.6.0"
+      "from": "connect-livereload@0.5.4"
     },
     "console-browserify": {
       "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <1.2.0"
+      "from": "console-browserify@1.1.0"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0"
+      "from": "core-util-is@1.0.2"
     },
     "crypt": {
       "version": "0.0.1",
-      "from": "crypt@>=0.0.1 <0.1.0"
+      "from": "crypt@0.0.1"
     },
     "cryptiles": {
       "version": "0.2.2",
-      "from": "cryptiles@>=0.2.0 <0.3.0"
+      "from": "cryptiles@0.2.2"
     },
     "ctype": {
       "version": "0.5.3",
@@ -224,17 +228,17 @@
     },
     "dashdash": {
       "version": "1.13.0",
-      "from": "dashdash@>=1.10.1 <2.0.0",
+      "from": "dashdash@1.13.0",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0"
+          "from": "assert-plus@1.0.0"
         }
       }
     },
     "date-now": {
       "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0"
+      "from": "date-now@0.1.4"
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
@@ -242,11 +246,11 @@
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0"
+      "from": "debug@2.2.0"
     },
     "debuglog": {
       "version": "1.0.1",
-      "from": "debuglog@>=1.0.1 <2.0.0"
+      "from": "debuglog@1.0.1"
     },
     "decamelize": {
       "version": "1.1.2",
@@ -262,41 +266,41 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0"
+      "from": "destroy@1.0.4"
     },
     "dezalgo": {
       "version": "1.0.3",
-      "from": "dezalgo@>=1.0.0 <2.0.0"
+      "from": "dezalgo@1.0.3"
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "from": "dom-serializer@0.1.0",
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0"
+          "from": "domelementtype@1.1.3"
         },
         "entities": {
           "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0"
+          "from": "entities@1.1.1"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0"
+      "from": "domelementtype@1.3.0"
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0"
+      "from": "domhandler@2.3.0"
     },
     "domutils": {
       "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0"
+      "from": "domutils@1.5.1"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.0.1 <1.0.0"
+      "from": "ecc-jsbn@0.1.1"
     },
     "ee-first": {
       "version": "1.1.1",
@@ -304,7 +308,7 @@
     },
     "entities": {
       "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0"
+      "from": "entities@1.0.0"
     },
     "error-ex": {
       "version": "1.3.0",
@@ -316,7 +320,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0"
+      "from": "escape-html@1.0.3"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -324,23 +328,23 @@
     },
     "esprima": {
       "version": "1.0.4",
-      "from": "esprima@>=1.0.2 <1.1.0"
+      "from": "esprima@1.0.4"
     },
     "etag": {
       "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0"
+      "from": "etag@1.7.0"
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "from": "eventemitter2@>=0.4.13 <0.5.0"
+      "from": "eventemitter2@0.4.14"
     },
     "exit": {
       "version": "0.1.2",
-      "from": "exit@>=0.1.1 <0.2.0"
+      "from": "exit@0.1.2"
     },
     "extend": {
       "version": "3.0.0",
-      "from": "extend@>=3.0.0 <3.1.0"
+      "from": "extend@3.0.0"
     },
     "extsprintf": {
       "version": "1.0.2",
@@ -348,7 +352,7 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "from": "file-sync-cmp@>=0.1.0 <0.2.0"
+      "from": "file-sync-cmp@0.1.1"
     },
     "finalhandler": {
       "version": "0.4.1",
@@ -364,37 +368,37 @@
     },
     "findup-sync": {
       "version": "0.1.3",
-      "from": "findup-sync@>=0.1.2 <0.2.0",
+      "from": "findup-sync@0.1.3",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.9 <3.3.0"
+          "from": "glob@3.2.11"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0"
+          "from": "lodash@2.4.2"
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0"
+          "from": "minimatch@0.3.0"
         }
       }
     },
     "forever-agent": {
       "version": "0.5.2",
-      "from": "forever-agent@>=0.5.0 <0.6.0"
+      "from": "forever-agent@0.5.2"
     },
     "form-data": {
       "version": "0.1.4",
-      "from": "form-data@>=0.1.0 <0.2.0",
+      "from": "form-data@0.1.4",
       "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0"
-        },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.11 <1.3.0"
+          "from": "mime@1.2.11"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "async@0.9.2"
         }
       }
     },
@@ -404,21 +408,21 @@
     },
     "fs-extra": {
       "version": "0.23.1",
-      "from": "fs-extra@>=0.23.1 <0.24.0",
+      "from": "fs-extra@0.23.1",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0"
+          "from": "graceful-fs@4.1.3"
         }
       }
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0"
+      "from": "generate-function@2.0.0"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0"
+      "from": "generate-object-property@1.2.0"
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -426,47 +430,61 @@
     },
     "getobject": {
       "version": "0.1.0",
-      "from": "getobject@>=0.1.0 <0.2.0"
+      "from": "getobject@0.1.0"
+    },
+    "git-rev-sync": {
+      "version": "1.4.0",
+      "from": "git-rev-sync@1.4.0",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.2",
+          "from": "graceful-fs@4.1.2"
+        },
+        "shelljs": {
+          "version": "0.5.1",
+          "from": "shelljs@0.5.1"
+        }
+      }
     },
     "github-url-from-git": {
       "version": "1.4.0",
-      "from": "github-url-from-git@>=1.3.0 <2.0.0"
+      "from": "github-url-from-git@1.4.0"
     },
     "github-url-from-username-repo": {
       "version": "1.0.2",
-      "from": "github-url-from-username-repo@>=1.0.0 <2.0.0"
+      "from": "github-url-from-username-repo@1.0.2"
     },
     "glob": {
       "version": "3.1.21",
-      "from": "glob@>=3.1.21 <3.2.0",
+      "from": "glob@3.1.21",
       "dependencies": {
         "inherits": {
           "version": "1.0.2",
-          "from": "inherits@>=1.0.0 <2.0.0"
+          "from": "inherits@1.0.2"
         }
       }
     },
     "graceful-fs": {
       "version": "1.2.3",
-      "from": "graceful-fs@>=1.2.0 <1.3.0"
+      "from": "graceful-fs@1.2.3"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0"
+      "from": "graceful-readlink@1.0.1"
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@>=0.4.5 <0.5.0",
+      "from": "grunt@0.4.5",
       "dependencies": {
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0"
+          "from": "lodash@0.9.2"
         }
       }
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "from": "grunt-cli@>=0.1.13 <0.2.0"
+      "from": "grunt-cli@0.1.13"
     },
     "grunt-contrib-compass": {
       "version": "1.0.3",
@@ -474,17 +492,17 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0"
+          "from": "async@0.9.2"
         }
       }
     },
     "grunt-contrib-connect": {
       "version": "0.11.2",
-      "from": "grunt-contrib-connect@>=0.11.2 <0.12.0",
+      "from": "grunt-contrib-connect@0.11.2",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0"
+          "from": "async@0.9.2"
         }
       }
     },
@@ -494,35 +512,35 @@
     },
     "grunt-contrib-jasmine": {
       "version": "0.9.2",
-      "from": "grunt-contrib-jasmine@>=0.9.2 <0.10.0",
+      "from": "grunt-contrib-jasmine@0.9.2",
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0"
-        },
-        "ansi-styles": {
-          "version": "2.2.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0"
-        },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0"
+          "from": "chalk@1.1.1"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0"
+          "from": "lodash@2.4.2"
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "from": "ansi-regex@2.0.0"
+        },
+        "ansi-styles": {
+          "version": "2.2.0",
+          "from": "ansi-styles@2.2.0"
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "from": "has-ansi@2.0.0"
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0"
+          "from": "strip-ansi@3.0.1"
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0"
+          "from": "supports-color@2.0.0"
         }
       }
     },
@@ -532,201 +550,201 @@
     },
     "grunt-contrib-requirejs": {
       "version": "0.4.4",
-      "from": "grunt-contrib-requirejs@>=0.4.4 <0.5.0"
+      "from": "grunt-contrib-requirejs@0.4.4"
     },
     "grunt-exec": {
       "version": "0.4.6",
-      "from": "grunt-exec@>=0.4.6 <0.5.0"
+      "from": "grunt-exec@0.4.6"
     },
     "grunt-json-generator": {
       "version": "0.1.0",
-      "from": "grunt-json-generator@>=0.1.0 <0.2.0"
+      "from": "grunt-json-generator@0.1.0"
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+      "from": "grunt-legacy-log@0.1.3",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0"
+          "from": "lodash@2.4.2"
         },
         "underscore.string": {
           "version": "2.3.3",
-          "from": "underscore.string@>=2.3.3 <2.4.0"
+          "from": "underscore.string@2.3.3"
         }
       }
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+      "from": "grunt-legacy-log-utils@0.1.1",
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0"
+          "from": "lodash@2.4.2"
         },
         "underscore.string": {
           "version": "2.3.3",
-          "from": "underscore.string@>=2.3.3 <2.4.0"
+          "from": "underscore.string@2.3.3"
         }
       }
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+      "from": "grunt-legacy-util@0.2.0",
       "dependencies": {
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0"
+          "from": "lodash@0.9.2"
         }
       }
     },
     "grunt-lib-phantomjs": {
       "version": "0.7.1",
-      "from": "grunt-lib-phantomjs@>=0.7.1 <0.8.0",
+      "from": "grunt-lib-phantomjs@0.7.1",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.0 <5.0.0"
+          "from": "semver@4.3.6"
         }
       }
     },
     "grunt-properties-to-json": {
       "version": "0.5.1",
-      "from": "grunt-properties-to-json@>=0.5.1 <0.6.0",
+      "from": "grunt-properties-to-json@0.5.1",
       "dependencies": {
         "lodash": {
           "version": "3.6.0",
-          "from": "lodash@>=3.6.0 <3.7.0"
+          "from": "lodash@3.6.0"
         }
       }
     },
     "grunt-rename": {
       "version": "0.1.4",
-      "from": "grunt-rename@>=0.1.4 <0.2.0"
+      "from": "grunt-rename@0.1.4"
     },
     "grunt-retire": {
       "version": "0.3.12",
-      "from": "grunt-retire@latest",
+      "from": "grunt-retire@0.3.12",
       "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0"
-        },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.0 <1.6.0"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0"
-        },
-        "bl": {
-          "version": "1.0.3",
-          "from": "bl@>=1.0.0 <1.1.0"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@>=2.0.0 <3.0.0"
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@>=2.0.0 <3.0.0"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "form-data@>=1.0.0-rc3 <1.1.0"
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@>=3.1.0 <3.2.0"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0"
-        },
-        "oauth-sign": {
-          "version": "0.8.1",
-          "from": "oauth-sign@>=0.8.0 <0.9.0"
-        },
-        "qs": {
-          "version": "5.2.0",
-          "from": "qs@>=5.2.0 <5.3.0"
-        },
-        "readable-stream": {
-          "version": "2.0.5",
-          "from": "readable-stream@>=2.0.5 <2.1.0"
+          "from": "async@1.5.2"
         },
         "request": {
           "version": "2.67.0",
-          "from": "request@>=2.67.0 <2.68.0"
+          "from": "request@2.67.0"
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0"
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@0.6.0"
+        },
+        "bl": {
+          "version": "1.0.3",
+          "from": "bl@1.0.3"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "from": "boom@2.10.1"
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@0.11.0"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@1.0.5"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@2.0.5"
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@1.0.0"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@0.6.1"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3",
+          "from": "form-data@1.0.0-rc3"
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@3.1.3"
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@2.16.3"
+        },
+        "oauth-sign": {
+          "version": "0.8.1",
+          "from": "oauth-sign@0.8.1"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@1.1.1"
+        },
+        "qs": {
+          "version": "5.2.0",
+          "from": "qs@5.2.0"
         },
         "sntp": {
           "version": "1.0.9",
-          "from": "sntp@>=1.0.0 <2.0.0"
+          "from": "sntp@1.0.9"
+        },
+        "readable-stream": {
+          "version": "2.0.5",
+          "from": "readable-stream@2.0.5"
         }
       }
     },
     "grunt-template-jasmine-requirejs": {
       "version": "0.2.3",
-      "from": "grunt-template-jasmine-requirejs@>=0.2.3 <0.3.0"
+      "from": "grunt-template-jasmine-requirejs@0.2.3"
     },
     "handlebars": {
       "version": "4.0.5",
-      "from": "handlebars@>=4.0.5 <5.0.0",
+      "from": "handlebars@4.0.5",
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0"
+          "from": "async@1.5.2"
         }
       }
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@>=2.0.2 <2.1.0",
+      "from": "har-validator@2.0.6",
       "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@1.1.1"
+        },
         "ansi-regex": {
           "version": "2.0.0",
-          "from": "ansi-regex@>=2.0.0 <3.0.0"
+          "from": "ansi-regex@2.0.0"
         },
         "ansi-styles": {
           "version": "2.2.0",
-          "from": "ansi-styles@>=2.1.0 <3.0.0"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0"
+          "from": "ansi-styles@2.2.0"
         },
         "has-ansi": {
           "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0"
+          "from": "has-ansi@2.0.0"
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0"
+          "from": "strip-ansi@3.0.1"
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0"
+          "from": "supports-color@2.0.0"
         }
       }
     },
@@ -740,11 +758,11 @@
     },
     "hoek": {
       "version": "0.9.1",
-      "from": "hoek@>=0.9.0 <0.10.0"
+      "from": "hoek@0.9.1"
     },
     "hooker": {
       "version": "0.2.3",
-      "from": "hooker@>=0.2.3 <0.3.0"
+      "from": "hooker@0.2.3"
     },
     "hosted-git-info": {
       "version": "2.1.4",
@@ -752,25 +770,25 @@
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
+      "from": "htmlparser2@3.8.3",
       "dependencies": {
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.0 <1.2.0"
+          "from": "readable-stream@1.1.13"
         }
       }
     },
     "http-errors": {
       "version": "1.3.1",
-      "from": "http-errors@>=1.3.1 <1.4.0"
+      "from": "http-errors@1.3.1"
     },
     "http-signature": {
       "version": "0.10.1",
-      "from": "http-signature@>=0.10.0 <0.11.0"
+      "from": "http-signature@0.10.1"
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "from": "iconv-lite@>=0.2.11 <0.3.0"
+      "from": "iconv-lite@0.2.11"
     },
     "indent-string": {
       "version": "2.1.0",
@@ -778,15 +796,15 @@
     },
     "inflight": {
       "version": "1.0.4",
-      "from": "inflight@>=1.0.4 <2.0.0"
+      "from": "inflight@1.0.4"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <3.0.0"
+      "from": "inherits@2.0.1"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.2.0 <2.0.0"
+      "from": "ini@1.3.4"
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -794,7 +812,7 @@
     },
     "is-buffer": {
       "version": "1.0.2",
-      "from": "is-buffer@>=1.0.2 <1.1.0"
+      "from": "is-buffer@1.0.2"
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -806,15 +824,15 @@
     },
     "is-my-json-valid": {
       "version": "2.13.1",
-      "from": "is-my-json-valid@>=2.12.4 <3.0.0"
+      "from": "is-my-json-valid@2.13.1"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0"
+      "from": "is-property@1.0.2"
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0"
+      "from": "is-typedarray@1.0.0"
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -826,45 +844,45 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0"
+      "from": "isstream@0.1.2"
     },
     "jasmine-core": {
       "version": "2.4.1",
-      "from": "jasmine-core@>=2.0.4 <3.0.0"
+      "from": "jasmine-core@2.4.1"
     },
     "jju": {
       "version": "1.3.0",
-      "from": "jju@>=1.1.0 <2.0.0"
+      "from": "jju@1.3.0"
     },
     "jodid25519": {
       "version": "1.0.2",
-      "from": "jodid25519@>=1.0.0 <2.0.0"
+      "from": "jodid25519@1.0.2"
     },
     "js-yaml": {
       "version": "2.0.5",
-      "from": "js-yaml@>=2.0.5 <2.1.0"
+      "from": "js-yaml@2.0.5"
     },
     "jsbn": {
       "version": "0.1.0",
-      "from": "jsbn@>=0.1.0 <0.2.0"
+      "from": "jsbn@0.1.0"
     },
     "jshint": {
       "version": "2.9.1",
       "from": "jshint@2.9.1",
       "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0"
-        },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.0 <2.1.0"
+          "from": "minimatch@2.0.10"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@3.7.0"
         }
       }
     },
     "json-parse-helpfulerror": {
       "version": "1.0.3",
-      "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0"
+      "from": "json-parse-helpfulerror@1.0.3"
     },
     "json-schema": {
       "version": "0.2.2",
@@ -872,11 +890,11 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.0 <5.1.0"
+      "from": "json-stringify-safe@5.0.1"
     },
     "jsonfile": {
       "version": "2.2.3",
-      "from": "jsonfile@>=2.1.0 <3.0.0"
+      "from": "jsonfile@2.2.3"
     },
     "jsonpointer": {
       "version": "2.0.0",
@@ -884,7 +902,7 @@
     },
     "jsprim": {
       "version": "1.2.2",
-      "from": "jsprim@>=1.2.2 <2.0.0"
+      "from": "jsprim@1.2.2"
     },
     "kew": {
       "version": "0.4.0",
@@ -892,11 +910,11 @@
     },
     "kind-of": {
       "version": "3.0.2",
-      "from": "kind-of@>=3.0.2 <4.0.0"
+      "from": "kind-of@3.0.2"
     },
     "lazy-cache": {
       "version": "1.0.3",
-      "from": "lazy-cache@>=1.0.3 <2.0.0"
+      "from": "lazy-cache@1.0.3"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -904,7 +922,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0"
+          "from": "graceful-fs@4.1.3"
         }
       }
     },
@@ -914,7 +932,7 @@
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0"
+      "from": "longest@1.0.1"
     },
     "loud-rejection": {
       "version": "1.3.0",
@@ -922,7 +940,7 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "from": "lru-cache@>=2.0.0 <3.0.0"
+      "from": "lru-cache@2.7.3"
     },
     "map-obj": {
       "version": "1.0.1",
@@ -930,7 +948,7 @@
     },
     "md5": {
       "version": "2.0.0",
-      "from": "md5@>=2.0.0 <2.1.0"
+      "from": "md5@2.0.0"
     },
     "meow": {
       "version": "3.7.0",
@@ -950,7 +968,7 @@
     },
     "minimatch": {
       "version": "0.2.14",
-      "from": "minimatch@>=0.2.12 <0.3.0"
+      "from": "minimatch@0.2.14"
     },
     "minimist": {
       "version": "1.2.0",
@@ -958,13 +976,17 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "from": "mkdirp@0.5.1",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8"
         }
       }
+    },
+    "moment": {
+      "version": "2.12.0",
+      "from": "moment@2.12.0"
     },
     "morgan": {
       "version": "1.7.0",
@@ -980,11 +1002,11 @@
     },
     "node-uuid": {
       "version": "1.4.7",
-      "from": "node-uuid@>=1.4.0 <1.5.0"
+      "from": "node-uuid@1.4.7"
     },
     "nopt": {
       "version": "1.0.10",
-      "from": "nopt@>=1.0.10 <1.1.0"
+      "from": "nopt@1.0.10"
     },
     "normalize-package-data": {
       "version": "2.3.5",
@@ -996,11 +1018,11 @@
       "dependencies": {
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <3.1.0"
+          "from": "nopt@3.0.6"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
+          "from": "semver@4.3.6"
         }
       }
     },
@@ -1010,7 +1032,7 @@
     },
     "oauth-sign": {
       "version": "0.4.0",
-      "from": "oauth-sign@>=0.4.0 <0.5.0"
+      "from": "oauth-sign@0.4.0"
     },
     "object-assign": {
       "version": "4.0.1",
@@ -1018,15 +1040,15 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0"
+      "from": "on-finished@2.3.0"
     },
     "on-headers": {
       "version": "1.0.1",
-      "from": "on-headers@>=1.0.0 <1.1.0"
+      "from": "on-headers@1.0.1"
     },
     "once": {
       "version": "1.3.3",
-      "from": "once@>=1.3.0 <1.4.0"
+      "from": "once@1.3.3"
     },
     "onetime": {
       "version": "1.1.0",
@@ -1038,21 +1060,21 @@
     },
     "opn": {
       "version": "1.0.2",
-      "from": "opn@>=1.0.0 <2.0.0"
+      "from": "opn@1.0.2"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
+      "from": "optimist@0.6.1",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0"
+          "from": "minimist@0.0.10"
         }
       }
     },
     "os-homedir": {
       "version": "1.0.1",
-      "from": "os-homedir@>=1.0.0 <2.0.0"
+      "from": "os-homedir@1.0.1"
     },
     "os-tmpdir": {
       "version": "1.0.1",
@@ -1060,11 +1082,11 @@
     },
     "osenv": {
       "version": "0.1.3",
-      "from": "osenv@>=0.1.0 <0.2.0"
+      "from": "osenv@0.1.3"
     },
     "package": {
       "version": "1.0.1",
-      "from": "package@>=1.0.0 <1.2.0"
+      "from": "package@1.0.1"
     },
     "parse-json": {
       "version": "2.2.0",
@@ -1072,7 +1094,7 @@
     },
     "parseurl": {
       "version": "1.3.1",
-      "from": "parseurl@>=1.3.1 <1.4.0"
+      "from": "parseurl@1.3.1"
     },
     "path-exists": {
       "version": "2.1.0",
@@ -1080,7 +1102,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+      "from": "path-is-absolute@1.0.0"
     },
     "path-type": {
       "version": "1.1.0",
@@ -1088,13 +1110,13 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0"
+          "from": "graceful-fs@4.1.3"
         }
       }
     },
     "phantomjs": {
       "version": "1.9.19",
-      "from": "phantomjs@>=1.9.15 <2.0.0"
+      "from": "phantomjs@1.9.19"
     },
     "pify": {
       "version": "2.3.0",
@@ -1110,7 +1132,7 @@
     },
     "portscanner": {
       "version": "1.0.0",
-      "from": "portscanner@>=1.0.0 <2.0.0",
+      "from": "portscanner@1.0.0",
       "dependencies": {
         "async": {
           "version": "0.1.15",
@@ -1120,7 +1142,7 @@
     },
     "process-nextick-args": {
       "version": "1.0.6",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0"
+      "from": "process-nextick-args@1.0.6"
     },
     "progress": {
       "version": "1.1.8",
@@ -1128,57 +1150,57 @@
     },
     "properties-parser": {
       "version": "0.2.3",
-      "from": "properties-parser@>=0.2.3 <0.3.0"
+      "from": "properties-parser@0.2.3"
     },
     "proto-list": {
       "version": "1.2.4",
-      "from": "proto-list@>=1.2.1 <1.3.0"
+      "from": "proto-list@1.2.4"
     },
     "qs": {
       "version": "1.2.2",
-      "from": "qs@>=1.2.0 <1.3.0"
+      "from": "qs@1.2.2"
     },
     "range-parser": {
       "version": "1.0.3",
-      "from": "range-parser@>=1.0.3 <1.1.0"
+      "from": "range-parser@1.0.3"
     },
     "read-installed": {
       "version": "3.1.5",
-      "from": "read-installed@>=3.1.0 <3.2.0",
+      "from": "read-installed@3.1.5",
       "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0"
-        },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
+          "from": "semver@4.3.6"
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "graceful-fs@3.0.8"
         }
       }
     },
     "read-package-json": {
       "version": "1.3.3",
-      "from": "read-package-json@>=1.0.0 <2.0.0",
+      "from": "read-package-json@1.3.3",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.3 <6.0.0"
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0"
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0"
+          "from": "glob@5.0.15"
         },
         "normalize-package-data": {
           "version": "1.0.3",
-          "from": "normalize-package-data@>=1.0.0 <2.0.0"
+          "from": "normalize-package-data@1.0.3"
+        },
+        "graceful-fs": {
+          "version": "3.0.8",
+          "from": "graceful-fs@3.0.8"
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@3.0.0"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0"
+          "from": "semver@4.3.6"
         }
       }
     },
@@ -1192,15 +1214,15 @@
     },
     "readable-stream": {
       "version": "1.0.33",
-      "from": "readable-stream@>=1.0.26 <1.1.0"
+      "from": "readable-stream@1.0.33"
     },
     "readdir-scoped-modules": {
       "version": "1.0.2",
-      "from": "readdir-scoped-modules@>=1.0.0 <2.0.0",
+      "from": "readdir-scoped-modules@1.0.2",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
-          "from": "graceful-fs@>=4.1.2 <5.0.0"
+          "from": "graceful-fs@4.1.3"
         }
       }
     },
@@ -1210,7 +1232,7 @@
     },
     "repeat-string": {
       "version": "1.5.2",
-      "from": "repeat-string@>=1.5.2 <2.0.0"
+      "from": "repeat-string@1.5.2"
     },
     "repeating": {
       "version": "2.0.0",
@@ -1222,7 +1244,7 @@
       "dependencies": {
         "mime-types": {
           "version": "1.0.2",
-          "from": "mime-types@>=1.0.1 <1.1.0"
+          "from": "mime-types@1.0.2"
         }
       }
     },
@@ -1232,39 +1254,39 @@
     },
     "request-promise": {
       "version": "2.0.0",
-      "from": "request-promise@>=2.0.0 <3.0.0",
+      "from": "request-promise@2.0.0",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.0 <4.0.0"
+          "from": "lodash@3.10.1"
         }
       }
     },
     "requirejs": {
       "version": "2.1.22",
-      "from": "requirejs@>=2.1.0 <2.2.0"
+      "from": "requirejs@2.1.22"
     },
     "resolve": {
       "version": "0.3.1",
-      "from": "resolve@>=0.3.1 <0.4.0"
+      "from": "resolve@0.3.1"
     },
     "retire": {
       "version": "1.1.4",
-      "from": "retire@>=1.1.0 <1.2.0",
+      "from": "retire@1.1.4",
       "dependencies": {
         "commander": {
           "version": "2.5.1",
-          "from": "commander@>=2.5.0 <2.6.0"
+          "from": "commander@2.5.1"
         }
       }
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0"
+      "from": "right-align@0.1.3"
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@>=2.2.8 <2.3.0"
+      "from": "rimraf@2.2.8"
     },
     "semver": {
       "version": "5.1.0",
@@ -1280,29 +1302,23 @@
     },
     "send": {
       "version": "0.13.1",
-      "from": "send@0.13.1",
-      "dependencies": {
-        "depd": {
-          "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0"
-        }
-      }
+      "from": "send@0.13.1"
     },
     "serve-index": {
       "version": "1.7.3",
-      "from": "serve-index@>=1.7.1 <2.0.0"
+      "from": "serve-index@1.7.3"
     },
     "serve-static": {
       "version": "1.10.2",
-      "from": "serve-static@>=1.10.0 <2.0.0"
+      "from": "serve-static@1.10.2"
     },
     "shelljs": {
       "version": "0.3.0",
-      "from": "shelljs@>=0.3.0 <0.4.0"
+      "from": "shelljs@0.3.0"
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0"
+      "from": "sigmund@1.0.1"
     },
     "signal-exit": {
       "version": "2.1.2",
@@ -1310,15 +1326,15 @@
     },
     "slide": {
       "version": "1.1.6",
-      "from": "slide@>=1.1.3 <1.2.0"
+      "from": "slide@1.1.6"
     },
     "sntp": {
       "version": "0.2.4",
-      "from": "sntp@>=0.2.0 <0.3.0"
+      "from": "sntp@0.2.4"
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0"
+      "from": "source-map@0.4.4"
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -1338,29 +1354,29 @@
     },
     "sshpk": {
       "version": "1.7.4",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "from": "sshpk@1.7.4",
       "dependencies": {
         "asn1": {
           "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0"
+          "from": "asn1@0.2.3"
         },
         "assert-plus": {
           "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0"
+          "from": "assert-plus@0.2.0"
         }
       }
     },
     "statuses": {
       "version": "1.2.1",
-      "from": "statuses@>=1.0.0 <2.0.0"
+      "from": "statuses@1.2.1"
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0"
+      "from": "string_decoder@0.10.31"
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@>=0.0.4 <0.1.0"
+      "from": "stringstream@0.0.5"
     },
     "strip-ansi": {
       "version": "0.3.0",
@@ -1376,7 +1392,7 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.0 <1.1.0"
+      "from": "strip-json-comments@1.0.4"
     },
     "supports-color": {
       "version": "0.2.0",
@@ -1384,11 +1400,11 @@
     },
     "temporary": {
       "version": "0.0.8",
-      "from": "temporary@>=0.0.8 <0.0.9"
+      "from": "temporary@0.0.8"
     },
     "throttleit": {
       "version": "0.0.2",
-      "from": "throttleit@>=0.0.2 <0.1.0"
+      "from": "throttleit@0.0.2"
     },
     "tmp": {
       "version": "0.0.24",
@@ -1396,7 +1412,7 @@
     },
     "tough-cookie": {
       "version": "2.2.1",
-      "from": "tough-cookie@>=0.12.0"
+      "from": "tough-cookie@2.2.1"
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -1404,11 +1420,11 @@
     },
     "tunnel-agent": {
       "version": "0.4.2",
-      "from": "tunnel-agent@>=0.4.0 <0.5.0"
+      "from": "tunnel-agent@0.4.2"
     },
     "tweetnacl": {
       "version": "0.14.1",
-      "from": "tweetnacl@>=0.13.0 <1.0.0"
+      "from": "tweetnacl@0.14.1"
     },
     "uglify-js": {
       "version": "2.6.2",
@@ -1416,17 +1432,17 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0"
+          "from": "async@0.2.10"
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@>=0.5.1 <0.6.0"
+          "from": "source-map@0.5.3"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0"
+      "from": "uglify-to-browserify@1.0.2"
     },
     "uid-number": {
       "version": "0.0.5",
@@ -1434,23 +1450,23 @@
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@>=1.7.0 <1.8.0"
+      "from": "underscore@1.7.0"
     },
     "underscore.string": {
       "version": "2.2.1",
-      "from": "underscore.string@>=2.2.1 <2.3.0"
+      "from": "underscore.string@2.2.1"
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@>=1.0.0 <1.1.0"
+      "from": "unpipe@1.0.0"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0"
+      "from": "util-deprecate@1.0.2"
     },
     "util-extend": {
       "version": "1.0.3",
-      "from": "util-extend@>=1.0.1 <2.0.0"
+      "from": "util-extend@1.0.3"
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -1470,7 +1486,7 @@
     },
     "which": {
       "version": "1.0.9",
-      "from": "which@>=1.0.5 <1.1.0"
+      "from": "which@1.0.9"
     },
     "window-size": {
       "version": "0.1.0",
@@ -1478,23 +1494,23 @@
     },
     "wordwrap": {
       "version": "0.0.3",
-      "from": "wordwrap@>=0.0.2 <0.1.0"
+      "from": "wordwrap@0.0.3"
     },
     "wrappy": {
       "version": "1.0.1",
-      "from": "wrappy@>=1.0.0 <2.0.0"
+      "from": "wrappy@1.0.1"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0"
+      "from": "xtend@4.0.1"
     },
     "yargs": {
       "version": "3.10.0",
-      "from": "yargs@>=3.10.0 <3.11.0",
+      "from": "yargs@3.10.0",
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0"
+          "from": "camelcase@1.2.1"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,12 @@
     "start": "grunt start-server-open",
     "package": "grunt package",
     "prerelease": "grunt bump-prerelease-version",
-    "shrinkwrap": "grunt shrinkwrap-remove-resolved"
+    "shrinkwrap": "grunt shrinkwrap-remove-resolved",
+    "getfullversion": "node buildtools/getcifullversion/ci-fullversion.js"
   },
   "devDependencies": {
+    "app-root-path": "1.0.0",
+    "git-rev-sync": "1.4.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-compass": "1.0.3",
@@ -43,6 +46,7 @@
     "grunt-template-jasmine-requirejs": "0.2.3",
     "handlebars": "4.0.5",
     "lodash": "4.1.0",
+    "moment": "2.12.0",
     "open": "0.0.5",
     "request-promise": "2.0.0",
     "semver": "5.1.0"


### PR DESCRIPTION
Adding a build property to be used internally by our Storage manager (Artifactory) as
a reference to the git commit ID that generated the npm package.

Result in Artifactory (i.e.):
`buildVersion=1.1.8-alpha.50-201603142253-4f216ab`
**Note:** I decided to use `buildVersion` as the name of the property for consistency with Core.

Relates: OKTA-81227

Bacon: test
CI run: http://bacon.trex.saasure.com/#!/commits/okta-signin-widget/sha/4f216abac7d2e7c2463c9565a07ce713bf7e627b

@shiqiyang-okta @rchild-okta @Ujjwalreddy-okta @kelvinzhu-okta @ajinkyasuryawanshi-okta 
