### PR TITLE
:seedling: Expose AuthJS on SignIn object

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Contributors should read our [contributing guidelines](./CONTRIBUTING.md) if the
   * [remove](#remove)
   * [on](#onevent-callback-context)
   * [off](#offevent-callback)
+  * [authClient](#authclient)
   * [session.get](#sessiongetcallback)
   * [session.refresh](#sessionrefreshcallback)
   * [session.close](#sessionclosecallback)
@@ -316,6 +317,20 @@ signIn.off('pageRendered');
 
 // Unsubscribe the onPageRendered listener from the 'pageRendered' event
 signIn.off('pageRendered', onPageRendered);
+```
+
+## authClient
+
+Returns the underlying `@okta/okta-auth-js` object used by the widget. See [AuthJS](https://github.com/okta/okta-auth-js#api) for a list of available methods.
+
+```javascript
+// Check for an existing authClient transaction
+signIn.authClient.tx.exists();
+if (exists) {
+  console.log('A session exists!');
+} else {
+  console.log('A session does not exist.');
+};
 ```
 
 ## session.get(callback)

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -130,10 +130,18 @@ var OktaSignIn = (function () {
       .fail(error);
     }
 
+    /**
+     * Returns the Okta Auth JS auth client.
+     */
+    function getAuthClient() {
+      return authClient;
+    }
+
     // Properties exposed on OktaSignIn object.
     return {
       renderEl: render,
       signOut: closeSession,
+      authClient: getAuthClient(),
       idToken: {
         refresh: refreshIdToken
       },

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -130,18 +130,11 @@ var OktaSignIn = (function () {
       .fail(error);
     }
 
-    /**
-     * Returns the Okta Auth JS auth client.
-     */
-    function getAuthClient() {
-      return authClient;
-    }
-
     // Properties exposed on OktaSignIn object.
     return {
       renderEl: render,
       signOut: closeSession,
-      authClient: getAuthClient(),
+      authClient: authClient,
       idToken: {
         refresh: refreshIdToken
       },

--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -47,4 +47,24 @@ describe('Basic flows', function() {
     expect(el.isDisplayed()).toBe(true);
   });
 
+  it('can call authClient methods', function() {
+    // Ensure the widget exists
+    var el = element(by.css('#okta-sign-in'));
+    expect(el.isDisplayed()).toBe(true);
+
+    function getToken() {
+      return oktaSignIn.authClient.tokenManager.get('idToken');
+    }
+
+    // Set a fake token into localStorage
+    var token = JSON.stringify({
+      idToken: { foo: 'bar' }
+    });
+    browser.executeScript(`window.localStorage.setItem('okta-token-storage', '${token}');`);
+
+    // Retrieve the token
+    browser.executeScript(getToken).then(function(storedToken) {
+      expect(storedToken).toEqual({foo: 'bar'});
+    });
+  });
 });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -1,0 +1,78 @@
+/* eslint max-params:[0, 2], max-len:[2, 180] */
+define([
+  'widget/OktaSignIn',
+  'helpers/util/Expect'
+],
+function (Widget, Expect) {
+
+  var url = 'https://foo.com';
+  var signIn = new Widget({
+    baseUrl: url
+  });
+
+  Expect.describe('OktaSignIn initialization', function () {
+    Expect.describe('At the root level', function () {
+      it('has a renderEl method', function () {
+        expect(signIn.renderEl).toBeDefined();
+      });
+      it('has a signOut method', function () {
+        expect(signIn.renderEl).toBeDefined();
+      });
+      it('has an authClient method', function () {
+        expect(signIn.authClient).toBeDefined();
+        expect(signIn.authClient.options.url).toEqual(url);
+      });
+      it('has a tokenManager method', function () {
+        expect(signIn.tokenManager).toBeDefined();
+      });
+      it('has a hide method', function () {
+        expect(signIn.hide).toBeDefined();
+      });
+      it('has a show method', function () {
+        expect(signIn.show).toBeDefined();
+      });
+      it('has a remove method', function () {
+        expect(signIn.remove).toBeDefined();
+      });
+    });
+
+    Expect.describe('IdToken', function () {
+      it('has an idToken method', function () {
+        expect(signIn.idToken).toBeDefined();
+      });
+      it('has an idToken.refresh method', function () {
+        expect(signIn.idToken.refresh).toBeDefined();
+      });
+    });
+
+    Expect.describe('Session', function () {
+      it('has a session method', function () {
+        expect(signIn.session).toBeDefined();
+      });
+      it('has a session.close method', function () {
+        expect(signIn.session.close).toBeDefined();
+      });
+      it('has a session.exists method', function () {
+        expect(signIn.session.exists).toBeDefined();
+      });
+      it('has a session.get method', function () {
+        expect(signIn.session.get).toBeDefined();
+      });
+      it('has a session.refresh method', function () {
+        expect(signIn.session.refresh).toBeDefined();
+      });
+    });
+
+    Expect.describe('Token', function () {
+      it('has a token method', function () {
+        expect(signIn.token).toBeDefined();
+      });
+      it('has a token.hasTokensInUrl method', function () {
+        expect(signIn.token.hasTokensInUrl).toBeDefined();
+      });
+      it('has a token.parseTokensFromUrl method', function () {
+        expect(signIn.token.parseTokensFromUrl).toBeDefined();
+      });
+    });
+  });
+});

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -16,9 +16,9 @@ function (Widget, Expect) {
         expect(signIn.renderEl).toBeDefined();
       });
       it('has a signOut method', function () {
-        expect(signIn.renderEl).toBeDefined();
+        expect(signIn.signOut).toBeDefined();
       });
-      it('has an authClient method', function () {
+      it('has an authClient object', function () {
         expect(signIn.authClient).toBeDefined();
         expect(signIn.authClient.options.url).toEqual(url);
       });


### PR DESCRIPTION
### Description
Exposes the underlying `@okta/okta-auth-js` object used when initializing the widget.

Currently the Widget wraps AuthJS and exposes a subset of methods needed by developers. This PR aims to expose the entire object for the most flexibility.

### Resolves
[OKTA-168960](https://oktainc.atlassian.net/browse/OKTA-168960) & [REQ-13006](https://oktainc.atlassian.net/browse/REQ-13006)