### PR TITLE
:arrow_up: upgrade authjs version to 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-signin-widget",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "webpack": "1.13.1"
   },
   "dependencies": {
-    "@okta/okta-auth-js": "1.11.0",
+    "@okta/okta-auth-js": "1.13.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.26.0",
     "backbone": "1.2.1",


### PR DESCRIPTION
Last release [commit](https://github.com/okta/okta-signin-widget/commit/d71767c31942e96de37c11ecf697d4c8fe9c430e) downgraded authjs version, so we need to bring it back up.
The reason this happened is because we released a version based on one sha before authjs was upgraded

Right now, [package-lock.json has correctly version 1.13.0](https://github.com/okta/okta-signin-widget/blob/master/package-lock.json#L8), but [package.json has 1.11.0](https://github.com/okta/okta-signin-widget/blob/master/package.json#L92). This PR will fix this inconsistency

Resolves: OKTA-160858