### PR TITLE
:memo: Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ var signIn = new OktaSignIn(
 );
 ```
 
+> **Note**: `https://{yourOktaDomain}` can be any Okta organization. See [Basic config options](#basic-config-options) for more information.
+
 ## renderEl(options, success, error)
 
 Renders the widget to the DOM, and passes control back to your app through the success and error callback functions when the user has entered a success or error state.
@@ -356,8 +358,9 @@ signIn.session.get(function (res) {
   }
   // No session, or error retrieving the session. Render the Sign-In Widget.
   else if (res.status === 'INACTIVE') {
-    signIn.renderEl(
-      {el: '#osw-container'},
+    signIn.renderEl({
+        el: '#osw-container'
+      },
       function success(res) {
         // showApp() if res.status === 'SUCCESS'
       },
@@ -470,8 +473,9 @@ After receiving an `access_token` or `id_token`, add it to the `tokenManager` to
 
 ```javascript
 // Example showing a success callback when authParams.responseType = 'id_token'
-signIn.renderEl(
-  {el: '#osw-container'},
+signIn.renderEl({
+    el: '#osw-container'
+  },
   function (res) {
     if (res.status !== 'SUCCESS') {
       return;

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ Loading our assets directly from the CDN is a good choice if you want an easy wa
 To use the CDN, include links to the JS and CSS files in your HTML:
 
 ```html
-<!-- Latest CDN production Javascript and CSS: 2.7.0 -->
+<!-- Latest CDN production Javascript and CSS: 2.9.0 -->
 <script
-  src="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.7.0/js/okta-sign-in.min.js"
+  src="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.9.0/js/okta-sign-in.min.js"
   type="text/javascript"></script>
 <link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.7.0/css/okta-sign-in.min.css"
+  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.9.0/css/okta-sign-in.min.css"
   type="text/css"
   rel="stylesheet"/>
 
 <!-- Theme file: Customize or replace this file if you want to override our default styles -->
 <link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.7.0/css/okta-theme.css"
+  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.9.0/css/okta-theme.css"
   type="text/css"
   rel="stylesheet"/>
 ```
@@ -101,7 +101,7 @@ To install [@okta/okta-signin-widget](https://www.npmjs.com/package/@okta/okta-s
 
 ```bash
 # Run this command in your project root folder.
-[project-root-folder]$ npm install @okta/okta-signin-widget --save
+npm install @okta/okta-signin-widget --save
 ```
 
 The widget source files and assets will be installed to `node_modules/@okta/okta-signin-widget/dist`, and will have this directory structure:
@@ -132,6 +132,10 @@ node_modules/@okta/okta-signin-widget/dist/
     # down through `npm install` (which allows you to use your own version of
     # jquery, etc).
     okta-sign-in.entry.js
+
+    # Development version of okta-sign-in.min.js. Equipped with helpful
+    # console warning messages for common configuration errors.
+    okta-sign-in.js
 
   # Localized strings that are used to display all text and labels in the
   # widget. Three output formats are included - json, jsonp, and properties
@@ -174,7 +178,11 @@ Creates a new instance of the Sign-In Widget with the provided options. The widg
 - `config` - Options that are used to configure the widget
 
 ```javascript
-var signIn = new OktaSignIn({baseUrl: 'https://acme.okta.com'});
+var signIn = new OktaSignIn(
+  {
+    baseUrl: 'https://{yourOktaDomain}'
+  }
+);
 ```
 
 ## renderEl(options, success, error)
@@ -326,7 +334,7 @@ Returns the underlying `@okta/okta-auth-js` object used by the widget. See [Auth
 
 ```javascript
 // Check for an existing authClient transaction
-signIn.authClient.tx.exists();
+var exists = signIn.authClient.tx.exists();
 if (exists) {
   console.log('A session exists!');
 } else {
@@ -417,7 +425,7 @@ Parses the access or ID Tokens from the url after a successful authentication re
 
 ```javascript
 var signIn = new OktaSignIn({
-  baseUrl: 'https://acme.okta.com',
+  baseUrl: 'https://{yourOktaDomain}',
   clientId: '{{myClientId}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
   authParams: {
@@ -462,16 +470,18 @@ After receiving an `access_token` or `id_token`, add it to the `tokenManager` to
 
 ```javascript
 // Example showing a success callback when authParams.responseType = 'id_token'
-signIn.renderEl({el: '#osw-container'}, function (res) {
-  if (res.status !== 'SUCCESS') {
-    return;
+signIn.renderEl(
+  {el: '#osw-container'},
+  function (res) {
+    if (res.status !== 'SUCCESS') {
+      return;
+    }
+
+    // When specifying authParams.responseType as 'id_token' or 'token', the
+    // response is the token itself
+    signIn.tokenManager.add('my_id_token', res);
   }
-
-  // When specifying authParams.responseType as 'id_token' or 'token', the
-  // response is the token itself
-  signIn.tokenManager.add('my_id_token', res);
-});
-
+);
 ```
 
 ## `OIDC` tokenManager.get(key)
@@ -568,7 +578,7 @@ The only required configuration option is `baseUrl`. All others are optional.
 ```javascript
 // Basic example
 var config = {
-  baseUrl: 'https://acme.okta.com',
+  baseUrl: 'https://{yourOktaDomain}',
   logo: '/path/to/logo.png',
   helpSupportNumber: '(123) 456-7890',
   language: 'en',
@@ -865,6 +875,7 @@ customButtons: [{
 #### Registration Button
 
 You can add a registration link to the primary auth page by setting `features.registration` to `true` and by adding the following config options.
+
 ```javascript
 // An example that adds a registration button underneath the login form on the primary auth page
 registration: {
@@ -873,8 +884,8 @@ registration: {
   }
 }
 ```
-- **registration.click** - Function that is called when the registration button is clicked
 
+- **registration.click** - Function that is called when the registration button is clicked
 
 ## Registration
 
@@ -884,7 +895,7 @@ To add registration into your application, configure your Okta admin settings to
 
 ```javascript
     var signIn = new OktaSignIn({
-      baseUrl: 'https://acme.okta.com',
+      baseUrl: 'https://{yourOktaDomain}',
       // If you are using version 2.8 or higher of the widget, clientId is not required while configuring
       // registration. Instead the widget relies on policy setup with Self Service Registration. For help
       // with setting up Self Service Registration contact support@okta.com. Registration should continue
@@ -1014,7 +1025,7 @@ Then, in the widget configuration, set `features.idpDiscovery` to `true` and add
 
 ```javascript
 var signIn = new OktaSignIn({
-  baseUrl: 'https://your-org.okta.com',
+  baseUrl: 'https://{yourOktaDomain}',
   ... ...
   idpDiscovery: {
     requestContext: '/a/app/request/context',
@@ -1176,7 +1187,7 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
 
     ```javascript
     authParams: {
-      issuer: 'https://your-org.okta.com/oauth2/default'
+      issuer: 'https://{yourOktaDomain}/oauth2/default'
     }
     ```
 
@@ -1184,8 +1195,8 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
 
     ```javascript
     authParams: {
-      issuer: 'https://your-org.okta.com/oauth2/default',
-      authorizeUrl: 'https://your-org.okta.com/oauth2/default/v1/authorize'
+      issuer: 'https://{yourOktaDomain}/oauth2/default',
+      authorizeUrl: 'https://{yourOktaDomain}/oauth2/default/v1/authorize'
     }
     ```
 
@@ -1271,20 +1282,21 @@ Need to know if the Sign-In Widget supports your browser requirements?  Please s
 1. Clone this repo and navigate to the new `okta-signin-widget` folder.
 
     ```bash
-    $ git clone git@github.com:okta/okta-signin-widget.git && cd okta-signin-widget
+    git clone git@github.com:okta/okta-signin-widget.git
+    cd okta-signin-widget
     ```
 
 2. [Install Bundler](http://bundler.io/) if you don't already have it, and then install our Ruby dependencies.
 
     ```bash
-    [okta-signin-widget]$ gem install bundler
-    [okta-signin-widget]$ bundle install
+    gem install bundler
+    bundle install
     ```
 
 3. Install our Node dependencies.
 
     ```bash
-    [okta-signin-widget]$ npm install
+    npm install
     ```
 
 4. Create a `.widgetrc` file in the `okta-signin-widget` directory with an entry for `baseUrl`.
@@ -1292,7 +1304,7 @@ Need to know if the Sign-In Widget supports your browser requirements?  Please s
     ```javascript
     {
       "widgetOptions": {
-        "baseUrl": "https://your-org.okta.com"
+        "baseUrl": "https://{yourOktaDomain}"
       }
     }
     ```
@@ -1300,7 +1312,7 @@ Need to know if the Sign-In Widget supports your browser requirements?  Please s
 5. Build the widget, start a local connect server that hosts it, and launch a browser window with the widget running.
 
     ```bash
-    [okta-signin-widget]$ npm start
+    npm start
     ```
 
 6. Finally, enable CORS support for our new server by [following these instructions](http://developer.okta.com/docs/guides/okta_sign-in_widget.html#configuring-cors-support-on-your-okta-organization). You can now authenticate to Okta using your very own, customizable widget!
@@ -1320,6 +1332,6 @@ The `.widgetrc` file is a configuration file that saves your local widget settin
 | --- | --- |
 | `npm start` | Build the widget, start the server, and open a browser window with the widget loaded |
 | `npm run build:dev` | Build an unminified version of the widget |
-| `npm run build:release` | Build a minified, uglified version of the widget (`okta-sign-in.min.js`) and a non-minified **development** version of the widget (`okta-sigin-in.js`).|
+| `npm run build:release` | Build a minified, uglified version of the widget (`okta-sign-in.min.js`) and a non-minified **development** version of the widget (`okta-sign-in.js`).|
 | `npm test` | Run unit tests |
 | `npm run lint` | Run jshint and scss linting tests |


### PR DESCRIPTION
- Updates CDN version to latest `2.9.0`
- Replaces occurrences of `*.okta.com` and `*.oktapreview.com` with universal `{yourOktaDomain}` (what we do with developer.okta.com today).
- Removes bash-only commands
- Updates readability on some objects