### PR TITLE
Modify the css to show the app-logo banner always for SP initiated flow

### DIFF
--- a/assets/sass/modules/_app-login-banner.scss
+++ b/assets/sass/modules/_app-login-banner.scss
@@ -5,10 +5,6 @@
   margin-bottom: 10px;
   min-width: $container-min-width;
 
-  @include max-height-mq(700px) {
-    display: none;
-  }
-
   .applogin-background {
     background-color: #fff;
     @include opacity(0.9);
@@ -31,6 +27,10 @@
 
     @include max-width-mq($container-width) {
       width: 100%;
+    }
+
+    @include max-height-mq(750px) {
+      padding: 10px 0;
     }
 
     h1 {


### PR DESCRIPTION
OKTA-91641 - Before the fix, we were hiding the app logo banner if the device height was < 700px. The fix (1) removes this hiding logic and (2) reduces the padding in the app-logo banner to save 20px in the page's height. 

Before:
![screen shot 2016-06-13 at 3 07 26 pm](https://cloud.githubusercontent.com/assets/12504056/16024944/5726faa4-3179-11e6-95d9-4d0441370d55.png)

After:
![screen shot 2016-06-13 at 3 11 43 pm](https://cloud.githubusercontent.com/assets/12504056/16024948/602fafe2-3179-11e6-94c2-9d3fa2bfd5c1.png)
