### PR TITLE
Remember device changes -

### DIFF
--- a/resources/nls/login.properties
+++ b/resources/nls/login.properties
@@ -8,7 +8,7 @@
 ########################################
 signout = Sign Out
 remember = Remember me
-rememberDevice = Remember Device
+rememberDevice = Trust this device
 unlockaccount = Unlock account?
 needhelp = Need help signing in?
 goback = Back to Sign In

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -13,21 +13,18 @@
 define([
   'okta',
   './BaseLoginModel',
-  'util/Enums',
-  'vendor/plugins/jquery.cookie'
+  'util/CookieUtil',
+  'util/Enums'
 ],
-function (Okta, BaseLoginModel, Enums) {
+function (Okta, BaseLoginModel, CookieUtil, Enums) {
 
-  var $ = Okta.$;
   var _ = Okta._;
-  var LAST_USERNAME_COOKIE_NAME = 'ln';
-  var DAYS_SAVE_REMEMBER = 365;
 
   return BaseLoginModel.extend({
 
     props: function () {
       var settingsUsername = this.settings && this.settings.get('username'),
-          cookieUsername = $.cookie(LAST_USERNAME_COOKIE_NAME),
+          cookieUsername = CookieUtil.getCookieUsername(),
           remember = false,
           username;
       if (settingsUsername) {
@@ -71,13 +68,10 @@ function (Okta, BaseLoginModel, Enums) {
       // Only delete the cookie if its owner says so. This allows other
       // users to log in on a one-off basis.
       if (!remember && lastUsername === username) {
-        $.removeCookie(LAST_USERNAME_COOKIE_NAME, { path: '/' });
+        CookieUtil.removeUsernameCookie();
       }
       else if (remember) {
-        $.cookie(LAST_USERNAME_COOKIE_NAME, username, {
-          expires: DAYS_SAVE_REMEMBER,
-          path: '/'
-        });
+        CookieUtil.setUsernameCookie(username);
       }
 
       //the 'save' event here is triggered and used in the BaseLoginController
@@ -100,7 +94,7 @@ function (Okta, BaseLoginModel, Enums) {
         // Specific event handled by the Header for the case where the security image is not
         // enabled and we want to show a spinner. (Triggered only here and handled only by Header).
         this.appState.trigger('removeLoading');
-        $.removeCookie(LAST_USERNAME_COOKIE_NAME, { path: '/' });
+        CookieUtil.removeUsernameCookie();
       }, this))
       .fin(_.bind(function () {
         this.appState.trigger('loading', false);

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -51,6 +51,7 @@ function (Okta, Errors, BrowserFeatures) {
       'features.securityImage': ['boolean', true, false],
       'features.rememberMe': ['boolean', true, true],
       'features.rememberDevice': ['boolean', true, true],
+      'features.rememberDeviceAlways': ['boolean', true, false],
       'features.smsRecovery': ['boolean', true, false],
       'features.windowsVerify': ['boolean', true, false],
       'features.selfServiceUnlock': ['boolean', true, false],

--- a/src/util/CookieUtil.js
+++ b/src/util/CookieUtil.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define(['okta', 'vendor/plugins/jquery.cookie'], function (Okta) {
+
+  var $ = Okta.$;
+  var LAST_USERNAME_COOKIE_NAME = 'ln';
+  var REMEMBER_DEVICE_COOKIE_NAME = 'rdln';
+  var DAYS_SAVE_REMEMBER = 365;
+
+  function removeCookie (name) {
+    $.removeCookie(name, { path: '/' });
+  }
+
+  function setCookie (name, value) {
+    $.cookie(name, value, {
+      expires: DAYS_SAVE_REMEMBER,
+      path: '/'
+    });
+  }
+
+  var fn = {};
+
+  fn.getCookieUsername = function () {
+    return $.cookie(LAST_USERNAME_COOKIE_NAME);
+  };
+
+  fn.setUsernameCookie = function (username) {
+    setCookie(LAST_USERNAME_COOKIE_NAME, username);
+  };
+
+  fn.removeUsernameCookie = function () {
+    removeCookie(LAST_USERNAME_COOKIE_NAME);
+  };
+
+  fn.getCookieDeviceUsername = function () {
+    return $.cookie(REMEMBER_DEVICE_COOKIE_NAME);
+  };
+
+  fn.setDeviceCookie = function (username) {
+    setCookie(REMEMBER_DEVICE_COOKIE_NAME, username);
+  };
+
+  fn.removeDeviceCookie = function () {
+    removeCookie(REMEMBER_DEVICE_COOKIE_NAME);
+  };
+
+  return fn;
+});

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta'], function (Okta) {
+define(['okta' , './CookieUtil'], function (Okta, CookieUtil) {
 
   var fn = {};
 
@@ -129,6 +129,23 @@ define(['okta'], function (Okta) {
 
   fn.getFactorSortOrder = function (provider, factorType) {
     return factorData[fn.getFactorName(provider, factorType)].sortOrder;
+  };
+
+  fn.getRememberDeviceValue = function (settings, appState) {
+    var username = appState && appState.get('username');
+    var rememberDeviceAlways = settings && settings.get('features.rememberDeviceAlways');
+    var rememberDeviceUsername = CookieUtil.getCookieDeviceUsername();
+    var rememberDevice = false;
+
+    // rememberDevice is true if 'rememberDeviceAlways' is on or
+    // if the last username is same as the current username.
+    if (rememberDeviceAlways) {
+      rememberDevice = true;
+    } else if (rememberDeviceUsername || username) {
+      rememberDevice = (rememberDeviceUsername === username);
+    }
+
+    return rememberDevice;
   };
 
   return fn;

--- a/test/helpers/dom/MfaVerifyForm.js
+++ b/test/helpers/dom/MfaVerifyForm.js
@@ -63,6 +63,14 @@ define(['./Form'], function (Form) {
       return this.checkbox(REMEMBER_DEVICE);
     },
 
+    rememberDeviceLabelText: function () {
+      return this.checkboxLabelText(REMEMBER_DEVICE);
+    },
+
+    isRememberDeviceChecked: function () {
+      return this.checkbox(REMEMBER_DEVICE).prop('checked');
+    },
+
     setRememberDevice: function (val) {
       var rememberDevice = this.rememberDeviceCheckbox();
       rememberDevice.prop('checked', val);

--- a/test/spec/LoginRouter_spec.js
+++ b/test/spec/LoginRouter_spec.js
@@ -389,6 +389,28 @@ function (Okta, Q, Backbone, xdomain, SharedUtil, OktaAuth, Util, Expect, Router
         expect(form.isSecurityQuestion()).toBe(true);
       });
     });
+    itp('checks the remember device by default for a returning user', function () {
+      Util.mockCookie('rdln', 'testuser');
+      return setup()
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.router.navigate('signin');
+        return tick(test);
+      })
+      .then(function (test) {
+        var form = new PrimaryAuthForm($sandbox);
+        expect(form.isPrimaryAuth()).toBe(true);
+        test.setNextResponse(resMfa);
+        form.setUsername('testuser');
+        form.setPassword('pass');
+        form.submit();
+        return tick(test);
+      })
+      .then(function () {
+        var form = new MfaVerifyForm($sandbox);
+        expect(form.isRememberDeviceChecked()).toBe(true);
+      });
+    });
 
     describe('OIDC - okta is the idp and oauth2 is enabled', function () {
       itp('creates an iframe with the correct url when authStatus is SUCCESS', function () {


### PR DESCRIPTION
1. Add "Trust this device" checkbox
2. Add an option to show/hide the checkbox (features.rememberDevice)
3. Add an option to check this checkbox by default (features.rememberDeviceAlways)
4. Store the remember device option in the cookie and check it by default the next time the same user logs in.
5. Remember Device for DUO factor

bacon:test
resolves:OKTA-85436

@haishengwu-okta @rchild-okta 
