### PR TITLE
:art: Add babel and async/await support to okta-signin-widget

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "amd": true
   },
   "parserOptions": {
-    "ecmaVersion": 3
+    "ecmaVersion": 2017
   },
   "globals": {
     "spyOnEvent": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@okta/okta-auth-js": {
       "version": "1.8.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/okta-auth-js/-/@okta/okta-auth-js-1.8.0.tgz",
-      "integrity": "sha1-D2nQ1asbA1mpp94FN2uwVOPJgvg=",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-1.8.0.tgz",
+      "integrity": "sha1-D9c2XyHIcznV4ko2tP4FJDC3xyg=",
       "requires": {
         "Base64": "0.3.0",
         "q": "1.4.1",
@@ -18,13 +18,13 @@
     },
     "abbrev": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/abbrev/-/abbrev-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "accepts": {
       "version": "1.3.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/accepts/-/accepts-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
@@ -34,13 +34,13 @@
     },
     "acorn": {
       "version": "5.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU=",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -49,7 +49,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -57,13 +57,13 @@
     },
     "adm-zip": {
       "version": "0.4.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/adm-zip/-/adm-zip-0.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
       "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
       "dev": true
     },
     "agent-base": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/agent-base/-/agent-base-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
@@ -73,7 +73,7 @@
       "dependencies": {
         "semver": {
           "version": "5.0.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
           "dev": true
         }
@@ -81,7 +81,7 @@
     },
     "ajv": {
       "version": "4.11.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ajv/-/ajv-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
@@ -91,13 +91,13 @@
     },
     "ajv-keywords": {
       "version": "1.5.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
         "kind-of": "3.2.2",
@@ -107,37 +107,37 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "2.3.11",
@@ -146,19 +146,19 @@
     },
     "app-root-path": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/app-root-path/-/app-root-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-1.0.0.tgz",
       "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30=",
       "dev": true
     },
     "aproba": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
@@ -168,7 +168,7 @@
     },
     "argparse": {
       "version": "1.0.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/argparse/-/argparse-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
@@ -177,7 +177,7 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -186,25 +186,25 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-differ/-/array-differ-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -213,37 +213,37 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asn1/-/asn1-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
       "requires": {
@@ -252,36 +252,36 @@
     },
     "assert-plus": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "autoprefixer": {
       "version": "6.7.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
@@ -295,31 +295,31 @@
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
       "version": "1.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aws4/-/aws4-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "axe-core": {
       "version": "2.0.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/axe-core/-/axe-core-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.0.7.tgz",
       "integrity": "sha1-sToNXd15YqKE9/y54EV7/zcBdqo=",
       "dev": true
     },
     "axe-webdriverjs": {
       "version": "0.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/axe-webdriverjs/-/axe-webdriverjs-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.4.0.tgz",
       "integrity": "sha1-C0YnlPWaM9WVr7umkX3NnDUAfjc=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -330,7 +330,7 @@
     },
     "babel-core": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-core/-/babel-core-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
@@ -357,7 +357,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -365,7 +365,7 @@
     },
     "babel-generator": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-generator/-/babel-generator-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
@@ -381,7 +381,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -389,7 +389,7 @@
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
@@ -400,7 +400,7 @@
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
@@ -412,7 +412,7 @@
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
@@ -424,7 +424,7 @@
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
@@ -435,7 +435,7 @@
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
@@ -448,7 +448,7 @@
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
@@ -458,7 +458,7 @@
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
@@ -468,7 +468,7 @@
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
@@ -478,7 +478,7 @@
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
@@ -489,7 +489,7 @@
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
@@ -502,7 +502,7 @@
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
@@ -516,7 +516,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
@@ -526,7 +526,7 @@
     },
     "babel-loader": {
       "version": "6.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-loader/-/babel-loader-6.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "dev": true,
       "requires": {
@@ -538,7 +538,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -547,7 +547,7 @@
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
@@ -556,25 +556,25 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
@@ -585,7 +585,7 @@
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
@@ -594,7 +594,7 @@
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
@@ -603,7 +603,7 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
@@ -616,7 +616,7 @@
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
@@ -633,7 +633,7 @@
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
@@ -643,7 +643,7 @@
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
@@ -652,7 +652,7 @@
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
@@ -662,7 +662,7 @@
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
@@ -671,7 +671,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
@@ -682,7 +682,7 @@
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
@@ -691,7 +691,7 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
@@ -702,7 +702,7 @@
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
@@ -714,7 +714,7 @@
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
@@ -725,7 +725,7 @@
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
@@ -736,7 +736,7 @@
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
@@ -746,7 +746,7 @@
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
@@ -760,7 +760,7 @@
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
@@ -770,7 +770,7 @@
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
@@ -779,7 +779,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
@@ -790,7 +790,7 @@
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
@@ -799,7 +799,7 @@
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
@@ -808,7 +808,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
@@ -819,7 +819,7 @@
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
@@ -830,7 +830,7 @@
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
@@ -839,7 +839,7 @@
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
@@ -849,7 +849,7 @@
     },
     "babel-polyfill": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
         "babel-runtime": "6.26.0",
@@ -859,8 +859,8 @@
     },
     "babel-preset-env": {
       "version": "1.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha1-LeHHgqeAoKXWBdGZyVdZbaQ8ROQ=",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
+      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -897,8 +897,8 @@
       "dependencies": {
         "browserslist": {
           "version": "2.3.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserslist/-/browserslist-2.3.3.tgz",
-          "integrity": "sha1-KwyrxNKEifaCWYYFhYoHgvFLFUw=",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
+          "integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
           "dev": true,
           "requires": {
             "caniuse-lite": "1.0.30000715",
@@ -907,15 +907,15 @@
         },
         "semver": {
           "version": "5.4.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
@@ -930,7 +930,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
         "core-js": "2.5.0",
@@ -939,14 +939,14 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.11.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         }
       }
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
@@ -959,7 +959,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -976,7 +976,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -988,13 +988,13 @@
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backbone": {
       "version": "1.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/backbone/-/backbone-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.1.tgz",
       "integrity": "sha1-1yGcXtSeXhMdv/ryXJbW0sw8oD4=",
       "requires": {
         "underscore": "1.8.3"
@@ -1002,36 +1002,36 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "Base64": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/Base64/-/Base64-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
       "integrity": "sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8="
     },
     "base64-js": {
       "version": "1.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/basic-auth/-/basic-auth-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
@@ -1041,19 +1041,19 @@
     },
     "big.js": {
       "version": "3.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/big.js/-/big.js-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
       "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.10.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "bl": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bl/-/bl-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
       "dev": true,
       "requires": {
@@ -1062,7 +1062,7 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -1071,13 +1071,13 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
     },
     "body-parser": {
       "version": "1.14.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/body-parser/-/body-parser-1.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
       "dev": true,
       "requires": {
@@ -1095,7 +1095,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -1104,7 +1104,7 @@
         },
         "http-errors": {
           "version": "1.3.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-errors/-/http-errors-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
@@ -1114,19 +1114,19 @@
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
           "dev": true
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "qs": {
           "version": "5.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
           "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
           "dev": true
         }
@@ -1134,7 +1134,7 @@
     },
     "boom": {
       "version": "2.10.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/boom/-/boom-2.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
@@ -1143,7 +1143,7 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
@@ -1153,7 +1153,7 @@
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/braces/-/braces-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
@@ -1164,7 +1164,7 @@
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
@@ -1173,7 +1173,7 @@
     },
     "browserslist": {
       "version": "1.7.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserslist/-/browserslist-1.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
@@ -1183,7 +1183,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1194,19 +1194,19 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "bytes": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bytes/-/bytes-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
       "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
       "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caller-path/-/caller-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
@@ -1215,18 +1215,18 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1236,7 +1236,7 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
@@ -1244,7 +1244,7 @@
     },
     "caniuse-api": {
       "version": "1.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
@@ -1256,25 +1256,25 @@
     },
     "caniuse-db": {
       "version": "1.0.30000715",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
       "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo=",
       "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30000715",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
       "integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA=",
       "dev": true
     },
     "caseless": {
       "version": "0.11.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
         "align-text": "0.1.4",
@@ -1283,7 +1283,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1296,7 +1296,7 @@
       "dependencies": {
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -1304,7 +1304,7 @@
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chokidar/-/chokidar-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
@@ -1320,13 +1320,13 @@
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clap": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clap/-/clap-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
       "dev": true,
       "requires": {
@@ -1335,7 +1335,7 @@
     },
     "cli": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli/-/cli-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
@@ -1345,8 +1345,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -1361,7 +1361,7 @@
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
@@ -1370,13 +1370,13 @@
     },
     "cli-width": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli-width/-/cli-width-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
     },
     "clipboard": {
       "version": "1.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clipboard/-/clipboard-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.6.1.tgz",
       "integrity": "sha1-ZcW2VIEkZrD6q4Lca6Dx0vjkvlM=",
       "requires": {
         "good-listener": "1.2.2",
@@ -1386,7 +1386,7 @@
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
         "center-align": "0.1.3",
@@ -1396,26 +1396,26 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         }
       }
     },
     "clone": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clone/-/clone-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/coa/-/coa-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
@@ -1424,19 +1424,19 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "coffee-script": {
       "version": "1.3.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/coffee-script/-/coffee-script-1.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color/-/color-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
@@ -1447,7 +1447,7 @@
     },
     "color-convert": {
       "version": "1.9.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-convert/-/color-convert-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
@@ -1456,13 +1456,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
@@ -1471,7 +1471,7 @@
     },
     "colormin": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colormin/-/colormin-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
@@ -1482,13 +1482,13 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/combined-stream/-/combined-stream-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
@@ -1497,25 +1497,25 @@
     },
     "commander": {
       "version": "2.11.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-stream/-/concat-stream-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
       "dev": true,
       "requires": {
@@ -1526,8 +1526,8 @@
     },
     "connect": {
       "version": "3.6.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/connect/-/connect-3.6.3.tgz",
-      "integrity": "sha1-9zINRqJbS+e0g6IjZRfySx4n4wE=",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
+      "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -1538,13 +1538,13 @@
     },
     "connect-livereload": {
       "version": "0.5.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/connect-livereload/-/connect-livereload-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
       "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
       "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -1553,42 +1553,42 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
       "version": "0.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
       "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI=",
       "dev": true
     },
     "content-type": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/content-type/-/content-type-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
       "dev": true
     },
     "core-js": {
       "version": "2.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/core-js/-/core-js-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
       "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
       "version": "3.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
@@ -1598,8 +1598,8 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -1608,8 +1608,8 @@
         },
         "which": {
           "version": "1.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.3.0.tgz",
-          "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -1619,7 +1619,7 @@
     },
     "cryptiles": {
       "version": "2.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cryptiles/-/cryptiles-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
@@ -1628,7 +1628,7 @@
     },
     "crypto-browserify": {
       "version": "3.2.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
       "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
       "dev": true,
       "requires": {
@@ -1639,13 +1639,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
@@ -1685,7 +1685,7 @@
     },
     "csso": {
       "version": "2.3.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/csso/-/csso-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
@@ -1695,7 +1695,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -1703,7 +1703,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -1712,16 +1712,16 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -1730,7 +1730,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -1738,19 +1738,19 @@
     },
     "date-format": {
       "version": "0.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-format/-/date-format-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
       "integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=",
       "dev": true
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "date-time": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-time/-/date-time-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
@@ -1759,13 +1759,13 @@
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.6.8.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "requires": {
@@ -1774,30 +1774,30 @@
     },
     "debuglog": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debuglog/-/debuglog-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
@@ -1812,36 +1812,36 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegate": {
       "version": "3.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delegate/-/delegate-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
       "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0="
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/depd/-/depd-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
       "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
@@ -1850,7 +1850,7 @@
     },
     "dezalgo": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dezalgo/-/dezalgo-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
@@ -1860,13 +1860,13 @@
     },
     "diff": {
       "version": "2.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/diff/-/diff-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
       "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
       "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/doctrine/-/doctrine-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
@@ -1876,7 +1876,7 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
@@ -1886,13 +1886,13 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
@@ -1900,19 +1900,19 @@
     },
     "domain-browser": {
       "version": "1.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domain-browser/-/domain-browser-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
@@ -1921,7 +1921,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -1931,7 +1931,7 @@
     },
     "each-async": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/each-async/-/each-async-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
@@ -1941,7 +1941,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
@@ -1951,31 +1951,31 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
       "version": "1.3.18",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
       "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
       "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/encodeurl/-/encodeurl-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "enhanced-resolve": {
       "version": "0.9.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
       "requires": {
@@ -1986,7 +1986,7 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/memory-fs/-/memory-fs-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
           "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
           "dev": true
         }
@@ -1994,13 +1994,13 @@
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
     "errno": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/errno/-/errno-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
@@ -2009,7 +2009,7 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/error-ex/-/error-ex-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
@@ -2017,9 +2017,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.27",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es5-ext/-/es5-ext-0.10.27.tgz",
-      "integrity": "sha1-v5JrBYxisctd4aiHkwZztqptmmY=",
+      "version": "0.10.29",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.29.tgz",
+      "integrity": "sha512-KXla9NXo5sdaEkGSmbFPYgjH6m75kxsthL6GDRSug/Y2OiMoYm0I9giL39j4cgmaFmAbkIFJ6gG+SGKnLSmOvA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -2028,29 +2028,29 @@
     },
     "es5-shim": {
       "version": "4.5.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es5-shim/-/es5-shim-4.5.9.tgz",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
       "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
       "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -2059,12 +2059,12 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -2072,41 +2072,41 @@
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27",
+        "es5-ext": "0.10.29",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -2118,7 +2118,7 @@
     },
     "eslint": {
       "version": "3.19.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/eslint/-/eslint-3.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
@@ -2161,7 +2161,7 @@
       "dependencies": {
         "concat-stream": {
           "version": "1.6.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-stream/-/concat-stream-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
@@ -2172,8 +2172,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2186,8 +2186,8 @@
         },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -2201,7 +2201,7 @@
         },
         "shelljs": {
           "version": "0.7.8",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.7.8.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
@@ -2212,8 +2212,8 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -2221,7 +2221,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
@@ -2229,7 +2229,7 @@
     },
     "espree": {
       "version": "3.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/espree/-/espree-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
@@ -2239,13 +2239,13 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esquery/-/esquery-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
@@ -2254,7 +2254,7 @@
     },
     "esrecurse": {
       "version": "4.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esrecurse/-/esrecurse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
@@ -2264,59 +2264,59 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
       "version": "1.8.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/etag/-/etag-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
       "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.27"
+        "es5-ext": "0.10.29"
       }
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/exit-hook/-/exit-hook-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -2325,7 +2325,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -2334,13 +2334,13 @@
     },
     "extend": {
       "version": "3.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extend/-/extend-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -2349,7 +2349,7 @@
     },
     "extract-zip": {
       "version": "1.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extract-zip/-/extract-zip-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
       "dev": true,
       "requires": {
@@ -2361,19 +2361,19 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-0.7.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -2384,19 +2384,19 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -2405,7 +2405,7 @@
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
@@ -2414,7 +2414,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -2424,7 +2424,7 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
@@ -2434,19 +2434,19 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fill-range/-/fill-range-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
@@ -2459,8 +2459,8 @@
     },
     "finalhandler": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha1-GFdPLnxLmLiuOyMMIfIB8xvbP7c=",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
       "dev": true,
       "requires": {
         "debug": "2.6.8",
@@ -2474,7 +2474,7 @@
     },
     "find-cache-dir": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "dev": true,
       "requires": {
@@ -2485,7 +2485,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -2495,7 +2495,7 @@
     },
     "findup-sync": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/findup-sync/-/findup-sync-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
@@ -2505,7 +2505,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -2515,13 +2515,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -2533,7 +2533,7 @@
     },
     "flat-cache": {
       "version": "1.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/flat-cache/-/flat-cache-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
@@ -2545,19 +2545,19 @@
     },
     "flatten": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/flatten/-/flatten-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -2566,13 +2566,13 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
       "dev": true,
       "requires": {
@@ -2583,8 +2583,8 @@
       "dependencies": {
         "async": {
           "version": "2.5.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -2594,13 +2594,13 @@
     },
     "fresh": {
       "version": "0.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fresh/-/fresh-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
@@ -2611,13 +2611,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
@@ -2629,13 +2629,13 @@
     },
     "function-bind": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/function-bind/-/function-bind-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -2651,7 +2651,7 @@
     },
     "gaze": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/gaze/-/gaze-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
@@ -2660,13 +2660,13 @@
     },
     "generate-function": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/generate-function/-/generate-function-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -2675,25 +2675,25 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -2702,7 +2702,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -2710,7 +2710,7 @@
     },
     "git-rev-sync": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/git-rev-sync/-/git-rev-sync-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.4.0.tgz",
       "integrity": "sha1-7svJo5XaFBw+qn5N/Yb8I+qemug=",
       "dev": true,
       "requires": {
@@ -2720,7 +2720,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
           "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
           "dev": true
         }
