### PR TITLE
:seedling: Add async credentials processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,9 @@ var signIn = new OktaSignIn(config);
     }
     ```
 
-- **processCreds:** Synchronous hook to handle the credentials before they are sent to Okta in the Primary Auth, Password Expiration, and Password Reset flows.
+- **processCreds:** Hook to handle the credentials before they are sent to Okta in the Primary Auth, Password Expiration, and Password Reset flows.
+
+    If processCreds takes a single argument it will be executed as a synchonous hook:
 
     ```javascript
     // Passed a creds object {username, password}
@@ -579,6 +581,31 @@ var signIn = new OktaSignIn(config);
         user: creds.username,
         passwordBytes: creds.password,
         keyType: 'KEY_TYPE_PASSWORD_PLAIN'
+      });
+    }
+    ```
+
+    If processCreds takes two arguments it will be executed as an asynchonous hook:
+
+    ```javascript
+    // Passed a creds object {username, password} and a callback for further processing
+    processCreds: function (creds, callback) {
+      // This example demonstrates optional legacy form-based logon
+      $.ajax({
+        method: "POST",
+        url: "/logontype",
+        data: {
+          username : creds.username
+        },
+        success: function (logontype) {
+          if (logontype == "LEGACY") {
+            $('#legacyUser').val(creds.username);
+            $('#legacyPassword').val(creds.password);
+            $('#legacyLogonForm').submit();
+          } else {
+            callback();
+          }
+        }
       });
     }
     ```

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -151,13 +151,20 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Tex
     initialize: function () {
       this.listenTo(this.form, 'save', function () {
         var processCreds = this.settings.get('processCreds');
-        if (_.isFunction(processCreds)) {
-          processCreds({
+        if (!_.isFunction(processCreds)) {
+          this.model.save();
+        } else {
+          var creds = {
             username: this.options.appState.get('userEmail'),
             password: this.model.get('newPassword')
-          });
+          };
+          if (processCreds.length === 2) {
+            processCreds(creds, _.bind(this.model.save, this.model));
+          } else {
+            processCreds(creds);
+            this.model.save();
+          }
         }
-        this.model.save();
       });
     }
 

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -84,13 +84,20 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, FooterSign
     initialize: function () {
       this.listenTo(this.form, 'save', function () {
         var processCreds = this.settings.get('processCreds');
-        if (_.isFunction(processCreds)) {
-          processCreds({
+        if (!_.isFunction(processCreds)) {
+          this.model.save();
+        } else {
+          var creds = {
             username: this.options.appState.get('userEmail'),
             password: this.model.get('newPassword')
-          });
+          };
+          if (processCreds.length === 2) {
+            processCreds(creds, _.bind(this.model.save, this.model));
+          } else {
+            processCreds(creds);
+            this.model.save();
+          }
         }
-        this.model.save();
       });
     }
 

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -24,8 +24,12 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expec
   var itp = Expect.itp;
   var tick = Expect.tick;
   var processCredsSpy = jasmine.createSpy('processCredsSpy');
+  var processCredsAsyncSpy = jasmine.createSpy('processCredsAsyncSpy');
 
-  function setup(res) {
+  function setup(settings, res) {
+    var customProcessCredsSpy = settings ?
+      settings.processCreds || processCredsSpy :
+      processCredsSpy;
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
     var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
@@ -35,7 +39,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expec
       features: { securityImage: true },
       authClient: authClient,
       globalSuccessFn: function () {},
-      processCreds: processCredsSpy
+      processCreds: customProcessCredsSpy
     });
     Util.registerRouter(router);
     Util.mockRouterNavigate(router);
@@ -53,7 +57,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expec
 
   function setupWarn(numDays) {
     resPassWarn.response._embedded.policy.expiration.passwordExpireDays = numDays;
-    return setup(resPassWarn);
+    return setup(undefined, resPassWarn);
   }
 
   function submitNewPass(test, oldPass, newPass, confirmPass) {
@@ -125,6 +129,43 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expec
             password: 'newpwd'
           });
           expect($.ajax.calls.count()).toBe(1);
+        });
+      });
+      itp('calls async processCreds function before saving a model', function () {
+        return setup({
+          'processCreds': function(creds, callback) {
+            processCredsAsyncSpy(creds, callback);
+            callback();
+          }
+        }).then(function (test) {
+          $.ajax.calls.reset();
+          processCredsAsyncSpy.calls.reset();
+          test.setNextResponse(resSuccess);
+          submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
+          expect(processCredsAsyncSpy.calls.count()).toBe(1);
+          expect(processCredsAsyncSpy).toHaveBeenCalledWith({
+            username: 'inca@clouditude.net',
+            password: 'newpwd'
+          }, jasmine.any(Function));
+          expect($.ajax.calls.count()).toBe(1);
+        });
+      });
+      itp('calls async processCreds function and can prevent saving a model', function () {
+        return setup({
+          'processCreds': function(creds, callback) {
+            processCredsAsyncSpy(creds, callback);
+          }
+        }).then(function (test) {
+          $.ajax.calls.reset();
+          processCredsAsyncSpy.calls.reset();
+          test.setNextResponse(resSuccess);
+          submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
+          expect(processCredsAsyncSpy.calls.count()).toBe(1);
+          expect(processCredsAsyncSpy).toHaveBeenCalledWith({
+            username: 'inca@clouditude.net',
+            password: 'newpwd'
+          }, jasmine.any(Function));
+          expect($.ajax.calls.count()).toBe(0);
         });
       });
       itp('saves the new password successfully', function () {


### PR DESCRIPTION
Allow credentials processing to be asynchronous. This allows the
credentials processing function to do things like AJAX calls if
necessary.

 - Add asyncProcessCreds function to settings

 - Support asyncProcessCreds in Primary Auth Form

 - Preserve device fingerprinting as part of the delegate callback