### PR TITLE
Prevent showing tooltip if security image is not visible

### DIFF
--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -41,6 +41,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       el.removeAttr('aria-describedby');
       el.find('.accessibility-text').text(imgDescription);
       el.css('background-image', 'url(' + _.escape(imgSrc) + ')');
+      return;
     }
   }
 

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -41,11 +41,14 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       el.removeAttr('aria-describedby');
       el.find('.accessibility-text').text(imgDescription);
       el.css('background-image', 'url(' + _.escape(imgSrc) + ')');
-      return;
     }
   }
 
   function antiPhishingMessage (image, host, shown) {
+    if(!image.is(':visible')){
+      return;
+    }
+
     // Show the message that the user has not logged in from this device before.
     image.qtip({
       prerender: true,
@@ -64,7 +67,14 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
         viewport: $('body')
       },
       hide: {event: false, fixed: true},
-      show: {event: false, delay: 200}
+      show: {event: false, delay: 200},
+      events: {
+        move: function(event, api) {
+          if (!api.elements.target.is(':visible')) {
+            api.destroy(true);
+          }
+        }
+      }
     });
     image.qtip('toggle', shown);
   }

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -46,12 +46,11 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
   }
 
   function antiPhishingMessage (image, host) {
-    function showQtip() {
+    $(window).on('resize.securityBeaconQtip', _.debounce(function () {
       if(image.is(':visible')){
         image.qtip('show');
       }
-    }
-    $(window).on('resize.securityBeaconQtip', _.debounce(showQtip, 300));
+    }, 300));
 
     // Show the message that the user has not logged in from this device before.
     image.qtip({
@@ -84,7 +83,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       }
     });
 
