### PR TITLE
:bug: Fix banner css in sign in widget.

### DIFF
--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -23,6 +23,10 @@
   z-index: -5;
 }
 
+.okta-container {
+  @import 'modules/app-login-banner';
+}
+
 // scss-lint:disable IdSelector
 #okta-sign-in {
 // scss-lint:enable IdSelector
@@ -46,7 +50,6 @@
   @import 'modules/factors-dropdown';
   @import 'modules/footer';
   @import 'modules/enroll';
-  @import 'modules/app-login-banner';
   @import 'modules/accessibility';
   @import 'modules/registration';
 


### PR DESCRIPTION
- Move `@import modules/app-login-banner` outside of okta-sign-in  container  
-  Created new class  .okta-container and moved `@import modules/app-login-banner` inside it
- Related okta-core PR https://github.com/okta/okta-core/pull/23084

@santhoshbalakrishnan @hor-kanchan-okta @rchild-okta 
before : 


<img width="629" alt="screen shot 2017-09-21 at 4 44 06 pm" src="https://user-images.githubusercontent.com/23267876/30725834-48d29caa-9efc-11e7-86ca-6ebfdd650886.png">


after: 

<img width="1431" alt="screen shot 2017-09-21 at 6 22 35 pm" src="https://user-images.githubusercontent.com/23267876/30725845-5693c6f2-9efc-11e7-9cf8-6f1d78c22c7e.png">
