### PR TITLE
:bug: Fixes Okta Verify polling issue when switching factors

### DIFF
--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -18,9 +18,9 @@ function (Okta, Q) {
 
   var _ = Okta._;
   var KNOWN_ERRORS = [
-    'OAuthError', 
-    'AuthSdkError', 
-    'AuthPollStopError', 
+    'OAuthError',
+    'AuthSdkError',
+    'AuthPollStopError',
     'AuthApiError'
   ];
 
@@ -48,10 +48,10 @@ function (Okta, Q) {
     manageTransaction: function (fn) {
       var self = this,
           res = fn.call(this, this.appState.get('transaction'), _.bind(this.setTransaction, this));
-      
+
       // If it's a promise, listen for failures
       if (Q.isPromiseAlike(res)) {
-        res.fail(function(err) {
+        return res.fail(function(err) {
           if (err.name === 'AuthPollStopError') {
             return;
           }


### PR DESCRIPTION
* We continute to poll even after user navigates to another factor after
triggering a MFA verify. This was due to the fact that the transaction state not being set
when sing MFA verify until the poll complted with a success/failure.

The fix here is that the transaction is updated when we get the first response from server.

Polling stops when you switch factors

![bugfix2](https://user-images.githubusercontent.com/17267130/37006236-4e62ee24-208c-11e8-8a49-1523354a2609.gif)
