### PR TITLE
:arrow_up: Use Node 8

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,7 @@ cd ${OKTA_HOME}/${REPO}
 setup_service grunt
 setup_service bundler
 
-# Use newer, faster npm
-npm install -g npm@4.0.2
+setup_service node v8.1.1
 
 # Install required dependencies
 npm install -g @okta/ci-update-package


### PR DESCRIPTION
Since we are moving toward using ES6 (see `buildtools/webpack/plugins.js`), we will need to ensure our Bacon environment is up-to-date.

This PR updates our build environment to use the same as `okta-ui`.