### PR TITLE
Resolves OKTA-98474, OKTA-98474

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -192,6 +192,25 @@
 
 }
 
+// Windows Hello Enrollment
+.enroll-windows-hello,
+.verify-windows-hello {
+  .o-form-fieldset-container > .okta-form-subtitle {
+    margin-top: 15px;
+    margin-bottom: 20px;
+  }
+
+  .okta-infobox-error b {
+    font-weight: bold;
+  }
+
+  .okta-waiting-spinner {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+}
+
 /* TOTP Factor Enrollment */
 .device-type-input {
 

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -83,7 +83,7 @@ define(['okta'], function (Okta) {
     },
     'WINDOWS_HELLO': {
       label: 'factor.windowsHello',
-      description: 'factor.windowsHello.description',
+      description: 'factor.windowsHello.signin.description',
       iconClassName: 'mfa-windows-hello',
       sortOrder: 10
     },

--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -18,30 +18,6 @@ define([
 function (Okta, Q) {
 
   function adaptToOkta(promise) {
-    promise = promise['catch'](function (error) {
-      var errorSummary = null;
-
-      switch (error.message) {
-      case 'NotSupportedError':
-        errorSummary = Okta.loc('enroll.windowsHello.error.notConfigured', 'login');
-        break;
-
-      case 'NotFoundError':
-        break;
-
-      case 'AbortError':
-        break;
-      }
-
-      error.xhr = {
-        responseJSON: {
-          errorSummary: errorSummary
-        }
-      };
-
-      throw error;
-    });
-
     return new Q(promise);
   }
 

--- a/src/views/mfa-verify/WindowsHelloErrorMessageView.js
+++ b/src/views/mfa-verify/WindowsHelloErrorMessageView.js
@@ -16,16 +16,31 @@ define([
   ],
   function (Okta, BaseView) {
 
+    // Have to be unescaped for the html in enroll.windowsHello.error.notConfiguredHtml
     var template = '\
       <span class="icon error-24"></span>\
-      <h4><strong>{{i18n code="enroll.windowsHello.error.notWindows" bundle="login"}}</strong></h4>\
+      <h4><strong>{{{message}}}</strong></h4>\
     ';
 
     return BaseView.extend({
       template: template,
       className: 'okta-infobox-error infobox infobox-error infobox-md margin-btm-25',
       attributes: {
-        'data-se': 'o-form-error-not-windows'
+        'data-se': 'o-form-error-windows-hello'
+      },
+
+      message: '',
+
+      initialize: function (options) {
+        if (options && options.message) {
+          this.message = options.message;
+        }
+      },
+
+      getTemplateData: function () {
+        return {
+          message: this.message
+        };
       }
     });
   });

--- a/src/views/shared/Spinner.js
+++ b/src/views/shared/Spinner.js
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define(['okta'], function (Okta) {
+
+  return Okta.View.extend({
+    className: 'okta-waiting-spinner',
+    attributes: {
+      'data-se': 'o-form-okta-waiting-spinner'
+    },
+    modelEvents: {
+      'spinner:show': 'show',
+      'spinner:hide': 'hide'
+    },
+
+    initialize: function (options) {
+      if(options && options.visible === false){
+        this.hide();
+      }
+    },
+
+    show: function () {
+      this.$el.removeClass('hide');
+    },
+
+    hide: function () {
+      this.$el.addClass('hide');
+    }
+  });
+
+});

--- a/test/unit/helpers/dom/EnrollWindowsHelloForm.js
+++ b/test/unit/helpers/dom/EnrollWindowsHelloForm.js
@@ -2,8 +2,12 @@ define(['./Form'], function (Form) {
 
   return Form.extend({
 
-    hasErrorNotWindows: function () {
-      return this.el('o-form-error-not-windows').length == 1;
+    hasErrorWindowsHello: function () {
+      return this.el('o-form-error-windows-hello').length == 1;
+    },
+
+    spinner: function () {
+      return this.el('o-form-okta-waiting-spinner');
     },
 
     backLink: function () {

--- a/test/unit/spec/Spinner_spec.js
+++ b/test/unit/spec/Spinner_spec.js
@@ -1,0 +1,48 @@
+define([
+  'helpers/util/Expect',
+  'okta',
+  'views/shared/Spinner'
+],
+function (Expect, Okta, Spinner) {
+  Expect.describe('Spinner', function () {
+    it('does not have "hide" class if "visible" option is undefined', function () {
+      this.spinner = new Spinner({
+        model: new Okta.BaseModel()
+      });
+
+      expect(this.spinner.$el.hasClass('hide')).toBe(false);
+    });
+
+    it('has "hide" class if "visible" option is false', function () {
+      this.spinner = new Spinner({
+        model: new Okta.BaseModel(),
+        visible: false
+      });
+
+      expect(this.spinner.$el.hasClass('hide')).toBe(true);
+    });
+
+    Expect.describe('modelEvents', function () {
+      beforeEach(function () {
+        this.spinner = new Spinner({
+          model: new Okta.BaseModel()
+        });
+
+        this.spinner.render();
+      });
+
+      it('removes "hide" class after "spinner:show" model event', function () {
+        this.spinner.model.trigger('spinner:show');
+        expect(this.spinner.$el.hasClass('hide')).toBe(false);
+      });
+
+      it('adds "hide" class after "spinner:hide" model event', function () {
+        this.spinner.model.trigger('spinner:show');
+        expect(this.spinner.$el.hasClass('hide')).toBe(false);
+
+        this.spinner.model.trigger('spinner:hide');
+        expect(this.spinner.$el.hasClass('hide')).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Windows Hello Beta Changes UX

Resolves OKTA-98474, OKTA-98474

- Added spinner while Windows Hello is authenticating the user.
- Added errors for NotFoundError if Windows Hello factor was enrolled from another PC or was reconfigured on the current.
- Catch AbortError and don't show any error.
- Start Windows Hello verification immediately if Windows Hello is the only configured factor.

![screen shot 2016-09-29 at 7 58 08 pm](https://cloud.githubusercontent.com/assets/17706432/18963805/14f03190-867f-11e6-9c6d-488dc223789c.png)
![screen shot 2016-09-29 at 7 55 56 pm](https://cloud.githubusercontent.com/assets/17706432/18963810/16adcd8a-867f-11e6-8468-94080b96b1a8.png)
![screen shot 2016-09-29 at 7 56 50 pm](https://cloud.githubusercontent.com/assets/17706432/18963812/16cac0c0-867f-11e6-8426-0341cc2f1d81.png)


@mauriciocastillosilva-okta 
@rchild-okta 

Please, review.
