### PR TITLE
:bug: Fix checkbox css. Correct the checkbox image height.

### DIFF
--- a/assets/sass/common/shared/o-forms/_o-form.scss
+++ b/assets/sass/common/shared/o-forms/_o-form.scss
@@ -444,7 +444,7 @@ only screen and (min-resolution: 2dppx) {
   .custom-checkbox {
     label {
       background: url('../img/ui/forms/checkbox-01@2x.png') no-repeat;
-      background-size: 50px 1055px;
+      background-size: 50px 1155px;
     }
   }
 }


### PR DESCRIPTION
Resolves OKTA-112865

Default
<img width="404" alt="default" src="https://cloud.githubusercontent.com/assets/22689859/21905804/8ed72046-d8bd-11e6-91e5-717bdaab347d.png">

When focus
<img width="402" alt="focus" src="https://cloud.githubusercontent.com/assets/22689859/21905801/8ed3d86e-d8bd-11e6-8e26-17ff79373141.png">

When on hover
<img width="405" alt="onhover" src="https://cloud.githubusercontent.com/assets/22689859/21905803/8ed5e672-d8bd-11e6-9493-55f708ea5b58.png">

When checked but no focus and hover
<img width="410" alt="checked" src="https://cloud.githubusercontent.com/assets/22689859/21905800/8ec25152-d8bd-11e6-9a00-dc769bf2b7f8.png">

When checked and on hover
<img width="403" alt="checked and onhover" src="https://cloud.githubusercontent.com/assets/22689859/21905802/8ed47c92-d8bd-11e6-86c5-2cbd8019cf6f.png">