### PR TITLE
:bug: Firefox on iOS make Google Auth text readable

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -403,6 +403,7 @@
 [name="sharedSecret"] {
   text-align: center;
   cursor: text;
+  opacity: 1;
 }
 
 .enroll-activation-link-sent {

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -628,6 +628,7 @@
       &[disabled] {
       /* -- Input Fields: disabled input field -- */
         color: $medium-text-color;
+        -webkit-text-fill-color: $medium-text-color;
         /* background: #f4f4f4; */
       }
 


### PR DESCRIPTION
Firefox on iOS make Google Auth text readable

Resolves: OKTA-124746

Reviewers:

@samerfanek-okta 