### PR TITLE
:bug: handle unlock recoveryType before anything else

### DIFF
--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -100,15 +100,15 @@ function (Okta, Util, OAuth2Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
 
     switch (res.status) {
     case 'SUCCESS':
+      if(res.recoveryType === Enums.RECOVERY_TYPE_UNLOCK) {
+        router.navigate('signin/account-unlocked', {trigger: true});
+        return;
+      }
+
       // If the desired end result object needs to have idToken (and not sessionToken),
       // get the id token from session token before calling the global success function.
       if (router.settings.get('oauth2Enabled')) {
         OAuth2Util.getTokens(router.settings, {sessionToken: res.sessionToken}, router.controller);
-        return;
-      }
-
-      if(res.recoveryType === Enums.RECOVERY_TYPE_UNLOCK) {
-        router.navigate('signin/account-unlocked', {trigger: true});
         return;
       }
 


### PR DESCRIPTION
When status is SUCCESS and we are in recoveryType unlock, we should redirect to the success unlocked view before handling any other SUCCESS possible outcome.

Before we were trying to handle an oauth token exchange for a sessionToken, but during unlock we don't get a sessionToken.

Resolves: OKTA-119625