### PR TITLE
:seedling: Support http only cookie for autoPush

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@okta/okta-signin-widget",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@okta/okta-auth-js": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-1.11.0.tgz",
-      "integrity": "sha1-k6/QIE1w1vasBCBmfa/Ff156j/4=",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-auth-js/-/okta-auth-js-1.13.0.tgz",
+      "integrity": "sha1-9KX3Oku+MquqULuYWkp0rjnHYkg=",
       "requires": {
         "Base64": "0.3.0",
         "q": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack": "1.13.1"
   },
   "dependencies": {
-    "@okta/okta-auth-js": "1.11.0",
+    "@okta/okta-auth-js": "1.13.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.26.0",
     "backbone": "1.2.1",

--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -124,14 +124,6 @@ function (Okta, Checkbox, BaseLoginController, CookieUtil, TOTPForm, YubikeyForm
         this.options.appState.set('trapMfaRequiredResponse', false);
         return true;
       }
-      // update auto push cookie after user accepts Okta Verify MFA
-      if (this.options.factorType == 'push') {
-        if (this.settings.get('features.autoPush') && this.model.get('autoPush')) {
-          CookieUtil.setAutoPushCookie(this.options.appState.get('userId'));
-        } else {
-          CookieUtil.removeAutoPushCookie(this.options.appState.get('userId'));
-        }
-      }
       return false;
     },
 

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -586,6 +586,12 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
         fn: function (policy) {
           return policy && policy.rememberDeviceByDefault;
         }
+      },
+      'factorsPolicyInfo' : {
+        deps: ['policy'],
+        fn: function (policy) {
+          return (policy && policy.factorsPolicyInfo) ? policy.factorsPolicyInfo: null;
+        }
       }
     },
 

