### PR TITLE
:Bug:  Fix bundle in sign in widget.

### DIFF
--- a/src/util/Bundles.js
+++ b/src/util/Bundles.js
@@ -216,9 +216,11 @@ define([
         // properties are not translated
         this.login = _.extend({}, login, bundles.login);
         this.country = _.extend({}, country, bundles.country);
+        this.courage = _.extend({}, login, bundles.login);
         if (parsedOverrides[lowerCaseLanguage]) {
           _.extend(this.login, parsedOverrides[lowerCaseLanguage]['login']);
           _.extend(this.country, parsedOverrides[lowerCaseLanguage]['country']);
+          _.extend(this.courage, parsedOverrides[lowerCaseLanguage]['login']);
         }
         this.currentLanguage = language;
       }, this));

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -6,6 +6,10 @@ define(['okta/jquery', 'okta/underscore', './Dom'], function ($, _, Dom) {
       return this.el('o-form-head').trimmedText();
     },
 
+    errorBannerText: function () {
+      return this.el('o-form-error-container').trimmedText();
+    },
+
     subtitleText: function () {
       return this.el('o-form-explain').trimmedText();
     },

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -6,10 +6,6 @@ define(['okta/jquery', 'okta/underscore', './Dom'], function ($, _, Dom) {
       return this.el('o-form-head').trimmedText();
     },
 
-    errorBannerText: function () {
-      return this.el('o-form-error-container').trimmedText();
-    },
-
     subtitleText: function () {
       return this.el('o-form-explain').trimmedText();
     },

--- a/test/unit/helpers/xhr/labels_login_ja.js
+++ b/test/unit/helpers/xhr/labels_login_ja.js
@@ -4,6 +4,6 @@ define({
   'response': {
     'enroll.call.setup': 'JA: enroll.call.setup',
     'security.disliked_food': 'JA: What is the food you least liked as a child?',
-    'oform.errorbanner.title': 'Japanese error banner title'
+    'oform.errorbanner.title': 'JA: Japanese error banner title'
   }
 });

--- a/test/unit/helpers/xhr/labels_login_ja.js
+++ b/test/unit/helpers/xhr/labels_login_ja.js
@@ -3,6 +3,7 @@ define({
   'responseType': 'json',
   'response': {
     'enroll.call.setup': 'JA: enroll.call.setup',
-    'security.disliked_food': 'JA: What is the food you least liked as a child?'
+    'security.disliked_food': 'JA: What is the food you least liked as a child?',
+    'oform.errorbanner.title': 'Japanese error banner title'
   }
 });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -975,6 +975,48 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
           expect(test.form.selectedCountry()).toBe('Nihon');
         });
       });
+
+      itp('overrides text for keys in courage bundle for non english languages', function () {
+        return setupLanguage({
+          settings: {
+            language: 'NL',
+            i18n: {
+              'nl': {
+                'oform.errorbanner.title': 'Dutch error banner title'
+              }
+            }
+          }
+        })
+        .then(function (test) {
+          test.form.submit();
+          expect(test.form.errorBannerText()).toBe('Dutch error banner title');
+        });
+      });
+
+      itp('Text for keys in courage bundle are in jp as set in settings.language', function () {
+        return setupLanguage({
+          mockLanguageRequest: 'ja',
+          settings: {
+            language: 'ja'
+          }
+        })
+        .then(function(test){
+          test.form.submit();
+          expect(test.form.errorBannerText()).toBe('Japanese error banner title');
+        });
+      });
+
+      itp('Text for keys in courage bundle are in en as set in settings.language', function () {
+        return setupLanguage({
+          settings: {
+            language: 'en'
+          }
+        })
+        .then(function(test){
+          test.form.submit();
+          expect(test.form.errorBannerText()).toBe('We found some errors. Please review the form and make corrections.');
+        });
+      });
     });
 
     Expect.describe('Config: "assets"', function () {
@@ -1296,7 +1338,8 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
               ja: {
                 login: {
                   'enroll.call.setup': 'JA: enroll.call.setup',
-                  'security.disliked_food': 'JA: What is the food you least liked as a child?'
+                  'security.disliked_food': 'JA: What is the food you least liked as a child?',
+                  'oform.errorbanner.title': 'Japanese error banner title'
                 },
                 country: {
                   'JP': 'JA: country.JP'

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -976,7 +976,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         });
       });
 
-      itp('overrides text for keys in courage bundle for non english languages', function () {
+      itp('overrides text in the courage bundle for non English language', function () {
         return setupLanguage({
           settings: {
             language: 'NL',
@@ -993,7 +993,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         });
       });
 
-      itp('Text for keys in courage bundle are in jp as set in settings.language', function () {
+      itp('Strings in courage bundle are in jp as set in settings.language', function () {
         return setupLanguage({
           mockLanguageRequest: 'ja',
           settings: {
@@ -1002,16 +1002,12 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         })
         .then(function(test){
           test.form.submit();
-          expect(test.form.errorMessage()).toBe('Japanese error banner title');
+          expect(test.form.errorMessage()).toBe('JA: Japanese error banner title');
         });
       });
 
-      itp('Text for keys in courage bundle are in en as set in settings.language', function () {
-        return setupLanguage({
-          settings: {
-            language: 'en'
-          }
-        })
+      itp('Strings in courage bundle are in en by default', function () {
+        return setupLanguage({})
         .then(function(test){
           test.form.submit();
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1339,7 +1335,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
                 login: {
                   'enroll.call.setup': 'JA: enroll.call.setup',
                   'security.disliked_food': 'JA: What is the food you least liked as a child?',
-                  'oform.errorbanner.title': 'Japanese error banner title'
+                  'oform.errorbanner.title': 'JA: Japanese error banner title'
                 },
                 country: {
                   'JP': 'JA: country.JP'

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -989,7 +989,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         })
         .then(function (test) {
           test.form.submit();
-          expect(test.form.errorBannerText()).toBe('Dutch error banner title');
+          expect(test.form.errorMessage()).toBe('Dutch error banner title');
         });
       });
 
@@ -1002,7 +1002,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         })
         .then(function(test){
           test.form.submit();
-          expect(test.form.errorBannerText()).toBe('Japanese error banner title');
+          expect(test.form.errorMessage()).toBe('Japanese error banner title');
         });
       });
 
@@ -1014,7 +1014,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         })
         .then(function(test){
           test.form.submit();
-          expect(test.form.errorBannerText()).toBe('We found some errors. Please review the form and make corrections.');
+          expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
       });
     });


### PR DESCRIPTION
 - In the sign in widget, we don't use the courage bundle that is referenced inside courage components. To fix this there was a change to point all courage bundle references to login. We made this change in most places, but a few places were missed.

@mauriciocastillosilva-okta @hor-kanchan-okta @rchild-okta 

@upteam-okta 

Test by changing browser language

<img width="427" alt="screen shot 2017-10-02 at 4 15 11 pm" src="https://user-images.githubusercontent.com/23267876/31103646-e960e364-a78c-11e7-9cf5-0970a9e6a233.png">

