### PR TITLE
Fix onSuccess example

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,11 +873,11 @@ To add registration into your application, configure your Okta admin settings to
         },
         preSubmit: function (postData, onSuccess, onFailure) {
            // handle preSubmit callback
-           onSuccess(schema);
+           onSuccess(postData);
         },
         postSubmit: function (response, onSuccess, onFailure) {
             // handle postsubmit callback
-           onSuccess(schema);
+           onSuccess(response);
         }
       },
       features: {

--- a/README.md
+++ b/README.md
@@ -869,12 +869,15 @@ To add registration into your application, configure your Okta admin settings to
       registration: {
         parseSchema: function(schema, onSuccess, onFailure) {
            // handle parseSchema callback
+           onSuccess(schema);
         },
         preSubmit: function (postData, onSuccess, onFailure) {
            // handle preSubmit callback
+           onSuccess(schema);
         },
         postSubmit: function (response, onSuccess, onFailure) {
             // handle postsubmit callback
+           onSuccess(schema);
         }
       },
       features: {


### PR DESCRIPTION
The example will not work unless `onSuccess()` is called.