@@ -2728,7 +2728,7 @@
     },
     "glob": {
       "version": "3.1.21",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.1.21.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
       "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
       "dev": true,
       "requires": {
@@ -2739,19 +2739,19 @@
       "dependencies": {
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -2763,7 +2763,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -2773,7 +2773,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -2782,13 +2782,13 @@
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -2802,8 +2802,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2818,7 +2818,7 @@
     },
     "globule": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globule/-/globule-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
@@ -2829,8 +2829,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2845,7 +2845,7 @@
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
         "delegate": "3.1.3"
@@ -2853,13 +2853,13 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "grunt": {
       "version": "0.4.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
@@ -2887,7 +2887,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -2897,7 +2897,7 @@
           "dependencies": {
             "underscore.string": {
               "version": "2.4.0",
-              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
@@ -2905,25 +2905,25 @@
         },
         "async": {
           "version": "0.1.22",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.1.22.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
           "dev": true
         },
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
@@ -2933,13 +2933,13 @@
         },
         "lodash": {
           "version": "0.9.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -2949,7 +2949,7 @@
         },
         "underscore": {
           "version": "1.7.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore/-/underscore-1.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
           "dev": true
         }
@@ -2957,7 +2957,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -2968,7 +2968,7 @@
     },
     "grunt-contrib-connect": {
       "version": "0.11.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-connect/-/grunt-contrib-connect-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.11.2.tgz",
       "integrity": "sha1-HAoHB9OzKNnPO0tJDrhMSV2Tau0=",
       "dev": true,
       "requires": {
@@ -2984,7 +2984,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -2992,7 +2992,7 @@
     },
     "grunt-contrib-copy": {
       "version": "0.8.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-copy/-/grunt-contrib-copy-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.0.tgz",
       "integrity": "sha1-7jAn5l5PL/uVJakDwZ79gKjyR5s=",
       "dev": true,
       "requires": {
@@ -3002,19 +3002,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
           "dev": true
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -3027,7 +3027,7 @@
         },
         "has-ansi": {
           "version": "0.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-ansi/-/has-ansi-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
@@ -3036,7 +3036,7 @@
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
@@ -3045,7 +3045,7 @@
         },
         "supports-color": {
           "version": "0.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
           "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
           "dev": true
         }
@@ -3053,7 +3053,7 @@
     },
     "grunt-contrib-jasmine": {
       "version": "0.9.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.9.2.tgz",
       "integrity": "sha1-qMovO4gCRTchN3X8u5iL2dkflqw=",
       "dev": true,
       "requires": {
@@ -3067,7 +3067,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         }
@@ -3075,7 +3075,7 @@
     },
     "grunt-contrib-jshint": {
       "version": "0.11.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
       "integrity": "sha1-p+AAQnuwB4SMEJkmSGDASFtHQdM=",
       "dev": true,
       "requires": {
@@ -3085,7 +3085,7 @@
     },
     "grunt-contrib-requirejs": {
       "version": "0.4.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
       "integrity": "sha1-h/IWWpgeSKRdIvjMUpnQk0AxuXI=",
       "dev": true,
       "requires": {
@@ -3094,7 +3094,7 @@
     },
     "grunt-contrib-watch": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
@@ -3106,7 +3106,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -3114,7 +3114,7 @@
     },
     "grunt-eslint": {
       "version": "19.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-eslint/-/grunt-eslint-19.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-19.0.0.tgz",
       "integrity": "sha1-u3TDeQYVmc7B9mFp3vKonYYthhs=",
       "dev": true,
       "requires": {
@@ -3124,19 +3124,19 @@
     },
     "grunt-exec": {
       "version": "0.4.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-exec/-/grunt-exec-0.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-0.4.6.tgz",
       "integrity": "sha1-KJBKXVvS+gq2XGuU0jxbGAq5nSM=",
       "dev": true
     },
     "grunt-json-generator": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-json-generator/-/grunt-json-generator-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-json-generator/-/grunt-json-generator-0.1.0.tgz",
       "integrity": "sha1-z8Xj14VFuxVWESi3pYKXGasils0=",
       "dev": true
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
@@ -3149,19 +3149,19 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -3169,7 +3169,7 @@
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
@@ -3180,19 +3180,19 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -3200,7 +3200,7 @@
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
@@ -3215,13 +3215,13 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.1.22.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
           "dev": true
         },
         "lodash": {
           "version": "0.9.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
@@ -3229,7 +3229,7 @@
     },
     "grunt-lib-phantomjs": {
       "version": "0.7.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
       "integrity": "sha1-pJasEEvI6ELiaJN0nVTEkFR16Pw=",
       "dev": true,
       "requires": {
@@ -3241,7 +3241,7 @@
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
@@ -3249,7 +3249,7 @@
     },
     "grunt-postcss": {
       "version": "0.8.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-postcss/-/grunt-postcss-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.8.0.tgz",
       "integrity": "sha1-jzCor2B5A84MRfAfC+QsYOMc6w4=",
       "dev": true,
       "requires": {
@@ -3260,7 +3260,7 @@
     },
     "grunt-retire": {
       "version": "0.3.12",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-retire/-/grunt-retire-0.3.12.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-retire/-/grunt-retire-0.3.12.tgz",
       "integrity": "sha1-ko34nQ5lE792vQYOGVTJ0+kncKE=",
       "dev": true,
       "requires": {
@@ -3271,7 +3271,7 @@
     },
     "grunt-sass": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-sass/-/grunt-sass-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-2.0.0.tgz",
       "integrity": "sha1-kHTPnXtFkuIPd4jKpye4+aoGtgo=",
       "dev": true,
       "requires": {
@@ -3282,13 +3282,13 @@
     },
     "grunt-template-jasmine-requirejs": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz",
       "integrity": "sha1-KIcw4jNOC/JBfUsj9vEtrYxT8xg=",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/handlebars/-/handlebars-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
       "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
       "requires": {
         "async": "1.5.2",
@@ -3299,13 +3299,13 @@
     },
     "har-schema": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-schema/-/har-schema-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
       "version": "2.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
@@ -3317,7 +3317,7 @@
     },
     "has": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has/-/has-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
@@ -3326,7 +3326,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3335,19 +3335,19 @@
     },
     "has-flag": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-flag/-/has-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hasha": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hasha/-/hasha-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
@@ -3357,7 +3357,7 @@
     },
     "hawk": {
       "version": "3.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hawk/-/hawk-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
@@ -3369,13 +3369,13 @@
     },
     "hoek": {
       "version": "2.16.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hoek/-/hoek-2.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
@@ -3385,25 +3385,25 @@
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
@@ -3416,13 +3416,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3436,7 +3436,7 @@
     },
     "http-browserify": {
       "version": "1.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-browserify/-/http-browserify-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "dev": true,
       "requires": {
@@ -3446,7 +3446,7 @@
       "dependencies": {
         "Base64": {
           "version": "0.2.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/Base64/-/Base64-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
           "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
           "dev": true
         }
@@ -3454,7 +3454,7 @@
     },
     "http-errors": {
       "version": "1.6.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-errors/-/http-errors-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
       "dev": true,
       "requires": {
@@ -3466,7 +3466,7 @@
     },
     "http-signature": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-signature/-/http-signature-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
@@ -3477,13 +3477,13 @@
     },
     "https-browserify": {
       "version": "0.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/https-browserify/-/https-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
       "integrity": "sha1-s//f5zSyo9Sp79WOhlTJH86G6v0=",
       "dev": true
     },
     "https-proxy-agent": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
@@ -3494,25 +3494,25 @@
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
     },
     "ieee754": {
       "version": "1.1.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ieee754/-/ieee754-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ignore/-/ignore-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
     "imports-loader": {
       "version": "0.6.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/imports-loader/-/imports-loader-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
       "dev": true,
       "requires": {
@@ -3522,7 +3522,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.1.43",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.1.43.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
@@ -3533,19 +3533,19 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/in-publish/-/in-publish-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -3554,19 +3554,19 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -3576,19 +3576,19 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
       "version": "1.3.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ini/-/ini-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -3609,13 +3609,13 @@
     },
     "interpret": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/interpret/-/interpret-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
     "invariant": {
       "version": "2.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/invariant/-/invariant-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
@@ -3624,25 +3624,25 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -3651,12 +3651,12 @@
     },
     "is-buffer": {
       "version": "1.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-buffer/-/is-buffer-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3665,13 +3665,13 @@
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -3680,19 +3680,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -3701,7 +3701,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -3710,7 +3710,7 @@
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
@@ -3719,7 +3719,7 @@
     },
     "is-my-json-valid": {
       "version": "2.16.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
@@ -3731,7 +3731,7 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -3740,13 +3740,13 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
@@ -3755,7 +3755,7 @@
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
@@ -3764,31 +3764,31 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
@@ -3797,13 +3797,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-svg": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-svg/-/is-svg-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
@@ -3812,31 +3812,31 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
@@ -3845,13 +3845,13 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jasmine": {
       "version": "2.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine/-/jasmine-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
       "integrity": "sha1-kBbdpFMhPSesbUPcTqlzFaGJCF4=",
       "dev": true,
       "requires": {
@@ -3862,7 +3862,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -3872,13 +3872,13 @@
         },
         "jasmine-core": {
           "version": "2.4.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine-core/-/jasmine-core-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
           "integrity": "sha1-b4OrOg8WlRcizgfSBsdz1XzIOL4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -3890,46 +3890,46 @@
     },
     "jasmine-core": {
       "version": "2.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine-core/-/jasmine-core-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.7.0.tgz",
       "integrity": "sha1-UP+MT5LY71wLLBuEbdJj7YUVIJE=",
       "dev": true
     },
     "jasminewd2": {
       "version": "0.0.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasminewd2/-/jasminewd2-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.9.tgz",
       "integrity": "sha1-1r5AhB1EDb4c7uWgeN5iaDsOVqc=",
       "dev": true
     },
     "jquery": {
       "version": "1.12.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery/-/jquery-1.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.1.tgz",
       "integrity": "sha1-nMNM5HgNTOuQxEMo8HEGTwGWDBg="
     },
     "jquery-placeholder": {
       "version": "2.0.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery-placeholder/-/jquery-placeholder-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/jquery-placeholder/-/jquery-placeholder-2.0.7.tgz",
       "integrity": "sha1-zHZLvd+2PFRbnq+cymkt2SFov+I="
     },
     "jquery.cookie": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
       "integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs="
     },
     "js-base64": {
       "version": "2.1.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-base64/-/js-base64-2.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
@@ -3939,20 +3939,20 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
     "jshint": {
       "version": "2.9.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jshint/-/jshint-2.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
@@ -3968,13 +3968,13 @@
       "dependencies": {
         "lodash": {
           "version": "3.7.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
           "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
           "dev": true
         },
         "shelljs": {
           "version": "0.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
           "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
           "dev": true
         }
@@ -3982,25 +3982,25 @@
     },
     "json-loader": {
       "version": "0.5.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-loader/-/json-loader-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
       "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha1-UBg80bLSUnXeBp6ecbRnrJ6rlzo=",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -4009,19 +4009,19 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -4030,19 +4030,19 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -4054,7 +4054,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -4062,7 +4062,7 @@
     },
     "junit-report-builder": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/junit-report-builder/-/junit-report-builder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-1.1.1.tgz",
       "integrity": "sha1-+IWufHECgorqAlwEXxHJBifAEpI=",
       "dev": true,
       "requires": {
@@ -4074,7 +4074,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -4082,13 +4082,13 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
         "is-buffer": "1.1.5"
@@ -4096,7 +4096,7 @@
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
@@ -4105,12 +4105,12 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -4119,7 +4119,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -4129,13 +4129,13 @@
     },
     "livereload-js": {
       "version": "2.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/livereload-js/-/livereload-js-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
       "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
       "dev": true
     },
     "load-grunt-tasks": {
       "version": "3.5.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
       "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
       "dev": true,
       "requires": {
@@ -4147,7 +4147,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4160,7 +4160,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -4171,7 +4171,7 @@
     },
     "loader-utils": {
       "version": "0.2.17",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loader-utils/-/loader-utils-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
@@ -4183,48 +4183,48 @@
     },
     "lodash": {
       "version": "4.17.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-4.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loose-envify/-/loose-envify-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
@@ -4233,7 +4233,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -4243,37 +4243,37 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "macaddress": {
       "version": "0.2.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/macaddress/-/macaddress-0.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "memory-fs": {
       "version": "0.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/memory-fs/-/memory-fs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "dev": true,
       "requires": {
@@ -4283,7 +4283,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4301,7 +4301,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4309,7 +4309,7 @@
     },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/micromatch/-/micromatch-2.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
@@ -4330,19 +4330,19 @@
     },
     "mime": {
       "version": "1.3.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime/-/mime-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
       "dev": true
     },
     "mime-db": {
       "version": "1.29.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime-db/-/mime-db-1.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
       "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.16",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime-types/-/mime-types-2.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
       "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
@@ -4351,8 +4351,8 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -4360,12 +4360,12 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4374,7 +4374,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4382,13 +4382,13 @@
     },
     "moment": {
       "version": "2.12.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/moment/-/moment-2.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
       "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY=",
       "dev": true
     },
     "morgan": {
       "version": "1.8.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/morgan/-/morgan-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
       "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
       "dev": true,
       "requires": {
@@ -4401,13 +4401,13 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multimatch": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/multimatch/-/multimatch-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
@@ -4419,31 +4419,31 @@
     },
     "mute-stream": {
       "version": "0.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mute-stream/-/mute-stream-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "nan": {
       "version": "2.6.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nan/-/nan-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "node-gyp": {
       "version": "3.6.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-gyp/-/node-gyp-3.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
@@ -4464,8 +4464,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -4478,7 +4478,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
@@ -4487,7 +4487,7 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -4495,7 +4495,7 @@
     },
     "node-libs-browser": {
       "version": "0.6.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
       "integrity": "sha1-JEgG1E0xngSLyGB7XMTq+aKdLjw=",
       "dev": true,
       "requires": {
@@ -4526,13 +4526,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4546,7 +4546,7 @@
     },
     "node-sass": {
       "version": "4.5.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-sass/-/node-sass-4.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
@@ -4572,13 +4572,13 @@
       "dependencies": {
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-2.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
@@ -4589,8 +4589,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -4603,7 +4603,7 @@
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -4613,13 +4613,13 @@
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.81.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -4649,7 +4649,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
@@ -4658,7 +4658,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -4667,21 +4667,21 @@
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
     },
     "node-uuid": {
       "version": "1.4.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-uuid/-/node-uuid-1.4.8.tgz",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
       "dev": true
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -4690,8 +4690,8 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -4702,7 +4702,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -4711,13 +4711,13 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-url/-/normalize-url-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
       "integrity": "sha1-swB/JZOx+NAVtNWlpijOIr88bxM=",
       "dev": true,
       "requires": {
@@ -4729,8 +4729,8 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -4741,37 +4741,37 @@
     },
     "null-loader": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/null-loader/-/null-loader-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz",
       "integrity": "sha1-F76av80/8OFRL2/Er8sfUDk3j64=",
       "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -4781,7 +4781,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -4790,13 +4790,13 @@
     },
     "on-headers": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/on-headers/-/on-headers-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -4805,25 +4805,25 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "open": {
       "version": "0.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/open/-/open-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
       "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
       "dev": true
     },
     "opn": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/opn/-/opn-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
       "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "0.0.10",
@@ -4832,7 +4832,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -4846,7 +4846,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -4854,25 +4854,25 @@
     },
     "options": {
       "version": "0.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/options/-/options-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
     "os-browserify": {
       "version": "0.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-browserify/-/os-browserify-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -4881,13 +4881,13 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/osenv/-/osenv-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
@@ -4897,19 +4897,19 @@
     },
     "package": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/package/-/package-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
       "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
       "dev": true
     },
     "pako": {
       "version": "0.2.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pako/-/pako-0.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -4921,7 +4921,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -4930,25 +4930,25 @@
     },
     "parse-ms": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-ms/-/parse-ms-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
       "dev": true
     },
     "parseurl": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parseurl/-/parseurl-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -4957,25 +4957,25 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-parse/-/path-parse-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -4986,25 +4986,25 @@
     },
     "pbkdf2-compat": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
       "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og=",
       "dev": true
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/performance-now/-/performance-now-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "phantomjs": {
       "version": "1.9.20",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/phantomjs/-/phantomjs-1.9.20.tgz",
+      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz",
       "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
       "dev": true,
       "requires": {
@@ -5020,7 +5020,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs-extra/-/fs-extra-0.26.7.tgz",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
@@ -5033,7 +5033,7 @@
         },
         "which": {
           "version": "1.2.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.2.14.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
@@ -5044,19 +5044,19 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -5065,7 +5065,7 @@
     },
     "pkg-dir": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
@@ -5074,7 +5074,7 @@
     },
     "pkg-up": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkg-up/-/pkg-up-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
@@ -5083,19 +5083,19 @@
     },
     "plur": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/plur/-/plur-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pluralize/-/pluralize-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "portscanner": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/portscanner/-/portscanner-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
       "integrity": "sha1-sUu9olfRTDEPqcwJaCrwLUCWGAI=",
       "dev": true,
       "requires": {
@@ -5104,7 +5104,7 @@
     },
     "postcss": {
       "version": "5.2.17",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss/-/postcss-5.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
       "requires": {
@@ -5116,7 +5116,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -5124,7 +5124,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
@@ -5135,7 +5135,7 @@
     },
     "postcss-colormin": {
       "version": "2.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
@@ -5146,7 +5146,7 @@
     },
     "postcss-convert-values": {
       "version": "2.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
@@ -5156,7 +5156,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
@@ -5165,7 +5165,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
@@ -5174,7 +5174,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
@@ -5183,7 +5183,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
@@ -5192,7 +5192,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
@@ -5202,7 +5202,7 @@
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
@@ -5212,7 +5212,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
@@ -5223,7 +5223,7 @@
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
@@ -5232,7 +5232,7 @@
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
@@ -5245,13 +5245,13 @@
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
       "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
       "dev": true
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
@@ -5262,7 +5262,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
@@ -5272,7 +5272,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
@@ -5284,7 +5284,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
@@ -5296,7 +5296,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
@@ -5305,7 +5305,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
@@ -5317,7 +5317,7 @@
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
@@ -5327,7 +5327,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
@@ -5337,7 +5337,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
@@ -5346,7 +5346,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
@@ -5357,7 +5357,7 @@
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
@@ -5368,7 +5368,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
@@ -5380,7 +5380,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
@@ -5391,13 +5391,13 @@
     },
     "postcss-value-parser": {
       "version": "3.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
@@ -5408,25 +5408,25 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-ms": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
@@ -5437,31 +5437,31 @@
     },
     "private": {
       "version": "0.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/private/-/private-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
       "dev": true
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "protractor": {
       "version": "4.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/protractor/-/protractor-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.4.tgz",
       "integrity": "sha1-ZFnfWtWfh0mOcwttrhkv7rYfh/A=",
       "dev": true,
       "requires": {
@@ -5480,8 +5480,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5496,36 +5496,36 @@
     },
     "prr": {
       "version": "0.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prr/-/prr-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "q": {
       "version": "1.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/q/-/q-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "qs": {
       "version": "5.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
       "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
       "dev": true
     },
     "query-string": {
       "version": "3.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/query-string/-/query-string-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
       "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
       "dev": true,
       "requires": {
@@ -5534,20 +5534,20 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -5556,7 +5556,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -5565,7 +5565,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -5576,7 +5576,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -5587,13 +5587,13 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "raw-body": {
       "version": "2.1.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/raw-body/-/raw-body-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
       "dev": true,
       "requires": {
@@ -5604,13 +5604,13 @@
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bytes/-/bytes-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
           "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
           "dev": true
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
           "dev": true
         }
@@ -5618,13 +5618,13 @@
     },
     "read-installed": {
       "version": "4.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-installed/-/read-installed-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "requires": {
         "debuglog": "1.0.1",
         "graceful-fs": "4.1.11",
-        "read-package-json": "2.0.11",
+        "read-package-json": "2.0.12",
         "readdir-scoped-modules": "1.0.2",
         "semver": "5.1.0",
         "slide": "1.1.6",
@@ -5632,21 +5632,22 @@
       }
     },
     "read-package-json": {
-      "version": "2.0.11",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-package-json/-/read-package-json-2.0.11.tgz",
-      "integrity": "sha1-Xj4e8x5xRtkfu3m/n7HnYRtnAGw=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "json-parse-better-errors": "1.0.1",
-        "normalize-package-data": "2.4.0"
+        "normalize-package-data": "2.4.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5661,7 +5662,7 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -5672,7 +5673,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -5682,7 +5683,7 @@
     },
     "readable-stream": {
       "version": "2.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "dev": true,
       "requires": {
@@ -5696,7 +5697,7 @@
     },
     "readdir-scoped-modules": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
@@ -5708,7 +5709,7 @@
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readdirp/-/readdirp-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
@@ -5720,7 +5721,7 @@
     },
     "readline2": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readline2/-/readline2-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
@@ -5731,7 +5732,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -5740,8 +5741,8 @@
       "dependencies": {
         "resolve": {
           "version": "1.4.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
@@ -5751,7 +5752,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -5761,7 +5762,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
@@ -5772,7 +5773,7 @@
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
@@ -5780,7 +5781,7 @@
     },
     "reduce-function-call": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
@@ -5789,7 +5790,7 @@
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
@@ -5797,19 +5798,19 @@
     },
     "regenerate": {
       "version": "1.3.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerate/-/regenerate-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
       "dev": true
     },
     "regenerator-runtime": {
       "version": "0.10.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
       "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "regenerator-transform": {
       "version": "0.10.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -5819,7 +5820,7 @@
     },
     "regex-cache": {
       "version": "0.4.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regex-cache/-/regex-cache-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
@@ -5829,7 +5830,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
@@ -5840,13 +5841,13 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -5855,7 +5856,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -5863,24 +5864,24 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeat-element/-/repeat-element-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -5889,7 +5890,7 @@
     },
     "request": {
       "version": "2.67.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.67.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
       "dev": true,
       "requires": {
@@ -5917,7 +5918,7 @@
     },
     "request-progress": {
       "version": "2.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request-progress/-/request-progress-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
@@ -5926,7 +5927,7 @@
     },
     "request-promise": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request-promise/-/request-promise-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-2.0.0.tgz",
       "integrity": "sha1-6J1q4O3DqXyJT5Z6i/UCXCPRPbM=",
       "dev": true,
       "requires": {
@@ -5937,7 +5938,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -5945,19 +5946,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -5967,30 +5968,30 @@
     },
     "requirejs": {
       "version": "2.1.22",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/requirejs/-/requirejs-2.1.22.tgz",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz",
       "integrity": "sha1-3Xj9LTQYDA1ixyS1uK68BmTgNm8=",
       "dev": true
     },
     "reqwest": {
       "version": "2.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reqwest/-/reqwest-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/reqwest/-/reqwest-2.0.5.tgz",
       "integrity": "sha1-APsVrEkYxBnKgrQ/JMeIguZgOaE="
     },
     "resolve": {
       "version": "0.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve/-/resolve-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
       "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
       "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-pkg": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
       "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
       "dev": true,
       "requires": {
@@ -5999,7 +6000,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-from/-/resolve-from-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         }
@@ -6007,7 +6008,7 @@
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
@@ -6017,7 +6018,7 @@
     },
     "retire": {
       "version": "1.1.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/retire/-/retire-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/retire/-/retire-1.1.6.tgz",
       "integrity": "sha1-8ZQ2tc879+0soslilvETqgR5WNU=",
       "dev": true,
       "requires": {
@@ -6030,7 +6031,7 @@
       "dependencies": {
         "commander": {
           "version": "2.5.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
           "integrity": "sha1-I8Yfbke+FDzALnrUuxxH9c1aKIM=",
           "dev": true
         }
@@ -6038,7 +6039,7 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
         "align-text": "0.1.4"
@@ -6046,19 +6047,19 @@
     },
     "rimraf": {
       "version": "2.2.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
     "ripemd160": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ripemd160/-/ripemd160-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
       "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
       "dev": true
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -6067,19 +6068,19 @@
     },
     "rx-lite": {
       "version": "3.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rx-lite/-/rx-lite-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sass-graph/-/sass-graph-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
@@ -6091,13 +6092,13 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cliui/-/cliui-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
@@ -6108,8 +6109,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -6122,7 +6123,7 @@
         },
         "yargs": {
           "version": "7.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs/-/yargs-7.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
@@ -6145,7 +6146,7 @@
     },
     "saucelabs": {
       "version": "1.3.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/saucelabs/-/saucelabs-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
       "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
       "dev": true,
       "requires": {
@@ -6154,13 +6155,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -6170,12 +6171,12 @@
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/select/-/select-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "selenium-webdriver": {
       "version": "2.53.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
       "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
       "dev": true,
       "requires": {
@@ -6188,7 +6189,7 @@
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/adm-zip/-/adm-zip-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
           "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
           "dev": true
         }
@@ -6196,13 +6197,13 @@
     },
     "semver": {
       "version": "5.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
       "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
       "dev": true
     },
     "send": {
       "version": "0.15.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/send/-/send-0.15.4.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
       "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "dev": true,
       "requires": {
@@ -6223,7 +6224,7 @@
     },
     "serve-index": {
       "version": "1.9.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/serve-index/-/serve-index-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
       "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
       "dev": true,
       "requires": {
@@ -6238,7 +6239,7 @@
     },
     "serve-static": {
       "version": "1.12.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/serve-static/-/serve-static-1.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
       "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
       "dev": true,
       "requires": {
@@ -6250,67 +6251,67 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "setprototypeof": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
       "dev": true
     },
     "sha.js": {
       "version": "2.2.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sha.js/-/sha.js-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
       "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo=",
       "dev": true
     },
     "shelljs": {
       "version": "0.5.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.1.tgz",
       "integrity": "sha1-D8DD+Q+HGEAjoSWnu83jFEe09GQ=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "slide": {
       "version": "1.1.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slide/-/slide-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sntp/-/sntp-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
@@ -6319,7 +6320,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sort-keys/-/sort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
@@ -6328,13 +6329,13 @@
     },
     "source-list-map": {
       "version": "0.1.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-list-map/-/source-list-map-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
       "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
       "dev": true
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": "1.0.1"
@@ -6342,8 +6343,8 @@
     },
     "source-map-support": {
       "version": "0.4.16",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map-support/-/source-map-support-0.4.16.tgz",
-      "integrity": "sha1-Fv7PmCEkZ9AX1Yair2jWKLlCHNg=",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
+      "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
       "dev": true,
       "requires": {
         "source-map": "0.5.6"
@@ -6351,7 +6352,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -6359,7 +6360,7 @@
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
@@ -6368,25 +6369,25 @@
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sshpk/-/sshpk-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
@@ -6402,7 +6403,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -6410,13 +6411,13 @@
     },
     "statuses": {
       "version": "1.3.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/statuses/-/statuses-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
@@ -6425,7 +6426,7 @@
     },
     "stream-browserify": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
       "requires": {
@@ -6435,13 +6436,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -6455,19 +6456,19 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -6478,13 +6479,13 @@
     },
     "stringstream": {
       "version": "0.0.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stringstream/-/stringstream-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -6493,13 +6494,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -6508,13 +6509,13 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
       "version": "3.2.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
@@ -6523,7 +6524,7 @@
     },
     "svgo": {
       "version": "0.7.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/svgo/-/svgo-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
@@ -6538,7 +6539,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -6552,20 +6553,20 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6574,7 +6575,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -6585,13 +6586,13 @@
     },
     "tapable": {
       "version": "0.1.10",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tapable/-/tapable-0.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -6602,7 +6603,7 @@
     },
     "temporary": {
       "version": "0.0.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/temporary/-/temporary-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
@@ -6611,25 +6612,25 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "time-grunt": {
       "version": "1.4.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/time-grunt/-/time-grunt-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
@@ -6644,13 +6645,13 @@
     },
     "time-zone": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/time-zone/-/time-zone-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz",
       "integrity": "sha1-Sncotqwo2w4Aj1FAQ/1VW9VXO0Y=",
       "dev": true
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -6659,12 +6660,12 @@
     },
     "tiny-emitter": {
       "version": "1.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
       "integrity": "sha1-q0BaIf/tgUp2wZc5ZICT1wZU/ss="
     },
     "tiny-lr": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
@@ -6678,7 +6679,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -6687,13 +6688,13 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "qs": {
           "version": "5.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
           "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
           "dev": true
         }
@@ -6701,62 +6702,62 @@
     },
     "tmp": {
       "version": "0.0.24",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tmp/-/tmp-0.0.24.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
       "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.2.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tryit": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tryit/-/tryit-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -6765,7 +6766,7 @@
     },
     "type-is": {
       "version": "1.6.15",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/type-is/-/type-is-1.6.15.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "dev": true,
       "requires": {
@@ -6775,18 +6776,18 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "u2f-api-polyfill": {
       "version": "0.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/u2f-api-polyfill/-/u2f-api-polyfill-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/u2f-api-polyfill/-/u2f-api-polyfill-0.4.1.tgz",
       "integrity": "sha1-bkFcRz7vxAqJc/NycZUrUtRD2a0="
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
@@ -6797,7 +6798,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "optional": true
         }
@@ -6805,35 +6806,35 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
     },
     "ultron": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ultron/-/ultron-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore.string": {
       "version": "2.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqid": {
       "version": "4.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniqid/-/uniqid-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
@@ -6842,19 +6843,19 @@
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/url/-/url-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
@@ -6864,7 +6865,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -6872,7 +6873,7 @@
     },
     "user-home": {
       "version": "2.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/user-home/-/user-home-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
@@ -6881,7 +6882,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
@@ -6890,7 +6891,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         }
@@ -6898,25 +6899,25 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "util-extend": {
       "version": "1.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util-extend/-/util-extend-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
       "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/utils-merge/-/utils-merge-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
@@ -6926,13 +6927,13 @@
     },
     "vendors": {
       "version": "1.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/vendors/-/vendors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
       "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -6943,7 +6944,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -6951,7 +6952,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -6960,13 +6961,13 @@
     },
     "walkdir": {
       "version": "0.0.7",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/walkdir/-/walkdir-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
       "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik=",
       "dev": true
     },
     "watchpack": {
       "version": "0.2.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/watchpack/-/watchpack-0.2.9.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
       "requires": {
@@ -6977,7 +6978,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -6985,7 +6986,7 @@
     },
     "webdriver-manager": {
       "version": "10.2.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webdriver-manager/-/webdriver-manager-10.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.5.tgz",
       "integrity": "sha1-ZDPBpksDg4jCle0NydqnHl31Ak4=",
       "dev": true,
       "requires": {
@@ -7003,13 +7004,13 @@
       "dependencies": {
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-2.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
@@ -7020,8 +7021,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7034,7 +7035,7 @@
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -7044,19 +7045,19 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.81.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -7086,7 +7087,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
@@ -7095,13 +7096,13 @@
         },
         "semver": {
           "version": "5.4.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
@@ -7110,7 +7111,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -7119,15 +7120,15 @@
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
     },
     "webpack": {
       "version": "1.13.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webpack/-/webpack-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.1.tgz",
       "integrity": "sha1-CmnojlvcWTk5NS1dd94PmsnQhx4=",
       "dev": true,
       "requires": {
@@ -7150,25 +7151,25 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         },
         "interpret": {
           "version": "0.6.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/interpret/-/interpret-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
           "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.6.4",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-js/-/uglify-js-2.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
           "requires": {
@@ -7180,7 +7181,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
               "dev": true
             }
@@ -7190,7 +7191,7 @@
     },
     "webpack-core": {
       "version": "0.6.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webpack-core/-/webpack-core-0.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
@@ -7200,7 +7201,7 @@
     },
     "websocket-driver": {
       "version": "0.6.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/websocket-driver/-/websocket-driver-0.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "dev": true,
       "requires": {
@@ -7209,32 +7210,32 @@
     },
     "websocket-extensions": {
       "version": "0.1.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
       "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
       "dev": true
     },
     "whet.extend": {
       "version": "0.9.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/whet.extend/-/whet.extend-0.9.9.tgz",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
       "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
       "dev": true
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
       "dev": true
     },
     "which-module": {
       "version": "1.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which-module/-/which-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -7242,17 +7243,17 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -7262,13 +7263,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/write/-/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -7277,7 +7278,7 @@
     },
     "ws": {
       "version": "1.1.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ws/-/ws-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
       "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
       "dev": true,
       "requires": {
@@ -7287,12 +7288,12 @@
     },
     "xhr2": {
       "version": "0.1.3",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xhr2/-/xhr2-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
       "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
     },
     "xml2js": {
       "version": "0.4.4",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xml2js/-/xml2js-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
       "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
       "dev": true,
       "requires": {
@@ -7302,7 +7303,7 @@
       "dependencies": {
         "sax": {
           "version": "0.6.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sax/-/sax-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
           "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
           "dev": true
         }
@@ -7310,7 +7311,7 @@
     },
     "xmlbuilder": {
       "version": "2.6.5",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
       "integrity": "sha1-b/etYPty0idk8AehZLd/K/FABSY=",
       "dev": true,
       "requires": {
@@ -7319,7 +7320,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -7327,25 +7328,25 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "1.2.1",
@@ -7356,7 +7357,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
@@ -7365,7 +7366,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -7373,7 +7374,7 @@
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,53 +1,46 @@
 {
   "name": "@okta/okta-signin-widget",
-  "version": "1.13.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@okta/okta-auth-js": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-1.8.0.tgz",
-      "integrity": "sha1-D9c2XyHIcznV4ko2tP4FJDC3xyg=",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/okta-auth-js/-/@okta/okta-auth-js-1.8.0.tgz",
+      "integrity": "sha1-D2nQ1asbA1mpp94FN2uwVOPJgvg=",
       "requires": {
         "Base64": "0.3.0",
         "q": "1.4.1",
         "reqwest": "2.0.5",
         "tiny-emitter": "1.1.0",
         "xhr2": "0.1.3"
-      },
-      "dependencies": {
-        "Base64": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.3.0.tgz",
-          "integrity": "sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8="
-        }
       }
     },
     "abbrev": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/abbrev/-/abbrev-1.1.0.tgz",
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
     "accepts": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "negotiator": "0.6.1"
       }
     },
     "acorn": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha1-U/4WERH5EquZnuiHqQoLxSgi/XU=",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -56,7 +49,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -64,13 +57,13 @@
     },
     "adm-zip": {
       "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/adm-zip/-/adm-zip-0.4.7.tgz",
       "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
       "dev": true
     },
     "agent-base": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
@@ -80,7 +73,7 @@
       "dependencies": {
         "semver": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
           "dev": true
         }
@@ -88,7 +81,7 @@
     },
     "ajv": {
       "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
@@ -96,9 +89,15 @@
         "json-stable-stringify": "1.0.1"
       }
     },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
         "kind-of": "3.2.2",
@@ -108,58 +107,58 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "app-root-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/app-root-path/-/app-root-path-1.0.0.tgz",
       "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30=",
       "dev": true
     },
     "aproba": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aproba/-/aproba-1.1.2.tgz",
+      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
       "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
@@ -169,7 +168,7 @@
     },
     "argparse": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
@@ -178,7 +177,7 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -187,25 +186,25 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -214,37 +213,37 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
       "requires": {
@@ -253,41 +252,41 @@
     },
     "assert-plus": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "autoprefixer": {
       "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000699",
+        "caniuse-db": "1.0.30000715",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.17",
@@ -296,32 +295,32 @@
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "axe-core": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.0.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/axe-core/-/axe-core-2.0.7.tgz",
       "integrity": "sha1-sToNXd15YqKE9/y54EV7/zcBdqo=",
       "dev": true
     },
     "axe-webdriverjs": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-0.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/axe-webdriverjs/-/axe-webdriverjs-0.4.0.tgz",
       "integrity": "sha1-C0YnlPWaM9WVr7umkX3NnDUAfjc=",
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -329,47 +328,710 @@
         "js-tokens": "3.0.2"
       }
     },
+    "babel-core": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.8",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-loader": {
+      "version": "6.4.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-loader/-/babel-loader-6.4.1.tgz",
+      "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.10.5"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
+      "integrity": "sha1-LeHHgqeAoKXWBdGZyVdZbaQ8ROQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.3.3",
+        "invariant": "2.2.2",
+        "semver": "5.4.1"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.3.3",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserslist/-/browserslist-2.3.3.tgz",
+          "integrity": "sha1-KwyrxNKEifaCWYYFhYoHgvFLFUw=",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000715",
+            "electron-to-chromium": "1.3.18"
+          }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
+          "dev": true
+        }
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.0",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.16"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.0",
+        "regenerator-runtime": "0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.0",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+        }
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.8",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "dev": true
+    },
     "backbone": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/backbone/-/backbone-1.2.1.tgz",
       "integrity": "sha1-1yGcXtSeXhMdv/ryXJbW0sw8oD4=",
       "requires": {
         "underscore": "1.8.3"
       }
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
-      "dev": true
+      "version": "0.3.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/Base64/-/Base64-0.3.0.tgz",
+      "integrity": "sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8="
     },
     "base64-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
       "dev": true
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
@@ -379,19 +1041,19 @@
     },
     "big.js": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/big.js/-/big.js-3.1.3.tgz",
       "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.10.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
     },
     "bl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bl/-/bl-1.0.3.tgz",
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
       "dev": true,
       "requires": {
@@ -400,7 +1062,7 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -409,20 +1071,20 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
       "dev": true
     },
     "body-parser": {
       "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/body-parser/-/body-parser-1.14.2.tgz",
       "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
       "dev": true,
       "requires": {
         "bytes": "2.2.0",
         "content-type": "1.0.2",
         "debug": "2.2.0",
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "http-errors": "1.3.1",
         "iconv-lite": "0.4.13",
         "on-finished": "2.3.0",
@@ -433,7 +1095,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -442,7 +1104,7 @@
         },
         "http-errors": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-errors/-/http-errors-1.3.1.tgz",
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
@@ -452,19 +1114,19 @@
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
           "dev": true
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "qs": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.2.0.tgz",
           "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
           "dev": true
         }
@@ -472,7 +1134,7 @@
     },
     "boom": {
       "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
@@ -481,25 +1143,17 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
-      },
-      "dependencies": {
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        }
       }
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
@@ -510,7 +1164,7 @@
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
@@ -519,17 +1173,17 @@
     },
     "browserslist": {
       "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000699",
-        "electron-to-chromium": "1.3.15"
+        "caniuse-db": "1.0.30000715",
+        "electron-to-chromium": "1.3.18"
       }
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -540,19 +1194,19 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "bytes": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bytes/-/bytes-2.2.0.tgz",
       "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
       "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
@@ -561,18 +1215,18 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -582,7 +1236,7 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         }
@@ -590,31 +1244,37 @@
     },
     "caniuse-api": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000699",
+        "caniuse-db": "1.0.30000715",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000699",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000699.tgz",
-      "integrity": "sha1-WvSRqxx3dWGjK0P+JT1qcHHM+Xk=",
+      "version": "1.0.30000715",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+      "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000715",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+      "integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA=",
       "dev": true
     },
     "caseless": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
         "align-text": "0.1.4",
@@ -623,7 +1283,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -636,7 +1296,7 @@
       "dependencies": {
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -644,13 +1304,12 @@
     },
     "chokidar": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.0",
+        "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -660,14 +1319,14 @@
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clap": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
       "dev": true,
       "requires": {
@@ -676,7 +1335,7 @@
     },
     "cli": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli/-/cli-1.0.1.tgz",
       "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
@@ -686,8 +1345,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -697,21 +1356,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
@@ -720,30 +1370,23 @@
     },
     "cli-width": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
     },
     "clipboard": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
-      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "version": "1.6.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clipboard/-/clipboard-1.6.1.tgz",
+      "integrity": "sha1-ZcW2VIEkZrD6q4Lca6Dx0vjkvlM=",
       "requires": {
         "good-listener": "1.2.2",
         "select": "1.1.2",
-        "tiny-emitter": "2.0.1"
-      },
-      "dependencies": {
-        "tiny-emitter": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.1.tgz",
-          "integrity": "sha1-5lkZ2R5Ijip49+voJ6VsaxiNUa8="
-        }
+        "tiny-emitter": "1.1.0"
       }
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
         "center-align": "0.1.3",
@@ -753,26 +1396,26 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         }
       }
     },
     "clone": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
@@ -781,19 +1424,19 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "coffee-script": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
@@ -804,31 +1447,31 @@
     },
     "color-convert": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.2"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
+      "version": "1.1.3",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.2"
+        "color-name": "1.1.3"
       }
     },
     "colormin": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
@@ -839,13 +1482,13 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
@@ -854,19 +1497,25 @@
     },
     "commander": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-stream/-/concat-stream-1.5.0.tgz",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
       "dev": true,
       "requires": {
@@ -876,26 +1525,26 @@
       }
     },
     "connect": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
