### PR TITLE
:bug: Allow Q to be externally provided

### DIFF
--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -50,7 +50,7 @@ function (Okta, Q) {
           res = fn.call(this, this.appState.get('transaction'), _.bind(this.setTransaction, this));
       
       // If it's a promise, listen for failures
-      if (Q.isPromise(res)) {
+      if (Q.isPromiseAlike(res)) {
         res.fail(function(err) {
           if (err.name === 'AuthPollStopError') {
             return;
@@ -68,7 +68,7 @@ function (Okta, Q) {
           res = fn.call(this, this.settings.getAuthClient());
 
       // If it's a promise, then chain to it
-      if (Q.isPromise(res)) {
+      if (Q.isPromiseAlike(res)) {
         return res.then(function(trans) {
           self.trigger('setTransaction', trans);
           return trans;


### PR DESCRIPTION
Today, `okta-sign-in.entry.js` allows a user to provide their own version of Q. The problem is we use `Q.isPromise(obj)`, which checks to make sure the object is an instance of that particular version of Q.

We use Q in okta-auth-js and okta-signin-widget. It seems that there are multiple versions of Q being bundled when devs require `okta-sign-in.entry.js`. This means the `Q.isPromise(obj)` check will fail, even though the object is a valid Promise.

We should determine why two versions of Q are being included. However, the current `Q.isPromise` solution is too rigid. It won't work if we decide to allow customers to provide their own Promise libraries in okta-auth-js. The `Q.isPromiseAlike` method is a better match for what we're checking: "is this a Promise we can use?".