### PR TITLE
OKTA-98768 Unable to see full field label/tip on new sign-in flow

### DIFF
--- a/assets/sass/modules/_qtip.scss
+++ b/assets/sass/modules/_qtip.scss
@@ -10,6 +10,10 @@
   font-weight: normal;
 }
 
+.qtip-title {
+  word-break: break-all;
+}
+
 .security-image-qtip.qtip-custom {
   font-size: $font-size-small;
   line-height: 1.4;


### PR DESCRIPTION
added word break to qtip-title
<img width="784" alt="screen shot 2016-08-23 at 4 45 48 pm" src="https://cloud.githubusercontent.com/assets/20933838/17894190/317e91b2-6951-11e6-9c1d-8b7fb361920c.png">