-      "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
+      "version": "3.6.3",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/connect/-/connect-3.6.3.tgz",
+      "integrity": "sha1-9zINRqJbS+e0g6IjZRfySx4n4wE=",
       "dev": true,
       "requires": {
-        "debug": "2.6.7",
-        "finalhandler": "1.0.3",
+        "debug": "2.6.8",
+        "finalhandler": "1.0.4",
         "parseurl": "1.3.1",
         "utils-merge": "1.0.0"
       }
     },
     "connect-livereload": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/connect-livereload/-/connect-livereload-0.5.4.tgz",
       "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
       "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -904,42 +1553,53 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/constants-browserify/-/constants-browserify-0.0.1.tgz",
       "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI=",
       "dev": true
     },
     "content-type": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/content-type/-/content-type-1.0.2.tgz",
       "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.5.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+    },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -947,9 +1607,9 @@
           }
         },
         "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "version": "1.3.0",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.3.0.tgz",
+          "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -959,7 +1619,7 @@
     },
     "cryptiles": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
@@ -968,7 +1628,7 @@
     },
     "crypto-browserify": {
       "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
       "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
       "dev": true,
       "requires": {
@@ -979,13 +1639,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
@@ -1025,7 +1685,7 @@
     },
     "csso": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
@@ -1035,7 +1695,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -1043,7 +1703,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -1052,16 +1712,16 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.27"
       }
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -1070,7 +1730,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -1078,19 +1738,19 @@
     },
     "date-format": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-format/-/date-format-0.0.2.tgz",
       "integrity": "sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=",
       "dev": true
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "date-time": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/date-time/-/date-time-1.1.0.tgz",
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
@@ -1099,14 +1759,14 @@
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
     "debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "version": "2.6.8",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -1114,30 +1774,30 @@
     },
     "debuglog": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
