### PR TITLE
:bug: fix mobile icons alignment

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -213,10 +213,10 @@
   .o-form-input > span {
     display: table;
     width: 100%;
-  }
 
-  .custom-radio {
-    display: table-cell;
+    > div {
+      display: table-cell;
+    }
   }
 
   label,


### PR DESCRIPTION
After update courage to the latest version, there was a change in how we create radio inputs (added an extra div element), this breaks the horizontal alignment for enrolling verify and google auth. 
Resolves: OKTA-143977

Before: 
![widgetverifyenroll-css-missaligned](https://user-images.githubusercontent.com/6979296/31289693-8263c128-aa7e-11e7-996f-78d0438a97b7.png)

After:
![widgetverifyenroll-css-fix](https://user-images.githubusercontent.com/6979296/31289698-86eb0634-aa7e-11e7-859d-f80fbe369a60.png)

