### PR TITLE
Use input with type=tel to automaticaly open numeric keyboard on mobile devices

### DIFF
--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -256,7 +256,7 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           name: 'passCode',
           input: TextBox,
-          type: 'text',
+          type: 'tel',
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')
           },

--- a/src/views/enroll-factors/EnterPasscodeForm.js
+++ b/src/views/enroll-factors/EnterPasscodeForm.js
@@ -34,7 +34,7 @@ define([
         FormType.Input({
           name: 'passCode',
           input: TextBox,
-          type: 'text',
+          type: 'tel',
           placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')

--- a/src/views/mfa-verify/InlineTOTPForm.js
+++ b/src/views/mfa-verify/InlineTOTPForm.js
@@ -21,7 +21,7 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
       className: 'o-form-fieldset o-form-label-top inline-input auth-passcode',
       name: 'answer',
       input: TextBox,
-      type: 'text'
+      type: 'tel'
     });
     form.add(Okta.createButton({
       attributes: { 'data-se': 'inline-totp-verify' },

--- a/src/views/mfa-verify/PassCodeForm.js
+++ b/src/views/mfa-verify/PassCodeForm.js
@@ -112,7 +112,7 @@ define(['okta', 'vendor/lib/q', 'views/shared/TextBox'], function (Okta, Q, Text
         className: 'o-form-fieldset o-form-label-top auth-passcode',
         name: 'answer',
         input: TextBox,
-        type: 'text'
+        type: 'tel'
       });
       if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -37,7 +37,7 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
         className: 'o-form-fieldset o-form-label-top auth-passcode',
         name: 'answer',
         input: TextBox,
-        type: maskPasswordField ? 'password' : 'text'
+        type: maskPasswordField ? 'password' : 'tel'
       });
 
       if (this.options.appState.get('allowRememberDevice')) {

--- a/test/unit/spec/EnrollCall_spec.js
+++ b/test/unit/spec/EnrollCall_spec.js
@@ -488,6 +488,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
       itp('shows enter code input', function () {
         return setupAndSendValidCode().then(function (test) {
           Expect.isVisible(test.form.codeField());
+          expect(test.form.codeField().attr('type')).toBe('tel');
         });
       });
       itp('shows verify button when enrolled', function () {

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -521,7 +521,7 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, AuthContainer, Form, Beacon, Expec
         return setupAndSendValidCode()
         .then(function (test) {
           $.ajax.calls.reset();
-          expect(test.form.codeField().attr('type')).toBe('text');
+          expect(test.form.codeField().attr('type')).toBe('tel');
           test.form.setCode(123456);
           test.setNextResponse(resEnrollSuccess);
           test.form.submit();

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -340,7 +340,7 @@ function (_, $, Q, OktaAuth, LoginUtil, StringUtil, Util, DeviceTypeForm, Barcod
           .then(function (test) {
             Expect.isVisible(test.passCodeForm.form());
             Expect.isVisible(test.passCodeForm.codeField());
-            expect(test.passCodeForm.codeField().attr('type')).toBe('text');
+            expect(test.passCodeForm.codeField().attr('type')).toBe('tel');
           });
         });
         itp('returns to factor list when browser\'s back button is clicked', function () {
@@ -398,6 +398,7 @@ function (_, $, Q, OktaAuth, LoginUtil, StringUtil, Util, DeviceTypeForm, Barcod
           .then(function (test) {
             Expect.isVisible(test.passCodeForm.form());
             Expect.isVisible(test.passCodeForm.codeField());
+            expect(test.passCodeForm.codeField().attr('type')).toBe('tel');
           });
         });
         itp('shows error in case of an error response', function () {

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -801,7 +801,7 @@ function (Okta,
         });
         itp('has a passCode field', function () {
           return setupGoogleTOTP().then(function (test) {
-            expectHasAnswerField(test);
+            expectHasAnswerField(test, 'tel');
           });
         });
         itp('has a masked passCode field for RSA', function () {
@@ -1085,7 +1085,7 @@ function (Okta,
         });
         itp('has a passCode field', function () {
           return setupSMS().then(function (test) {
-            expectHasAnswerField(test);
+            expectHasAnswerField(test, 'tel');
           });
         });
         itp('has remember device checkbox', function () {
@@ -1385,7 +1385,7 @@ function (Okta,
         });
         itp('has a passCode field', function () {
           return setupCall().then(function (test) {
-            expectHasAnswerField(test);
+            expectHasAnswerField(test, 'tel');
           });
         });
         itp('clears the passcode text field on clicking the "Call" button', function () {
@@ -1671,7 +1671,7 @@ function (Okta,
         });
         itp('has a passCode field', function () {
           return setupEmail().then(function (test) {
-            expectHasAnswerField(test);
+            expectHasAnswerField(test, 'tel');
           });
         });
         itp('has remember device checkbox', function () {
@@ -2190,7 +2190,7 @@ function (Okta,
               var form = test.form[1];
               form.inlineTOTPAdd().click();
               expect(form.inlineTOTPAdd().length).toBe(0);
-              Expect.isTextField(form.answerField());
+              expectHasAnswerField({ form: form }, 'tel');
               Expect.isLink(form.inlineTOTPVerify());
               expect(test.form[1].inlineTOTPVerifyText()).toEqual('Verify');
             });


### PR DESCRIPTION
![screenshot_20171218-181339](https://user-images.githubusercontent.com/17706432/34116382-2598baca-e421-11e7-86dc-8923b37e4bb8.jpg)
<img width="593" alt="screen shot 2017-12-18 at 6 02 56 pm" src="https://user-images.githubusercontent.com/17706432/34115272-d26e8922-e41d-11e7-9d9a-f47648a46625.png">
<img width="388" alt="screen shot 2017-12-29 at 4 06 42 pm" src="https://user-images.githubusercontent.com/17706432/34438863-62d71b18-ecb2-11e7-868c-78cf141cb23d.png">

Resolves OKTA-79239

@mauriciocastillosilva-okta 
@eugenebakaiev-okta 
Please, review.
