### PR TITLE
:bug: Revert "Change type from ‘text’ to ‘number’ in textboxes"

### DIFF
--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -256,7 +256,7 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           name: 'passCode',
           input: TextBox,
-          type: 'number',
+          type: 'text',
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')
           },

--- a/src/views/enroll-factors/EnterPasscodeForm.js
+++ b/src/views/enroll-factors/EnterPasscodeForm.js
@@ -34,7 +34,7 @@ define([
         FormType.Input({
           name: 'passCode',
           input: TextBox,
-          type: 'number',
+          type: 'text',
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -520,7 +520,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, AuthContainer, Form, Beacon, Expec
         return setupAndSendValidCode()
         .then(function (test) {
           $.ajax.calls.reset();
-          expect(test.form.codeField().attr('type')).toBe('number');
+          expect(test.form.codeField().attr('type')).toBe('text');
           test.form.setCode(123456);
           test.setNextResponse(resEnrollSuccess);
           test.form.submit();

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -339,7 +339,7 @@ function (_, $, Q, OktaAuth, LoginUtil, StringUtil, Util, DeviceTypeForm, Barcod
           .then(function (test) {
             Expect.isVisible(test.passCodeForm.form());
             Expect.isVisible(test.passCodeForm.codeField());
-            expect(test.passCodeForm.codeField().attr('type')).toBe('number');
+            expect(test.passCodeForm.codeField().attr('type')).toBe('text');
           });
         });
         itp('returns to factor list when browser\'s back button is clicked', function () {


### PR DESCRIPTION
Revert "Change type from ‘text’ to ‘number’ in textboxes for number values" since it didn't fix its bug and caused a localization issue

Resolves: [OKTA-144887](https://oktainc.atlassian.net/browse/OKTA-144887)

## Screenshot
![screen shot 2017-11-13 at 2 15 59 pm](https://user-images.githubusercontent.com/19613940/32752212-37c2bf12-c87d-11e7-8ad4-a1699c677bf0.png)

@mauriciocastillosilva-okta @hor-kanchan-okta 