### PR TITLE
Revert ":bug: workaround for OracleTap mobile app submit event (#208)"

### DIFF
--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -25,17 +25,6 @@ define([
     saveId: 'okta-signin-submit',
     layout: 'o-form-theme',
 
-    constructor: function (options) {
-      // OKTA-118336
-      // Need to add iframe to deal with the Oracle Tap Android app,
-      // which ignores e.preventDefault() and reloads the page.
-
-      var target = this.attributes.target = _.uniqueId('iframe');
-
-      Okta.Form.call(this, options);
-      this.add('<iframe name="' + target + '" style="display:none"></iframe>');
-    },
-
     // If socialAuth is configured, the title moves from the form to
     // the top of the container (and is rendered in socialAuth).
     title: function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -358,13 +358,6 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
           expect(signInButton.attr('id')).toEqual('okta-signin-submit');
         });
       });
-      itp('has an iframe for Oracle Tap Android app (OKTA-118336)', function () {
-        return setup().then(function (test) {
-          var iframe = test.form.$('iframe');
-          expect(iframe.length).toBe(1);
-          expect(iframe.attr('name')).toEqual(test.form.primaryAuthForm().attr('target'));
-        });
-      });
 
       itp('has a rememberMe checkbox if features.rememberMe is true', function () {
         return setup().then(function (test) {


### PR DESCRIPTION
:bug: Revert ":bug: workaround for OracleTap mobile app submit event (#208)"

Revert ":bug: workaround for OracleTap mobile app submit event (#208)" since it didn't solve that customer bug but it caused another regression. The regression broke the authentication workflow when opening a Office 365 online file with Office 2010 desktop.

Resolves: [OKTA-133546](https://oktainc.atlassian.net/browse/OKTA-133546)

@hor-kanchan-okta @mauriciocastillosilva-okta @samerfanek-okta 

![o365-working](https://user-images.githubusercontent.com/19613940/28947352-43ccf64c-7864-11e7-8689-2924d08d5029.gif)
