### PR TITLE
:bug: Removes spinner in reset password page on fail

### DIFF
--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -55,17 +55,13 @@
   @import 'modules/registration';
 
   &.can-remove-beacon {
-    .auth-content {
-      padding-top: 40px;
-    }
-
     @include max-height-mq(550px) {
       .beacon-container {
         display: none;
       }
 
       .auth-content {
-        padding-top: 0;
+        padding-top: 20px;
       }
 
       .enroll-choices {
@@ -96,64 +92,64 @@
   font-family: $fonts;
   color: $medium-text-color;
 
-  div, 
-  span, 
-  applet, 
-  object, 
+  div,
+  span,
+  applet,
+  object,
   iframe,
-  h1, 
-  h2, 
-  h3, 
-  h4, 
-  h5, 
-  h6, 
-  p, 
-  blockquote, 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
   pre,
-  a, 
-  abbr, 
-  acronym, 
-  address, 
-  big, 
-  cite, 
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
   code,
-  del, 
-  dfn, 
-  em, 
-  img, 
-  ins, 
-  kbd, 
-  q, 
-  s, 
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
   samp,
-  small, 
-  strike, 
-  strong, 
-  sub, 
-  sup, 
-  tt, 
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
   var,
-  b, 
-  u, 
-  i, 
+  b,
+  u,
+  i,
   center,
-  dl, 
-  dt, 
-  dd, 
-  ol, 
-  ul, 
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
   li,
-  fieldset, 
-  form, 
-  label, 
+  fieldset,
+  form,
+  label,
   legend,
-  table, 
-  caption, 
-  tbody, 
-  tfoot, 
-  thead, 
-  tr, 
-  th, 
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
   td {
     margin: 0;
     padding: 0;

--- a/src/RecoveryLoadingController.js
+++ b/src/RecoveryLoadingController.js
@@ -29,6 +29,7 @@ define(['okta', 'util/FormController'], function (Okta, FormController) {
       })
       .fail(function () {
         self.options.appState.trigger('loading', false);
+        self.appState.trigger('removeLoading');
       });
     },
 


### PR DESCRIPTION
## Description

**Issue:** If security image is disabled, the spinner still remains in the loading state,

**Fix:** Trigger 'removeLoading' to remove the spinner in the case of no security image. Setting loading to 'false' removes the spinner in the case where security image exists.

Also modifying CSS to remove overlap of beacon on the infobox error. Made sure we still look good on other pages as well. Check screenshots.

## Reviewers

- @hor-kanchan-okta 
- @mauriciocastillosilva-okta 
- @lboyette-okta 

## Screenshots

**After**

See that the spinner disappears here:

![reset-spinner](https://user-images.githubusercontent.com/24683447/32810303-3d8004aa-c94f-11e7-8bff-62ab141ca7ab.gif)

Responsiveness with the minor CSS change to auth content padding:

![after-css-signin](https://user-images.githubusercontent.com/24683447/32810807-8452d194-c951-11e7-9631-31ddea96a3ae.gif)
![after-css](https://user-images.githubusercontent.com/24683447/32810808-846f711e-c951-11e7-9436-cebe704a289f.gif)

**Before**

Note the overlap between beacon and infobox error:

<img width="1107" alt="screen shot 2017-11-14 at 2 10 56 pm" src="https://user-images.githubusercontent.com/24683447/32810304-3d987008-c94f-11e7-9169-aaa2a71948e9.png">