### PR TITLE
:seedling: custom sign-out url

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,12 @@ var signIn = new OktaSignIn(config);
     helpSupportNumber: '(123) 456-7890'
     ```
 
+- **signOutUrl:** url to redirect when a user clicks the sign out link. If not provided, the widget will navigate to primary auth.
+
+    ```javascript
+    signOutUrl: 'https://www.signmeout.com'
+    ```
+
 ## Username and password
 
 - **username:** Prefills the username input with the provided username

--- a/README.md
+++ b/README.md
@@ -588,10 +588,10 @@ var signIn = new OktaSignIn(config);
     helpSupportNumber: '(123) 456-7890'
     ```
 
-- **signOutUrl:** url to redirect when a user clicks the sign out link. If not provided, the widget will navigate to primary auth.
+- **signOutLink:** URL to redirect when a user clicks the sign out link. If not provided, the widget will navigate to primary auth.
 
     ```javascript
-    signOutUrl: 'https://www.signmeout.com'
+    signOutLink: 'https://www.signmeout.com'
     ```
 
 ## Username and password

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ Contributors should read our [contributing guidelines](./CONTRIBUTING.md) if the
 * [Configuration](#configuration)
   * [Basic config options](#basic-config-options)
   * [Username and password](#username-and-password)
-  * [Customizing language and text](#customizing-language-and-text)
-  * [Changing help links](#changing-help-links)
-  * [Adding Custom Buttons](#adding-custom-buttons)
-  * [Adding Registration Button](#adding-registration-button)
+  * [Language and text](#language-and-text)
+  * [Links](#links)
+  * [Buttons](#buttons)
   * [OpenId Connect](#openid-connect)
   * [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   * [Feature flags](#feature-flags)
@@ -588,12 +587,6 @@ var signIn = new OktaSignIn(config);
     helpSupportNumber: '(123) 456-7890'
     ```
 
-- **signOutLink:** URL to redirect when a user clicks the sign out link. If not provided, the widget will navigate to primary auth.
-
-    ```javascript
-    signOutLink: 'https://www.signmeout.com'
-    ```
-
 ## Username and password
 
 - **username:** Prefills the username input with the provided username
@@ -662,7 +655,7 @@ var signIn = new OktaSignIn(config);
     }
     ```
 
-## Customizing language and text
+## Language and text
 
 - **language:** Set the language of the widget. If no language is specified, the widget will choose a language based on the user's browser preferences if it is supported, or defaults to `en`.
 
@@ -770,9 +763,13 @@ var signIn = new OktaSignIn(config);
     }
     ```
 
-## Changing help links
+## Links
 
-You can override the help link urls on the Primary Auth page by setting the following config options. If you'd like to change the help link text, use the `i18n` config option.
+You can override a link URL by setting the following config options. If you'd like to change the link text, use the `i18n` config option.
+
+#### Help Links
+
+Set the following config options to override the help link URLs on the Primary Auth page.
 
 ```javascript
 // An example that overrides all help links, and sets two custom links
@@ -801,7 +798,19 @@ helpLinks: {
 
 - **helpLinks.custom** - Array of custom link objects `{text, href}` that will be added to the *"Need help signing in?"* section.
 
-## Adding Custom Buttons
+#### Sign Out Link
+
+Set the following config option to override the sign out link URL. If not provided, the widget will navigate to Primary Auth.
+
+```javascript
+signOutLink: 'https://www.signmeout.com'
+```
+
+## Buttons
+
+You can add buttons to the Primary Auth page by setting the following config options.
+
+#### Custom Buttons
 
 You can add custom buttons underneath the login form on the primary auth page by setting the following config options. If you'd like to change the divider text, use the `i18n` config option.
 
@@ -823,10 +832,9 @@ customButtons: [{
 
 - **customButtons.click** - Function that is called when the button is clicked
 
-## Adding Registration Button
+#### Registration Button
 
-You can add a registration link to the primary auth page by setting `features.registration` to `true` and by adding the following config options. If you'd like to change the text, use the `i18n` config option.
-
+You can add a registration link to the primary auth page by setting `features.registration` to `true` and by adding the following config options.
 ```javascript
 // An example that adds a registration button underneath the login form on the primary auth page
 registration: {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -48,6 +48,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       'recoveryToken': ['string', false, undefined],
       'stateToken': ['string', false, undefined],
       'username' : ['string', false],
+      'signOutUrl': ['string', false],
 
       // Function to transform the username before passing it to the API
       // for Primary Auth, Forgot Password and Unlock Account.

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -48,7 +48,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       'recoveryToken': ['string', false, undefined],
       'stateToken': ['string', false, undefined],
       'username' : ['string', false],
-      'signOutUrl': ['string', false],
+      'signOutLink': ['string', false],
 
       // Function to transform the username before passing it to the API
       // for Primary Auth, Forgot Password and Unlock Account.

--- a/src/views/expired-password/Footer.js
+++ b/src/views/expired-password/Footer.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/Enums'], function (Okta, Enums) {
+define(['okta', 'util/Enums', 'shared/util/Util'], function (Okta, Enums, Util) {
 
   return Okta.View.extend({
     template: '\
@@ -30,8 +30,12 @@ define(['okta', 'util/Enums'], function (Okta, Enums) {
           return transaction.cancel();
         })
         .then(function () {
-          self.state.set('navigateDir', Enums.DIRECTION_BACK);
-          self.options.appState.trigger('navigate', '');
+          if (self.settings.get('signOutUrl')) {
+            Util.redirect(self.settings.get('signOutUrl'));
+          } else {
+            self.state.set('navigateDir', Enums.DIRECTION_BACK);
+            self.options.appState.trigger('navigate', '');
+          }
         });
       },
       'click .js-skip' : function (e) {

--- a/src/views/expired-password/Footer.js
+++ b/src/views/expired-password/Footer.js
@@ -30,8 +30,8 @@ define(['okta', 'util/Enums', 'shared/util/Util'], function (Okta, Enums, Util) 
           return transaction.cancel();
         })
         .then(function () {
-          if (self.settings.get('signOutUrl')) {
-            Util.redirect(self.settings.get('signOutUrl'));
+          if (self.settings.get('signOutLink')) {
+            Util.redirect(self.settings.get('signOutLink'));
           } else {
             self.state.set('navigateDir', Enums.DIRECTION_BACK);
             self.options.appState.trigger('navigate', '');

--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -29,8 +29,8 @@ define(['okta', 'util/Enums', 'shared/util/Util'], function (Okta, Enums, Util) 
           return transaction.cancel();
         })
         .then(function() {
-          if (self.settings.get('signOutUrl')) {
-            Util.redirect(self.settings.get('signOutUrl'));
+          if (self.settings.get('signOutLink')) {
+            Util.redirect(self.settings.get('signOutLink'));
           } else {
             self.state.set('navigateDir', Enums.DIRECTION_BACK);
             self.options.appState.trigger('navigate', '');

--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/Enums'], function (Okta, Enums) {
+define(['okta', 'util/Enums', 'shared/util/Util'], function (Okta, Enums, Util) {
 
   var _ = Okta._;
 
@@ -29,8 +29,12 @@ define(['okta', 'util/Enums'], function (Okta, Enums) {
           return transaction.cancel();
         })
         .then(function() {
-          self.state.set('navigateDir', Enums.DIRECTION_BACK);
-          self.options.appState.trigger('navigate', '');
+          if (self.settings.get('signOutUrl')) {
+            Util.redirect(self.settings.get('signOutUrl'));
+          } else {
+            self.state.set('navigateDir', Enums.DIRECTION_BACK);
+            self.options.appState.trigger('navigate', '');
+          }
         });
       }
     },

--- a/test/unit/helpers/dom/MfaVerifyForm.js
+++ b/test/unit/helpers/dom/MfaVerifyForm.js
@@ -143,6 +143,10 @@ define(['./Form'], function (Form) {
 
     getAutocomplete: function () {
       return this.autocomplete(ANSWER_FIELD);
+    },
+
+    signoutLink: function ($sandbox) {
+      return $sandbox.find('[data-se=signout-link]');
     }
 
   });

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -9,6 +9,7 @@ define([
   'util/Util',
   'util/CryptoUtil',
   'util/CookieUtil',
+  'shared/util/Util',
   'helpers/mocks/Util',
   'helpers/dom/MfaVerifyForm',
   'helpers/dom/Beacon',
@@ -54,6 +55,7 @@ function (Okta,
           LoginUtil,
           CryptoUtil,
           CookieUtil,
+          SharedUtil,
           Util,
           MfaVerifyForm,
           Beacon,
@@ -454,15 +456,58 @@ function (Okta,
       });
       Expect.describe('Sign out link', function () {
         itp('is visible', function () {
-          return setupWithFirstFactor({factorType: 'question'}).then(function () {
-            Expect.isVisible($sandbox.find('[data-se=signout-link]'));
+          return setupWithFirstFactor({factorType: 'question'}).then(function (test) {
+            Expect.isVisible(test.form.signoutLink($sandbox));
           });
         });
         itp('is not present if features.hideSignOutLinkInMFA is true', function () {
-          return setupSecurityQuestion({'features.hideSignOutLinkInMFA': true}).then(function () {
-            expect($sandbox.find('[data-se=signout-link]').length).toBe(0);
+          return setupSecurityQuestion({'features.hideSignOutLinkInMFA': true}).then(function (test) {
+            expect(test.form.signoutLink($sandbox).length).toBe(0);
           });
         });
+
+        itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+          return setupSecurityQuestion()
+          .then(function (test) {
+            $.ajax.calls.reset();
+            test.setNextResponse(resSuccess);
+            test.form.signoutLink($sandbox).click();
+            return Expect.waitForPrimaryAuth(test);
+          })
+          .then(function (test) {
+            expect($.ajax.calls.count()).toBe(1);
+            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              url: 'https://foo.com/api/v1/authn/cancel',
+              data: {
+                stateToken: 'testStateToken'
+              }
+            });
+            Expect.isPrimaryAuth(test.router.controller);
+          });
+        });
+
+        itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
+        function () {
+          return setupSecurityQuestion({ signOutUrl: 'http://www.goodbye.com' })
+          .then(function (test) {
+            spyOn(SharedUtil, 'redirect');
+            $.ajax.calls.reset();
+            test.setNextResponse(resSuccess);
+            test.form.signoutLink($sandbox).click();
+            return tick();
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(1);
+            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              url: 'https://foo.com/api/v1/authn/cancel',
+              data: {
+                stateToken: 'testStateToken'
+              }
+            });
+            expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+          });
+        });
+
       });
       Expect.describe('Remember device', function () {
         itp('is rendered', function () {

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -488,7 +488,7 @@ function (Okta,
 
         itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
         function () {
-          return setupSecurityQuestion({ signOutUrl: 'http://www.goodbye.com' })
+          return setupSecurityQuestion({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
             spyOn(SharedUtil, 'redirect');
             $.ajax.calls.reset();

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -152,7 +152,7 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, PasswordExpiredForm, B
       });
       itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
       function () {
-        return setup({ signOutUrl: 'http://www.goodbye.com' }).then(function (test) {
+        return setup({ signOutLink: 'http://www.goodbye.com' }).then(function (test) {
           spyOn(SharedUtil, 'redirect');
           $.ajax.calls.reset();
           test.setNextResponse(resSuccess);

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -140,7 +140,7 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, PasswordResetForm, Bea
 
     itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
     function () {
-      return setup({ signOutUrl: 'http://www.goodbye.com' })
+      return setup({ signOutLink: 'http://www.goodbye.com' })
       .then(function (test) {
         spyOn(SharedUtil, 'redirect');
         $.ajax.calls.reset();

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -92,7 +92,7 @@ function (Q, _, $, OktaAuth, SharedUtil, Util, RecoveryChallengeForm, Beacon, Ex
     });
     itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
     function () {
-      return setup({ signOutUrl: 'http://www.goodbye.com' })
+      return setup({ signOutLink: 'http://www.goodbye.com' })
       .then(function (test) {
         spyOn(SharedUtil, 'redirect');
         $.ajax.calls.reset();

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -84,7 +84,7 @@ function (Q, _, $, OktaAuth, SharedUtil, Util, RecoveryQuestionForm, Beacon, Exp
     });
     itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
     function () {
-      return setup({ signOutUrl: 'http://www.goodbye.com' })
+      return setup({ signOutLink: 'http://www.goodbye.com' })
       .then(function (test) {
         spyOn(SharedUtil, 'redirect');
         $.ajax.calls.reset();


### PR DESCRIPTION
If a custom sign out url is provided, 'Sign out' links will redirect to it instead of navigating to the primary auth view.

Resolves: OKTA-129771