### PR TITLE
Make @okta/i18n and @okta/courage optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "webpack": "1.13.1"
   },
   "dependencies": {
-    "@okta/courage": "1.3.0-beta.30",
-    "@okta/i18n": "1.22.0",
     "handlebars": "4.0.5",
     "jquery": "1.12.1",
     "jquery.cookie": "1.4.1",
@@ -72,6 +70,8 @@
     "q": "1.4.1"
   },
   "optionalDependencies": {
+    "@okta/courage": "1.3.0-beta.30",
+    "@okta/i18n": "1.22.0",
     "@okta/ci-pkginfo": "1.2.0",
     "@okta/ci-update-package": "1.4.0",
     "@okta/install-with-shrinkwrap": "1.4.0"


### PR DESCRIPTION
Resolves: OKTA-94736

Npm removes the entire node_modules folder when we publish, even if the files are included in .npmignore. BundledDependencies fixes this problem, but it doesn't currently work on scoped dependencies. This is a temporary workaround.

@rchild-okta 
@alexeystadnikov-okta 