### PR TITLE
Add aria-label to the input fields on the signin page.

### DIFF
--- a/src/views/shared/TextBox.js
+++ b/src/views/shared/TextBox.js
@@ -52,8 +52,8 @@ function ($, Handlebars, BrowserFeatures, TextBox) {
           <span class="icon input-icon {{params.icon}}"></span>\
         {{/if}}\
       {{/if}}\
-      <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" \
-        id="{{inputId}}" value="{{value}}" autocomplete="off"/>\
+      <input type="{{type}}" placeholder="{{placeholder}}" aria-label="{{placeholder}}"\
+        name="{{name}}" id="{{inputId}}" value="{{value}}" autocomplete="off"/>\
     '),
 
     postRender: function () {

--- a/test/unit/spec/TextBox_spec.js
+++ b/test/unit/spec/TextBox_spec.js
@@ -1,0 +1,22 @@
+define([
+  'helpers/util/Expect',
+  'okta',
+  'views/shared/TextBox',
+  'sandbox'
+],
+function (Expect, Okta, TextBox, $sandbox) {
+  Expect.describe('TextBox', function () {
+    it('the value of aria-label is same as the placeholder', function () {
+      var placeHolderValue = 'Test Value 123';
+  
+      var textbox = new TextBox({
+        model: new Okta.BaseModel(),
+        id: Okta._.uniqueId('textbox'),
+        placeholder: placeHolderValue
+      });
+
+      $sandbox.html(textbox.render().el);  
+      expect(textbox.$('#' + textbox.options.inputId).attr('aria-label')).toEqual(placeHolderValue);
+    });
+  });
+});


### PR DESCRIPTION
:bug: Add aria-label to input fields

To be 508 compliance, all form elements must have unique and descriptive labels.
Add an 'aria-label' attribute and use the same value as the placeholder which is a 
localized string.

RESOLVES OKTA-104131