### PR TITLE
Okta Verify Auto Push

### DIFF
--- a/resources/nls/login.properties
+++ b/resources/nls/login.properties
@@ -9,6 +9,7 @@
 signout = Sign Out
 remember = Remember me
 rememberDevice = Trust this device
+autoPush = Send push automatically
 unlockaccount = Unlock account?
 needhelp = Need help signing in?
 goback = Back to Sign In

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -175,6 +175,15 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
           return factors && factors.length > 1;
         }
       },
+      'userId': {
+        deps: ['lastAuthResponse'],
+        fn: function (res) {
+          if (!res._embedded || !res._embedded.user) {
+            return null;
+          }
+          return res._embedded.user.id;
+        }
+      },
       'isPwdExpiringSoon': {
         deps: ['lastAuthResponse'],
         fn: function (res) {

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -75,7 +75,8 @@ function (Okta, CookieUtil, factorUtil, BaseLoginModel) {
       'answer': 'string',
       'backupFactor': 'object',
       'showAnswer': 'boolean',
-      'rememberDevice': 'boolean'
+      'rememberDevice': 'boolean',
+      'autoPush': ['boolean', true, false]
     },
 
     derived: {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -52,6 +52,7 @@ function (Okta, Errors, BrowserFeatures) {
       'features.rememberMe': ['boolean', true, true],
       'features.rememberDevice': ['boolean', true, true],
       'features.rememberDeviceAlways': ['boolean', true, false],
+      'features.autoPush': ['boolean', true, false],
       'features.smsRecovery': ['boolean', true, false],
       'features.windowsVerify': ['boolean', true, false],
       'features.selfServiceUnlock': ['boolean', true, false],

--- a/src/util/CookieUtil.js
+++ b/src/util/CookieUtil.js
@@ -10,11 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'vendor/plugins/jquery.cookie'], function (Okta) {
+define(['okta', 'util/CryptoUtil', 'vendor/plugins/jquery.cookie'], function (Okta, CryptoUtil) {
 
   var $ = Okta.$;
   var LAST_USERNAME_COOKIE_NAME = 'ln';
   var REMEMBER_DEVICE_COOKIE_NAME = 'rdln';
+  var AUTO_PUSH_COOKIE_PREFIX  = 'auto_push_';
   var DAYS_SAVE_REMEMBER = 365;
 
   function removeCookie (name) {
@@ -26,6 +27,10 @@ define(['okta', 'vendor/plugins/jquery.cookie'], function (Okta) {
       expires: DAYS_SAVE_REMEMBER,
       path: '/'
     });
+  }
+
+  function getAutoPushKey(userId) {
+    return AUTO_PUSH_COOKIE_PREFIX + CryptoUtil.getStringHash(userId);
   }
 
   var fn = {};
@@ -52,6 +57,27 @@ define(['okta', 'vendor/plugins/jquery.cookie'], function (Okta) {
 
   fn.removeDeviceCookie = function () {
     removeCookie(REMEMBER_DEVICE_COOKIE_NAME);
+  };
+
+  fn.isAutoPushEnabled = function (userId) {
+    if (userId === undefined) {
+      return false;
+    }
+    return $.cookie(getAutoPushKey(userId)) === 'true';
+  };
+
+  fn.setAutoPushCookie = function (userId) {
+    if (userId === undefined) {
+      return;
+    }
+    setCookie(getAutoPushKey(userId), true);
+  };
+
+  fn.removeAutoPushCookie = function (userId) {
+    if (userId === undefined) {
+      return;
+    }
+    removeCookie(getAutoPushKey(userId));
   };
 
   return fn;

--- a/src/util/CryptoUtil.js
+++ b/src/util/CryptoUtil.js
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define(function () {
+  var fn = {};
+  
+   // Light weight hashing algorithm that hashes string into an integer between 0 and 4294967295
+   // Not recommended for data set of size greater than 10000
+   // https://www.npmjs.com/package/string-hash
+  fn.getStringHash = function (str) {
+    var hash = 5381,
+        i = str.length;
+    while(i) {
+      hash = (hash * 33) ^ str.charCodeAt(--i);
+    }
+    return hash >>> 0;
+  };
+  
+  return fn;
+});

--- a/src/views/mfa-verify/PushForm.js
+++ b/src/views/mfa-verify/PushForm.js
@@ -10,8 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta'], function (Okta) {
+define(['okta',
+        'util/CookieUtil'
+], function (Okta, CookieUtil) {
 
+  var _ = Okta._;
   // deviceName is escaped on BaseForm (see BaseForm's template)
   var titleTpl = Okta.Handlebars.compile('{{factorName}} ({{{deviceName}}})');
 
@@ -49,6 +52,12 @@ define(['okta'], function (Okta) {
         factorName: this.model.get('factorLabel'),
         deviceName: this.model.get('deviceName')
       });
+
+      if (this.settings.get('features.autoPush') && CookieUtil.isAutoPushEnabled(this.options.appState.get('userId'))) {
+        this.model.set('autoPush', true);
+        // trigger push once DOM is fully loaded
+        _.defer(_.bind(this.submit, this));
+      }
     },
     setSubmitState: function (ableToSubmit) {
       var button = this.$el.find('.button');
@@ -62,7 +71,9 @@ define(['okta'], function (Okta) {
       }
     },
     submit: function (e) {
-      e.preventDefault();
+      if (e !== undefined) {
+        e.preventDefault();
+      }
       if (this.enabled) {
         this.setSubmitState(false);
         this.doSave();

--- a/test/helpers/dom/MfaVerifyForm.js
+++ b/test/helpers/dom/MfaVerifyForm.js
@@ -3,6 +3,7 @@ define(['./Form'], function (Form) {
   var ANSWER_FIELD = 'answer';
   var SHOW_ANSWER_FIELD = 'showAnswer';
   var REMEMBER_DEVICE = 'rememberDevice';
+  var AUTO_PUSH = 'autoPush';
 
   return Form.extend({
 
@@ -79,6 +80,28 @@ define(['./Form'], function (Form) {
       var rememberDevice = this.rememberDeviceCheckbox();
       rememberDevice.prop('checked', val);
       rememberDevice.trigger('change');
+    },
+
+    autoPushCheckbox: function () {
+      return this.checkbox(AUTO_PUSH);
+    },
+
+    autoPushLabelText: function () {
+      return this.checkboxLabelText(AUTO_PUSH);
+    },
+
+    isAutoPushChecked: function () {
+      return this.checkbox(AUTO_PUSH).prop('checked');
+    },
+
+    setAutoPush: function (val) {
+      var autoPush = this.autoPushCheckbox();
+      autoPush.prop('checked', val);
+      autoPush.trigger('change');
+    },
+
+    isPushSent: function () {
+      return this.button('.mfa-verify ').val() === 'Push sent!';
     },
 
     smsSendCode: function () {

--- a/test/helpers/xhr/MFA_REQUIRED_oktaVerifyTotpOnly.js
+++ b/test/helpers/xhr/MFA_REQUIRED_oktaVerifyTotpOnly.js
@@ -18,37 +18,6 @@ define({
       },
       "factors": [
         {
-          "id": "opfhw7v2OnxKpftO40g3",
-          "factorType": "push",
-          "provider": "OKTA",
-          "vendorName": "OKTA",
-          "profile": {
-            "credentialId": "administrator1@clouditude.net",
-            "deviceType": "SmartPhone_IPhone",
-            "keys": [{
-              "kty": "PKIX",
-              "use": "sig",
-              "kid": "default",
-              "x5c": [
-                "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7FChGVis3ZuMsu2gkpzNvwQ7KZ8hO98/\nVxptGzx6K5uZPNjGxtE8wxkbvjZXQ5m5FTRNp4flVQ7ZuPhl/T+g7vAfhZZ+vjQAzyA3Ep5GsDBG\nnhQAYmsfJrVX8GH0TQx20kbBW4LsW4odQaITvLb1p3iudj7765KVPRFu0B3zY4niOkiJ94FU9r1w\nBi0EjFBP4Z0HBM2/7pKi338jmVIujLJFQbh1iqM6XxfAHYAajeD9mfyJshlpLMK4Yn/a7OEMpUIw\nrhDykhgaZJv6M0npd9mhitBkxdu3xPEZVUFB2tWN8M9D97BTl+tmMDALkW2wFaeg5UDFfy4dZY1S\nAN8lmwIDAQAB\n"
-              ]
-            }],
-            "name": "Yuming's iPhone",
-            "platform": "IOS",
-            "version": "9.3.1"
-          },
-          "_links": {
-            "verify": {
-              "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/opfhw7v2OnxKpftO40g3\/verify",
-              "hints": {
-                "allow": [
-                  "POST"
-                ]
-              }
-            }
-          }
-        },
-        {
           "id": "osthw62MEvG6YFuHe0g3",
               "factorType": "token:software:totp",
               "provider": "OKTA",

--- a/test/spec/CryptoUtil_spec.js
+++ b/test/spec/CryptoUtil_spec.js
@@ -1,0 +1,19 @@
+define([
+  'jquery',
+  'util/CryptoUtil'
+],
+function ($, CryptoUtil) {
+  describe('CryptoUtil', function () {
+    it('hash string to unique integer', function () {
+      var original = {};
+      var hashed = {};
+      var name;
+      for (var i = 0; i < 100; i++) {
+        name = Math.random().toString(36).substr(2, 10);
+        original[name] = true;
+        hashed[CryptoUtil.getStringHash(name)] = true;
+      }
+      expect(Object.keys(original).length).toEqual(Object.keys(hashed).length);
+    });
+  });
+});


### PR DESCRIPTION
Adding auto push checkbox to Okta Verify factor

[Requirement Doc] (https://oktawiki.atlassian.net/wiki/display/PM/Theme:+Core+MFA+Invest#Theme:CoreMFAInvest-AutoPushforNewSignOnUI)
[Design Doc] (https://oktawiki.atlassian.net/wiki/display/eng/Okta+Verify+Auto+Push+Design)

![push](https://cloud.githubusercontent.com/assets/13754731/14834359/f648db8e-0bb8-11e6-93c4-00c983d396f7.gif)

OKTA-86615

Not included in this PR: consolidate trustDevice, rememberMe, and autoPush into a single cookie, wanted to collect more feedback on benefit of doing this before proceeding

Backend feature flag PR: https://github.com/okta/okta-core/pull/14085

@rchild-okta @mauriciocastillosilva-okta @srinivasanagandla-okta @Ujjwalreddy-okta