### PR TITLE
Add aria alert for security images.

### DIFF
--- a/assets/sass/modules/_beacon.scss
+++ b/assets/sass/modules/_beacon.scss
@@ -76,6 +76,12 @@
   @include box-shadow(0 0 0 15px);
 }
 
+.auth-beacon-description {
+  display: block;
+  height: 0;
+  overflow: hidden;
+}
+
 .undefined-user {
   background-image: url('../img/security/default.png');
 

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -21,6 +21,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
     // are hard coded into the css and the value returned by the server
     // is ignored.
     var imgSrc = appState.get('securityImage'),
+        imgDescription = appState.get('securityImageDescription'),
         isUndefinedUser = appState.get('isUndefinedUser'),
         isNewUser = appState.get('isNewUser'),
         isSecurityImage = !isUndefinedUser && !isNewUser;
@@ -36,6 +37,9 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       return;
     }
     if (isSecurityImage) {
+      // TODO: Newer versions of qtip will remove aria-describedby on their own when destroy() is called.
+      el.removeAttr('aria-describedby');
+      el.find('.auth-beacon-description').text(imgDescription);
       el.css('background-image', 'url(' + _.escape(imgSrc) + ')');
       return;
     }
@@ -120,7 +124,8 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
         <div class="circle right"></div>\
       </div>\
     </div>\
-    <div class="bg-helper auth-beacon auth-beacon-security" data-se="security-beacon">\
+    <div aria-live="polite" role="image" class="bg-helper auth-beacon auth-beacon-security" data-se="security-beacon">\
+      <span class="auth-beacon-description"></span>\
       <div class="okta-sign-in-beacon-border auth-beacon-border js-auth-beacon-border">\
       </div>\
     </div>\

--- a/test/unit/helpers/xhr/security_image.js
+++ b/test/unit/helpers/xhr/security_image.js
@@ -3,6 +3,7 @@ define({
   "responseType": "json",
   "response": {
     result: 'success',
-    pwdImg: '../../../test/unit/assets/1x1.gif'
+    pwdImg: '../../../test/unit/assets/1x1.gif',
+    imageDescription: 'a single pixel'
   }
 });

--- a/test/unit/helpers/xhr/security_image_fail.js
+++ b/test/unit/helpers/xhr/security_image_fail.js
@@ -3,6 +3,7 @@ define({
   "responseType": "json",
   "response": {
     result: 'success',
-    pwdImg: '/img/security/unknown.png'
+    pwdImg: '/img/security/unknown.png',
+    imageDescription: ''
   }
 });

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -881,6 +881,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
             success: undefined
           });
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(../../../test/unit/assets/1x1.gif)');
+          expect($('.auth-beacon-description').text()).toBe('a single pixel');
         });
       });
       itp('waits for username field to lose focus before fetching the security image', function () {
@@ -967,6 +968,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
         .then(waitForBeaconChange)
         .then(function () {
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(../../../test/unit/assets/1x1.gif)');
+          expect($('.auth-beacon-description').text()).toBe('a single pixel');
         });
       });
       itp('calls globalErrorFn if cors is not enabled and security image request is made', function () {


### PR DESCRIPTION
Puts the security image name into a span with aria tags so that it is read out loud by screen readers.

Bacon: test
Resolves: OKTA-115417