### PR TITLE
:bug: Minor UX tweaks for OAuth2 Consent

### DIFF
--- a/assets/sass/modules/_consent.scss
+++ b/assets/sass/modules/_consent.scss
@@ -33,9 +33,18 @@
     left: 59px;
 
     .client-logo {
+      border-radius: $border-radius-default;
+    }
+
+    .custom-logo {
       width: 70px;
       height: 70px;
-      border-radius: $border-radius-default;
+    }
+
+    .default-logo {
+      width: 50px;
+      height: 50px;
+      padding: 10px;
     }
   }
 
@@ -71,6 +80,7 @@
     padding-top: 20px;
     padding-bottom: 25px;
     text-align: center;
+    word-wrap: break-word;
 
     p {
       font-size: 16px;

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -28,6 +28,7 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
   var $ = Okta.$;
   var compile = Okta.Handlebars.compile;
 
+  var DEFAULT_APP_LOGO = '/img/logos/default.png';
   var USER_NOT_SEEN_ON_DEVICE = '/img/security/unknown.png';
   var UNDEFINED_USER = '/img/security/default.png';
   var NEW_USER = '/img/security/unknown-device.png';
@@ -432,6 +433,12 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
             return '';
           }
           return userProfile.firstName + ' ' + userProfile.lastName;
+        }
+      },
+      'defaultAppLogo' : {
+        deps: ['baseUrl'],
+        fn: function (baseUrl) {
+          return baseUrl + DEFAULT_APP_LOGO;
         }
       },
       'expiresAt': {

--- a/src/views/consent/ConsentBeacon.js
+++ b/src/views/consent/ConsentBeacon.js
@@ -31,15 +31,20 @@ define(['okta'], function (Okta) {
       </div>\
       <div class="logo-wrapper consent-beacon-client">\
         <div class="consent-beacon-border"/>\
-          {{#if clientLogo}}\
-            <img class="client-logo" src="{{clientLogo}}" />\
+          {{#if customLogo}}\
+            <img class="client-logo custom-logo" src="{{customLogo}}" />\
+          {{else}}\
+            <img class="client-logo default-logo" src="{{defaultLogo}}" />\
           {{/if}}\
         </div>\
       </div>\
     ',
 
     getTemplateData: function () {
-      return { clientLogo: this.options.appState.get('targetLogo') && this.options.appState.get('targetLogo').href };
+      return {
+        customLogo: this.options.appState.get('targetLogo') && this.options.appState.get('targetLogo').href,
+        defaultLogo: this.options.appState.get('defaultAppLogo')
+      };
     },
 
     equals: function (Beacon) {

--- a/test/unit/helpers/xhr/CONSENT_REQUIRED.js
+++ b/test/unit/helpers/xhr/CONSENT_REQUIRED.js
@@ -12,10 +12,6 @@ define({
         "label": "Janky App",
         "clientId": "8WUqrTzUG9RyJt2C6Gmm",
         "_links": {
-          "logo": {
-            "href": "https://example.com/logo.png",
-            "type": "image/png"
-          },
           "about": {
             "href": "https://example.com/about.html",
             "type": "text/html"

--- a/test/unit/spec/ConsentRequired_spec.js
+++ b/test/unit/spec/ConsentRequired_spec.js
@@ -20,6 +20,10 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, ConsentRequiredForm, E
   var itp = Expect.itp;
   var tick = Expect.tick;
 
+  function deepClone(res) {
+    return JSON.parse(JSON.stringify(res));
+  }
+
   function setup(settings, res) {
     settings || (settings = {});
     var successSpy = jasmine.createSpy('successSpy');
@@ -50,6 +54,16 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, ConsentRequiredForm, E
     return Expect.waitForConsentRequired(settings);
   }
 
+  function setupClientLogo() {
+    var resConsentRequiredClientLogo = deepClone(resConsentRequired);
+    var customLogo = {
+      href: 'https://example.com/custom-logo.png',
+      type: 'image/png'
+    };
+    resConsentRequiredClientLogo.response._embedded.target._links.logo = customLogo;
+    return setup(undefined, resConsentRequiredClientLogo);
+  }
+
   Expect.describe('ConsentRequired', function () {
 
     Expect.describe('ConsentBeacon', function () {
@@ -58,9 +72,14 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, ConsentRequiredForm, E
           expect(test.form.userLogo()).toHaveClass('person-16-gray');
         });
       });
-      itp('has the correct client logo', function () {
+      itp('has the default logo if client logo is not provided', function () {
         return setup().then(function (test) {
-          expect(test.form.clientLogo()).toHaveAttr('src', 'https://example.com/logo.png');
+          expect(test.form.clientLogo()).toHaveAttr('src', 'https://example.okta.com/img/logos/default.png');
+        });
+      });
+      itp('has the correct client logo', function () {
+        return setupClientLogo().then(function (test) {
+          expect(test.form.clientLogo()).toHaveAttr('src', 'https://example.com/custom-logo.png');
         });
       });
     });


### PR DESCRIPTION
- Break words when client/app name or user name is too long.
- Load Default logo when Client logo is not customized

## Screenshots

Default Logo:
![screen shot 2017-10-18 at 6 22 24 pm](https://user-images.githubusercontent.com/19613940/31750035-5d5b54fa-b432-11e7-8bee-a1522eab1d66.png)

<img width="487" alt="screen shot 2017-10-19 at 10 54 46 am" src="https://user-images.githubusercontent.com/19613940/31786069-064140e6-b4bc-11e7-83f9-3daa8f18465d.png">

Custom Logo:
![screen shot 2017-10-18 at 6 23 56 pm](https://user-images.githubusercontent.com/19613940/31750036-5d769832-b432-11e7-8f35-f722a52546ce.png)

Resolves: [OKTA-145549](https://oktainc.atlassian.net/browse/OKTA-145549)

@mauriciocastillosilva-okta @hor-kanchan-okta @larsjohansen-okta 