--- a/src/util/CookieUtil.js
+++ b/src/util/CookieUtil.js
@@ -10,11 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/CryptoUtil', 'jquery.cookie'], function (Okta, CryptoUtil) {
+define(['okta', 'jquery.cookie'], function (Okta) {
 
   var $ = Okta.$;
   var LAST_USERNAME_COOKIE_NAME = 'ln';
-  var AUTO_PUSH_COOKIE_PREFIX  = 'auto_push_';
   var DAYS_SAVE_REMEMBER = 365;
 
   function removeCookie (name) {
@@ -26,10 +25,6 @@ define(['okta', 'util/CryptoUtil', 'jquery.cookie'], function (Okta, CryptoUtil)
       expires: DAYS_SAVE_REMEMBER,
       path: '/'
     });
-  }
-
-  function getAutoPushKey(userId) {
-    return AUTO_PUSH_COOKIE_PREFIX + CryptoUtil.getStringHash(userId);
   }
 
   var fn = {};
@@ -44,27 +39,6 @@ define(['okta', 'util/CryptoUtil', 'jquery.cookie'], function (Okta, CryptoUtil)
 
   fn.removeUsernameCookie = function () {
     removeCookie(LAST_USERNAME_COOKIE_NAME);
-  };
-
-  fn.isAutoPushEnabled = function (userId) {
-    if (userId === undefined) {
-      return false;
-    }
-    return $.cookie(getAutoPushKey(userId)) === 'true';
-  };
-
-  fn.setAutoPushCookie = function (userId) {
-    if (userId === undefined) {
-      return;
-    }
-    setCookie(getAutoPushKey(userId), true);
-  };
-
-  fn.removeAutoPushCookie = function (userId) {
-    if (userId === undefined) {
-      return;
-    }
-    removeCookie(getAutoPushKey(userId));
   };
 
   return fn;

--- a/src/views/mfa-verify/PushForm.js
+++ b/src/views/mfa-verify/PushForm.js
@@ -87,7 +87,12 @@ define(['okta', 'util/CookieUtil', 'util/Util'], function (Okta, CookieUtil, Uti
       }
     },
     postRender: function() {
-      if (this.settings.get('features.autoPush') && CookieUtil.isAutoPushEnabled(this.options.appState.get('userId'))) {
+      var factorsPolicyInfo = this.options.appState.get('factorsPolicyInfo');
+      var id = this.model.get('id');
+      var isAutoPushEnabled = (this.settings.get('features.autoPush') && factorsPolicyInfo &&
+                              factorsPolicyInfo[id]) ? factorsPolicyInfo[id]['autoPushEnabled'] : false;
+
+      if (isAutoPushEnabled) {
         this.model.set('autoPush', true);
         // bind after $el has been rendered, and trigger push once DOM is fully loaded
         _.defer(_.bind(this.submit, this));

--- a/test/unit/helpers/mocks/Util.js
+++ b/test/unit/helpers/mocks/Util.js
@@ -1,4 +1,4 @@
-/* eslint no-global-assign: 0, max-statements: [2, 31] */
+/* eslint no-global-assign: 0, max-statements: [2, 32] */
 define([
   'okta/jquery',
   'okta/underscore',
@@ -295,6 +295,17 @@ function ($, _, Backbone, Q, Duo) {
 
   fn.deepCopy = function (res) {
     return JSON.parse(JSON.stringify(res));
+  };
+
+  fn.getAutoPushResponse = function (response, autoPushVal) {
+    var responseCopy = fn.deepCopy(response);
+    var embeddedResponse = responseCopy['response']['_embedded'];
+    var factors = embeddedResponse['factors'];
+    var factorId = _.findWhere(factors, {factorType: 'push', provider: 'OKTA'}).id;
+    var policy = embeddedResponse['policy'];
+
+    policy['factorsPolicyInfo'][factorId]['autoPushEnabled'] = autoPushVal;
+    return responseCopy;
   };
 
   return fn;

--- a/test/unit/helpers/xhr/MFA_REQUIRED_allFactors.js
+++ b/test/unit/helpers/xhr/MFA_REQUIRED_allFactors.js
@@ -19,7 +19,12 @@ define({
       "policy": {
         "allowRememberDevice": true,
         "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceByDefault": false,
+        "factorsPolicyInfo":{
+            "opfhw7v2OnxKpftO40g3":{
+               "autoPushEnabled": false
+            }
+         }
       },
       "factors": [{
         "id": "ufshpdkgNun3xNE3W0g3",

--- a/test/unit/helpers/xhr/MFA_REQUIRED_oktaVerify.js
+++ b/test/unit/helpers/xhr/MFA_REQUIRED_oktaVerify.js
@@ -19,7 +19,12 @@ define({
       "policy": {
         "allowRememberDevice": true,
         "rememberDeviceLifetimeInMinutes": 0,
-        "rememberDeviceByDefault": false
+        "rememberDeviceByDefault": false,
+        "factorsPolicyInfo":{
+            "opfhw7v2OnxKpftO40g3":{
+               "autoPushEnabled": false
+            }
+         }
       },
       "factors": [
         {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1,11 +1,10 @@
-/* eslint max-params: [2, 32], max-statements: [2, 43], max-len: [2, 180], camelcase:0 */
+/* eslint max-params: [2, 32], max-statements: [2, 44], max-len: [2, 180], camelcase:0 */
 define([
   'okta',
   'vendor/lib/q',
   'backbone',
   'shared/util/Util',
   'util/CryptoUtil',
-  'util/CookieUtil',
   'util/Logger',
   '@okta/okta-auth-js/jquery',
   'helpers/mocks/Util',
@@ -33,7 +32,7 @@ define([
   'helpers/xhr/labels_login_ja',
   'helpers/xhr/labels_country_ja'
 ],
-function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAuth, Util, Expect, Router,
+function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, OktaAuth, Util, Expect, Router,
           $sandbox, PrimaryAuthForm, IDPDiscoveryForm, RecoveryForm, MfaVerifyForm, EnrollCallForm, resSuccess, resRecovery,
           resMfa, resMfaRequiredDuo, resMfaRequiredOktaVerify, resMfaChallengeDuo, resMfaChallengePush,
           resMfaEnroll, errorInvalidToken, resUnauthenticated, resSuccessStepUp, Errors, BrowserFeatures,
@@ -568,8 +567,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         expect(form.isSecurityQuestion()).toBe(true);
       });
     });
-    itp('checks auto push by default for a returning user', function () {
-      Util.mockCookie('auto_push_' + CryptoUtil.getStringHash('00uhn6dAGR4nUB4iY0g3'), 'true');
+    itp('checks auto push by default for a returning user with autoPush true', function () {
       return setup({'features.autoPush': true})
       .then(function (test) {
         Util.mockRouterNavigate(test.router);
@@ -581,7 +579,8 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         expect(form.isPrimaryAuth()).toBe(true);
         // Respond with MFA_REQUIRED
         // Verify is immediately called, so respond with MFA_CHALLENGE
-        test.setNextResponse([resMfaRequiredOktaVerify, resMfaChallengePush]);
+        var resAutoPushTrue = Util.getAutoPushResponse(resMfaRequiredOktaVerify, true);
+        test.setNextResponse([resAutoPushTrue, resMfaChallengePush]);
         form.setUsername('testuser');
         form.setPassword('pass');
         form.submit();
@@ -594,7 +593,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         expect(form.isPushSent()).toBe(true);
         expect($.ajax.calls.count()).toBe(2);
         Expect.isJsonPost($.ajax.calls.argsFor(1), {
-          url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify',
+          url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?autoPush=true',
           data: {
             stateToken: 'testStateToken'
           }
@@ -624,8 +623,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         expect(form.isPushSent()).toBe(false);
       });
     });
-    itp('auto push updates cookie on MFA success', function () {
-      spyOn(CookieUtil, 'removeAutoPushCookie');
+    itp('sends autoPush=false as url param when auto push checkbox is unchecked', function () {
       return setup({'features.autoPush': true})
       .then(function (test) {
         Util.mockRouterNavigate(test.router);
@@ -642,13 +640,19 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CookieUtil, Logger, OktaAut
         return Expect.waitForMfaVerify(test);
       })
       .then(function (test) {
-        test.setNextResponse(resSuccess);
+        test.setNextResponse(resMfaChallengePush);
         var form = new MfaVerifyForm($sandbox);
         form.submit();
-        return tick(test);
+        return tick();
       })
       .then(function () {
-        expect(CookieUtil.removeAutoPushCookie).toHaveBeenCalledWith('00ui0jgywTAHxYGMM0g3');
+        expect($.ajax.calls.count()).toBe(2);
+        Expect.isJsonPost($.ajax.calls.argsFor(1), {
+          url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?autoPush=false',
+          data: {
+            stateToken: 'testStateToken'
+          }
+        });
       });
     });
 


### PR DESCRIPTION
Removes support for autoPush as js readable cookie.
Note: Users will need to re-enroll in auto push with this change

Resolves: OKTA-157892