### PR TITLE
Disable forms/content + update spinner when clicking Sign In/Verify buttons.

### DIFF
--- a/assets/sass/modules/_beacon.scss
+++ b/assets/sass/modules/_beacon.scss
@@ -9,9 +9,9 @@
   transform: scale(0, 0);
 
   &.beacon-small {
-    height: 10px;
-    width: 10px;
-    bottom: -5px;
+    height: 20px;
+    width: 20px;
+    bottom: -10px;
 
     .beacon-blank {
       width: 50px;
@@ -43,7 +43,7 @@
     z-index: 10;
     width: 91px;
     height: 91px;
-    border: 2px solid rgb(221, 221, 221);
+    border: 2px solid #a7a7a7;
     border-radius: 50%;
     position: absolute;
     // This clip shows everything from 6 to 12 o'clock
@@ -88,7 +88,7 @@
 
 .auth-beacon-border {
   position: absolute;
-  border: 2px solid rgb(221, 221, 221);
+  border: 2px solid #a7a7a7;
   border-radius: 50%;
   bottom: -5px;
   left: -5px;
@@ -107,7 +107,7 @@
   right: -5px;
   border-radius: 50%;
   border: 2px solid transparent;
-  border-top-color: #bbb;
+  border-top-color: #007dc1;
   -webkit-transform: translateZ(0);
   -ms-transform: translateZ(0);
   transform: translateZ(0);

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -142,7 +142,7 @@
 
   .okta-sign-in-beacon-border {
   /* -- Main Background and Border Colors -- */
-    border-color: rgb(221, 221, 221);
+    border-color: #a7a7a7;
   }
 
   .okta-form-divider {

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -46,13 +46,20 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
           <a href="{{href}}" class="link js-custom">{{text}}</a></li>\
         {{/each}}\
         <li>\
-        <a href="{{helpLinkUrl}}" data-se="help-link" class="link js-help-link">\
+        <a href="{{helpLinkUrl}}" data-se="help-link" class="link js-help-link" target="_blank">\
         {{i18n code="help" bundle="login"}}\
         </a>\
         </li>\
       </ul>\
     ',
     className: 'auth-footer',
+
+    initialize: function () {
+      this.listenTo(this.state, 'change:enabled', function(model, enable) {
+        this.$(':link').toggleClass('o-form-disabled', !enable);
+      });
+    },
+
     getTemplateData: function () {
       var helpLinkUrl;
       var customHelpPage = this.settings.get('helpLinks.help');
@@ -73,10 +80,18 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
     events: {
       'click .js-help': function (e) {
         e.preventDefault();
+        if(!this.state.get('enabled')) {
+          return;
+        }
+
         this.toggleLinks(e);
       },
       'click .js-forgot-password' : function (e) {
         e.preventDefault();
+        if(!this.state.get('enabled')) {
+          return;
+        }
+
         var customResetPasswordPage = this.settings.get('helpLinks.forgotPassword');
         if (customResetPasswordPage) {
           Util.redirect(customResetPasswordPage);
@@ -87,6 +102,10 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
       },
       'click .js-unlock' : function (e) {
         e.preventDefault();
+        if(!this.state.get('enabled')) {
+          return;
+        }
+
         var customUnlockPage = this.settings.get('helpLinks.unlock');
         if (customUnlockPage) {
           Util.redirect(customUnlockPage);
@@ -100,6 +119,9 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
 
   return BaseLoginController.extend({
     className: 'primary-auth',
+
+    state: { enabled: true },
+
     View: PrimaryAuthForm,
 
     constructor: function (options) {
@@ -144,6 +166,12 @@ function (Okta, PrimaryAuthForm, SocialAuth, PrimaryAuthModel, Util, BaseLoginCo
           // reset AppState to an undefined user.
           this.options.appState.set('username', '');
         }
+      });
+      this.listenTo(this.model, 'save', function () {
+        this.state.set('enabled', false);
+      });
+      this.listenTo(this.model, 'error', function () {
+        this.state.set('enabled', true);
       });
     }
 

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -48,6 +48,14 @@ define([
       if (this.settings.get('features.preventBrowserFromSavingOktaPassword')) {
         this.add(PasswordJammer);
       }
+      this.listenTo(this.state, 'change:enabled', function(model, enable) {
+        if(enable) {
+          this.enable();
+        }
+        else {
+          this.disable();
+        }
+      });
     },
 
     inputs: function () {

--- a/test/helpers/dom/PrimaryAuthForm.js
+++ b/test/helpers/dom/PrimaryAuthForm.js
@@ -177,8 +177,21 @@ define(['jquery', 'underscore', './Form'], function ($, _, Form) {
 
     socialAuthButtons: function () {
       return this.$('.social-auth-button');
-    }
+    },
 
+    linksAppearDisabled: function() {
+      return this.$('a.link.o-form-disabled').length === this.$('a.link').length;
+    },
+
+    inputsDisabled: function() {
+      return this.usernameField().is(':disabled') &&
+          this.passwordField().is(':disabled') &&
+          this.rememberMeCheckbox().is(':disabled');
+    },
+
+    isDisabled: function() {
+      return this.inputsDisabled() && this.linksAppearDisabled();
+    }
   });
 
 });


### PR DESCRIPTION
Enlarge spinner w/o beacon
Change spinner grey to a7a7a7, blue to 007dc1
Disable fields on request

Resolves:OKTA-86427

![okta-loginpage-disable](https://cloud.githubusercontent.com/assets/17075654/14446327/7e80efac-0009-11e6-9685-44d560a07a3b.png)
![okta-signin-disabled](https://cloud.githubusercontent.com/assets/17075654/14446328/7e81b374-0009-11e6-81dc-a0787037374c.png)
