### PR TITLE
:bug: Fixes Bacon build script for non-root permissions

### DIFF
--- a/ci-scripts/okta-signin-widget-build.sh
+++ b/ci-scripts/okta-signin-widget-build.sh
@@ -18,8 +18,8 @@ PUBLISH_TEST_SUITE_ID=D2E90D99-59B8-42FB-9B45-E0E10C1369E1
 REGISTRY="https://artifacts.aue1d.saasure.com/artifactory/api/npm/npm-okta"
 
 # Install required dependencies
-npm install -g @okta/ci-update-package
-npm install -g @okta/ci-pkginfo
+npm install @okta/ci-update-package
+npm install @okta/ci-pkginfo
 
 function usage() {
   OUTPUTCODE=$1


### PR DESCRIPTION
Since global installs require root access via Bacon, changing this to a local package.