-    showQtip();
+    image.qtip('toggle', image.is(':visible'));
   }
 
   function destroyAntiPhishingMessage(image) {

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -71,15 +71,6 @@ define(['okta/jquery', 'okta/underscore', './Form'], function ($, _, Form) {
       return api ? api.destroyed : true;
     },
 
-    isSecurityImageTooltipVisible: function () {
-      var api = this.tooltipApi(SECURITY_BEACON);
-      return api ? api.tooltip.is(':visible') : true;
-    },
-
-    applyQtipCssRule: function () {
-      this.$root.append($('<style>.okta-security-image-tooltip { display:none }</style>'));
-    },
-
     securityBeacon: function () {
       return this.el(SECURITY_BEACON);
     },

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -71,6 +71,10 @@ define(['okta/jquery', 'okta/underscore', './Form'], function ($, _, Form) {
       return api ? api.destroyed : true;
     },
 
+    securityBeaconContainer: function () {
+      return this.$('.js-security-beacon');
+    },
+
     securityBeacon: function () {
       return this.el(SECURITY_BEACON);
     },

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -71,12 +71,21 @@ define(['okta/jquery', 'okta/underscore', './Form'], function ($, _, Form) {
       return api ? api.destroyed : true;
     },
 
-    securityBeaconContainer: function () {
-      return this.$('.js-security-beacon');
+    isSecurityImageTooltipVisible: function () {
+      var api = this.tooltipApi(SECURITY_BEACON);
+      return api ? api.tooltip.is(':visible') : true;
+    },
+
+    applyQtipCssRule: function () {
+      this.$root.append($('<style>.okta-security-image-tooltip { display:none }</style>'));
     },
 
     securityBeacon: function () {
       return this.el(SECURITY_BEACON);
+    },
+
+    securityBeaconContainer: function () {
+      return this.$('.beacon-container');
     },
 
     editingUsername: function (val) {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -951,6 +951,18 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
           expect(test.form.securityImageTooltipText()).toEqual('This is the first time you are connecting to foo.com from this browser×');
         });
       });
+      itp('does not show anti-phishing message if security image is hidden', function () {
+        return setup({ features: { securityImage: true }})
+        .then(function (test) {
+          test.setNextResponse(resSecurityImageFail);
+          test.form.securityBeaconContainer().hide();
+          test.form.setUsername('testuser');
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
+        });
+      });
       itp('guards against XSS when showing the anti-phishing message', function () {
         return setup({
           baseUrl: 'http://foo<i>xss</i>bar.com?bar=<i>xss</i>',

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -954,58 +954,45 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
       itp('does not show anti-phishing message if security image is hidden', function () {
         return setup({ features: { securityImage: true }})
         .then(function (test) {
-          test.form.applyQtipCssRule();
-          return tick(test);
-        })
-        .then(function (test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.securityBeaconContainer().hide();
+          spyOn($.qtip.prototype, 'toggle').and.callThrough();
           test.form.setUsername('testuser');
           $(window).trigger('resize');
           return waitForBeaconChange(test);
         })
         .then(function (test) {
-          expect(test.form.isSecurityImageTooltipVisible()).toBe(false);
+          expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({0: false}));
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
           return tick(test);
         })
-        .then(function (test) {
-          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
+        .then(function () {
+          expect($.qtip.prototype.toggle.calls.argsFor(1)).toEqual(jasmine.objectContaining({0: true}));
         });
       });
       itp('show anti-phishing message if security image become visible', function () {
         return setup({ features: { securityImage: true }})
         .then(function (test) {
-          test.form.applyQtipCssRule();
-          return tick(test);
-        })
-        .then(function (test) {
+          spyOn($.qtip.prototype, 'toggle').and.callThrough();
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
         .then(function (test) {
-          $(window).trigger('resize');
-          return waitForBeaconChange(test);
-        })
-        .then(function (test) {
-          return waitForBeaconChange(test);
-        })
-        .then(function (test) {
-          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
+          expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({0: true}));
           test.form.securityBeaconContainer().hide();
           $(window).trigger('resize');
           return waitForBeaconChange(test);
         })
         .then(function (test) {
-          expect(test.form.isSecurityImageTooltipVisible()).toBe(false);
+          expect($.qtip.prototype.toggle.calls.argsFor(1)).toEqual(jasmine.objectContaining({0: false}));
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
-          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
+        .then(function () {
+          expect($.qtip.prototype.toggle.calls.argsFor(2)).toEqual(jasmine.objectContaining({0: true}));
         });
       });
       itp('guards against XSS when showing the anti-phishing message', function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params:[2, 28], max-statements:[2, 38], camelcase:0, max-len:[2, 180] */
+/* eslint max-params:[2, 28], max-statements:[2, 40], camelcase:0, max-len:[2, 180] */
 define([
   'okta/underscore',
   'okta/jquery',
@@ -954,13 +954,58 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
       itp('does not show anti-phishing message if security image is hidden', function () {
         return setup({ features: { securityImage: true }})
         .then(function (test) {
+          test.form.applyQtipCssRule();
+          return tick(test);
+        })
+        .then(function (test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.securityBeaconContainer().hide();
+          test.form.setUsername('testuser');
+          $(window).trigger('resize');
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipVisible()).toBe(false);
+          test.form.securityBeaconContainer().show();
+          $(window).trigger('resize');
+          return tick(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
+        });
+      });
+      itp('show anti-phishing message if security image become visible', function () {
+        return setup({ features: { securityImage: true }})
+        .then(function (test) {
+          test.form.applyQtipCssRule();
+          return tick(test);
+        })
+        .then(function (test) {
+          test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
         .then(function (test) {
-          expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
+          $(window).trigger('resize');
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
+          test.form.securityBeaconContainer().hide();
+          $(window).trigger('resize');
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipVisible()).toBe(false);
+          test.form.securityBeaconContainer().show();
+          $(window).trigger('resize');
+          return waitForBeaconChange(test);
+        })
+        .then(function (test) {
+          expect(test.form.isSecurityImageTooltipVisible()).toBe(true);
         });
       });
       itp('guards against XSS when showing the anti-phishing message', function () {


### PR DESCRIPTION
Resolves: OKTA-120613

- Don't show qtip if securityImage is not visible.
- Destroy qtip if window is resized and securityImage become not visible

@mauriciocastillosilva-okta 
@anishashetty-okta 
Please, review.
