### PR TITLE
:bug: Fix webpack.release file

### DIFF
--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -35,7 +35,6 @@ entryConfig.externals = {
     'root': 'handlebars'
   },
   'q': true,
-  'qtip': '@okta/qtip2',
   'u2f-api-polyfill': true,
   'underscore': true,
   'vendor/lib/q': 'q'


### PR DESCRIPTION
:bug: Fix webpack.release.config file

Remove qtip2 from webpack.release since is not taken anymore from external repo

Resolves: [OKTA-131608](https://oktainc.atlassian.net/browse/OKTA-131608)

@hor-kanchan-okta @ukilon-okta @jmelberg-okta 