### PR TITLE
:bug: Remove anti-phishing tooltip when moving to a new page

### DIFF
--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -132,8 +132,11 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       this.listenTo(options.appState, 'change:securityImage', this.update);
       this.listenTo(options.appState, 'loading', function (isLoading) {
         this.$el.toggleClass('beacon-loading', isLoading);
+        this.removeAntiPhishingMessage();
       });
       this.options.appState.set('beaconType', 'security');
+
+      this.listenTo(options.appState, 'navigate', this.removeAntiPhishingMessage);
     },
 
     postRender: function () {
@@ -142,6 +145,11 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
 
     equals: function (Beacon) {
       return Beacon && this instanceof Beacon;
+    },
+
+    removeAntiPhishingMessage: function () {
+      var image = this.$el.find('.auth-beacon-security');
+      image.qtip('destroy');
     }
 
   });

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -78,10 +78,8 @@ define(['jquery', 'underscore', './Dom'], function ($, _, Dom) {
       return this.inputWrap(field).closest('[data-se="o-form-fieldset"]').find('label').trimmedText();
     },
 
-    tooltipText: function (field) {
-      var api,
-          element,
-          tooltipText,
+    tooltipApi: function (field) {
+      var element,
           formInput = this.inputWrap(field);
 
       if (formInput.length) {
@@ -90,7 +88,14 @@ define(['jquery', 'underscore', './Dom'], function ($, _, Dom) {
         element = this.el(field);
       }
 
-      api = $(element).qtip('api');
+      return $(element).qtip('api');
+    },
+
+    tooltipText: function (field) {
+      var api,
+          tooltipText;
+
+      api = this.tooltipApi(field);
       tooltipText = api ? api.show().tooltip.text() : undefined;
 
       // Remove the tooltip from the DOM to

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -66,9 +66,9 @@ define(['jquery', 'underscore', './Form'], function ($, _, Form) {
       return this.tooltipText(SECURITY_BEACON);
     },
 
-    securityImageTooltipDestroyed: function () {
+    isSecurityImageTooltipDestroyed: function () {
       var api = this.tooltipApi(SECURITY_BEACON);
-      return api ? api.destroyed : undefined;
+      return api ? api.destroyed : true;
     },
 
     securityBeacon: function () {

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -66,6 +66,11 @@ define(['jquery', 'underscore', './Form'], function ($, _, Form) {
       return this.tooltipText(SECURITY_BEACON);
     },
 
+    securityImageTooltipDestroyed: function () {
+      var api = this.tooltipApi(SECURITY_BEACON);
+      return api ? api.destroyed : undefined;
+    },
+
     securityBeacon: function () {
       return this.el(SECURITY_BEACON);
     },

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -946,13 +946,13 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
         })
         .then(function (test) {
           // Tooltip exists
-          expect(test.form.securityImageTooltipDestroyed()).toBe(false);
+          expect(test.form.isSecurityImageTooltipDestroyed()).toBe(false);
           spyOn(test.router, 'navigate');
           test.form.helpFooter().click();
           test.form.unlockLink().click();
           expect(test.router.navigate).toHaveBeenCalledWith('signin/unlock', {trigger: true});
-          // Undefined, since the qtip-api for this element is now gone
-          expect(test.form.securityImageTooltipDestroyed()).toBe(undefined);
+          // Verify tooltip is gone
+          expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
         });
       });
       itp('updates security beacon immediately if rememberMe is available', function () {


### PR DESCRIPTION
- Issue is that the tooltip was not removed when going to unlock/forgot-password pages.

Resolves: OKTA-117900
Bacon: test