### PR TITLE
:seedling: Send device fingerprint to get security image

### DIFF
--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -99,7 +99,7 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
       if (this.settings.get('features.securityImage')) {
         var self = this;
         this.listenTo(this, 'change:username', function (model, username) {
-          getSecurityImage(this.get('baseUrl'), username, model.get('deviceFingerprint'))
+          getSecurityImage(this.get('baseUrl'), username, this.get('deviceFingerprint'))
           .then(function (image) {
             model.set('securityImage', image.securityImage);
             model.set('securityImageDescription', image.securityImageDescription);

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -51,10 +51,6 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       };
     },
 
-    local: {
-      deviceFingerprint: ['string', false]
-    },
-
     getUsernameAndRemember: function(cookieUsername) {
       var settingsUsername = this.settings && this.settings.get('username'),
           rememberMeEnabled = this.settings && this.settings.get('features.rememberMe'),
@@ -160,12 +156,14 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       // Add the custom header for fingerprint if needed, and then remove it afterwards
       // Since we only need to send it for primary auth
       if (deviceFingerprintEnabled) {
-        authClient.options.headers['X-Device-Fingerprint'] = this.get('deviceFingerprint');
+        authClient.options.headers['X-Device-Fingerprint'] = this.appState.get('deviceFingerprint');
       }
+      var self = this;
       return func(signInArgs)
       .fin(function () {
         if (deviceFingerprintEnabled) {
           delete authClient.options.headers['X-Device-Fingerprint'];
+          self.appState.unset('deviceFingerprint'); //Fingerprint can only be used once
         }
       });
     }

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -49,7 +49,7 @@ define([
           }
           return DeviceFingerprint.generateDeviceFingerprint(self.settings.get('baseUrl'), self.$el)
           .then(function (fingerprint) {
-            self.model.set('deviceFingerprint', fingerprint);
+            self.options.appState.set('deviceFingerprint', fingerprint);
           })
           .fail(function () {
             // Keep going even if device fingerprint fails

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -422,10 +422,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           expect($.ajax.calls.count()).toBe(1);
           expect($.ajax.calls.argsFor(0)[0]).toEqual({
             url: 'https://foo.com/login/getimage?username=testuser@clouditude.net',
-            type: 'get',
-            dataType: undefined,
-            data: undefined,
-            success: undefined
+            dataType: 'json'
           });
         });
       });
@@ -558,10 +555,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           expect($.ajax.calls.count()).toBe(1);
           expect($.ajax.calls.argsFor(0)[0]).toEqual({
             url: 'https://foo.com/login/getimage?username=testuser@clouditude.net',
-            type: 'get',
-            dataType: undefined,
-            data: undefined,
-            success: undefined
+            dataType: 'json'
           });
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(../../../test/unit/assets/1x1.gif)');
           expect(test.form.accessibilityText()).toBe('a single pixel');

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -13,6 +13,7 @@ define([
   'models/IDPDiscovery',
   'LoginRouter',
   'util/BrowserFeatures',
+  'util/DeviceFingerprint',
   'util/Errors',
   'shared/util/Util',
   'helpers/util/Expect',
@@ -24,8 +25,8 @@ define([
   'sandbox'
 ],
 function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, Beacon, IDPDiscovery,
-          Router, BrowserFeatures, Errors, SharedUtil, Expect, resSecurityImage, resSecurityImageFail,
-          resSuccess, resSuccessOktaIDP, resError, $sandbox) {
+          Router, BrowserFeatures, DeviceFingerprint, Errors, SharedUtil, Expect,
+          resSecurityImage, resSecurityImageFail, resSuccess, resSuccessOktaIDP, resError, $sandbox) {
 
   var itp = Expect.itp;
   var tick = Expect.tick;
@@ -451,6 +452,43 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
             resource: 'acct:testuser@clouditude.net',
             requestContext: undefined
           });
+        });
+      });
+    });
+
+    Expect.describe('Device Fingerprint', function () {
+      itp('contains fingerprint header in get security image request if feature is enabled', function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+          var deferred = Q.defer();
+          deferred.resolve('thisIsTheDeviceFingerprint');
+          return deferred.promise;
+        });
+        return setup({ features: { securityImage: true, deviceFingerprinting: true }})
+        .then(function (test) {
+          test.setNextResponse(resSecurityImage);
+          test.form.setUsername('testuser@clouditude.net');
+          return waitForBeaconChange(test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
+          var ajaxArgs = $.ajax.calls.argsFor(0);
+          expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
+        });
+      });
+      itp('does not contain fingerprint header in get security image request if feature is disabled', function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
+        return setup({ features: { securityImage: true }})
+        .then(function (test) {
+          test.setNextResponse(resSecurityImage);
+          test.form.setUsername('testuser@clouditude.net');
+          return waitForBeaconChange(test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
+          var ajaxArgs = $.ajax.calls.argsFor(0);
+          expect(ajaxArgs[0].headers).toBeUndefined();
         });
       });
     });


### PR DESCRIPTION
Security Image API accepts now the device fingerprint header, which helps fetching the image in devices that have been used before but do not have the proximity cookie stored.
So adding the fingerprint header to the getImage request
- Note: we cannot reuse the same fingerprint twice due to the nonce (it is only valid once), so we generate one for getImage and a different one for primaryAuth

Resolves: OKTA-100304

Screencast:
![devicefingerprintingetimage](https://user-images.githubusercontent.com/6979296/34278111-a88a5fd6-e65d-11e7-8a41-4f4a6b64786b.gif)
