### PR TITLE
honor idp discovery feature for all other paths

### DIFF
--- a/src/LoginRouter.js
+++ b/src/LoginRouter.js
@@ -143,14 +143,14 @@ function (BaseLoginRouter,
       'signin/register': 'register',
       'signin/register-complete': 'registerComplete',
       'signin/consent': 'consentRequired',
-      '*wildcard': 'wildcard'
+      '*wildcard': 'defaultAuth'
     },
 
     // Route handlers that do not require a stateToken. If the page is refreshed,
     // these functions will not require a status call to refresh the stateToken.
     stateLessRouteHandlers: [
       'defaultAuth', 'idpDiscovery', 'primaryAuth', 'forgotPassword', 'recoveryLoading',
-      'unlockAccount', 'refreshAuthState', 'register', 'registerComplete', 'wildcard'
+      'unlockAccount', 'refreshAuthState', 'register', 'registerComplete'
     ],
 
     defaultAuth: function() {
@@ -168,15 +168,6 @@ function (BaseLoginRouter,
 
     primaryAuth: function () {
       this.render(PrimaryAuthController, { Beacon: SecurityBeacon });
-    },
-
-    wildcard: function (route) {
-      if (route === 'login/login.htm') {
-        this.defaultAuth();
-      }
-      else {
-        this.primaryAuth();
-      }
     },
 
     verifyDuo: function () {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -395,7 +395,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, OktaAuth, Util, Exp
         expect(form.isIDPDiscovery()).toBe(true);
       });
     });
-    itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function () {
+    itp('navigates to PrimaryAuth for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function () {
       return setup({'features.idpDiscovery': false})
       .then(function (test) {
         Util.mockRouterNavigate(test.router);
@@ -407,7 +407,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, OktaAuth, Util, Exp
         expect(form.isPrimaryAuth()).toBe(true);
       });
     });
-    itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is true', function () {
+    itp('navigates to IDPDiscovery for /any/other when features.idpDiscovery is true', function () {
       return setup({'features.idpDiscovery': true})
       .then(function (test) {
         Util.mockRouterNavigate(test.router);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 32], max-statements: [2, 44], max-len: [2, 180], camelcase:0 */
+/* eslint max-params: [2, 32], max-statements: 0, max-len: [2, 180], camelcase:0 */
 define([
   'okta',
   'vendor/lib/q',
@@ -383,11 +383,47 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, OktaAuth, Util, Exp
         expect(form.isPrimaryAuth()).toBe(true);
       });
     });
-    itp('navigates to PrimaryAuth for all other wildcard routes', function () {
+    itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is true', function () {
       return setup({'features.idpDiscovery': true})
       .then(function (test) {
         Util.mockRouterNavigate(test.router);
-        test.router.navigate('login/default');
+        test.router.navigate('/app/salesforce/abc123sef/sso/saml');
+        return Expect.waitForIDPDiscovery();
+      })
+      .then(function () {
+        var form = new IDPDiscoveryForm($sandbox);
+        expect(form.isIDPDiscovery()).toBe(true);
+      });
+    });
+    itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function () {
+      return setup({'features.idpDiscovery': false})
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.router.navigate('/app/salesforce/abc123sef/sso/saml');
+        return Expect.waitForPrimaryAuth();
+      })
+      .then(function () {
+        var form = new PrimaryAuthForm($sandbox);
+        expect(form.isPrimaryAuth()).toBe(true);
+      });
+    });
+    itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is true', function () {
+      return setup({'features.idpDiscovery': true})
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.router.navigate('any/other');
+        return Expect.waitForIDPDiscovery();
+      })
+      .then(function () {
+        var form = new IDPDiscoveryForm($sandbox);
+        expect(form.isIDPDiscovery()).toBe(true);
+      });
+    });
+    itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is false', function () {
+      return setup({'features.idpDiscovery': false})
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.router.navigate('any/other');
         return Expect.waitForPrimaryAuth();
       })
       .then(function () {


### PR DESCRIPTION
- don't whitelist for primary auth v.s. idp discovery auth but only relies on the feature to determine whether run idp discovery flow or primary auth flow.
- therefore shift the logic to backend to set up the auth flow.
- video: https://okta.box.com/s/l640apxbvql99s9h7dqb8qfs16nvk27i
- OKTA-163556

@mauriciocastillosilva-okta @yuliu-okta 
^ @hor-kanchan-okta 
