### PR TITLE
:Bug: Fix password validation when no username is provided.

### DIFF
--- a/src/util/RegistrationFormFactory.js
+++ b/src/util/RegistrationFormFactory.js
@@ -41,6 +41,23 @@ define([
     }
     return userNameParts.filter(Boolean);
   };
+
+  var passwordContainsUserName = function(username, password) {
+    if(!username) {
+      return false;
+    }
+    username = username.toLowerCase();
+    password = password.toLowerCase();
+    var usernameArr = getParts(username);
+    //check if each username part contains password
+    for (var i=0; i < usernameArr.length; i++){
+      var usernamePart = usernameArr[i];
+      if (password.indexOf(usernamePart) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  };
   
   var checkSubSchema = function(subSchema, value, model) {
     var minLength = subSchema.get('minLength');
@@ -58,26 +75,12 @@ define([
         return false;
       }
     }
-
-    var passwordContainsUserName = function(username, password){
-      var usernameArr = getParts(username);
-      //check if each username part contains password
-      for (var i=0; i < usernameArr.length; i++){
-        var usernamePart = usernameArr[i];
-        if (password.indexOf(usernamePart) !== -1){
-          return true;
-        }
-      }
-    };
     
     if (_.isString(regex)) {
       if (regex === '^[#/userName]') {
-        var username = model.get('userName').toLowerCase();
-
-        var password = value.toLowerCase();
-        if(username.length && password.length && passwordContainsUserName(username, password)) {
-          return false;
-        }
+        var username = model.get('userName');
+        var password = value;
+        return !passwordContainsUserName(username, password);
       } else {
         if (!new RegExp(regex).test(value)) {
           return false;
@@ -165,6 +168,7 @@ define([
 
   return {
     createInputOptions : fnCreateInputOptions,
-    getUsernameParts: getParts
+    getUsernameParts: getParts,
+    passwordContainsUserName: passwordContainsUserName
   };
 });

--- a/test/unit/spec/RegistrationFormFactory_spec.js
+++ b/test/unit/spec/RegistrationFormFactory_spec.js
@@ -130,5 +130,17 @@ function (SchemaProperty, RegistrationFormFactory) {
 
     });
 
+    describe('PasswordContainsUserName', function () {
+      it('returns false if password does not contain username or no username ', function () {
+        expect(RegistrationFormFactory.passwordContainsUserName('administrator1', 'Abcd1234')).toEqual(false);
+        expect(RegistrationFormFactory.passwordContainsUserName(null, 'Abcd1234')).toEqual(false);
+      });
+      it('returns true if password does contain username ', function () {
+        expect(RegistrationFormFactory.passwordContainsUserName('abcd@okta.com', 'Abcd1234')).toEqual(true);
+        expect(RegistrationFormFactory.passwordContainsUserName('abc', 'abc')).toEqual(true);
+        expect(RegistrationFormFactory.passwordContainsUserName('abc', 'abc@okta.com')).toEqual(true);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
- Fixed password complexity validation when username  field is empty. 
- Added tests for passwordContainsUserName function to check for null values. 

Resolves: OKTA-143940

@hor-kanchan-okta 

@upteam-okta 