### PR TITLE
:bug: Hide Sign Out link during MFA based on settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,9 +612,11 @@ var signIn = new OktaSignIn(config);
   - `fi` - Finnish
   - `fr` - French
   - `hu` - Hungarian
+  - `id` - Indonesian
   - `it` - Italian
   - `ja` - Japanese
   - `ko` - Korean
+  - `ms` - Malaysian
   - `nl-NL` - Dutch
   - `pt-BR` - Portuguese (Brazil)
   - `ro` - Romanian
@@ -898,6 +900,8 @@ features: {
 - **features.selfServiceUnlock** - Display the "Unlock Account" link to allow users to unlock their accounts. Defaults to `false`.
 
 - **features.multiOptionalFactorEnroll** - Allow users to enroll in multiple optional factors before finishing the authentication flow. Default behavior is to force enrollment of all required factors and skip optional factors. Defaults to `false`.
+
+- **features.hideSignOutLinkInMFA** - Hides the sign out link for MFA challenge. Defaults to `false`.
 
 # Events
 

--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/*jshint maxcomplexity:12, maxparams:11 */
+/*jshint maxcomplexity:13, maxparams:11 */
 define([
   'okta',
   'shared/views/forms/inputs/CheckBox',
@@ -107,7 +107,9 @@ function (Okta, Checkbox, BaseLoginController, CookieUtil, TOTPForm, YubikeyForm
         });
       }
 
-      this.add(new FooterSignout(this.toJSON()));
+      if (!this.settings.get('features.hideSignOutLinkInMFA')) {
+        this.add(new FooterSignout(this.toJSON()));
+      }
     },
 
     trapAuthResponse: function () {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -73,6 +73,7 @@ function (Okta, Errors, BrowserFeatures, Util, Logger, config) {
       'features.multiOptionalFactorEnroll': ['boolean', true, false],
       'features.preventBrowserFromSavingOktaPassword': ['boolean', true, true],
       'features.deviceFingerprinting': ['boolean', false, false],
+      'features.hideSignOutLinkInMFA' : ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -402,6 +402,18 @@ function (Okta,
           });
         });
       });
+      Expect.describe('Sign out link', function () {
+        itp('is visible', function () {
+          return setupWithFirstFactor({factorType: 'question'}).then(function () {
+            Expect.isVisible($sandbox.find('[data-se=signout-link]'));
+          });
+        });
+        itp('is not present if features.hideSignOutLinkInMFA is true', function () {
+          return setupSecurityQuestion({'features.hideSignOutLinkInMFA': true}).then(function () {
+            expect($sandbox.find('[data-se=signout-link]').length).toBe(0);
+          });
+        });
+      });
       Expect.describe('Remember device', function () {
         itp('is rendered', function () {
           return setup(resAllFactors).then(function (test) {


### PR DESCRIPTION
Settings new prop: hideSignOutLinkInMFA
This is used for App Sign in Flows, when we only need to do MFA. It does not make sense to have a SignOut link in that flow (that sign out will not kill the user session, but only the app session we are trying to login in too. Plus it redirects to the main login form, which also does not make sense)

Resolves: OKTA-114022
Bacon: test