### PR TITLE
:seedling: Send relayState param with registration post call.

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -127,6 +127,19 @@ function (
         }
       });
     },
+    getJsonFromUrl: function(url) {
+      var query = url.substr(1);
+      var result = {};
+      query.split('&').forEach(function(part) {
+        var item = part.split('=');
+        result[item[0]] = item[1];
+      });
+      return result;
+    },
+    getRelayStateData: function () {
+      var urlParams = this.getJsonFromUrl(window.location.search);
+      return urlParams.fromURI || '';
+    },
     createRegistrationModel: function (modelProperties) {
       var self = this;
       var Model = Okta.Model.extend({
@@ -139,7 +152,10 @@ function (
         },
         toJSON: function() {
           var data = Okta.Model.prototype.toJSON.apply(this, arguments);
-          return {userProfile: data};
+          return {
+            userProfile: data,
+            relayState: self.getRelayStateData()
+          };
         },
         parse: function(resp) {
           this.set('activationToken', resp.activationToken);

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -127,6 +127,8 @@ function (
         }
       });
     },
+    // @param url (Eg: ?fromURI=%2Fapp%2FUserHome&query=blah)
+    // returns {fromURI:'%2Fapp%2FUserHome', query: blah}
     getJsonFromUrl: function(url) {
       var query = url.substr(1);
       var result = {};

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -170,6 +170,58 @@ function (Q, _, $, OktaAuth, Backbone, Util, Expect, Beacon, RegForm, RegSchema,
           expect(test.router.controller.model.settings.get('policyId')).toContain('5678');
         });
       });
+      itp('sends relay state with registration post if set', function () {
+        return setup().then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setEmail('test@example.com');
+          test.form.setPassword('Abcd1234');
+          spyOn(test.router.controller, 'getJsonFromUrl').and.callFake(function () {
+            return {
+              'fromURI': '%2Fapp%2FUserHome',
+              'query': 'blah'
+            };
+          });
+          var model = test.router.controller.model;
+          var postData = model.toJSON();
+          expect(postData.relayState).toBe('%2Fapp%2FUserHome');
+        });
+      });
+      itp('sends relay state as empty string with registration post if not set', function () {
+        return setup().then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setEmail('test@example.com');
+          test.form.setPassword('Abcd1234');
+          spyOn(test.router.controller, 'getJsonFromUrl').and.callFake(function () {
+            return {
+              'query': 'blah'
+            };
+          });
+          var model = test.router.controller.model;
+          var postData = model.toJSON();
+          expect(postData.relayState).toBe('');
+        });
+      });
+    });
+
+    Expect.describe('getJsonFromUrl', function () {
+      itp('extracts fromURI from url correctly if fromURI in the start', function () {
+        return setup().then(function (test) {
+          var result = test.router.controller.getJsonFromUrl('?fromURI=%2Fapp%2FUserHome&query=blah');
+          expect(result.fromURI).toBe('%2Fapp%2FUserHome');
+        });
+      });
+      itp('extracts fromURI from url correctly if fromURI in the end', function () {
+        return setup().then(function (test) {
+          var result = test.router.controller.getJsonFromUrl('?query=blah&fromURI=%2Fapp%2FUserHome');
+          expect(result.fromURI).toBe('%2Fapp%2FUserHome');
+        });
+      });
+      itp('fromURI is undefined if not present', function () {
+        return setup().then(function (test) {
+          var result = test.router.controller.getJsonFromUrl('?query=blah');
+          expect(result.fromURI).toBe(undefined);
+        });
+      });
     });
 
     Expect.describe('elements', function () {


### PR DESCRIPTION
- Sign in widget now sends a relayState param with registration post call which is the fromURI value of window.location.href 

Resolves : OKTA-152289

Reviewers: 
@hor-kanchan-okta @uvartak-okta 
