### PR TITLE
 :bug: Fix concurrent fingerprinting

### DIFF
--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -10,11 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 7] */
+/* eslint complexity: [2, 8] */
 
 define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
 
   return {
+    _isMessageFromCorrectSource: function($iframe, event) {
+      return event.source === $iframe[0].contentWindow;
+    },
     generateDeviceFingerprint: function (oktaDomainUrl, element) {
       if (!navigator.userAgent) {
         return Q.reject('user agent is not defined');
@@ -23,6 +26,7 @@ define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
       }
 
       var deferred = Q.defer();
+      var self = this;
 
       // Create iframe
       var $iframe = $('<iframe>', {
@@ -46,6 +50,9 @@ define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
       }
 
       function onMessageReceivedFromOkta(event) {
+        if (!self._isMessageFromCorrectSource($iframe, event)) {
+          return;
+        }
         if (!event || !event.data || event.origin != oktaDomainUrl) {
           handleError('no data');
           return;

--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -15,13 +15,17 @@
 define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
 
   return {
+    __getUserAgent: function() {
+      return navigator.userAgent;
+    },
     _isMessageFromCorrectSource: function($iframe, event) {
       return event.source === $iframe[0].contentWindow;
     },
     generateDeviceFingerprint: function (oktaDomainUrl, element) {
-      if (!navigator.userAgent) {
+      var userAgent = this.__getUserAgent();
+      if (!userAgent) {
         return Q.reject('user agent is not defined');
-      } else if (isWindowsPhone()) {
+      } else if (isWindowsPhone(userAgent)) {
         return Q.reject('device fingerprint is not supported on Windows phones');
       }
 
@@ -34,8 +38,8 @@ define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
       });
       $iframe.appendTo(element);
 
-      function isWindowsPhone() {
-        return navigator.userAgent.match(/windows phone|iemobile|wpdesktop/i);
+      function isWindowsPhone(userAgent) {
+        return userAgent.match(/windows phone|iemobile|wpdesktop/i);
       }
 
       function removeIframe() {

--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -15,14 +15,14 @@
 define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
 
   return {
-    __getUserAgent: function() {
+    getUserAgent: function() {
       return navigator.userAgent;
     },
-    _isMessageFromCorrectSource: function($iframe, event) {
+    isMessageFromCorrectSource: function($iframe, event) {
       return event.source === $iframe[0].contentWindow;
     },
     generateDeviceFingerprint: function (oktaDomainUrl, element) {
-      var userAgent = this.__getUserAgent();
+      var userAgent = this.getUserAgent();
       if (!userAgent) {
         return Q.reject('user agent is not defined');
       } else if (isWindowsPhone(userAgent)) {
@@ -54,7 +54,7 @@ define(['vendor/lib/q', 'okta/jquery'], function (Q, $) {
       }
 
       function onMessageReceivedFromOkta(event) {
-        if (!self._isMessageFromCorrectSource($iframe, event)) {
+        if (!self.isMessageFromCorrectSource($iframe, event)) {
           return;
         }
         if (!event || !event.data || event.origin != oktaDomainUrl) {

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -3,10 +3,9 @@ define([
   'vendor/lib/q',
   'helpers/util/Expect',
   'sandbox',
-  'util/DeviceFingerprint',
-  'helpers/mocks/Util'
+  'util/DeviceFingerprint'
 ],
-function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
+function ($, Q, Expect, $sandbox, DeviceFingerprint) {
 
   Expect.describe('DeviceFingerprint', function () {
 
@@ -18,8 +17,8 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
       window.postMessage(JSON.stringify(message), '*');
     }
 
-    function mockUserAgentCheck(userAgent) {
-      spyOn(DeviceFingerprint, '__getUserAgent').and.callFake(function() {
+    function mockUserAgent(userAgent) {
+      spyOn(DeviceFingerprint, 'getUserAgent').and.callFake(function() {
         return userAgent;
       });
     }
@@ -27,7 +26,7 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
     function bypassMessageSourceCheck() {
       // since we mock the Iframe messages the check to see if the message
       // sent from right iframe would fail.
-      spyOn(DeviceFingerprint, '_isMessageFromCorrectSource').and.callFake(function() {
+      spyOn(DeviceFingerprint, 'isMessageFromCorrectSource').and.callFake(function() {
         return true;
       });
     }
@@ -84,7 +83,7 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
     });
 
     it('fails if user agent is not defined', function (done) {
-      mockUserAgentCheck(undefined);
+      mockUserAgent(undefined);
       mockIFrameMessages(true);
       DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
         .then(function () {
@@ -97,7 +96,7 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
     });
 
     it('fails if it is called from a Windows phone', function (done) {
-      mockUserAgentCheck('Windows Phone');
+      mockUserAgent('Windows Phone');
       mockIFrameMessages(true);
       DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
       .then(function () {
@@ -118,13 +117,12 @@ function ($, Q, Expect, $sandbox, DeviceFingerprint, Util) {
         .fail(function (reason) {
           done.fail('Fingerprint promise should not have been rejected. ' +  reason);
         });
-      Util.mockSetTimeout();
-      setTimeout(function() {
+      Expect.tick().then(function() {
         // give it time to check if promise resolves or rejects.
         var $iFrame = $sandbox.find('iframe');
         expect($iFrame).toExist();
         done();
-      }, 1000);
+      });
     });
 
   });


### PR DESCRIPTION
 The signin widget runs the device fingerprinting code in an iframe and proceeds when the iframe posts back to the parent an event with type `FingerprintAvailable`. The problem is that the widget assumes that one one iframe will exist at a time and therefore only one `FingerprintAvailable` event will occur. This is a bad assumption. It is possible for multiple requests to request fingerprints at the same time but all requests will listen for the same `FingerprintAvailable` event regardless of which iframe generated it. This means that all concurrent fingerprint requests will generate unique fingerprints but all will use the first one that is returned. Because the fingerprints have one time tokens, this will cause failures

Checking iframe contentWindow with event sources makes sure that we only process messages received from the right iframe.