@@ -1152,36 +1812,45 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegate": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delegate/-/delegate-3.1.3.tgz",
       "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0="
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+      "version": "1.1.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
     "dezalgo": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dezalgo/-/dezalgo-1.0.3.tgz",
       "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "requires": {
@@ -1191,13 +1860,13 @@
     },
     "diff": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/diff/-/diff-2.2.3.tgz",
       "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
       "dev": true
     },
     "doctrine": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
@@ -1207,7 +1876,7 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
@@ -1217,13 +1886,13 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-1.1.1.tgz",
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
@@ -1231,19 +1900,19 @@
     },
     "domain-browser": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
       "dev": true
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
@@ -1252,7 +1921,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -1262,7 +1931,7 @@
     },
     "each-async": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
@@ -1272,7 +1941,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
@@ -1282,31 +1951,31 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.15",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz",
-      "integrity": "sha1-CDl5NIkcvPrrvRi4KpW1pIETg2k=",
+      "version": "1.3.18",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
       "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
     "enhanced-resolve": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
       "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
       "dev": true,
       "requires": {
@@ -1317,7 +1986,7 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/memory-fs/-/memory-fs-0.2.0.tgz",
           "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
           "dev": true
         }
@@ -1325,13 +1994,13 @@
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
     "errno": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
