### PR TITLE
Hides button during Windows Hello enrollment and verifying when spinner is displayed

### DIFF
--- a/src/EnrollWindowsHelloController.js
+++ b/src/EnrollWindowsHelloController.js
@@ -148,10 +148,10 @@ function (Okta, FormController, FormType, webauthn, Spinner, Footer, WindowsHell
         this.subtitle = Okta.loc('enroll.windowsHello.subtitle.loading', 'login');
 
         this.model.trigger('spinner:show');
-        this.$('.o-form-button-bar').addClass('hide');
         this._resetErrorMessage();
 
         this.render();
+        this.$('.o-form-button-bar').addClass('hide');
       },
 
       _stopEnrollment: function (errorMessage) {

--- a/src/VerifyWindowsHelloController.js
+++ b/src/VerifyWindowsHelloController.js
@@ -50,12 +50,16 @@ function (Okta, FormController, FormType, webauthn, Spinner, FooterSignout, Wind
               [{ id: factorData.profile.credentialId }]
             )
             .then(function (assertion) {
-              model.trigger('sync');
               return factor.verify({
                 authenticatorData: assertion.authenticatorData,
                 clientData: assertion.clientData,
                 signatureData: assertion.signature
               });
+            })
+            .then(function (data) {
+              model.trigger('sync');
+              model.trigger('signIn');
+              return data;
             })
             .fail(function (error) {
               switch (error.message) {
@@ -95,7 +99,7 @@ function (Okta, FormController, FormType, webauthn, Spinner, FooterSignout, Wind
           'request': '_startEnrollment',
           'error': '_stopEnrollment',
           'abort': '_stopEnrollment',
-          'sync': '_successEnrollment'
+          'signIn': '_successEnrollment'
         };
       },
 
@@ -130,10 +134,10 @@ function (Okta, FormController, FormType, webauthn, Spinner, FooterSignout, Wind
         this.subtitle = Okta.loc('verify.windowsHello.subtitle.loading', 'login');
 
         this.model.trigger('spinner:show');
-        this.$('.o-form-button-bar').addClass('hide');
         this._resetErrorMessage();
 
         this.render();
+        this.$('.o-form-button-bar').addClass('hide');
       },
 
 
@@ -174,6 +178,7 @@ function (Okta, FormController, FormType, webauthn, Spinner, FooterSignout, Wind
       _successEnrollment: function () {
         this.subtitle = Okta.loc('verify.windowsHello.subtitle.signingIn', 'login');
         this.render();
+        this.$('.o-form-button-bar').addClass('hide');
       },
 
       _resetErrorMessage: function () {

--- a/test/unit/helpers/dom/EnrollWindowsHelloForm.js
+++ b/test/unit/helpers/dom/EnrollWindowsHelloForm.js
@@ -12,6 +12,10 @@ define(['./Form'], function (Form) {
 
     backLink: function () {
       return this.el('back-link');
+    },
+
+    buttonBar: function () {
+      return this.$('.o-form-button-bar');
     }
   });
 

--- a/test/unit/spec/EnrollWindowsHello_spec.js
+++ b/test/unit/spec/EnrollWindowsHello_spec.js
@@ -153,9 +153,12 @@ function (Okta,
           test.setNextResponse(responseSuccess);
           expect(test.form.subtitleText())
             .toBe('Click below to enroll Windows Hello as a second form of authentication');
+          expect(test.form.buttonBar().hasClass('hide')).toBe(false);
+
           test.form.submit();
           expect(test.form.subtitleText())
             .toBe('Please wait while Windows Hello is loading...');
+          expect(test.form.buttonBar().hasClass('hide')).toBe(true);
         });
       });
 

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -1907,12 +1907,19 @@ function (Q,
           .then(function (test) {
             test.setNextResponse([resChallengeWebauthn, resSuccess]);
             expect(test.form.subtitleText()).toBe('Verify your identity with Windows Hello');
+            expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(false);
+
             test.form.submit();
             expect(test.form.subtitleText()).toBe('Please wait while Windows Hello is loading...');
+            expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(true);
             return Expect.waitForSpyCall(webauthn.getAssertion, test);
           })
           .then(function (test) {
+            return tick(test);
+          })
+          .then(function (test) {
             expect(test.form.subtitleText()).toBe('Signing into Okta...');
+            expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(true);
           });
         });
       });


### PR DESCRIPTION
Resolves OKTA-104478 (Windows Hello: remove button when spinner is displayed)

![screen shot 2016-10-18 at 7 02 44 pm](https://cloud.githubusercontent.com/assets/17706432/19486082/d792a670-9565-11e6-8d90-5dfae3f5ec02.png)

![screen shot 2016-10-18 at 7 02 03 pm](https://cloud.githubusercontent.com/assets/17706432/19486081/d779b2f0-9565-11e6-80ef-ed631db67372.png)

@mauriciocastillosilva-okta 
@ukilon-okta 
@rchild-okta 

Please, review.
