### PR TITLE
set pushState to false to avoid #route if pushState is not supported

### DIFF
--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -240,7 +240,7 @@ function (Okta, Backbone, xdomain, RefreshAuthStateController, Settings, Header,
     },
 
     start: function () {
-      var options = [];
+      var pushState = false;
       // Support for browser's back button.
       if (window.addEventListener) {
         window.addEventListener('popstate', _.bind(function(e) {
@@ -250,9 +250,9 @@ function (Okta, Backbone, xdomain, RefreshAuthStateController, Settings, Header,
             this.controller.back();
           }
         }, this));
-        options.push({pushState: true});
+        pushState = BrowserFeatures.supportsPushState();
       }
-      Okta.Router.prototype.start.apply(this, options);
+      Okta.Router.prototype.start.call(this, { pushState: pushState });
     }
 
   });

--- a/src/util/BrowserFeatures.js
+++ b/src/util/BrowserFeatures.js
@@ -49,6 +49,11 @@ define(function () {
     }
   };
 
+  fn.supportsPushState = function (win) {
+    win = win || window;
+    return !!(win.history && win.history.pushState);
+  };
+
   return fn;
 
 });

--- a/test/spec/LoginRouter_spec.js
+++ b/test/spec/LoginRouter_spec.js
@@ -149,6 +149,22 @@ function (Okta, Q, Backbone, xdomain, SharedUtil, OktaAuth, Util, Expect, Router
       var fn = function () { setup({ globalSuccessFn: undefined }); };
       expect(fn).toThrowError('A success handler is required');
     });
+    itp('set pushState true if pushState is supported', function () {
+      spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(true);
+      spyOn(Okta.Router.prototype, 'start');
+      return setup().then(function (test) {
+        test.router.start();
+        expect(Okta.Router.prototype.start).toHaveBeenCalledWith({ pushState: true });
+      });
+    });
+    itp('set pushState false if pushState is not supported', function () {
+      spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(false);
+      spyOn(Okta.Router.prototype, 'start');
+      return setup().then(function (test) {
+        test.router.start();
+        expect(Okta.Router.prototype.start).toHaveBeenCalledWith({ pushState: false });
+      });
+    });
     itp('initializes xdomain if cors is limited', function () {
       spyOn(xdomain, 'slaves');
       spyOn(BrowserFeatures, 'corsIsLimited').and.returnValue(true);


### PR DESCRIPTION
1. root/#login/default and root/ will fall to the LoginController.loginRouter, and redirect to IwaSsoLoginController for IWA case
2. IWA is redirected to IWA/login/default when a login is failed, in order to avoid endless loop back to IWA
3. IE 9 doesn't support pushState, based on the Backbone.Router http://backbonejs.org/docs/backbone.html#section-219, it will use #route
4. So, if a IWA user uses IE9, it falls into an endless loop, root/#login/default -> IWA -> root/#login/default

Resolves: OKTA-86282
Bacon: test