@@ -1340,7 +2009,7 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
@@ -1348,9 +2017,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.24",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
-      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+      "version": "0.10.27",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es5-ext/-/es5-ext-0.10.27.tgz",
+      "integrity": "sha1-v5JrBYxisctd4aiHkwZztqptmmY=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -1359,29 +2028,29 @@
     },
     "es5-shim": {
       "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es5-shim/-/es5-shim-4.5.9.tgz",
       "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA=",
       "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.27",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1390,12 +2059,12 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1403,41 +2072,41 @@
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.27"
       }
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -1449,17 +2118,17 @@
     },
     "eslint": {
       "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "doctrine": "2.0.0",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -1492,7 +2161,7 @@
       "dependencies": {
         "concat-stream": {
           "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/concat-stream/-/concat-stream-1.6.0.tgz",
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
@@ -1503,8 +2172,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -1515,25 +2184,10 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "readable-stream": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1547,7 +2201,7 @@
         },
         "shelljs": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.7.8.tgz",
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
@@ -1558,8 +2212,8 @@
         },
         "string_decoder": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1567,16 +2221,16 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
@@ -1585,13 +2239,13 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
@@ -1600,7 +2254,7 @@
     },
     "esrecurse": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
@@ -1610,59 +2264,59 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/etag/-/etag-1.8.0.tgz",
       "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.27"
       }
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -1671,7 +2325,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -1680,13 +2334,13 @@
     },
     "extend": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -1695,7 +2349,7 @@
     },
     "extract-zip": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
       "dev": true,
       "requires": {
@@ -1707,19 +2361,19 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -1729,20 +2383,20 @@
       }
     },
     "extsprintf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "version": "1.3.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -1751,7 +2405,7 @@
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
@@ -1760,7 +2414,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -1770,7 +2424,7 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
@@ -1780,19 +2434,19 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
@@ -1804,12 +2458,12 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "version": "1.0.4",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/finalhandler/-/finalhandler-1.0.4.tgz",
+      "integrity": "sha1-GFdPLnxLmLiuOyMMIfIB8xvbP7c=",
       "dev": true,
       "requires": {
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
@@ -1818,9 +2472,20 @@
         "unpipe": "1.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "0.1.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
+      }
+    },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -1830,7 +2495,7 @@
     },
     "findup-sync": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
@@ -1840,7 +2505,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -1850,13 +2515,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -1868,11 +2533,11 @@
     },
     "flat-cache": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -1880,19 +2545,19 @@
     },
     "flatten": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -1901,47 +2566,41 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-1.0.1.tgz",
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
       "dev": true,
       "requires": {
         "async": "2.5.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       },
       "dependencies": {
         "async": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-2.5.0.tgz",
+          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
         }
       }
     },
     "fresh": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fresh/-/fresh-0.5.0.tgz",
       "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
       "dev": true
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
@@ -1952,1025 +2611,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
-    },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
@@ -2982,13 +2629,13 @@
     },
     "function-bind": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/function-bind/-/function-bind-1.1.0.tgz",
       "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -3004,7 +2651,7 @@
     },
     "gaze": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
@@ -3013,13 +2660,13 @@
     },
     "generate-function": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -3028,25 +2675,25 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -3055,7 +2702,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -3063,7 +2710,7 @@
     },
     "git-rev-sync": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/git-rev-sync/-/git-rev-sync-1.4.0.tgz",
       "integrity": "sha1-7svJo5XaFBw+qn5N/Yb8I+qemug=",
       "dev": true,
       "requires": {
@@ -3073,7 +2720,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.1.2.tgz",
           "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
           "dev": true
         }
