### PR TITLE
:bug: Fix field errors from backend in okta-signin-widget

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 8] */
+/* eslint complexity: [2, 8], max-depth: [2, 3] */
 define(['okta'], function (Okta) {
 
   var Util = {};
@@ -38,14 +38,17 @@ define(['okta'], function (Okta) {
     // Assuming there is only one field error in a response
     if (xhr.responseJSON && xhr.responseJSON.errorCauses && xhr.responseJSON.errorCauses.length) {
       xhr.responseJSON.errorSummary = xhr.responseJSON.errorCauses[0].errorSummary;
-      // BaseForm will consume errorCauses before errorSummary if it is an array, so, we have to make sure to remove it
-      delete xhr.responseJSON.errorCauses;
     }
     // Replace error messages
     if (!_.isEmpty(xhr.responseJSON)) {
       var errorMsg = Okta.loc('errors.' + xhr.responseJSON.errorCode, 'login');
       if (errorMsg.indexOf('L10N_ERROR[') === -1) {
         xhr.responseJSON.errorSummary = errorMsg;
+        if (xhr.responseJSON && xhr.responseJSON.errorCauses && xhr.responseJSON.errorCauses.length) {
+          // BaseForm will consume errorCauses before errorSummary if it is an array,
+          // so, we have to make sure to remove it when we have a valid error code
+          delete xhr.responseJSON.errorCauses;
+        }
       }
     }
     return xhr;

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -32,14 +32,29 @@ define(['util/Util'], function (Util) {
           'errorSummary': 'errorSummary from errorCauses'
         }];
         var xhr = {
-          status: 400,
-          responseJSON: {
-            errorCauses: errorCauses
+          'status': 400,
+          'responseJSON': {
+            'errorCauses': errorCauses
           }
         };
         Util.transformErrorXHR(xhr);
         expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
-        expect(xhr.responseJSON.errorCauses).toBeDefined();
+        expect(xhr.responseJSON.errorCauses).toBe(errorCauses);
+      });
+      it('If there is an errorCauses array and there is an invalid error code, get errorSummary from errorCauses array', function () {
+        var errorCauses = [{
+          'errorSummary': 'errorSummary from errorCauses'
+        }];
+        var xhr = {
+          'status': 400,
+          'responseJSON': {
+            'errorCauses': errorCauses,
+            'errorCode': 'E01212AB'
+          }
+        };
+        Util.transformErrorXHR(xhr);
+        expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
+        expect(xhr.responseJSON.errorCauses).toBe(errorCauses);
       });
       it('If there is a valid error code, get errorSummary from that and delete errorCauses array', function () {
         var errorCauses = [{

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -39,6 +39,7 @@ define(['util/Util'], function (Util) {
         };
         Util.transformErrorXHR(xhr);
         expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
+        expect(xhr.responseJSON.errorCauses).toBeDefined();
       });
       it('If there is a valid error code, get errorSummary from that and delete errorCauses array', function () {
         var errorCauses = [{

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -27,7 +27,7 @@ define(['util/Util'], function (Util) {
         Util.transformErrorXHR(xhr);
         expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from responseText');
       });
-      it('If there is an errorCauses array and there is no valid error code, get errorSummary from errorCauses array', function () {
+      it('If there is an errorCauses array and there is no error code, get errorSummary from errorCauses array', function () {
         var errorCauses = [{
           'errorSummary': 'errorSummary from errorCauses'
         }];


### PR DESCRIPTION
Baseform uses the errorSummary in the errorCauses array to display error fields coming from backend. So, we cannot always delete the array, we should delete the array only when the backend doesn't return an error field. Everytime an error field is returned, if there is an errorCode in the response that will be invalid, since it requires the field parameters and we don't pass parameters to the Okta.loc function in okta-signin-widget. So, with this fix, everytime we get an error field from backend the errorCause array will not be deleted and the error field will be displayed correctly.

Resolves: [OKTA-148144](https://oktainc.atlassian.net/browse/OKTA-148144)

## Screenshot
![screen shot 2017-11-08 at 11 49 02 am](https://user-images.githubusercontent.com/19613940/32570998-da606cda-c47a-11e7-8e5b-835bd7f75dd3.png)

@mauriciocastillosilva-okta @hor-kanchan-okta 