### PR TITLE
:art: build source-map for okta-signin-in.entry.js

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -8,6 +8,7 @@ var VENDOR = path.resolve(__dirname, 'packages/@okta/courage/src/vendor');
 module.exports = function (outputFilename) {
   return {
     entry: ['./target/js/widget/OktaSignIn.js'],
+    devtool: 'source-map',
     output: {
       path: TARGET_JS,
       filename: outputFilename,

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -64,7 +64,7 @@ cdnConfig.plugins = [
     compress: {
       warnings: false
     },
-    sourceMap: false,
+    sourceMap: true,
     comments: function(node, comment) {
       // Remove other Okta copyrights
       var isLicense = /^!/.test(comment.value) ||


### PR DESCRIPTION
Issue: dist/ folder is built via `grunt build:release`, it includes all distributable files, however, the source-map file is missing, consequently, any projects consuming okta-signin-widget can't merge the source map and debug the codes in okta-signin-widget;
Fix: fix the webpack config for okta-sign-in.entry.js, and generate a map for it.