### PR TITLE
Remove registration.clientId parameter 

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -61,12 +61,9 @@ function (
   return BaseLoginController.extend({
     className: 'registration',
     initialize: function() {
-      var clientId = this.options.settings.get('registration.clientId');
+      var clientId = this.options.settings.get('clientId');
       var registrationApi = this.options.settings.get('baseUrl')+'/api/v1/registration/'+clientId;
 
-      if (!clientId) {
-        return false;
-      }
       var Schema = RegistrationSchema.extend({
         url: registrationApi+'/form'
       });

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -140,7 +140,6 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
 
       //Registration
       'registration.click': 'function',
-      'registration.clientId': 'string',
 
       //Consent
       'consent.cancel': 'function'

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -87,9 +87,6 @@ function (Q, _, $, OktaAuth, Util, Expect, Beacon, RegistrationForm, Registratio
 
   function setup(settings) {
     settings || (settings = {});
-    settings.registration = {
-      'clientId': '1234'
-    };
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
     var authClient = new OktaAuth({url: baseUrl});


### PR DESCRIPTION
Removed clientId parameter from within the registration config object

- Updated registration code to use clientId param from sign in widget config object instead of registration.clientId
- Within the sign in widget authScheme defaults to OAUTH2 
- If registration is enabled we want to use clientId but do not want  OAUTH flow to be triggered once registration is completed.
- We now set authScheme to SESSION if registration is enabled for okta-hosted usecases. This value is set when sign in widget is bootstrapped from loginpage_backbone.jsp. Related okta-core PR
https://github.com/okta/okta-core/pull/23708 
- https://github.com/okta/okta-signin-widget/blob/master/src/models/Settings.js#L200 will return false when clientId is set and authScheme is set to SESSION

Resolves: OKTA-135949
