### PR TITLE
:bug: Fix RAAS sign up button routing issue

### DIFF
--- a/src/views/shared/FooterRegistration.js
+++ b/src/views/shared/FooterRegistration.js
@@ -27,7 +27,8 @@ define([
       'click a.registration-link': 'handleClickEvent'
     },
 
-    handleClickEvent: function () {
+    handleClickEvent: function (e) {
+      e.preventDefault();
       var clickHandler = this.settings.get('registration.click');
       if (clickHandler) {
         clickHandler();


### PR DESCRIPTION
The problem is happening only when the signin widget features.router is set to off, which means that we don’t update the url when we change route.
When we press the “sign up” button and the router feature is on, “/signin/register“ is happened to the current url and everything works fine. However, if the feature is off, since the “sign up” button is <a> element with href=“#”, an “#” is appended to the current url causing it to reroute to the Primary Auth form immediately after routing to registration form.
This is not happening in our other signin widget buttons because we are calling the e.preventDefault() function.
Added the e.preventDefault() call to the sign up button to fix this problem.
Long term fix will be to remove the href=“#” to all our <a> buttons.

Resolves: [OKTA-154041](https://oktainc.atlassian.net/browse/OKTA-154041)

![signuproute](https://user-images.githubusercontent.com/19613940/35070272-90a147b0-fb91-11e7-80b2-55421888a17c.gif)

@hor-kanchan-okta 
