### PR TITLE
:bug: Hides send email link when emailRecovery is disabled

### DIFF
--- a/src/RecoveryChallengeController.js
+++ b/src/RecoveryChallengeController.js
@@ -150,7 +150,7 @@ function (Okta, FormController, FormType, Enums, FooterSignout, TextBox) {
         break;
       }
 
-      if (sendEmailLink) {
+      if (sendEmailLink && this.settings.get('features.emailRecovery')) {
         this.add(sendEmailLink);
       }
 

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 17], max-statements:[2, 35] */
+/* eslint max-params: [2, 17], max-statements:[2, 37] */
 define([
   'vendor/lib/q',
   'okta/underscore',
@@ -656,6 +656,18 @@ function (Q, _, $, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Reset via email');
         });
       });
+      itp('does not show the "Reset via email" link after sending sms if emailRecovery is false', function () {
+        return setupWithSmsWithoutEmail()
+        .then(function (test) {
+          test.setNextResponse(resChallengeSms);
+          test.form.setUsername('foo');
+          test.form.sendSms();
+          return Expect.waitForRecoveryChallenge(test);
+        })
+        .then(function (test) {
+          expect(test.form.hasSendEmailLink()).toBe(false);
+        });
+      });
       itp('sends an email when user clicks the "Reset via email" link, after sending sms', function () {
         return setupWithSms().then(function (test) {
           test.setNextResponse(resChallengeSms);
@@ -728,6 +740,18 @@ function (Q, _, $, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
         .then(function (test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Reset via email');
+        });
+      });
+      itp('does not show the "Reset via email" link after making a Voice Call if emailRecovery is false', function () {
+        return setupWithCallWithoutEmail()
+        .then(function (test) {
+          test.setNextResponse(resChallengeCall);
+          test.form.setUsername('foo');
+          test.form.makeCall();
+          return Expect.waitForRecoveryChallenge(test);
+        })
+        .then(function (test) {
+          expect(test.form.hasSendEmailLink()).toBe(false);
         });
       });
       itp('sends an email when user clicks the "Reset via email" link, after making a Voice Call', function () {

--- a/test/unit/spec/UnlockAccount_spec.js
+++ b/test/unit/spec/UnlockAccount_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 16], max-statements: [2, 22] */
+/* eslint max-params: [2, 16], max-statements: [2, 23] */
 define([
   'vendor/lib/q',
   'okta/underscore',
@@ -395,6 +395,18 @@ function (Q, _, $, OktaAuth, Util, AccountRecoveryForm, Beacon, Expect,
         .then(function (test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive an SMS? Unlock via email');
+        });
+      });
+      itp('does not show the "Unlock via email" link after sending sms if emailRecovery is false', function () {
+        return setupWithSmsWithoutEmail()
+        .then(function (test) {
+          test.setNextResponse(resChallengeSms);
+          test.form.setUsername('foo');
+          test.form.sendSms();
+          return Expect.waitForRecoveryChallenge(test);
+        })
+        .then(function (test) {
+          expect(test.form.hasSendEmailLink()).toBe(false);
         });
       });
       itp('sends an email when user clicks the "Unlock via email" link, after sending sms', function () {


### PR DESCRIPTION
Resolves: OKTA-139667

When emailRecovery is true

<img width="425" alt="screen shot 2017-08-31 at 10 28 53 am" src="https://user-images.githubusercontent.com/26014318/29936507-542b2250-8e37-11e7-9c47-223b305f0b9d.png">

When emailRecovery is false

<img width="425" alt="screen shot 2017-08-31 at 10 23 09 am" src="https://user-images.githubusercontent.com/26014318/29936516-60c87530-8e37-11e7-9531-9950a2ebe932.png">

