### PR TITLE
Fix padding on smaller screens when security image is hidden

### DIFF
--- a/assets/sass/_layout.scss
+++ b/assets/sass/_layout.scss
@@ -60,7 +60,9 @@
     padding-right: 20px;
   }
 
-  .can-remove-beacon & {
+  // scss-lint:disable IdSelector
+  #okta-sign-in.can-remove-beacon & {
+  // scss-lint:disable IdSelector
     padding-top: 40px;
 
     @include max-height-mq(550px) {
@@ -82,8 +84,9 @@
 
 .enroll-choices {
   padding-top: 20px;
-
-  .can-remove-beacon & {
+  // scss-lint:disable IdSelector
+  #okta-sign-in.can-remove-beacon & {
+  // scss-lint:disable IdSelector
     @include max-height-mq(550px) {
       padding-top: 15px;
     }

--- a/assets/sass/modules/_beacon.scss
+++ b/assets/sass/modules/_beacon.scss
@@ -19,7 +19,9 @@
     }
   }
 
-  .can-remove-beacon & {
+  // scss-lint:disable IdSelector
+  #okta-sign-in.can-remove-beacon & {
+  // scss-lint:disable IdSelector
     @include max-height-mq(550px) {
       display: none;
     }

--- a/assets/sass/modules/_header.scss
+++ b/assets/sass/modules/_header.scss
@@ -7,8 +7,9 @@
   -moz-transition: padding-bottom 0.4s;
   -webkit-transition: padding-bottom 0.4s;
   transition: padding-bottom 0.4s;
-
-  .can-remove-beacon & {
+  // scss-lint:disable IdSelector
+  #okta-sign-in.can-remove-beacon & {
+  // scss-lint:disable IdSelector
     @include max-height-mq(550px) {
       padding: 30px 90px 25px;
     }


### PR DESCRIPTION
### Description

- The specificity of auth-content and auth-header classes were more because of the addition of #okta-sign-in.
- Because of that anything under .can-remove-beacon .auth-* did not affect anything as id selector was more specific.
- Adding #okta-sign-in to .can-remove-beacon to imporove specificity, so that the padding overloads apply on small screens.

### Reviewers

- @rchild-okta 
- @lboyette-okta 
- @mauriciocastillosilva-okta 

### Additional reviewers

- @upteam-okta 

### Screenshare

![signin-security](https://user-images.githubusercontent.com/24683447/30223614-7c49730a-9480-11e7-8839-4e02562d7a91.gif)