@@ -3081,7 +2728,7 @@
     },
     "glob": {
       "version": "3.1.21",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.1.21.tgz",
       "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
       "dev": true,
       "requires": {
@@ -3092,21 +2739,31 @@
       "dependencies": {
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         }
       }
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -3116,7 +2773,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -3125,13 +2782,13 @@
     },
     "globals": {
       "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -3145,8 +2802,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -3156,21 +2813,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
         }
       }
     },
     "globule": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
@@ -3181,8 +2829,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -3192,27 +2840,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
         }
       }
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
         "delegate": "3.1.3"
@@ -3220,13 +2853,13 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "grunt": {
       "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
@@ -3254,7 +2887,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -3264,7 +2897,7 @@
           "dependencies": {
             "underscore.string": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
@@ -3272,25 +2905,25 @@
         },
         "async": {
           "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
           "dev": true
         },
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
@@ -3298,9 +2931,25 @@
             "esprima": "1.0.4"
           }
         },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
         "underscore": {
           "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore/-/underscore-1.7.0.tgz",
           "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
           "dev": true
         }
@@ -3308,7 +2957,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -3319,23 +2968,23 @@
     },
     "grunt-contrib-connect": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.11.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-connect/-/grunt-contrib-connect-0.11.2.tgz",
       "integrity": "sha1-HAoHB9OzKNnPO0tJDrhMSV2Tau0=",
       "dev": true,
       "requires": {
         "async": "0.9.2",
-        "connect": "3.6.2",
+        "connect": "3.6.3",
         "connect-livereload": "0.5.4",
         "morgan": "1.8.2",
         "opn": "1.0.2",
         "portscanner": "1.2.0",
         "serve-index": "1.9.0",
-        "serve-static": "1.12.3"
+        "serve-static": "1.12.4"
       },
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -3343,7 +2992,7 @@
     },
     "grunt-contrib-copy": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-copy/-/grunt-contrib-copy-0.8.0.tgz",
       "integrity": "sha1-7jAn5l5PL/uVJakDwZ79gKjyR5s=",
       "dev": true,
       "requires": {
@@ -3353,19 +3002,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
           "dev": true
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -3378,7 +3027,7 @@
         },
         "has-ansi": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
@@ -3387,7 +3036,7 @@
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
@@ -3396,7 +3045,7 @@
         },
         "supports-color": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-0.2.0.tgz",
           "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
           "dev": true
         }
@@ -3404,21 +3053,21 @@
     },
     "grunt-contrib-jasmine": {
       "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.9.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.9.2.tgz",
       "integrity": "sha1-qMovO4gCRTchN3X8u5iL2dkflqw=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "es5-shim": "4.5.9",
         "grunt-lib-phantomjs": "0.7.1",
-        "jasmine-core": "2.6.4",
+        "jasmine-core": "2.7.0",
         "lodash": "2.4.2",
         "rimraf": "2.2.8"
       },
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         }
@@ -3426,7 +3075,7 @@
     },
     "grunt-contrib-jshint": {
       "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.2.tgz",
       "integrity": "sha1-p+AAQnuwB4SMEJkmSGDASFtHQdM=",
       "dev": true,
       "requires": {
@@ -3436,7 +3085,7 @@
     },
     "grunt-contrib-requirejs": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
       "integrity": "sha1-h/IWWpgeSKRdIvjMUpnQk0AxuXI=",
       "dev": true,
       "requires": {
@@ -3445,7 +3094,7 @@
     },
     "grunt-contrib-watch": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
@@ -3457,7 +3106,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -3465,7 +3114,7 @@
     },
     "grunt-eslint": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-19.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-eslint/-/grunt-eslint-19.0.0.tgz",
       "integrity": "sha1-u3TDeQYVmc7B9mFp3vKonYYthhs=",
       "dev": true,
       "requires": {
@@ -3475,19 +3124,19 @@
     },
     "grunt-exec": {
       "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-0.4.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-exec/-/grunt-exec-0.4.6.tgz",
       "integrity": "sha1-KJBKXVvS+gq2XGuU0jxbGAq5nSM=",
       "dev": true
     },
     "grunt-json-generator": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-json-generator/-/grunt-json-generator-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-json-generator/-/grunt-json-generator-0.1.0.tgz",
       "integrity": "sha1-z8Xj14VFuxVWESi3pYKXGasils0=",
       "dev": true
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
@@ -3500,19 +3149,19 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -3520,7 +3169,7 @@
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
@@ -3531,19 +3180,19 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -3551,7 +3200,7 @@
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
@@ -3566,15 +3215,21 @@
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.1.22.tgz",
           "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
       }
     },
     "grunt-lib-phantomjs": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
       "integrity": "sha1-pJasEEvI6ELiaJN0nVTEkFR16Pw=",
       "dev": true,
       "requires": {
@@ -3586,7 +3241,7 @@
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         }
@@ -3594,7 +3249,7 @@
     },
     "grunt-postcss": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.8.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-postcss/-/grunt-postcss-0.8.0.tgz",
       "integrity": "sha1-jzCor2B5A84MRfAfC+QsYOMc6w4=",
       "dev": true,
       "requires": {
@@ -3605,7 +3260,7 @@
     },
     "grunt-retire": {
       "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/grunt-retire/-/grunt-retire-0.3.12.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-retire/-/grunt-retire-0.3.12.tgz",
       "integrity": "sha1-ko34nQ5lE792vQYOGVTJ0+kncKE=",
       "dev": true,
       "requires": {
@@ -3616,7 +3271,7 @@
     },
     "grunt-sass": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-sass/-/grunt-sass-2.0.0.tgz",
       "integrity": "sha1-kHTPnXtFkuIPd4jKpye4+aoGtgo=",
       "dev": true,
       "requires": {
@@ -3627,13 +3282,13 @@
     },
     "grunt-template-jasmine-requirejs": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz",
       "integrity": "sha1-KIcw4jNOC/JBfUsj9vEtrYxT8xg=",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/handlebars/-/handlebars-4.0.5.tgz",
       "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
       "requires": {
         "async": "1.5.2",
@@ -3644,13 +3299,13 @@
     },
     "har-schema": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-schema/-/har-schema-1.0.5.tgz",
       "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
       "dev": true
     },
     "har-validator": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
@@ -3662,7 +3317,7 @@
     },
     "has": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
@@ -3671,7 +3326,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3680,19 +3335,19 @@
     },
     "has-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hasha": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
@@ -3702,7 +3357,7 @@
     },
     "hawk": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
@@ -3714,31 +3369,41 @@
     },
     "hoek": {
       "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
@@ -3751,13 +3416,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3771,21 +3436,29 @@
     },
     "http-browserify": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-browserify/-/http-browserify-1.7.0.tgz",
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "dev": true,
       "requires": {
         "Base64": "0.2.1",
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "Base64": {
+          "version": "0.2.1",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/Base64/-/Base64-0.2.1.tgz",
+          "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+          "dev": true
+        }
       }
     },
     "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "version": "1.6.2",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
       "dev": true,
       "requires": {
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
@@ -3793,53 +3466,53 @@
     },
     "http-signature": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
+        "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
     },
     "https-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/https-browserify/-/https-browserify-0.0.0.tgz",
       "integrity": "sha1-s//f5zSyo9Sp79WOhlTJH86G6v0=",
       "dev": true
     },
     "https-proxy-agent": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "extend": "3.0.1"
       }
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
     },
     "ieee754": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ignore/-/ignore-3.3.3.tgz",
       "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
       "dev": true
     },
     "imports-loader": {
       "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/imports-loader/-/imports-loader-0.6.5.tgz",
       "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
       "dev": true,
       "requires": {
@@ -3849,7 +3522,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
@@ -3860,19 +3533,19 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -3881,19 +3554,19 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -3903,19 +3576,19 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ini/-/ini-1.3.4.tgz",
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -3932,57 +3605,58 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        }
       }
     },
     "interpret": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/interpret/-/interpret-1.0.3.tgz",
       "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3991,13 +3665,13 @@
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -4006,19 +3680,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -4027,7 +3701,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -4036,7 +3710,7 @@
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
@@ -4045,7 +3719,7 @@
     },
     "is-my-json-valid": {
       "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
@@ -4057,7 +3731,7 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -4066,13 +3740,13 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
@@ -4081,7 +3755,7 @@
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
@@ -4090,31 +3764,31 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
@@ -4123,13 +3797,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-svg": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
@@ -4138,31 +3812,31 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
@@ -4171,13 +3845,13 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jasmine": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine/-/jasmine-2.4.1.tgz",
       "integrity": "sha1-kBbdpFMhPSesbUPcTqlzFaGJCF4=",
       "dev": true,
       "requires": {
@@ -4188,7 +3862,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -4198,13 +3872,13 @@
         },
         "jasmine-core": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine-core/-/jasmine-core-2.4.1.tgz",
           "integrity": "sha1-b4OrOg8WlRcizgfSBsdz1XzIOL4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -4215,53 +3889,47 @@
       }
     },
     "jasmine-core": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.4.tgz",
-      "integrity": "sha1-3skmzQqfoof7bbXHVfpIfnTOysU=",
+      "version": "2.7.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasmine-core/-/jasmine-core-2.7.0.tgz",
+      "integrity": "sha1-UP+MT5LY71wLLBuEbdJj7YUVIJE=",
       "dev": true
     },
     "jasminewd2": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jasminewd2/-/jasminewd2-0.0.9.tgz",
       "integrity": "sha1-1r5AhB1EDb4c7uWgeN5iaDsOVqc=",
-      "dev": true
-    },
-    "jju": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
       "dev": true
     },
     "jquery": {
       "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery/-/jquery-1.12.1.tgz",
       "integrity": "sha1-nMNM5HgNTOuQxEMo8HEGTwGWDBg="
     },
     "jquery-placeholder": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jquery-placeholder/-/jquery-placeholder-2.0.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery-placeholder/-/jquery-placeholder-2.0.7.tgz",
       "integrity": "sha1-zHZLvd+2PFRbnq+cymkt2SFov+I="
     },
     "jquery.cookie": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jquery.cookie/-/jquery.cookie-1.4.1.tgz",
       "integrity": "sha1-1j3OIJ6raR/mMxbbCMqeR+D5OFs="
     },
     "js-base64": {
       "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
@@ -4271,14 +3939,20 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
     "jshint": {
       "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jshint/-/jshint-2.9.5.tgz",
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
@@ -4294,22 +3968,13 @@
       "dependencies": {
         "lodash": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.7.0.tgz",
           "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
           "dev": true
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "shelljs": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.3.0.tgz",
           "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
           "dev": true
         }
@@ -4317,28 +3982,25 @@
     },
     "json-loader": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-loader/-/json-loader-0.5.4.tgz",
       "integrity": "sha1-i6oTZaYy9Yo8RtIBdfxgAsluN94=",
       "dev": true
     },
-    "json-parse-helpfulerror": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-      "dev": true,
-      "requires": {
-        "jju": "1.3.0"
-      }
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha1-UBg80bLSUnXeBp6ecbRnrJ6rlzo=",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -4347,19 +4009,19 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -4368,31 +4030,31 @@
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "version": "1.4.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
+        "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
-        "verror": "1.3.6"
+        "verror": "1.10.0"
       },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -4400,7 +4062,7 @@
     },
     "junit-report-builder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/junit-report-builder/-/junit-report-builder-1.1.1.tgz",
       "integrity": "sha1-+IWufHECgorqAlwEXxHJBifAEpI=",
       "dev": true,
       "requires": {
@@ -4412,7 +4074,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -4420,13 +4082,13 @@
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
         "is-buffer": "1.1.5"
@@ -4434,7 +4096,7 @@
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
@@ -4443,12 +4105,12 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -4457,7 +4119,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -4467,13 +4129,13 @@
     },
     "livereload-js": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/livereload-js/-/livereload-js-2.2.2.tgz",
       "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
       "dev": true
     },
     "load-grunt-tasks": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/load-grunt-tasks/-/load-grunt-tasks-3.5.2.tgz",
       "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
       "dev": true,
       "requires": {
@@ -4485,7 +4147,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4498,7 +4160,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -4509,7 +4171,7 @@
     },
     "loader-utils": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
@@ -4520,49 +4182,58 @@
       }
     },
     "lodash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-      "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+      "version": "4.17.4",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -4572,37 +4243,37 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "macaddress": {
       "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "memory-fs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
       "dev": true,
       "requires": {
@@ -4612,7 +4283,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4630,7 +4301,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4638,7 +4309,7 @@
     },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
@@ -4659,43 +4330,42 @@
     },
     "mime": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime/-/mime-1.3.4.tgz",
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
       "dev": true
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "version": "1.29.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.16",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "1.29.0"
       }
     },
     "minimatch": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "version": "3.0.4",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4704,7 +4374,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4712,43 +4382,32 @@
     },
     "moment": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/moment/-/moment-2.12.0.tgz",
       "integrity": "sha1-3CVg0Zg41sBzGxpq+gRnUmTTYNY=",
       "dev": true
     },
     "morgan": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/morgan/-/morgan-1.8.2.tgz",
       "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
       "dev": true,
       "requires": {
         "basic-auth": "1.1.0",
         "debug": "2.6.8",
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multimatch": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
@@ -4756,46 +4415,35 @@
         "array-union": "1.0.2",
         "arrify": "1.0.1",
         "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        }
       }
     },
     "mute-stream": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "nan": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "node-gyp": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
