### PR TITLE
Fix checkbox image location in prod builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -305,6 +305,27 @@ module.exports = function (grunt) {
         }())
       }
     },
+  
+    search: {
+      noAbsoluteUrlsInCss: {
+        files: {
+          src: ['assets/sass/**/*.scss']
+        },
+        options: {
+          searchString: /url\([\'\"]\//g,
+          failOnMatch: true,
+          logFile: SCSSLINT_OUT_FILE,
+          logFormat: 'xml',
+          onMatch: function(match) {
+            grunt.log.errorlns('URLs starting with \'/\' are not allowed in SCSS files. ' +
+              'Fix this by replacing with a relative link.');
+            grunt.log.errorlns('Found in file: ' + match.file + '. Line: ' + match.line);
+            grunt.log.errorlns('Error log also written to: ' + SCSSLINT_OUT_FILE);
+            grunt.log.errorlns('');
+          }
+        }
+      }
+    },
 
     exec: {
       'clean': 'npm run clean',
@@ -536,6 +557,6 @@ module.exports = function (grunt) {
 
   grunt.task.registerTask('start-server', ['copy:server', 'connect:server']);
   grunt.task.registerTask('start-server-open', ['copy:server', 'connect:open']);
-  grunt.task.registerTask('lint', ['scss-lint', 'eslint']);
+  grunt.task.registerTask('lint', ['scss-lint', 'search:noAbsoluteUrlsInCss', 'eslint']);
   grunt.task.registerTask('default', ['lint', 'test']);
 };

--- a/assets/sass/modules/_forms.scss
+++ b/assets/sass/modules/_forms.scss
@@ -250,7 +250,7 @@
 
 .custom-checkbox {
   label {
-    background-image: url('/img/ui/forms/checkbox-sign-in-widget.png');
+    background-image: url('../img/ui/forms/checkbox-sign-in-widget.png');
   }
 
   label.focus {
@@ -267,7 +267,7 @@ only screen and (min-device-pixel-ratio: 2),
 only screen and (min-resolution: 2dppx) {
   .custom-checkbox {
     label {
-      background-image: url('/img/ui/forms/checkbox-sign-in-widget@2x.png');
+      background-image: url('../img/ui/forms/checkbox-sign-in-widget@2x.png');
       background-size: 50px 1155px;
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,13 +53,15 @@
     "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-jasmine": "0.9.2",
     "grunt-contrib-jshint": "0.11.2",
-    "grunt-eslint": "^19.0.0",
     "grunt-contrib-requirejs": "0.4.4",
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-exec": "0.4.6",
     "grunt-json-generator": "0.1.0",
     "grunt-postcss": "0.8.0",
     "grunt-retire": "0.3.12",
     "grunt-sass": "2.0.0",
+    "grunt-search": "^0.1.8",
     "grunt-template-jasmine-requirejs": "0.2.3",
     "imports-loader": "0.6.5",
     "json-loader": "0.5.4",
@@ -75,8 +77,7 @@
     "semver": "5.1.0",
     "time-grunt": "1.4.0",
     "webdriver-manager": "10.2.5",
-    "webpack": "1.13.1",
-    "grunt-contrib-watch": "1.0.0"
+    "webpack": "1.13.1"
   },
   "dependencies": {
     "@okta/okta-auth-js": "1.8.0",


### PR DESCRIPTION
1. Moved checkbox to relative URL.
2. Added post task to scss lint to fail on match of URL that starts with '/'

### Sample errors on console
```
[okta-signin-widget:fix-checkbox-image-location okta-signin-widget]$ grunt lint
Running "scss-lint:all" (scss-lint) task
>> Running: scss-lint

Running "search:noAbsoluteUrlsInCss" (search) task
>> URLs starting with '/' are not allowed in SCSS files.
>> Found in file: assets/sass/modules/_forms.scss. Line: 253
>> Error log also written to: build2/loginscss-checkstyle-result.xml
>> 
>> URLs starting with '/' are not allowed in SCSS files.
>> Found in file: assets/sass/modules/_forms.scss. Line: 270
>> Error log also written to: build2/loginscss-checkstyle-result.xml
>> 
Fatal error: Matches of /url\([\'\"]\//g found


Execution Time (2017-08-18 14:36:40 UTC-7)
loading tasks  524ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 20%
scss-lint:all   2.1s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 79%
Total 2.6s
```

Sample LOG XML:

```
<?xml version="1.0"?>
<search>
	<numResults>2</numResults>
	<creationDate>2017-08-18 22:23:25</creationDate>
	<results>
		<result>
			<file>assets/sass/modules/_forms.scss</file>
			<line>253</line>
			<match>url('/</match>
			<searchStr>/url\([\'\"]\//g</searchStr>
		</result>
		<result>
			<file>assets/sass/modules/_forms.scss</file>
			<line>270</line>
			<match>url('/</match>
			<searchStr>/url\([\'\"]\//g</searchStr>
		</result>
	</results>
</search>
```