### PR TITLE
:bug: Fix untraslated strings from error code in okta-signin-widget

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -38,6 +38,8 @@ define(['okta'], function (Okta) {
     // Assuming there is only one field error in a response
     if (xhr.responseJSON && xhr.responseJSON.errorCauses && xhr.responseJSON.errorCauses.length) {
       xhr.responseJSON.errorSummary = xhr.responseJSON.errorCauses[0].errorSummary;
+      // BaseForm will consume errorCauses before errorSummary if it is an array, so, we have to make sure to remove it
+      delete xhr.responseJSON.errorCauses;
     }
     // Replace error messages
     if (!_.isEmpty(xhr.responseJSON)) {

--- a/test/unit/helpers/xhr/PASSWORD_EXPIRED_error_oldpass.js
+++ b/test/unit/helpers/xhr/PASSWORD_EXPIRED_error_oldpass.js
@@ -7,7 +7,7 @@ define({
     "errorLink": "E0000014",
     "errorId": "oaecIzifuYzTV-5h3Ea46oxiw",
     "errorCauses": [{
-      "errorSummary": "oldPassword: The credentials provided were incorrect."
+      "errorSummary": "Old password is not correct"
     }]
   }
 });

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -294,7 +294,7 @@ function (Q, _, $, OktaAuth, LoginUtil, SharedUtil, Util, PasswordExpiredForm, B
         .then(function (test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe(
-            'We found some errors. Please review the form and make corrections.'
+            'Old password is not correct'
           );
         });
       });

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -1,6 +1,61 @@
+/* eslint max-len: [2, 140] */
 define(['util/Util'], function (Util) {
 
   describe('util/Util', function () {
+
+    describe('transformErrorXHR', function () {
+      it('errorSummary shows network connection error when status is 0', function () {
+        var xhr = {
+          'status': 0
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('Unable to connect to the server. Please check your network connection.');
+      });
+      it('errorSummary shows internal error when there are no responseJSON and no responseText', function () {
+        var xhr = {
+          'status': 400
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('There was an unexpected internal error. Please try again.');
+      });
+      it('errorSummary is set from responseText when there is no responseJSON', function () {
+        var responseText = '{"errorSummary": "errorSummary from responseText"}';
+        var xhr = {
+          'status': 400,
+          'responseText': responseText
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from responseText');
+      });
+      it('If there is an errorCauses array and there is no valid error code, get errorSummary from errorCauses array', function () {
+        var errorCauses = [{
+          'errorSummary': 'errorSummary from errorCauses'
+        }];
+        var xhr = {
+          status: 400,
+          responseJSON: {
+            errorCauses: errorCauses
+          }
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
+      });
+      it('If there is a valid error code, get errorSummary from that and delete errorCauses array', function () {
+        var errorCauses = [{
+          'errorSummary': 'errorSummary from errorCauses'
+        }];
+        var xhr = {
+          'status': 400,
+          'responseJSON': {
+            'errorCauses': errorCauses,
+            'errorCode': 'E0000017'
+          }
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('Password reset failed');
+        expect(xhr.responseJSON.errorCauses).not.toBeDefined();
+      });
+    });
 
     describe('expandLanguages', function () {
       it('works with an empty array', function () {


### PR DESCRIPTION
- Fix untranslated strings from error code in okta-signin-widget
- Add missing tests for transformErrorXHR function

Resolves: [OKTA-144534](https://oktainc.atlassian.net/browse/OKTA-144534)

## Screenshot
![screen shot 2017-10-25 at 2 20 53 pm](https://user-images.githubusercontent.com/19613940/32023979-d9979008-b98f-11e7-9a21-3eb673d17641.png)

@hor-kanchan-okta @upteam-okta 