### PR TITLE
Adds an aria alert to the forgot password form.

### DIFF
--- a/assets/sass/modules/_accessibility.scss
+++ b/assets/sass/modules/_accessibility.scss
@@ -1,0 +1,10 @@
+// This hides the content of the div, but it's still
+// technically rendered and "visible" in the DOM.
+// Sometimes aria tags haven't worked out nicely for us
+// (for instance, for images that are loaded via
+// background-image CSS instead of <img> tags).
+.accessibility-text {
+  display: block;
+  height: 0;
+  overflow: hidden;
+}

--- a/assets/sass/modules/_beacon.scss
+++ b/assets/sass/modules/_beacon.scss
@@ -76,12 +76,6 @@
   @include box-shadow(0 0 0 15px);
 }
 
-.auth-beacon-description {
-  display: block;
-  height: 0;
-  overflow: hidden;
-}
-
 .undefined-user {
   background-image: url('../img/security/default.png');
 

--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -29,4 +29,5 @@
 @import 'modules/enroll';
 @import 'modules/app-login-banner';
 @import 'modules/okta-footer';
+@import 'modules/accessibility';
 @import 'ie';

--- a/src/PwdResetEmailSentController.js
+++ b/src/PwdResetEmailSentController.js
@@ -40,6 +40,17 @@ function (Okta, Enums, FormController, FormType) {
       attributes: { 'data-se': 'pwd-reset-email-sent' },
       formChildren: function () {
         return [
+          FormType.View({
+            View: Okta.View.extend({
+              template: '\
+              <span class="accessibility-text" role="status">{{alert}}</span>\
+              ',
+              getTemplateData: function () {
+                return { 'alert': Okta.loc('password.forgot.emailSent.title', 'login') };
+              }
+            })
+          }),
+
           FormType.Button({
             title: Okta.loc('goback', 'login'),
             className: 'button button-primary button-wide',

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -39,7 +39,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
     if (isSecurityImage) {
       // TODO: Newer versions of qtip will remove aria-describedby on their own when destroy() is called.
       el.removeAttr('aria-describedby');
-      el.find('.auth-beacon-description').text(imgDescription);
+      el.find('.accessibility-text').text(imgDescription);
       el.css('background-image', 'url(' + _.escape(imgSrc) + ')');
       return;
     }
@@ -125,7 +125,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       </div>\
     </div>\
     <div aria-live="polite" role="image" class="bg-helper auth-beacon auth-beacon-security" data-se="security-beacon">\
-      <span class="auth-beacon-description"></span>\
+      <span class="accessibility-text"></span>\
       <div class="okta-sign-in-beacon-border auth-beacon-border js-auth-beacon-border">\
       </div>\
     </div>\

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -131,6 +131,10 @@ define(['jquery', 'underscore', './Dom'], function ($, _, Dom) {
 
     errorMessage: function () {
       return this.$('.okta-form-infobox-error p').text().trim();
+    },
+
+    accessibilityText: function() {
+      return this.$('.accessibility-text').text().trim();
     }
 
   });

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -250,6 +250,7 @@ function (Q, _, $, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
         })
         .then(function (test) {
           expect(test.form.titleText()).toBe('Email sent!');
+          expect(test.form.accessibilityText()).toBe('Email sent!');
           expect(test.form.getEmailSentConfirmationText().indexOf('baz@bar') >= 0).toBe(true);
           expect(test.form.backToLoginButton().length).toBe(1);
           test.form.goBackToLogin();

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -874,7 +874,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function () {
+        .then(function (test) {
           expect($.ajax.calls.count()).toBe(1);
           expect($.ajax.calls.argsFor(0)[0]).toEqual({
             url: 'https://foo.com/login/getimage?username=testuser',
@@ -884,7 +884,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
             success: undefined
           });
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(../../../test/unit/assets/1x1.gif)');
-          expect($('.auth-beacon-description').text()).toBe('a single pixel');
+          expect(test.form.accessibilityText()).toBe('a single pixel');
         });
       });
       itp('waits for username field to lose focus before fetching the security image', function () {
@@ -969,9 +969,9 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
         };
         return setup(options, [resSecurityImage])
         .then(waitForBeaconChange)
-        .then(function () {
+        .then(function (test) {
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(../../../test/unit/assets/1x1.gif)');
-          expect($('.auth-beacon-description').text()).toBe('a single pixel');
+          expect(test.form.accessibilityText()).toBe('a single pixel');
         });
       });
       itp('calls globalErrorFn if cors is not enabled and security image request is made', function () {


### PR DESCRIPTION
Whether this gets read out loud or not is unfortunately not very consistent. Voiceover seems to like doing its own thing. In general, typing the username and pressing enter does not get the text read. If the user clicks the reset button with the mouse, or tabs to it and then presses enter, they are likely (but still not guaranteed!) to get the text read.

Bacon: test
Resolves: OKTA-118645