### PR TITLE
:bug: Change type from ‘text’ to ‘number’ in textboxes for number vaues.

### DIFF
--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -249,7 +249,7 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           name: 'passCode',
           input: TextBox,
-          type: 'text',
+          type: 'number',
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')
           },

--- a/src/views/enroll-factors/EnterPasscodeForm.js
+++ b/src/views/enroll-factors/EnterPasscodeForm.js
@@ -34,7 +34,7 @@ define([
         FormType.Input({
           name: 'passCode',
           input: TextBox,
-          type: 'text',
+          type: 'number',
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')

--- a/src/views/shared/TextBox.js
+++ b/src/views/shared/TextBox.js
@@ -60,6 +60,14 @@ function ($, Handlebars, BrowserFeatures, TextBox) {
       var params = this.options.params,
           content;
 
+      if (this.options.type === 'number') {
+        var input = this.$('input');
+        input.attr({
+          pattern: '[0-9]*',
+          inputmode: 'numeric'
+        });
+      }
+
       if (params && params.innerTooltip) {
         content = createQtipContent(params.innerTooltip);
         this.$('.input-tooltip').qtip({

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -434,6 +434,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, AuthContainer, Form, Beacon, Expec
         return setupAndSendValidCode()
         .then(function (test) {
           $.ajax.calls.reset();
+          expect(test.form.codeField().attr('type')).toBe('number');
           test.form.setCode(123456);
           test.setNextResponse(resEnrollSuccess);
           test.form.submit();

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -339,6 +339,7 @@ function (_, $, Q, OktaAuth, LoginUtil, StringUtil, Util, DeviceTypeForm, Barcod
           .then(function (test) {
             Expect.isVisible(test.passCodeForm.form());
             Expect.isVisible(test.passCodeForm.codeField());
+            expect(test.passCodeForm.codeField().attr('type')).toBe('number');
           });
         });
         itp('returns to factor list when browser\'s back button is clicked', function () {

--- a/test/unit/spec/TextBox_spec.js
+++ b/test/unit/spec/TextBox_spec.js
@@ -18,5 +18,19 @@ function (Expect, Okta, TextBox, $sandbox) {
       $sandbox.html(textbox.render().el);  
       expect(textbox.$('#' + textbox.options.inputId).attr('aria-label')).toEqual(placeHolderValue);
     });
+
+    it('has appropriate attributes for type="number"', function () {
+      var textbox = new TextBox({
+        model: new Okta.BaseModel(),
+        id: Okta._.uniqueId('textbox'),
+        type: 'number'
+      });
+
+      $sandbox.html(textbox.render().el);
+      var input = textbox.$('#' + textbox.options.inputId);
+      expect(input.attr('type')).toEqual('number');
+      expect(input.attr('pattern')).toEqual('[0-9]*');
+      expect(input.attr('inputmode')).toEqual('numeric');
+    });
   });
 });


### PR DESCRIPTION
Resolves OKTA-79239.

Android:
![176bda40-c6db-11e6-9c50-24c8aff98a55](https://cloud.githubusercontent.com/assets/17706432/21392231/9b23eba4-c797-11e6-9b64-bc4db3b422e8.png)
![178a3b8e-c6db-11e6-9f8f-0bf67fcb2e5b](https://cloud.githubusercontent.com/assets/17706432/21392232/9b25ddb0-c797-11e6-831f-87c20ececd2c.png)

iPhone:
![20161221_161110](https://cloud.githubusercontent.com/assets/17706432/21392897/b27870e2-c79a-11e6-8d06-e9022661b41e.jpg)
![20161221_161129](https://cloud.githubusercontent.com/assets/17706432/21392909/baacdc80-c79a-11e6-8142-c18b4335a7fa.jpg)
![20161221_161028](https://cloud.githubusercontent.com/assets/17706432/21392903/b804c416-c79a-11e6-92cd-cf26a7a5958f.jpg)
![20161221_161039](https://cloud.githubusercontent.com/assets/17706432/21392900/b5761a1a-c79a-11e6-9efb-64999d1ecb83.jpg)

iPad:
![20161221_161427](https://cloud.githubusercontent.com/assets/17706432/21393024/4e969cd8-c79b-11e6-8892-b90e35dbc924.jpg)
![20161221_161354](https://cloud.githubusercontent.com/assets/17706432/21393028/5444adc8-c79b-11e6-8d7b-bc6fad2da12c.jpg)

Alerts were taken by the code in `TextBox:postRender`:
```
input.blur(function () {
          alert(this.value);
        });
```

@mauriciocastillosilva-okta 
@lboyette-okta 

Please, review.