@@ -4816,8 +4464,8 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -4828,18 +4476,9 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "nopt": {
           "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
@@ -4848,7 +4487,7 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -4856,7 +4495,7 @@
     },
     "node-libs-browser": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-libs-browser/-/node-libs-browser-0.6.0.tgz",
       "integrity": "sha1-JEgG1E0xngSLyGB7XMTq+aKdLjw=",
       "dev": true,
       "requires": {
@@ -4887,13 +4526,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4907,7 +4546,7 @@
     },
     "node-sass": {
       "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-sass/-/node-sass-4.5.3.tgz",
       "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
@@ -4933,25 +4572,25 @@
       "dependencies": {
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "mime-types": "2.1.16"
           }
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -4964,7 +4603,7 @@
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -4972,24 +4611,15 @@
             "har-schema": "1.0.5"
           }
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -5006,7 +4636,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
+            "mime-types": "2.1.16",
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
@@ -5019,7 +4649,7 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
@@ -5028,7 +4658,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -5037,21 +4667,21 @@
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
           "dev": true
         }
       }
     },
     "node-uuid": {
       "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
       "dev": true
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -5060,8 +4690,8 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -5072,22 +4702,22 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/normalize-url/-/normalize-url-1.4.1.tgz",
       "integrity": "sha1-swB/JZOx+NAVtNWlpijOIr88bxM=",
       "dev": true,
       "requires": {
@@ -5099,8 +4729,8 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -5111,37 +4741,37 @@
     },
     "null-loader": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/null-loader/-/null-loader-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/null-loader/-/null-loader-0.1.1.tgz",
       "integrity": "sha1-F76av80/8OFRL2/Er8sfUDk3j64=",
       "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -5151,7 +4781,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -5160,13 +4790,13 @@
     },
     "on-headers": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5175,25 +4805,25 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "open": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/open/-/open-0.0.5.tgz",
       "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
       "dev": true
     },
     "opn": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/opn/-/opn-1.0.2.tgz",
       "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "0.0.10",
@@ -5202,7 +4832,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -5216,7 +4846,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -5224,25 +4854,25 @@
     },
     "options": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
       "dev": true
     },
     "os-browserify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-browserify/-/os-browserify-0.1.2.tgz",
       "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -5251,13 +4881,13 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "dev": true,
       "requires": {
@@ -5267,19 +4897,19 @@
     },
     "package": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/package/-/package-1.0.1.tgz",
       "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
       "dev": true
     },
     "pako": {
       "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pako/-/pako-0.2.9.tgz",
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -5291,7 +4921,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -5300,25 +4930,25 @@
     },
     "parse-ms": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parse-ms/-/parse-ms-1.0.1.tgz",
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
       "dev": true
     },
     "parseurl": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/parseurl/-/parseurl-1.3.1.tgz",
       "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -5327,25 +4957,25 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -5356,25 +4986,25 @@
     },
     "pbkdf2-compat": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
       "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og=",
       "dev": true
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
     "phantomjs": {
       "version": "1.9.20",
-      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/phantomjs/-/phantomjs-1.9.20.tgz",
       "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
       "dev": true,
       "requires": {
@@ -5390,7 +5020,7 @@
       "dependencies": {
         "fs-extra": {
           "version": "0.26.7",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/fs-extra/-/fs-extra-0.26.7.tgz",
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
@@ -5403,7 +5033,7 @@
         },
         "which": {
           "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.2.14.tgz",
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
@@ -5414,28 +5044,37 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
       }
     },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
     "pkg-up": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
@@ -5444,19 +5083,19 @@
     },
     "plur": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/plur/-/plur-1.0.0.tgz",
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "portscanner": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/portscanner/-/portscanner-1.2.0.tgz",
       "integrity": "sha1-sUu9olfRTDEPqcwJaCrwLUCWGAI=",
       "dev": true,
       "requires": {
@@ -5465,7 +5104,7 @@
     },
     "postcss": {
       "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
       "requires": {
@@ -5477,7 +5116,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -5485,7 +5124,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
@@ -5496,7 +5135,7 @@
     },
     "postcss-colormin": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
@@ -5507,7 +5146,7 @@
     },
     "postcss-convert-values": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
@@ -5517,7 +5156,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
@@ -5526,7 +5165,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
@@ -5535,7 +5174,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
@@ -5544,7 +5183,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
@@ -5553,7 +5192,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
@@ -5563,7 +5202,7 @@
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
@@ -5573,7 +5212,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
@@ -5584,7 +5223,7 @@
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
@@ -5593,7 +5232,7 @@
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
@@ -5606,13 +5245,13 @@
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
       "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
       "dev": true
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
@@ -5623,7 +5262,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
@@ -5633,7 +5272,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
@@ -5645,7 +5284,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
@@ -5657,7 +5296,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
@@ -5666,7 +5305,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
@@ -5678,7 +5317,7 @@
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
@@ -5688,7 +5327,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
@@ -5698,7 +5337,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
@@ -5707,7 +5346,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
@@ -5718,7 +5357,7 @@
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
@@ -5729,7 +5368,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
@@ -5741,7 +5380,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
@@ -5752,13 +5391,13 @@
     },
     "postcss-value-parser": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
@@ -5769,25 +5408,25 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-ms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
@@ -5796,27 +5435,33 @@
         "plur": "1.0.0"
       }
     },
+    "private": {
+      "version": "0.1.7",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "protractor": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/protractor/-/protractor-4.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/protractor/-/protractor-4.0.4.tgz",
       "integrity": "sha1-ZFnfWtWfh0mOcwttrhkv7rYfh/A=",
       "dev": true,
       "requires": {
@@ -5829,14 +5474,14 @@
         "q": "1.4.1",
         "saucelabs": "1.3.0",
         "selenium-webdriver": "2.53.3",
-        "source-map-support": "0.4.15",
+        "source-map-support": "0.4.16",
         "webdriver-manager": "10.2.5"
       },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5846,50 +5491,41 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
         }
       }
     },
     "prr": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "q": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/q/-/q-1.4.1.tgz",
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "qs": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.2.1.tgz",
       "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw=",
       "dev": true
     },
     "query-string": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/query-string/-/query-string-3.0.3.tgz",
       "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
       "dev": true,
       "requires": {
@@ -5898,20 +5534,20 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -5920,7 +5556,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -5929,7 +5565,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -5940,7 +5576,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -5951,13 +5587,13 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "raw-body": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/raw-body/-/raw-body-2.1.7.tgz",
       "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
       "dev": true,
       "requires": {
@@ -5968,13 +5604,13 @@
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bytes/-/bytes-2.4.0.tgz",
           "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
           "dev": true
         },
         "iconv-lite": {
           "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/iconv-lite/-/iconv-lite-0.4.13.tgz",
           "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
           "dev": true
         }
@@ -5982,13 +5618,13 @@
     },
     "read-installed": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-installed/-/read-installed-4.0.3.tgz",
       "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "requires": {
         "debuglog": "1.0.1",
         "graceful-fs": "4.1.11",
-        "read-package-json": "2.0.10",
+        "read-package-json": "2.0.11",
         "readdir-scoped-modules": "1.0.2",
         "semver": "5.1.0",
         "slide": "1.1.6",
@@ -5996,21 +5632,21 @@
       }
     },
     "read-package-json": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.10.tgz",
-      "integrity": "sha512-iNWaEs9hW9nviu5rHADmkm/Ob5dvah5zajtTS1XbyERSzkWgSwWZ6Z12bION7bEAzVc2YRFWnAz8k/tAr+5/eg==",
+      "version": "2.0.11",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-package-json/-/read-package-json-2.0.11.tgz",
+      "integrity": "sha1-Xj4e8x5xRtkfu3m/n7HnYRtnAGw=",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "json-parse-helpfulerror": "1.0.3",
+        "json-parse-better-errors": "1.0.1",
         "normalize-package-data": "2.4.0"
       },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -6020,21 +5656,12 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
         }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -6045,7 +5672,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -6055,7 +5682,7 @@
     },
     "readable-stream": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "dev": true,
       "requires": {
@@ -6069,7 +5696,7 @@
     },
     "readdir-scoped-modules": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
       "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
       "dev": true,
       "requires": {
@@ -6081,7 +5708,7 @@
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
@@ -6089,22 +5716,11 @@
         "minimatch": "3.0.4",
         "readable-stream": "2.0.6",
         "set-immediate-shim": "1.0.1"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        }
       }
     },
     "readline2": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
@@ -6115,17 +5731,17 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-          "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+          "version": "1.4.0",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve/-/resolve-1.4.0.tgz",
+          "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
@@ -6135,7 +5751,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -6145,27 +5761,65 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
         "balanced-match": "0.4.2",
         "math-expression-evaluator": "1.2.17",
         "reduce-function-call": "1.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
       }
     },
     "reduce-function-call": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
         "balanced-match": "0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.3.2",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerate/-/regenerate-1.3.2.tgz",
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.7"
       }
     },
     "regex-cache": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
       "dev": true,
       "requires": {
@@ -6173,26 +5827,60 @@
         "is-primitive": "2.0.0"
       }
     },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -6201,7 +5889,7 @@
     },
     "request": {
       "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.67.0.tgz",
       "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
       "dev": true,
       "requires": {
@@ -6218,7 +5906,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "node-uuid": "1.4.8",
         "oauth-sign": "0.8.2",
         "qs": "5.2.1",
@@ -6229,7 +5917,7 @@
     },
     "request-progress": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
@@ -6238,7 +5926,7 @@
     },
     "request-promise": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request-promise/-/request-promise-2.0.0.tgz",
       "integrity": "sha1-6J1q4O3DqXyJT5Z6i/UCXCPRPbM=",
       "dev": true,
       "requires": {
@@ -6249,7 +5937,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -6257,19 +5945,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -6279,30 +5967,30 @@
     },
     "requirejs": {
       "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/requirejs/-/requirejs-2.1.22.tgz",
       "integrity": "sha1-3Xj9LTQYDA1ixyS1uK68BmTgNm8=",
       "dev": true
     },
     "reqwest": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/reqwest/-/reqwest-2.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/reqwest/-/reqwest-2.0.5.tgz",
       "integrity": "sha1-APsVrEkYxBnKgrQ/JMeIguZgOaE="
     },
     "resolve": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve/-/resolve-0.3.1.tgz",
       "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
       "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-pkg": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-pkg/-/resolve-pkg-0.1.0.tgz",
       "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
       "dev": true,
       "requires": {
@@ -6311,7 +5999,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         }
@@ -6319,7 +6007,7 @@
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
@@ -6329,7 +6017,7 @@
     },
     "retire": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/retire/-/retire-1.1.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/retire/-/retire-1.1.6.tgz",
       "integrity": "sha1-8ZQ2tc879+0soslilvETqgR5WNU=",
       "dev": true,
       "requires": {
@@ -6342,7 +6030,7 @@
       "dependencies": {
         "commander": {
           "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/commander/-/commander-2.5.1.tgz",
           "integrity": "sha1-I8Yfbke+FDzALnrUuxxH9c1aKIM=",
           "dev": true
         }
@@ -6350,7 +6038,7 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
         "align-text": "0.1.4"
@@ -6358,19 +6046,19 @@
     },
     "rimraf": {
       "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
     },
     "ripemd160": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ripemd160/-/ripemd160-0.2.0.tgz",
       "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
       "dev": true
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -6379,19 +6067,19 @@
     },
     "rx-lite": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
@@ -6403,13 +6091,13 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
@@ -6420,8 +6108,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -6432,24 +6120,9 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "yargs": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
@@ -6472,7 +6145,7 @@
     },
     "saucelabs": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.3.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/saucelabs/-/saucelabs-1.3.0.tgz",
       "integrity": "sha1-0kDoAJ33+ocwbsRXimm6O1xCT+4=",
       "dev": true,
       "requires": {
@@ -6481,13 +6154,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -6497,12 +6170,12 @@
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "selenium-webdriver": {
       "version": "2.53.3",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/selenium-webdriver/-/selenium-webdriver-2.53.3.tgz",
       "integrity": "sha1-0p/1qVff8aG0ncRXdW5OS/vc4IU=",
       "dev": true,
       "requires": {
@@ -6515,7 +6188,7 @@
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/adm-zip/-/adm-zip-0.4.4.tgz",
           "integrity": "sha1-ph7VrmkFw66lizplfSUDMJEFJzY=",
           "dev": true
         }
@@ -6523,24 +6196,24 @@
     },
     "semver": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.1.0.tgz",
       "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
       "dev": true
     },
     "send": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
