### PR TITLE
OKTA-89999: Better label for remember device

### DIFF
--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -89,12 +89,12 @@ function (Okta, Checkbox, BaseLoginController, CookieUtil, TOTPForm, YubikeyForm
         }
 
         // Remember Device checkbox resides outside of the Push and TOTP forms.
-        if (this.settings.get('features.rememberDevice')) {
+        if (this.options.appState.get('allowRememberDevice')) {
           this.add(Checkbox, {
             options: {
               model: this.model,
               name: 'rememberDevice',
-              placeholder: Okta.loc('rememberDevice', 'login'),
+              placeholder: this.options.appState.get('rememberDeviceLabel'),
               label: false,
               'label-top': true,
               className: 'margin-btm-0'

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -14,11 +14,10 @@
 define([
   'okta',
   'vendor/lib/q',
-  'util/CookieUtil',
   'util/FactorUtil',
   './BaseLoginModel'
 ],
-function (Okta, Q, CookieUtil, factorUtil, BaseLoginModel) {
+function (Okta, Q, factorUtil, BaseLoginModel) {
   var _ = Okta._;
 
   // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
@@ -173,7 +172,7 @@ function (Okta, Q, CookieUtil, factorUtil, BaseLoginModel) {
       this.settings = attributes.settings;
       this.appState = attributes.appState;
       // set the initial value for remember device.
-      attributes.rememberDevice = factorUtil.getRememberDeviceValue(this.settings, this.appState);
+      attributes.rememberDevice = factorUtil.getRememberDeviceValue(this.appState);
       return _.omit(attributes, ['settings', 'appState']);
     },
 
@@ -185,13 +184,7 @@ function (Okta, Q, CookieUtil, factorUtil, BaseLoginModel) {
 
     save: function () {
       var rememberDevice = !!this.get('rememberDevice');
-      var username = this.appState.get('username');
       // Set/Remove the remember device cookie based on the remember device input.
-      if (rememberDevice) {
-        CookieUtil.setDeviceCookie(username);
-      } else {
-        CookieUtil.removeDeviceCookie();
-      }
 
       return this.doTransaction(function (transaction) {
         var data = {
@@ -234,7 +227,6 @@ function (Okta, Q, CookieUtil, factorUtil, BaseLoginModel) {
         })
         .fail(function (err) {
           // Clean up the cookie on failure.
-          CookieUtil.removeDeviceCookie();
           throw err;
         });
       });

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -50,8 +50,6 @@ function (Okta, Errors, BrowserFeatures) {
       'features.router': ['boolean', true, false],
       'features.securityImage': ['boolean', true, false],
       'features.rememberMe': ['boolean', true, true],
-      'features.rememberDevice': ['boolean', true, true],
-      'features.rememberDeviceAlways': ['boolean', true, false],
       'features.autoPush': ['boolean', true, false],
       'features.smsRecovery': ['boolean', true, false],
       'features.windowsVerify': ['boolean', true, false],

--- a/src/util/CookieUtil.js
+++ b/src/util/CookieUtil.js
@@ -14,7 +14,6 @@ define(['okta', 'util/CryptoUtil', 'vendor/plugins/jquery.cookie'], function (Ok
 
   var $ = Okta.$;
   var LAST_USERNAME_COOKIE_NAME = 'ln';
-  var REMEMBER_DEVICE_COOKIE_NAME = 'rdln';
   var AUTO_PUSH_COOKIE_PREFIX  = 'auto_push_';
   var DAYS_SAVE_REMEMBER = 365;
 
@@ -45,18 +44,6 @@ define(['okta', 'util/CryptoUtil', 'vendor/plugins/jquery.cookie'], function (Ok
 
   fn.removeUsernameCookie = function () {
     removeCookie(LAST_USERNAME_COOKIE_NAME);
-  };
-
-  fn.getCookieDeviceUsername = function () {
-    return $.cookie(REMEMBER_DEVICE_COOKIE_NAME);
-  };
-
-  fn.setDeviceCookie = function (username) {
-    setCookie(REMEMBER_DEVICE_COOKIE_NAME, username);
-  };
-
-  fn.removeDeviceCookie = function () {
-    removeCookie(REMEMBER_DEVICE_COOKIE_NAME);
   };
 
   fn.isAutoPushEnabled = function (userId) {

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta' , './CookieUtil'], function (Okta, CookieUtil) {
+define(['okta'], function (Okta) {
 
   var fn = {};
 
@@ -140,21 +140,8 @@ define(['okta' , './CookieUtil'], function (Okta, CookieUtil) {
     return factorData[fn.getFactorName(provider, factorType)].sortOrder;
   };
 
-  fn.getRememberDeviceValue = function (settings, appState) {
-    var username = appState && appState.get('username');
-    var rememberDeviceAlways = settings && settings.get('features.rememberDeviceAlways');
-    var rememberDeviceUsername = CookieUtil.getCookieDeviceUsername();
-    var rememberDevice = false;
-
-    // rememberDevice is true if 'rememberDeviceAlways' is on or
-    // if the last username is same as the current username.
-    if (rememberDeviceAlways) {
-      rememberDevice = true;
-    } else if (rememberDeviceUsername || username) {
-      rememberDevice = (rememberDeviceUsername === username);
-    }
-
-    return rememberDevice;
+  fn.getRememberDeviceValue = function (appState) {
+    return appState && appState.get('rememberDeviceByDefault');
   };
 
   return fn;

--- a/src/views/mfa-verify/CallAndSMSForm.js
+++ b/src/views/mfa-verify/CallAndSMSForm.js
@@ -86,11 +86,11 @@ define(['okta', 'vendor/lib/q'], function (Okta, Q) {
         name: 'answer',
         type: 'text'
       });
-      if (this.settings.get('features.rememberDevice')) {
+      if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({
           label: false,
           'label-top': true,
-          placeholder: Okta.loc('rememberDevice', 'login'),
+          placeholder: this.options.appState.get('rememberDeviceLabel'),
           className: 'margin-btm-0',
           name: 'rememberDevice',
           type: 'checkbox'

--- a/src/views/mfa-verify/SecurityQuestionForm.js
+++ b/src/views/mfa-verify/SecurityQuestionForm.js
@@ -48,11 +48,11 @@ define(['okta'], function (Okta) {
         type: 'checkbox'
       });
 
-      if (this.settings.get('features.rememberDevice')) {
+      if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({
           label: false,
           'label-top': true,
-          placeholder: Okta.loc('rememberDevice', 'login'),
+          placeholder: this.options.appState.get('rememberDeviceLabel'),
           className: 'margin-btm-0',
           name: 'rememberDevice',
           type: 'checkbox'

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -36,11 +36,11 @@ define(['okta'], function (Okta) {
         type: 'text'
       });
 
-      if (this.settings.get('features.rememberDevice')) {
+      if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({
           label: false,
           'label-top': true,
-          placeholder: Okta.loc('rememberDevice', 'login'),
+          placeholder: this.options.appState.get('rememberDeviceLabel'),
           className: 'margin-btm-0',
           name: 'rememberDevice',
           type: 'checkbox'

--- a/src/views/mfa-verify/YubikeyForm.js
+++ b/src/views/mfa-verify/YubikeyForm.js
@@ -35,12 +35,12 @@ define(['okta'], function (Okta) {
         type: 'password'
       });
 
-      if (this.settings.get('features.rememberDevice')) {
+      if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({
           label: false,
           'label-top': true,
           className: 'margin-btm-0',
-          placeholder: Okta.loc('rememberDevice', 'login'),
+          placeholder: this.options.appState.get('rememberDeviceLabel'),
           name: 'rememberDevice',
           type: 'checkbox'
         });

--- a/test/helpers/xhr/MFA_REQUIRED_allFactors.js
+++ b/test/helpers/xhr/MFA_REQUIRED_allFactors.js
@@ -16,6 +16,11 @@ define({
           "timeZone": "America\/Los_Angeles"
         }
       },
+      "policy": {
+        "allowRememberDevice": true,
+        "rememberDeviceLifetimeInMinutes": 0,
+        "rememberDeviceByDefault": false
+      },
       "factors": [{
         "id": "ufshpdkgNun3xNE3W0g3",
         "factorType": "question",

--- a/test/helpers/xhr/MFA_REQUIRED_allFactors_OnPrem.js
+++ b/test/helpers/xhr/MFA_REQUIRED_allFactors_OnPrem.js
@@ -16,6 +16,11 @@ define({
           "timeZone": "America\/Los_Angeles"
         }
       },
+      "policy": {
+        "allowRememberDevice": true,
+        "rememberDeviceLifetimeInMinutes": 0,
+        "rememberDeviceByDefault": false
+      },
       "factors": [{
         "id": "ufshpdkgNun3xNE3W0g3",
         "factorType": "question",

--- a/test/helpers/xhr/MFA_REQUIRED_oktaVerify.js
+++ b/test/helpers/xhr/MFA_REQUIRED_oktaVerify.js
@@ -16,6 +16,11 @@ define({
           "timeZone": "America\/Los_Angeles"
         }
       },
+      "policy": {
+        "allowRememberDevice": true,
+        "rememberDeviceLifetimeInMinutes": 0,
+        "rememberDeviceByDefault": false
+      },
       "factors": [
         {
           "id": "opfhw7v2OnxKpftO40g3",

--- a/test/helpers/xhr/MFA_REQUIRED_oktaVerifyTotpOnly.js
+++ b/test/helpers/xhr/MFA_REQUIRED_oktaVerifyTotpOnly.js
@@ -16,6 +16,11 @@ define({
           "timeZone": "America\/Los_Angeles"
         }
       },
+      "policy": {
+        "allowRememberDevice": true,
+        "rememberDeviceLifetimeInMinutes": 0,
+        "rememberDeviceByDefault": false
+      },
       "factors": [
         {
           "id": "osthw62MEvG6YFuHe0g3",

--- a/test/helpers/xhr/MFA_REQUIRED_policy_always.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_always.js
@@ -17,20 +17,22 @@ define({
         }
       },
       "policy": {
-        "allowRememberDevice": true,
+        "allowRememberDevice": false,
         "rememberDeviceLifetimeInMinutes": 0,
         "rememberDeviceByDefault": false
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/helpers/xhr/MFA_REQUIRED_policy_device_based.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_device_based.js
@@ -22,15 +22,17 @@ define({
         "rememberDeviceByDefault": false
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/helpers/xhr/MFA_REQUIRED_policy_time_based.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_time_based.js
@@ -18,19 +18,21 @@ define({
       },
       "policy": {
         "allowRememberDevice": true,
-        "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceLifetimeInMinutes": 15,
+        "rememberDeviceByDefault": true
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/helpers/xhr/MFA_REQUIRED_policy_time_based_days.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_time_based_days.js
@@ -18,19 +18,21 @@ define({
       },
       "policy": {
         "allowRememberDevice": true,
-        "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceLifetimeInMinutes": 2880,
+        "rememberDeviceByDefault": true
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/helpers/xhr/MFA_REQUIRED_policy_time_based_hours.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_time_based_hours.js
@@ -18,19 +18,21 @@ define({
       },
       "policy": {
         "allowRememberDevice": true,
-        "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceLifetimeInMinutes": 120,
+        "rememberDeviceByDefault": true
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/helpers/xhr/MFA_REQUIRED_policy_time_based_min.js
+++ b/test/helpers/xhr/MFA_REQUIRED_policy_time_based_min.js
@@ -18,19 +18,21 @@ define({
       },
       "policy": {
         "allowRememberDevice": true,
-        "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceLifetimeInMinutes": 1,
+        "rememberDeviceByDefault": true
       },
       "factors": [{
-        "id": "ost947vv5GOSPjt9C0g4",
-        "factorType": "web",
-        "provider": "DUO",
+        "id": "ufshpdkgNun3xNE3W0g3",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
         "profile": {
-          "credentialId": "new@mail.com"
+          "question": "disliked_food",
+          "questionText": "What is the food you least liked as a child?"
         },
         "_links": {
           "verify": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ost947vv5GOSPjt9C0g4\/verify",
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/ufshpdkgNun3xNE3W0g3\/verify",
             "hints": {
               "allow": [
                 "POST"

--- a/test/spec/LoginRouter_spec.js
+++ b/test/spec/LoginRouter_spec.js
@@ -409,28 +409,6 @@ function (Okta, Q, Backbone, xdomain, SharedUtil, CryptoUtil, CookieUtil, OktaAu
         expect(form.isSecurityQuestion()).toBe(true);
       });
     });
-    itp('checks the remember device by default for a returning user', function () {
-      Util.mockCookie('rdln', 'testuser');
-      return setup()
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin');
-        return tick(test);
-      })
-      .then(function (test) {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-        test.setNextResponse(resMfa);
-        form.setUsername('testuser');
-        form.setPassword('pass');
-        form.submit();
-        return tick(test);
-      })
-      .then(function () {
-        var form = new MfaVerifyForm($sandbox);
-        expect(form.isRememberDeviceChecked()).toBe(true);
-      });
-    });
     itp('checks auto push by default for a returning user', function () {
       Util.mockCookie('auto_push_' + CryptoUtil.getStringHash('00uhn6dAGR4nUB4iY0g3'), 'true');
       return setup({'features.autoPush': true})


### PR DESCRIPTION
Remember Device use to say "Trust this device", but now instead it will convey a more meaningful text
- Do not challenge me on this device again
- Do not challenge me on this device for the next 15 minutes

Note: we won't show it if the server is set to prompt for mfa always

In addition I am removing the device cookie since it is no longer needed. The server will handle the logic for that

Screencast: https://okta.box.com/s/agm58j63aywxclop681r8lvqy4cvh2uw

@srinivasanagandla-okta can you take a look at FactorUtil.js please? This is the logic to figure out if we check or not the checkbox by default