### PR TITLE
:fire: Remove publishConfig from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
   "bugs": {
     "url": "https://github.com/okta/okta-signin-widget/issues"
   },
-  "publishConfig": {
-    "registry": "https://artifacts.aue1d.saasure.com/artifactory/api/npm/npm-okta"
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
It was pointing to our internal registry, so it is not needed
Resolves: OKTA-147982