-      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "version": "0.15.4",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/send/-/send-0.15.4.tgz",
+      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
       "dev": true,
       "requires": {
-        "debug": "2.6.7",
-        "depd": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "1.6.1",
+        "http-errors": "1.6.2",
         "mime": "1.3.4",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
@@ -6550,7 +6223,7 @@
     },
     "serve-index": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/serve-index/-/serve-index-1.9.0.tgz",
       "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
       "dev": true,
       "requires": {
@@ -6558,91 +6231,86 @@
         "batch": "0.6.1",
         "debug": "2.6.8",
         "escape-html": "1.0.3",
-        "http-errors": "1.6.1",
-        "mime-types": "2.1.15",
+        "http-errors": "1.6.2",
+        "mime-types": "2.1.16",
         "parseurl": "1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "serve-static": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
-      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "version": "1.12.4",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/serve-static/-/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.1",
-        "send": "0.15.3"
+        "send": "0.15.4"
       }
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "setprototypeof": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
       "dev": true
     },
     "sha.js": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sha.js/-/sha.js-2.2.6.tgz",
       "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo=",
       "dev": true
     },
     "shelljs": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/shelljs/-/shelljs-0.5.1.tgz",
       "integrity": "sha1-D8DD+Q+HGEAjoSWnu83jFEe09GQ=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "slide": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
@@ -6651,7 +6319,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
@@ -6660,22 +6328,22 @@
     },
     "source-list-map": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-list-map/-/source-list-map-0.1.8.tgz",
       "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
       "dev": true
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": "1.0.1"
       }
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.16",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map-support/-/source-map-support-0.4.16.tgz",
+      "integrity": "sha1-Fv7PmCEkZ9AX1Yair2jWKLlCHNg=",
       "dev": true,
       "requires": {
         "source-map": "0.5.6"
@@ -6683,7 +6351,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         }
@@ -6691,7 +6359,7 @@
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
@@ -6700,25 +6368,25 @@
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
@@ -6734,7 +6402,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -6742,13 +6410,13 @@
     },
     "statuses": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
@@ -6757,7 +6425,7 @@
     },
     "stream-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "dev": true,
       "requires": {
@@ -6767,13 +6435,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -6787,19 +6455,19 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -6810,13 +6478,13 @@
     },
     "stringstream": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -6825,13 +6493,13 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -6840,13 +6508,13 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
@@ -6855,7 +6523,7 @@
     },
     "svgo": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
@@ -6870,7 +6538,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -6879,37 +6547,25 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
         "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "version": "2.1.1",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6918,7 +6574,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -6929,13 +6585,13 @@
     },
     "tapable": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -6946,7 +6602,7 @@
     },
     "temporary": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/temporary/-/temporary-0.0.8.tgz",
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
@@ -6955,25 +6611,25 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "time-grunt": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/time-grunt/-/time-grunt-1.4.0.tgz",
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
@@ -6988,13 +6644,13 @@
     },
     "time-zone": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/time-zone/-/time-zone-0.1.0.tgz",
       "integrity": "sha1-Sncotqwo2w4Aj1FAQ/1VW9VXO0Y=",
       "dev": true
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -7003,12 +6659,12 @@
     },
     "tiny-emitter": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
       "integrity": "sha1-q0BaIf/tgUp2wZc5ZICT1wZU/ss="
     },
     "tiny-lr": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
@@ -7022,7 +6678,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "dev": true,
           "requires": {
@@ -7031,13 +6687,13 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
         "qs": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-5.1.0.tgz",
           "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
           "dev": true
         }
@@ -7045,50 +6701,62 @@
     },
     "tmp": {
       "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tmp/-/tmp-0.0.24.tgz",
       "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.2.2.tgz",
       "integrity": "sha1-yDoYMPTl7wuT7yo0iOck+N4Basc=",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tryit": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -7097,28 +6765,28 @@
     },
     "type-is": {
       "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "u2f-api-polyfill": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/u2f-api-polyfill/-/u2f-api-polyfill-0.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/u2f-api-polyfill/-/u2f-api-polyfill-0.4.1.tgz",
       "integrity": "sha1-bkFcRz7vxAqJc/NycZUrUtRD2a0="
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
@@ -7129,7 +6797,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "optional": true
         }
@@ -7137,35 +6805,35 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
     },
     "ultron": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "underscore.string": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqid": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
@@ -7174,19 +6842,19 @@
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
@@ -7196,7 +6864,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -7204,7 +6872,7 @@
     },
     "user-home": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
@@ -7213,7 +6881,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
@@ -7222,7 +6890,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         }
@@ -7230,25 +6898,25 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "util-extend": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/util-extend/-/util-extend-1.0.3.tgz",
       "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
@@ -7258,22 +6926,32 @@
     },
     "vendors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/vendors/-/vendors-1.0.1.tgz",
       "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
       "dev": true
     },
     "verror": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "version": "1.10.0",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "extsprintf": "1.0.2"
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
       }
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -7282,13 +6960,13 @@
     },
     "walkdir": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/walkdir/-/walkdir-0.0.7.tgz",
       "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik=",
       "dev": true
     },
     "watchpack": {
       "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/watchpack/-/watchpack-0.2.9.tgz",
       "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
       "dev": true,
       "requires": {
@@ -7299,7 +6977,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -7307,7 +6985,7 @@
     },
     "webdriver-manager": {
       "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/webdriver-manager/-/webdriver-manager-10.2.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webdriver-manager/-/webdriver-manager-10.2.5.tgz",
       "integrity": "sha1-ZDPBpksDg4jCle0NydqnHl31Ak4=",
       "dev": true,
       "requires": {
@@ -7320,30 +6998,30 @@
         "q": "1.4.1",
         "request": "2.81.0",
         "rimraf": "2.6.1",
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       },
       "dependencies": {
         "caseless": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/caseless/-/caseless-0.12.0.tgz",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "mime-types": "2.1.16"
           }
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7356,7 +7034,7 @@
         },
         "har-validator": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
@@ -7364,30 +7042,21 @@
             "har-schema": "1.0.5"
           }
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
@@ -7404,7 +7073,7 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
+            "mime-types": "2.1.16",
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
@@ -7417,7 +7086,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
@@ -7425,14 +7094,14 @@
           }
         },
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.4.1",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
@@ -7441,7 +7110,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
@@ -7450,15 +7119,15 @@
         },
         "uuid": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
           "dev": true
         }
       }
     },
     "webpack": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webpack/-/webpack-1.13.1.tgz",
       "integrity": "sha1-CmnojlvcWTk5NS1dd94PmsnQhx4=",
       "dev": true,
       "requires": {
@@ -7481,25 +7150,25 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         },
         "interpret": {
           "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/interpret/-/interpret-0.6.6.tgz",
           "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/uglify-js/-/uglify-js-2.6.4.tgz",
           "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
           "dev": true,
           "requires": {
@@ -7511,7 +7180,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/async/-/async-0.2.10.tgz",
               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
               "dev": true
             }
@@ -7521,7 +7190,7 @@
     },
     "webpack-core": {
       "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/webpack-core/-/webpack-core-0.6.9.tgz",
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
@@ -7531,7 +7200,7 @@
     },
     "websocket-driver": {
       "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/websocket-driver/-/websocket-driver-0.6.5.tgz",
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "dev": true,
       "requires": {
@@ -7540,32 +7209,32 @@
     },
     "websocket-extensions": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
       "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
       "dev": true
     },
     "whet.extend": {
       "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/whet.extend/-/whet.extend-0.9.9.tgz",
       "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
       "dev": true
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
       "dev": true
     },
     "which-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -7573,17 +7242,17 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -7593,13 +7262,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -7608,7 +7277,7 @@
     },
     "ws": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ws/-/ws-1.1.4.tgz",
       "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
       "dev": true,
       "requires": {
@@ -7618,12 +7287,12 @@
     },
     "xhr2": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.3.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xhr2/-/xhr2-0.1.3.tgz",
       "integrity": "sha1-y/xHWaabSoiOeM9PILBRA4dXvRE="
     },
     "xml2js": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xml2js/-/xml2js-0.4.4.tgz",
       "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
       "dev": true,
       "requires": {
@@ -7633,7 +7302,7 @@
       "dependencies": {
         "sax": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/sax/-/sax-0.6.1.tgz",
           "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk=",
           "dev": true
         }
@@ -7641,7 +7310,7 @@
     },
     "xmlbuilder": {
       "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
       "integrity": "sha1-b/etYPty0idk8AehZLd/K/FABSY=",
       "dev": true,
       "requires": {
@@ -7650,7 +7319,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -7658,25 +7327,25 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "1.2.1",
@@ -7687,7 +7356,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
@@ -7696,7 +7365,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -7704,7 +7373,7 @@
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "autoprefixer": "6.7.7",
     "axe-core": "2.0.7",
     "axe-webdriverjs": "0.4.0",
+    "babel-core": "6",
+    "babel-loader": "6",
+    "babel-preset-env": "^1.6.0",
     "cssnano": "3.10.0",
     "fs-extra": "1.0.0",
     "git-rev-sync": "1.4.0",
@@ -81,6 +84,7 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "1.8.0",
+    "babel-polyfill": "^6.23.0",
     "backbone": "1.2.1",
     "clipboard": "1.6.1",
     "handlebars": "4.0.5",

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -125,8 +125,8 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       border.removeClass('auth-beacon-border');
       await Animations.radialProgressBar({
         $el: radialProgressBar,
-        swap: function () {
-          image.fadeOut(duration, function () {
+        swap() {
+          image.fadeOut(duration, () => {
             setBackgroundImage(image, appState);
             image.fadeIn(duration);
           });

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -92,7 +92,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
     $(window).off('resize.securityBeaconQtip');
   }
 
-  function updateSecurityImage($el, appState, animate) {
+  async function updateSecurityImage($el, appState, animate) {
     var image = $el.find('.auth-beacon-security'),
         border = $el.find('.js-auth-beacon-border'),
         hasBorder = !appState.get('isUndefinedUser'),
@@ -123,7 +123,7 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
       // Animate loading the security beacon with a loading bar for the border
       // This occurrs when the username has been checked against Okta.
       border.removeClass('auth-beacon-border');
-      Animations.radialProgressBar({
+      await Animations.radialProgressBar({
         $el: radialProgressBar,
         swap: function () {
           image.fadeOut(duration, function () {
@@ -131,13 +131,11 @@ define(['okta', 'util/Animations'], function (Okta, Animations) {
             image.fadeIn(duration);
           });
         }
-      }).then(function () {
-        border.addClass('auth-beacon-border');
-      }).then(function () {
-        if (hasAntiPhishing) {
-          antiPhishingMessage(image, host);
-        }
       });
+      border.addClass('auth-beacon-border');
+      if (hasAntiPhishing) {
+        antiPhishingMessage(image, host);
+      }
     }
   }
 

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -6,7 +6,7 @@ var SHARED_JS = TARGET_JS + '/shared';
 // Return a function so that all consumers get a new copy of the config
 module.exports = function (outputFilename) {
   return {
-    entry: './target/js/widget/OktaSignIn.js',
+    entry: ['babel-polyfill', './target/js/widget/OktaSignIn.js'],
     output: {
       path: TARGET_JS,
       filename: outputFilename,
@@ -58,7 +58,8 @@ module.exports = function (outputFilename) {
         'shared/views/components/DropDown': EMPTY,
         'shared/util/markdownToHtml': EMPTY,
         'shared/util/Metrics': EMPTY,
-        'shared/views/wizard/BaseWizard': EMPTY
+        'shared/views/wizard/BaseWizard': EMPTY,
+        'vendor/plugins/vkbeautify.0.99.00.beta': EMPTY
       }
     },
 
@@ -99,7 +100,16 @@ module.exports = function (outputFilename) {
           ].map(function (file) {
             return path.resolve(TARGET_JS, 'shared', file);
           })
-        }
+        },
+        // Babel
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'babel-loader',
+          query: {
+            presets: ['env']
+          }
+        },
       ]
     },
 

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -3,7 +3,7 @@ var _             = require('underscore');
 var commonConfig  = require('./webpack.common.config');
 var testConfig    = commonConfig('main-tests.js');
 
-testConfig.entry = './target/js/test/unit/main.js';
+testConfig.entry = ['babel-polyfill', './target/js/test/unit/main.js'];
 testConfig.output.path = path.resolve(__dirname, 'target/test/unit');
 testConfig.devtool = '#inline-source-map';
 


### PR DESCRIPTION
:art: Add babel and async/await support to okta-signin-widget

- Add babel 6 like we have in okta-core (babel-loader 7 requires webpack 2 or 3).
- Add async/await support
- Add ES2017 support to ESLINT
- Remove 'vendor/plugins/vkbeautify.0.99.00.beta' dependency (didn't respect 'use strict' from babel, see https://github.com/vkiryukhin/vkBeautify/issues/21)
- Converted SecurityBeacon.js to async/await as an example
- Tested on chrome/safari/ff/ie11

Resolves: [OKTA-137899](https://oktainc.atlassian.net/browse/OKTA-137899)

@rchild-okta @rajaguruduraisamy-okta @ukilon-okta 