### PR TITLE
Add Device Fingerprint functionality

### DIFF
--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -67,8 +67,8 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
           password = this.get('password'),
           remember = this.get('remember'),
           lastUsername = this.get('lastUsername'),
-          multiOptionalFactorEnroll = this.get('multiOptionalFactorEnroll');
-      var deviceFingerprintEnabled = this.settings.get('features.deviceFingerprinting');
+          multiOptionalFactorEnroll = this.get('multiOptionalFactorEnroll'),
+          deviceFingerprintEnabled = this.settings.get('features.deviceFingerprinting');
 
       // Only delete the cookie if its owner says so. This allows other
       // users to log in on a one-off basis.
@@ -98,10 +98,12 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
             warnBeforePasswordExpired: true,
             multiOptionalFactorEnroll: multiOptionalFactorEnroll
           }
+        })
+        .fin(function () {
+          if (deviceFingerprintEnabled) {
+            delete authClient.options.headers['X-Device-Fingerprint'];
+          }
         });
-        if (deviceFingerprintEnabled) {
-          delete authClient.options.headers['X-Device-Fingerprint'];
-        }
         return signInPromise;
       })
       .fail(_.bind(function () {

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -91,7 +91,7 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
         if (deviceFingerprintEnabled) {
           authClient.options.headers['X-Device-Fingerprint'] = this.get('deviceFingerprint');
         }
-        var signInPromise = authClient.signIn({
+        return authClient.signIn({
           username: username,
           password: password,
           options: {
@@ -104,7 +104,6 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
             delete authClient.options.headers['X-Device-Fingerprint'];
           }
         });
-        return signInPromise;
       })
       .fail(_.bind(function () {
         this.trigger('error');

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -46,6 +46,10 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       };
     },
 
+    local: {
+      deviceFingerprint: ['string', false]
+    },
+
     constructor: function (options) {
       this.settings = options && options.settings;
       this.appState = options && options.appState;
@@ -64,6 +68,7 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
           remember = this.get('remember'),
           lastUsername = this.get('lastUsername'),
           multiOptionalFactorEnroll = this.get('multiOptionalFactorEnroll');
+      var deviceFingerprintEnabled = this.settings.get('features.deviceFingerprinting');
 
       // Only delete the cookie if its owner says so. This allows other
       // users to log in on a one-off basis.
@@ -80,7 +85,13 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
 
       this.appState.trigger('loading', true);
       return this.startTransaction(function (authClient) {
-        return authClient.signIn({
+
+        // Add the custom header for fingerprint if needed, and then remove it afterwards
+        // Since we only need to send it for primary auth
+        if (deviceFingerprintEnabled) {
+          authClient.options.headers['X-Device-Fingerprint'] = this.get('deviceFingerprint');
+        }
+        var signInPromise = authClient.signIn({
           username: username,
           password: password,
           options: {
@@ -88,6 +99,10 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
             multiOptionalFactorEnroll: multiOptionalFactorEnroll
           }
         });
+        if (deviceFingerprintEnabled) {
+          delete authClient.options.headers['X-Device-Fingerprint'];
+        }
+        return signInPromise;
       })
       .fail(_.bind(function () {
         this.trigger('error');

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -72,6 +72,7 @@ function (Okta, Errors, BrowserFeatures, Util, Logger, config) {
       'features.selfServiceUnlock': ['boolean', true, false],
       'features.multiOptionalFactorEnroll': ['boolean', true, false],
       'features.preventBrowserFromSavingOktaPassword': ['boolean', true, true],
+      'features.deviceFingerprinting': ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -1,0 +1,82 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*jshint latedef:false */
+/*global JSON */
+
+define(['vendor/lib/q', 'jquery'], function (Q, $) {
+
+  var iframeId = 'okta_fingerprint_iframe';
+
+  function removeIframe() {
+    var $fingerprintIFrame = $('#' + iframeId);
+    $fingerprintIFrame.off();
+    $fingerprintIFrame.remove();
+  }
+
+  return {
+    generateDeviceFingerprint: function (oktaDomainUrl) {
+      var deferred = Q.defer();
+
+      function removeListener() {
+        window.removeEventListener('message', onMessageReceivedFromOkta, false);
+      }
+
+      function handleError(reason) {
+        removeIframe();
+        removeListener();
+        deferred.reject(reason);
+      }
+
+      function onMessageReceivedFromOkta(event) {
+        /*jshint maxcomplexity:7*/
+        if (!event || !event.data || event.origin != oktaDomainUrl) {
+          handleError('no data');
+        }
+        try {
+          var message = eval('(' + event.data + ')');
+          if (message && message.type == 'FingerprintServiceReady') {
+            var actionMessage = {};
+            actionMessage.type = 'GetFingerprint';
+            sendMessageToOkta(actionMessage);
+          } else if (message && message.type == 'FingerprintAvailable') {
+            removeIframe();
+            removeListener();
+            deferred.resolve(message.fingerprint);
+          }
+        } catch (error) {
+          handleError(error);
+          //Ignore any errors since we could get other messages too
+        }
+        handleError('no data');
+      }
+
+      function sendMessageToOkta(message) {
+        var win = document.getElementById(iframeId).contentWindow;
+        if (win) {
+          win.postMessage(JSON.stringify(message), oktaDomainUrl);
+        }
+      }
+
+      // Attach listener
+      window.addEventListener('message', onMessageReceivedFromOkta, false);
+      // Create iframe
+      $('<iframe>', {
+        src: oktaDomainUrl + '/auth/services/devicefingerprint',
+        id:  iframeId,
+        style: 'display: none;'
+      }).appendTo('.auth-content');
+
+      return deferred.promise;
+    }
+  };
+});

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -46,7 +46,7 @@ define([
         }
         if (this.settings.get('features.deviceFingerprinting')) {
           var self = this;
-          DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'))
+          DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
           .then(function (fingerprint) {
             self.model.set('deviceFingerprint', fingerprint);
           })

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -49,10 +49,11 @@ define([
           DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'))
           .then(function (fingerprint) {
             self.model.set('deviceFingerprint', fingerprint);
-            self.model.save();
           })
           .fail(function () {
             // Keep going even if device fingerprint fails
+          })
+          .fin(function () {
             self.model.save();
           });
         } else {

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -18,14 +18,10 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint) {
       window.postMessage(JSON.stringify(message), '*');
     }
 
-    beforeEach(function () {
-      $sandbox.append('<div class="auth-content"></div>');
-    });
-
     it('iframe is created with the right src and it is hidden', function () {
       spyOn(window, 'addEventListener');
-      DeviceFingerprint.generateDeviceFingerprint('baseUrl');
-      var $iFrame = $('#okta_fingerprint_iframe');
+      DeviceFingerprint.generateDeviceFingerprint('baseUrl', $sandbox);
+      var $iFrame = $sandbox.find('iframe');
       expect($iFrame).toExist();
       expect($iFrame.attr('src')).toBe('baseUrl/auth/services/devicefingerprint');
       expect($iFrame.is(':visible')).toBe(false);
@@ -34,9 +30,8 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint) {
 
     it('returns a fingerprint if the communication with the iframe is successfull', function (done) {
       mockIFrameMessages(true);
-      DeviceFingerprint.generateDeviceFingerprint('file://')
+      DeviceFingerprint.generateDeviceFingerprint('file://', $sandbox)
       .then(function (fingerprint) {
-        expect(fingerprint).not.toBeUndefined();
         expect(fingerprint).toBe('thisIsTheFingerprint');
         done();
       })
@@ -47,7 +42,7 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint) {
 
     it('fails if there is a problem with communicating with the iframe', function (done) {
       mockIFrameMessages(false, null);
-      DeviceFingerprint.generateDeviceFingerprint('file://')
+      DeviceFingerprint.generateDeviceFingerprint('file://', $sandbox)
       .then(function () {
         done.fail('Fingerprint promise incorrectly resolved successful');
       })
@@ -59,7 +54,7 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint) {
 
     it('fails if there iframe sends and invalid message content', function (done) {
       mockIFrameMessages(false, { type: 'InvalidMessageType' });
-      DeviceFingerprint.generateDeviceFingerprint('file://')
+      DeviceFingerprint.generateDeviceFingerprint('file://', $sandbox)
       .then(function () {
         done.fail('Fingerprint promise incorrectly resolved successful');
       })

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -23,11 +23,13 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint) {
     });
 
     it('iframe is created with the right src and it is hidden', function () {
+      spyOn(window, 'addEventListener');
       DeviceFingerprint.generateDeviceFingerprint('baseUrl');
       var $iFrame = $('#okta_fingerprint_iframe');
       expect($iFrame).toExist();
       expect($iFrame.attr('src')).toBe('baseUrl/auth/services/devicefingerprint');
       expect($iFrame.is(':visible')).toBe(false);
+      expect(window.addEventListener).toHaveBeenCalledWith('message', jasmine.any(Function), false);
     });
 
     it('returns a fingerprint if the communication with the iframe is successfull', function (done) {

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -1,0 +1,71 @@
+/*global JSON */
+define([
+  'jquery',
+  'vendor/lib/q',
+  'helpers/util/Expect',
+  'sandbox',
+  'util/DeviceFingerprint'
+],
+function ($, Q, Expect, $sandbox, DeviceFingerprint) {
+
+  Expect.describe('DeviceFingerprint', function () {
+
+    function mockIFrameMessages(success, errorMessage) {
+      var message = success ? {
+        type: 'FingerprintAvailable',
+        fingerprint: 'thisIsTheFingerprint'
+      } : errorMessage;
+      window.postMessage(JSON.stringify(message), '*');
+    }
+
+    beforeEach(function () {
+      $sandbox.append('<div class="auth-content"></div>');
+    });
+
+    it('iframe is created with the right src and it is hidden', function () {
+      DeviceFingerprint.generateDeviceFingerprint('baseUrl');
+      var $iFrame = $('#okta_fingerprint_iframe');
+      expect($iFrame).toExist();
+      expect($iFrame.attr('src')).toBe('baseUrl/auth/services/devicefingerprint');
+      expect($iFrame.is(':visible')).toBe(false);
+    });
+
+    it('returns a fingerprint if the communication with the iframe is successfull', function (done) {
+      mockIFrameMessages(true);
+      DeviceFingerprint.generateDeviceFingerprint('file://')
+      .then(function (fingerprint) {
+        expect(fingerprint).not.toBeUndefined();
+        expect(fingerprint).toBe('thisIsTheFingerprint');
+        done();
+      })
+      .fail(function () {
+        done.fail('Fingerprint promise incorrectly failed');
+      });
+    });
+
+    it('fails if there is a problem with communicating with the iframe', function (done) {
+      mockIFrameMessages(false, null);
+      DeviceFingerprint.generateDeviceFingerprint('file://')
+      .then(function () {
+        done.fail('Fingerprint promise incorrectly resolved successful');
+      })
+      .fail(function (reason) {
+        expect(reason).not.toBeUndefined();
+        done();
+      });
+    });
+
+    it('fails if there iframe sends and invalid message content', function (done) {
+      mockIFrameMessages(false, { type: 'InvalidMessageType' });
+      DeviceFingerprint.generateDeviceFingerprint('file://')
+      .then(function () {
+        done.fail('Fingerprint promise incorrectly resolved successful');
+      })
+      .fail(function (reason) {
+        expect(reason).not.toBeUndefined();
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
- When flag is enabled, add a header with the calculated device fingerprint
- That header is then removed for further requests
Note: if the sign in request is not successful, we need to generate a new fingerprint (device fingerprints are valid one time only)

Resolves: OKTA-110557