### PR TITLE
Override focus() for text input in IE (to prevent placeholder text from disappearing)

### DIFF
--- a/src/util/BrowserFeatures.js
+++ b/src/util/BrowserFeatures.js
@@ -54,6 +54,10 @@ define(function () {
     return !!(win.history && win.history.pushState);
   };
 
+  fn.isIE = function () {
+    return /msie/i.test(navigator.userAgent);
+  };
+
   return fn;
 
 });

--- a/src/views/shared/TextBox.js
+++ b/src/views/shared/TextBox.js
@@ -17,10 +17,11 @@
 define([
   'jquery',
   'vendor/lib/handlebars-wrapper',
+  'util/BrowserFeatures',
   'shared/views/forms/inputs/TextBox',
   'qtip'
 ],
-function ($, Handlebars, TextBox) {
+function ($, Handlebars, BrowserFeatures, TextBox) {
 
   function hasTitleAndText(options) {
     var title = options.title,
@@ -76,6 +77,15 @@ function ($, Handlebars, TextBox) {
           show: {delay: 0}
         });
       }
+    },
+
+    // Override the focus() to ignore focus in IE. IE (8-11) has a known bug where
+    // the placeholder text disappears when the input field is focused.
+    focus: function () {
+      if (BrowserFeatures.isIE()) {
+        return;
+      }
+      return TextBox.prototype.focus.apply(this, arguments);
     }
 
   });

--- a/test/spec/PrimaryAuth_spec.js
+++ b/test/spec/PrimaryAuth_spec.js
@@ -197,6 +197,22 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, PrimaryAuthForm, Beacon,
           expect(tip).toEqual('Password');
         });
       });
+      itp('focuses on username field in browsers other than IE', function () {
+        spyOn(BrowserFeatures, 'isIE').and.returnValue(false);
+        return setup().then(function (test) {
+          var $username = test.form.usernameField();
+          // Focused element would be username DOM element
+          expect($username[0]).toBe(document.activeElement);
+        });
+      });
+      itp('does not focus on username field in IE', function () {
+        spyOn(BrowserFeatures, 'isIE').and.returnValue(true);
+        return setup().then(function (test) {
+          var $username = test.form.usernameField();
+          // Focused element would be body element
+          expect($username[0]).not.toBe(document.activeElement);
+        });
+      });
     });
 
     Expect.describe('customizing the tooltip', function () {


### PR DESCRIPTION
OKTA-84944