### PR TITLE
:bug: fix mobile icons alignment (#316)

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -213,10 +213,10 @@
   .o-form-input > span {
     display: table;
     width: 100%;
-  }
 
-  .custom-radio {
-    display: table-cell;
+    > div {
+      display: table-cell;
+    }
   }
 
   label,


### PR DESCRIPTION
After update courage to the latest version, there was a change in how we create radio inputs. Changing our css so the icons are horizontally aligned again.
Resolves: OKTA-143977