### PR TITLE
:bug: fix e2e tests

### DIFF
--- a/test/e2e/page-objects/FacebookPage.js
+++ b/test/e2e/page-objects/FacebookPage.js
@@ -15,6 +15,7 @@ var EC = protractor.ExpectedConditions;
 
 class FacebookPage {
   login(username, password) {
+    $('#email').clear();
     $('#email').sendKeys(username);
     $('#pass').sendKeys(password);
     $('[name=login]').click();


### PR DESCRIPTION
Facebook now remembers the username in the login page, so we need to clear it before typing any other username

Resolves: OKTA-127526