### PR TITLE
:bug: Add missing table row element

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -210,12 +210,16 @@
 /* TOTP Factor Enrollment */
 .device-type-input {
 
-  .o-form-input > span {
+  .o-form-input {
     display: table;
     width: 100%;
 
-    > div {
-      display: table-cell;
+    > span {
+      display: table-row;
+
+      > div {
+        display: table-cell;
+      }
     }
   }
 


### PR DESCRIPTION
In Mobile iOs devices, pressing the middle option for enrolling devices in Okta Verify was freezing the browser and the Okta Mobile app.
There is a missing table-row element, which in theory browsers will [add automatically](https://www.w3.org/TR/CSS2/tables.html#anonymous-boxes) (reason it works everywhere else) but seems that iOs is not doing that. So to prevent any future error, I am explicitly adding the row.

Resolves: OKTA-155395