### PR TITLE
Unable to see full field label/tip on new sign-in flow

### DIFF
--- a/assets/sass/modules/_qtip.scss
+++ b/assets/sass/modules/_qtip.scss
@@ -10,6 +10,10 @@
   font-weight: normal;
 }
 
+.qtip-title {
+  word-break: break-all;
+}
+
 .security-image-qtip.qtip-custom {
   font-size: $font-size-small;
   line-height: 1.4;


### PR DESCRIPTION
Added word break to qtip-title. See https://github.com/okta/okta-signin-widget/pull/98 for the original PR.

RESOLVES OKTA-98768 