### PR TITLE
Exclude vkbeautify from build

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -42,6 +42,7 @@ module.exports = function (outputFilename) {
         // v2 version. Continue to use the vendor file that is checked into
         // source.
         'duo': 'vendor/Duo-Web-v2.6',
+        'vendor/plugins/vkbeautify.0.99.00.beta': EMPTY
       }
     },
 
@@ -107,7 +108,6 @@ module.exports = function (outputFilename) {
             return path.resolve(TARGET_JS, 'shared', file);
           }).concat([
             /moment-tz/,
-            /vendor\/plugins\/vkbeautify/,
             /vendor\/plugins\/jquery.simplemodal/,
             /vendor\/plugins\/spin/,
             'jqueryui',


### PR DESCRIPTION
This works with only line 45 added. Line 110 is not necessary, but I think it should be cleaned up (removed) if I'm understanding the build process correctly.

This still needs: testing to make sure the widget really really doesn't need the `vkbeautify` package. 😄 
cc @santhoshbalakrishnan @rchild-okta 