### PR TITLE
:fire: Removes xdomain (IE8/IE9) support

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -789,34 +789,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-XDomain
-Version (if any):	0.7.5
-Brief Description:	A pure JavaScript CORS alternative. No server 
-configuration required - just add a proxy.html on the domain you wish to 
-communicate with. This library utilizes XHook to hook all XHR, so XDomain will 
-work seamlessly with any library.
-License	MIT
-
-Copyright © 2014 Jaime Pillora <dev@jpillora.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the 'Software'), to deal in 
-the Software without restriction, including without limitation the rights to 
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is furnished to do 
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all 
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
-SOFTWARE.
-
 Disclaimer and Limitation of Liability
 
 Disclaimer. OKTA AND ITS SUPPLIERS HEREBY DISCLAIM ALL (AND HAVE NOT AUTHORIZED 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1692,9 +1692,6 @@
     "ws": {
       "version": "1.1.1"
     },
-    "xdomain": {
-      "version": "0.7.3"
-    },
     "xhr2": {
       "version": "0.1.3"
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "q": "1.4.1",
     "qtip2": "3.0.3",
     "u2f-api-polyfill": "0.4.1",
-    "xdomain": "0.7.3",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -17,8 +17,7 @@
 define([
   'okta',
   'backbone',
-  './BrowserFeatures', // Note: BrowserFeatures must be loaded before xdomain, because xdomain overwrites the XHR object
-  'xdomain',
+  './BrowserFeatures',
   'RefreshAuthStateController',
   'models/Settings',
   'views/shared/Header',
@@ -30,7 +29,7 @@ define([
   './Errors',
   'util/Bundles'
 ],
-function (Okta, Backbone, BrowserFeatures, XDomain, RefreshAuthStateController, Settings, Header,
+function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings, Header,
           SecurityBeacon, AuthContainer, AppState, RouterUtil, Animations, Errors, Bundles) {
 
   var _ = Okta._,
@@ -75,8 +74,6 @@ function (Okta, Backbone, BrowserFeatures, XDomain, RefreshAuthStateController, 
     Events:  Backbone.Events,
 
     initialize: function (options) {
-      var xdomainSlaves;
-
       this.settings = new Settings(_.omit(options, 'el', 'authClient'), { parse: true });
       this.settings.setAuthClient(options.authClient);
 
@@ -84,22 +81,6 @@ function (Okta, Backbone, BrowserFeatures, XDomain, RefreshAuthStateController, 
         this.settings.callGlobalError(new Errors.ConfigError(
           Okta.loc('error.required.el')
         ));
-      }
-
-      // Use xdomain for IE8 and IE9 cross origin requests
-      // Note: xdomain only runs in a cross origin context, so it is safe to
-      // always start it (even if, for example, we're using this code on the
-      // okta login page)
-      if (BrowserFeatures.corsIsLimited()) {
-        // Notes:
-        // 1. Must manually set $.support.cors here since this is called after
-        //    jQuery has already determined cors support
-        // 2. After updating OktaAuth to not use reqwest, we should also add:
-        //    xhook.addWithCredentials = false
-        $.support.cors = true;
-        xdomainSlaves = {};
-        xdomainSlaves[this.settings.get('baseUrl')] = '/cors/proxy';
-        XDomain.xdomain.slaves(xdomainSlaves);
       }
 
       $('body > div').on('click', function () {

--- a/src/util/BrowserFeatures.js
+++ b/src/util/BrowserFeatures.js
@@ -12,18 +12,9 @@
 
 define(['underscore'], function (_) {
 
-  // Save a reference to the original XHR object, before it's overwritten by
-  // xdomain. Note: This file must be loaded before xdomain.
-  var XHR = window.XMLHttpRequest,
-      fn = {},
-      hasFullCorsSupport = 'withCredentials' in new XHR(),
+  var fn = {},
+      hasFullCorsSupport = 'withCredentials' in new window.XMLHttpRequest(),
       hasXDomainRequest = typeof XDomainRequest !== 'undefined';
-
-  // IE8 and IE9
-  fn.corsIsLimited = function () {
-    // IE10 has XDomainRequest, but it is removed in IE11
-    return hasXDomainRequest && !hasFullCorsSupport;
-  };
 
   fn.corsIsNotSupported = function () {
     return !(hasFullCorsSupport || hasXDomainRequest);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -4,7 +4,6 @@ define([
   'okta',
   'vendor/lib/q',
   'backbone',
-  'xdomain',
   'shared/util/Util',
   'util/CryptoUtil',
   'util/CookieUtil',
@@ -31,7 +30,7 @@ define([
   'helpers/xhr/labels_login_ja',
   'helpers/xhr/labels_country_ja'
 ],
-function (Okta, Q, Backbone, XDomain, SharedUtil, CryptoUtil, CookieUtil, OktaAuth, Util, Expect, Router,
+function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, OktaAuth, Util, Expect, Router,
           $sandbox, PrimaryAuthForm, RecoveryForm, MfaVerifyForm, EnrollCallForm, resSuccess, resRecovery,
           resMfa, resMfaRequiredDuo, resMfaRequiredOktaVerify, resMfaChallengeDuo, resMfaChallengePush,
           resMfaEnroll, errorInvalidToken, Errors, BrowserFeatures, labelsLoginJa, labelsCountryJa) {
@@ -208,28 +207,6 @@ function (Okta, Q, Backbone, XDomain, SharedUtil, CryptoUtil, CookieUtil, OktaAu
       return setup().then(function (test) {
         test.router.start();
         expect(Okta.Router.prototype.start).toHaveBeenCalledWith({ pushState: false });
-      });
-    });
-    itp('initializes xdomain if cors is limited', function () {
-      spyOn(XDomain.xdomain, 'slaves');
-      spyOn(BrowserFeatures, 'corsIsLimited').and.returnValue(true);
-      return setup().then(function () {
-        expect(XDomain.xdomain.slaves).toHaveBeenCalledWith({
-          'https://foo.com': '/cors/proxy'
-        });
-      });
-    });
-    itp('manually sets $.support.cors = true if cors is limited', function () {
-      spyOn(BrowserFeatures, 'corsIsLimited').and.returnValue(false);
-      return setup().then(function () {
-        expect($.support.cors).toBe(true);
-      });
-    });
-    itp('does not initialize xdomain if cors is supported fully', function () {
-      spyOn(XDomain.xdomain, 'slaves');
-      spyOn(BrowserFeatures, 'corsIsLimited').and.returnValue(false);
-      return setup().then(function () {
-        expect(XDomain.xdomain.slaves).not.toHaveBeenCalled();
       });
     });
 

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -38,8 +38,7 @@ entryConfig.externals = {
   'qtip': 'qtip2',
   'u2f-api-polyfill': true,
   'underscore': true,
-  'vendor/lib/q': 'q',
-  'xdomain': true
+  'vendor/lib/q': 'q'
 
   // We explicitly choose not to include jquery.placeholder in the externals
   // array because it requires a shim (requires work in their webpack.config).
@@ -68,10 +67,6 @@ cdnConfig.plugins = [
       // UglifyJS2 treats consecutive inline comments as separate comments, so we
       // need exceptions to include all relevant licenses.
       var exceptions = [
-        'XDomain - v0.7.5 - https://github.com/jpillora/xdomain',
-
-        'XHook - v1.3.5 - https://github.com/jpillora/xhook',
-
         'Chosen, a Select Box Enhancer',
         'by Patrick Filler for Harvest',
         'Version 0.11.1',


### PR DESCRIPTION
Resolves: OKTA-108157

This is necessary, because xdomain interferes with some libraries (such as AWS SDK for JavaScript). It also overwrites the global XMLHttpRequest, potentially causing conflicts with the sites in which the widget is embedded.

@rchild-okta 
@eugenebakaiev-okta 