### PR TITLE
:bug: Fixes tests not using promise helper

### DIFF
--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1024,7 +1024,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
     });
 
     Expect.describe('IDP Discovery', function () {
-      it('renders primary auth when idp is okta', function () {
+      itp('renders primary auth when idp is okta', function () {
         return setup()
         .then(function (test) {
           Util.mockRouterNavigate(test.router);
@@ -1038,7 +1038,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           expect(test.router.navigate).toHaveBeenCalledWith('signin', {trigger: true});
         });
       });
-      it('redirects to idp for idps other than okta', function () {
+      itp('redirects to idp for idps other than okta', function () {
         spyOn(SharedUtil, 'redirect');
         return setup()
         .then(function (test) {


### PR DESCRIPTION
When previously running tests, the following message was logged [in local and Travis builds](https://travis-ci.org/okta/okta-signin-widget/builds/375120314#L1677):
```
IDP Discovery
  - renders primary auth when idp is okta...
  >> Spec 'IDPDiscovery IDP Discovery renders primary auth when idp is okta' has no expectations. at 
  >> .grunt/grunt-contrib-jasmine/jasmine-html.js:106 specDone
...✓
  - redirects to idp for idps other than okta...
  >> Spec 'IDPDiscovery IDP Discovery redirects to idp for idps other than okta' has no expectations. at
  >> .grunt/grunt-contrib-jasmine/jasmine-html.js:106 specDone
...✓
```

Updating this to use the promise helper corrects this issue.