### PR TITLE
Fix checkbox image path

### DIFF
--- a/assets/sass/modules/_forms.scss
+++ b/assets/sass/modules/_forms.scss
@@ -250,7 +250,7 @@
 
 .custom-checkbox {
   label {
-    background-image: url('/img/ui/forms/checkbox-sign-in-widget.png');
+    background-image: url('../img/ui/forms/checkbox-sign-in-widget.png');
   }
 
   label.focus {
@@ -267,7 +267,7 @@ only screen and (min-device-pixel-ratio: 2),
 only screen and (min-resolution: 2dppx) {
   .custom-checkbox {
     label {
-      background-image: url('/img/ui/forms/checkbox-sign-in-widget@2x.png');
+      background-image: url('../img/ui/forms/checkbox-sign-in-widget@2x.png');
       background-size: 50px 1155px;
     }
   }

--- a/package.json
+++ b/package.json
@@ -91,13 +91,5 @@
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.1",
     "underscore": "1.8.3"
-  },
-  "optionalDependencies": {
-    "@okta/ci-pkginfo": "1.2.0",
-    "@okta/ci-update-package": "1.4.0",
-    "@okta/courage": "2.11.0",
-    "@okta/i18n": "28.15.0",
-    "@okta/install-with-shrinkwrap": "1.7.0",
-    "@okta/qtip2": "3.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,5 +91,13 @@
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.1",
     "underscore": "1.8.3"
+  },
+  "optionalDependencies": {
+    "@okta/ci-pkginfo": "1.2.0",
+    "@okta/ci-update-package": "1.4.0",
+    "@okta/courage": "2.11.0",
+    "@okta/i18n": "28.15.0",
+    "@okta/install-with-shrinkwrap": "1.7.0",
+    "@okta/qtip2": "3.0.6"
   }
 }


### PR DESCRIPTION
## Description
Running: `npm run build:release` builds a version of the widget with the incorrect path for the `checkbox` image.

See: [PR #164](https://github.com/okta/okta-signin-widget/blob/ca319e69bf7f87dd4cc66688c291f495d110d97b/assets/sass/modules/_forms.scss#L253).

Before this change, there's a 404 for these images.

![screen shot 2017-06-27 at 10 40 23 am](https://user-images.githubusercontent.com/17892/27606265-d9ebc666-5b3c-11e7-8201-005d24417c84.png)

**Note** The CDN version works fine.