### PR TITLE
Use handlebars wrapper instead of external handlebars

### DIFF
--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -160,7 +160,7 @@ var OktaSignIn = (function () {
     // Modify the underscore, handlebars, and jquery modules
     // Remove once these are explicitly required in Courage
     require('okta/underscore');
-    require('handlebars');
+    require('okta/handlebars');
     require('okta/jquery');
 
     OktaAuth = require('@okta/okta-auth-js/jquery');

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -22,7 +22,7 @@ module.exports = function (outputFilename) {
         'nls': '@okta/i18n/dist/json',
         'okta/jquery': SHARED_JS + '/util/jquery-wrapper',
         'okta/underscore': SHARED_JS + '/util/underscore-wrapper',
-        'okta/handlebars': 'handlebars/dist/handlebars',
+        'okta/handlebars': SHARED_JS + '/util/handlebars-wrapper',
         'okta/moment': 'moment/moment',
         'okta/moment-tz': EMPTY,
 


### PR DESCRIPTION
## Description

Point to Okta handlebars wrapper instead of external handlebars. This solves references to i18n and other helpers in templates.

This also solves the issue where okta-signin-widget did not load on samples.

## Reviewers

- @lboyette-okta 
-  @rchild-okta 