### PR TITLE
:memo: Add documentation to explain how to correctly Browserify the okta-signin-widget module

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,12 @@ After running `npm install`:
     // Use OktaSignIn
     var signIn = new OktaSignIn(/* configOptions */);
     ```
-3. [Browserify](http://browserify.org/) only: When you want to bundle your application with Browserify, you need to tell it that it doesn't have to parse the okta-signin-widget module. To do this, you need to add this flag when you run the `browserify` command:
-
+    **Note:** If you use [Browserify](http://browserify.org/) to bundle your app, you'll need to use the `--noparse` option:
     ```
-    // Don't parse @okta/okta-signin-widget
-    --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js/okta-sign-in.entry.js
-
-    // Example
-    browserify --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js/okta-sign-in.entry.js main.js -o bundle.js
+    browserify main.js \
+    --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js-okta-sign-in.entry.js \
+    --outfile=bundle.js
     ```
-    The reason is that if you run the command without this flag, Browserify will attempt to resolve paths in `require()` calls in the already bundled okta-signin-widget, while it should ignore them since the `okta-sign-in.entry.js` is a standalone file and doesn't need the external modules, they are already bundled in the same file.
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ After running `npm install`:
     // Use OktaSignIn
     var signIn = new OktaSignIn(/* configOptions */);
     ```
+3. [Browserify](http://browserify.org/) only: When you want to bundle your application with Browserify, you need to tell it that it doesn't have to parse the okta-signin-widget module. To do this, you need to add this flag when you run the `browserify` command:
+
+    ```
+    // Don't parse @okta/okta-signin-widget
+    --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js/okta-sign-in.entry.js
+
+    // Example
+    browserify --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js/okta-sign-in.entry.js main.js -o bundle.js
+    ```
+    The reason is that if you run the command without this flag, Browserify will attempt to resolve paths in `require()` calls in the already bundled okta-signin-widget, while it should ignore them since the `okta-sign-in.entry.js` is a standalone file and doesn't need the external modules, they are already bundled in the same file.
 
 # API
 


### PR DESCRIPTION
:memo: Add documentation to explain how to correctly Browserify the okta-signin-widget module

When developers tried to browserify an app that require the okta-signin-widget, the bundling failed because Browserify attempts to resolve paths in require() calls in the already bundled okta-signin-widget, while it should ignore them since the okta-sign-in.entry.js is a standalone file and doesn't need the external modules, they are already bundled in the same file. Added documentation to explain how to tell to browserify to not parse the okta-signin-widget module and run correctly.

Resolves: [OKTA-135028](https://oktainc.atlassian.net/browse/OKTA-135028)

@rchild-okta @rajaguruduraisamy-okta @haishengwu-okta @samerfanek-okta 