### PR TITLE
:seedling: Use default success/error handlers when not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,12 @@ var signIn = new OktaSignIn(
 
 ## renderEl(options, success, error)
 
-Renders the widget to the DOM, and passes control back to your app through the success and error callback functions when the user has entered a success or error state.
+Renders the widget to the DOM, and passes control back to your app through success and error callback functions when the user has entered a success or error state.
 
 - `options`
   - `el` - CSS selector which identifies the container element that the widget attaches to.
-- `success` - Function that is called when the user has completed an authentication flow.
-- `error` - Function that is called when the widget has been initialized with invalid config options, or has entered a state it cannot recover from.
+- `success` *(optional)* - Function that is called when the user has completed an authentication flow. If omitted, an empty function is used.
+- `error` *(optional)* - Function that is called when the widget has been initialized with invalid config options, or has entered a state it cannot recover from. If omitted, a default function is used to output warnings to the console when running in **development** mode.
 
 ```javascript
 signIn.renderEl(

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Renders the widget to the DOM, and passes control back to your app through succe
 
 - `options`
   - `el` - CSS selector which identifies the container element that the widget attaches to.
-- `success` *(optional)* - Function that is called when the user has completed an authentication flow. If omitted, an empty function is used.
-- `error` *(optional)* - Function that is called when the widget has been initialized with invalid config options, or has entered a state it cannot recover from. If omitted, a default function is used to output warnings to the console when running in **development** mode.
+- `success` *(optional)* - Function that is called when the user has completed an authentication flow. If an [OpenID Connect redirect flow](#openid-connect) is used, this function can be omitted.
+- `error` *(optional)* - Function that is called when the widget has been initialized with invalid config options, or has entered a state it cannot recover from. If omitted, a default function is used to output errors to the console.
 
 ```javascript
 signIn.renderEl(

--- a/buildtools/webpack/plugins.js
+++ b/buildtools/webpack/plugins.js
@@ -32,7 +32,6 @@ function uglify() {
         'Logger.log',
         'Logger.info',
         'Logger.warn',
-        'Logger.error',
         'Logger.deprecate'
       ],
     },

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -308,9 +308,6 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       if (!options.baseUrl) {
         this.callGlobalError(new ConfigError(Okta.loc('error.required.baseUrl')));
       }
-      else if (!options.globalSuccessFn) {
-        this.callGlobalError(new ConfigError(Okta.loc('error.required.success')));
-      }
       else if (BrowserFeatures.corsIsNotSupported()) {
         this.callGlobalError(new UnsupportedBrowserError(Okta.loc('error.unsupported.cors')));
       }

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint max-params: [2, 13], max-statements: [2, 18] */
+/* eslint max-params: [2, 14], max-statements: [2, 18] */
 // BaseLoginRouter contains the more complicated router logic - rendering/
 // transition, etc. Most router changes should happen in LoginRouter (which is
 // responsible for adding new routes)
@@ -27,10 +27,12 @@ define([
   './RouterUtil',
   './Animations',
   './Errors',
-  'util/Bundles'
+  'util/Bundles',
+  'util/Logger'
 ],
-function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings, Header,
-          SecurityBeacon, AuthContainer, AppState, RouterUtil, Animations, Errors, Bundles) {
+function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings,
+          Header, SecurityBeacon, AuthContainer, AppState, RouterUtil, Animations,
+          Errors, Bundles, Logger) {
 
   var _ = Okta._,
       $ = Okta.$;
@@ -74,6 +76,16 @@ function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings,
     Events:  Backbone.Events,
 
     initialize: function (options) {
+      // Create a default success and/or error handler if
+      // one is not provided.
+      if (!options.globalSuccessFn) {
+        options.globalSuccessFn = function () {};
+      }
+      if (!options.globalErrorFn) {
+        options.globalErrorFn = function(err) {
+          Logger.warn(err);
+        };
+      }
       this.settings = new Settings(_.omit(options, 'el', 'authClient'), { parse: true });
       this.settings.setAuthClient(options.authClient);
 

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -83,7 +83,7 @@ function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings,
       }
       if (!options.globalErrorFn) {
         options.globalErrorFn = function(err) {
-          Logger.warn(err);
+          Logger.error(err);
         };
       }
       this.settings = new Settings(_.omit(options, 'el', 'authClient'), { parse: true });

--- a/src/util/Logger.js
+++ b/src/util/Logger.js
@@ -13,8 +13,9 @@
 define(function () {
 
   function log(level, args) {
-    // Only log statements in development mode
-    if (DEBUG) {
+    // Only log statements in development mode or if
+    // throwing an error through console.error
+    if (DEBUG || level === 'error') {
       window.console[level].apply(window.console, args);
     }
   }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -5,7 +5,6 @@ var OktaSignIn = (function () {
   var config  = require('json!config/config'),
       _ = require('okta/underscore');
 
-
   function getProperties(authClient, LoginRouter, Util, config) {
 
     /**

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -5,6 +5,7 @@ var OktaSignIn = (function () {
   var config  = require('json!config/config'),
       _ = require('okta/underscore');
 
+
   function getProperties(authClient, LoginRouter, Util, config) {
 
     /**

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -28,6 +28,9 @@ define([
         this._origDeprecate = Logger.deprecate;
         Logger.deprecate = jasmine.createSpy('deprecate');
 
+        this._origWarn = Logger.warn;
+        Logger.warn = jasmine.createSpy('warn');
+
         this._origVersion = config.version;
         config.version = '9.9.99';
 
@@ -37,6 +40,7 @@ define([
 
       afterEach(function () {
         Logger.deprecate = this._origDeprecate;
+        Logger.warn = this._origWarn;
         config.version = this._origVersion;
         Util.clearAllTimeouts();
         Util.clearAllIntervals();

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -28,8 +28,8 @@ define([
         this._origDeprecate = Logger.deprecate;
         Logger.deprecate = jasmine.createSpy('deprecate');
 
-        this._origWarn = Logger.warn;
-        Logger.warn = jasmine.createSpy('warn');
+        this._origError = Logger.error;
+        Logger.error = jasmine.createSpy('error');
 
         this._origVersion = config.version;
         config.version = '9.9.99';
@@ -40,7 +40,7 @@ define([
 
       afterEach(function () {
         Logger.deprecate = this._origDeprecate;
-        Logger.warn = this._origWarn;
+        Logger.error = this._origError;
         config.version = this._origVersion;
         Util.clearAllTimeouts();
         Util.clearAllIntervals();

--- a/test/unit/spec/EnrollCall_spec.js
+++ b/test/unit/spec/EnrollCall_spec.js
@@ -36,7 +36,6 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollChoices_spec.js
+++ b/test/unit/spec/EnrollChoices_spec.js
@@ -35,8 +35,7 @@ function (_, $, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, Router,
         features: {
           securityImage: showSecurityImage
         },
-        authClient: authClient,
-        globalSuccessFn: function () {}
+        authClient: authClient
       });
       Util.registerRouter(router);
       Util.mockRouterNavigate(router);

--- a/test/unit/spec/EnrollDuo_spec.js
+++ b/test/unit/spec/EnrollDuo_spec.js
@@ -30,7 +30,6 @@ function (_, $, Duo, OktaAuth, Util, Beacon, Expect, Form, Router, $sandbox,
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollOnPrem_spec.js
+++ b/test/unit/spec/EnrollOnPrem_spec.js
@@ -31,7 +31,6 @@ function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -35,7 +35,6 @@ function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, Router, BrowserFeatures
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -37,7 +37,6 @@ function (Q, _, $, OktaAuth, LoginUtil, Util, AuthContainer, Form, Beacon, Expec
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollSymantecVip_spec.js
+++ b/test/unit/spec/EnrollSymantecVip_spec.js
@@ -30,7 +30,6 @@ function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -47,7 +47,6 @@ function (_, $, Q, OktaAuth, LoginUtil, StringUtil, Util, DeviceTypeForm, Barcod
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       }, settings));
       Util.registerRouter(router);

--- a/test/unit/spec/EnrollYubikey_spec.js
+++ b/test/unit/spec/EnrollYubikey_spec.js
@@ -26,7 +26,6 @@ function ($, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         el: $sandbox,
         baseUrl: baseUrl,
         authClient: authClient,
-        globalSuccessFn: function () {},
         'features.router': startRouter
       });
       Util.registerRouter(router);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -207,38 +207,24 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CourageLogger, Logger, Okta
     it('logs a ConfigError error if el is not passed as a widget param', function () {
       var fn = function () { setup({ el: undefined }); };
       expect(fn).not.toThrow();
-      expect(Logger.warn).toHaveBeenCalled();
+      expect(Logger.error).toHaveBeenCalled();
     });
     it('has the correct error message if el is not passed as a widget param', function () {
       var fn = function () { setup({ el: undefined }); };
       expect(fn).not.toThrow();
-      var err = Logger.warn.calls.mostRecent().args[0];
+      var err = Logger.error.calls.mostRecent().args[0];
       expect(err.name).toBe('CONFIG_ERROR');
       expect(err.message).toEqual('"el" is a required widget parameter');
     });
-    it('logs a ConfigError if baseUrl is not passed as a widget param', function () {
-      var fn = function () { setup({ baseUrl: undefined }); };
-      expect(fn).not.toThrowError(Errors.ConfigError);
-      expect(Logger.warn).toHaveBeenCalled();
+    it('throws a ConfigError if baseUrl is not passed as a widget param', function () {
+      var fn = function () { setup({ authClient: new OktaAuth({baseUrl: undefined }) }); };
+      expect(fn).toThrowError('No url passed to constructor. Required usage: new OktaAuth({url: "https://sample.okta.com"})');
     });
-    it('has the correct error message if baseUrl is not passed as a widget param', function () {
-      var fn = function () { setup({ baseUrl: undefined }); };
-      expect(fn).not.toThrow();
-      var err = Logger.warn.calls.mostRecent().args[0];
-      expect(err.name).toBe('CONFIG_ERROR');
-      expect(err.message).toEqual('"baseUrl" is a required widget parameter');
+    itp('renders the primary autenthentication form when no globalSuccessFn and globalErrorFn are passed as widget params', function () {
+      return expectPrimaryAuthRender({ globalSuccessFn: undefined, globalErrorFn: undefined });
     });
-    itp('uses a default globalSuccessFn if an undefined globalSuccessFn is passed as a widget param', function () {
-      return expectPrimaryAuthRender({ globalSuccessFn: undefined });
-    });
-    itp('uses a default globalSuccessFn if a null globalSuccessFn is passed as a widget param', function () {
-      return expectPrimaryAuthRender({ globalSuccessFn: null });
-    });
-    itp('uses a default globalErrorFn if an undefined globalErrorFn is passed as widget param', function () {
-      return expectPrimaryAuthRender({ globalErrorFn: undefined });
-    });
-    itp('uses a default globalErrorFn if a null globalErrorFn is passed as a widget param', function () {
-      return expectPrimaryAuthRender({ globalErrorFn: null });
+    itp('renders the primary autenthentication form when a null globalSuccessFn and globalErrorFn are passed as widget params', function () {
+      return expectPrimaryAuthRender({ globalSuccessFn: null, globalErrorFn: null });
     });
     itp('set pushState true if pushState is supported', function () {
       spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(true);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -33,7 +33,7 @@ define([
   'helpers/xhr/labels_login_ja',
   'helpers/xhr/labels_country_ja'
 ],
-function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth, Util, Expect, Router,
+function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CourageLogger, Logger, OktaAuth, Util, Expect, Router,
           $sandbox, PrimaryAuthForm, IDPDiscoveryForm, RecoveryForm, MfaVerifyForm, EnrollCallForm,
           resSuccess, resRecovery, resMfa, resMfaRequiredDuo, resMfaRequiredOktaVerify, resMfaChallengeDuo,
           resMfaChallengePush, resMfaEnroll, errorInvalidToken, resUnauthenticated, resSuccessStepUp,
@@ -170,21 +170,36 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       });
     }
 
+    function expectPrimaryAuthRender(options = {}, path = '') {
+      // Reusable stub to assert that the Primary Auth for renders
+      // given Widget parameters and a navigation path.
+      return setup(options)
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.router.navigate(path);
+        return Expect.waitForPrimaryAuth();
+      })
+      .then(function () {
+        var form = new PrimaryAuthForm($sandbox);
+        expect(form.isPrimaryAuth()).toBe(true);
+      });
+    }
+
     function expectUnexpectedFieldLog(arg1) {
       // These console warnings are called from Courage's Logger class, not
       // the Widget's. We need to assert that the following is called in specific
       // environments (window.okta && window.okta.debug are defined).
-      expect(Logger.warn).toHaveBeenCalledWith('Field not defined in schema', arg1);
+      expect(CourageLogger.warn).toHaveBeenCalledWith('Field not defined in schema', arg1);
     }
 
     it('logs a ConfigError error if unknown option is passed as a widget param', function () {
-      spyOn(Logger, 'warn');
+      spyOn(CourageLogger, 'warn');
       var fn = function () { setup({ foo: 'bla' }); };
       expect(fn).not.toThrowError(Errors.ConfigError);
       expectUnexpectedFieldLog('foo');
     });
     it('has the correct error message if unknown option is passed as a widget param', function () {
-      spyOn(Logger, 'warn');
+      spyOn(CourageLogger, 'warn');
       var fn = function () { setup({ foo: 'bla' }); };
       expect(fn).not.toThrow();
       expectUnexpectedFieldLog('foo');
@@ -192,74 +207,38 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
     it('logs a ConfigError error if el is not passed as a widget param', function () {
       var fn = function () { setup({ el: undefined }); };
       expect(fn).not.toThrow();
-      expect(DevLogger.warn).toHaveBeenCalled();
+      expect(Logger.warn).toHaveBeenCalled();
     });
     it('has the correct error message if el is not passed as a widget param', function () {
       var fn = function () { setup({ el: undefined }); };
       expect(fn).not.toThrow();
-      var err = DevLogger.warn.calls.mostRecent().args[0];
+      var err = Logger.warn.calls.mostRecent().args[0];
       expect(err.name).toBe('CONFIG_ERROR');
       expect(err.message).toEqual('"el" is a required widget parameter');
     });
     it('logs a ConfigError if baseUrl is not passed as a widget param', function () {
       var fn = function () { setup({ baseUrl: undefined }); };
       expect(fn).not.toThrowError(Errors.ConfigError);
-      expect(DevLogger.warn).toHaveBeenCalled();
+      expect(Logger.warn).toHaveBeenCalled();
     });
     it('has the correct error message if baseUrl is not passed as a widget param', function () {
       var fn = function () { setup({ baseUrl: undefined }); };
       expect(fn).not.toThrow();
-      var err = DevLogger.warn.calls.mostRecent().args[0];
+      var err = Logger.warn.calls.mostRecent().args[0];
       expect(err.name).toBe('CONFIG_ERROR');
       expect(err.message).toEqual('"baseUrl" is a required widget parameter');
     });
     itp('uses a default globalSuccessFn if an undefined globalSuccessFn is passed as a widget param', function () {
-      return setup({ globalSuccessFn: undefined })
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin/recovery-question');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ globalSuccessFn: undefined });
     });
     itp('uses a default globalSuccessFn if a null globalSuccessFn is passed as a widget param', function () {
-      return setup({ globalSuccessFn: null })
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin/recovery-question');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ globalSuccessFn: null });
     });
     itp('uses a default globalErrorFn if an undefined globalErrorFn is passed as widget param', function () {
-      return setup({ globalErrorFn: undefined })
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin/recovery-question');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ globalErrorFn: undefined });
     });
     itp('uses a default globalErrorFn if a null globalErrorFn is passed as a widget param', function () {
-      return setup({ globalErrorFn: null })
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin/recovery-question');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ globalErrorFn: null });
     });
     itp('set pushState true if pushState is supported', function () {
       spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(true);
@@ -345,7 +324,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       var fn = function () {
         setup({ foo: 'bar' });
       };
-      spyOn(Logger, 'warn');
+      spyOn(CourageLogger, 'warn');
       expect(fn).not.toThrow('field not allowed: foo');
       expectUnexpectedFieldLog('foo');
     });
@@ -388,16 +367,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       });
     });
     itp('navigates to PrimaryAuth if requesting a stateful url without a stateToken', function () {
-      return setup()
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('signin/recovery-question');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({}, 'signin/recovery-question');
     });
     itp('navigates to IDPDiscovery if features.idpDiscovery is set to true', function () {
       return setup({'features.idpDiscovery': true})
@@ -424,16 +394,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       });
     });
     itp('navigates to PrimaryAuth for /login/login.htm when features.idpDiscovery is false', function () {
-      return setup()
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('login/login.htm');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({}, 'login/login.htm');
     });
     itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is true', function () {
       return setup({'features.idpDiscovery': true})
@@ -448,16 +409,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       });
     });
     itp('navigates to PrimaryAuth for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function () {
-      return setup({'features.idpDiscovery': false})
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('/app/salesforce/abc123sef/sso/saml');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ 'features.idpDiscovery': false }, '/app/salesforce/abc123sef/sso/saml');
     });
     itp('navigates to IDPDiscovery for /any/other when features.idpDiscovery is true', function () {
       return setup({'features.idpDiscovery': true})
@@ -472,16 +424,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, Logger, DevLogger, OktaAuth
       });
     });
     itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is false', function () {
-      return setup({'features.idpDiscovery': false})
-      .then(function (test) {
-        Util.mockRouterNavigate(test.router);
-        test.router.navigate('any/other');
-        return Expect.waitForPrimaryAuth();
-      })
-      .then(function () {
-        var form = new PrimaryAuthForm($sandbox);
-        expect(form.isPrimaryAuth()).toBe(true);
-      });
+      return expectPrimaryAuthRender({ 'features.idpDiscovery': false }, 'any/other');
     });
     itp('refreshes auth state on stateful url if it needs a refresh', function () {
       return setup()

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -5,11 +5,11 @@ define([
   'util/Logger'
 ],
 function (Widget, Expect, Logger) {
-  var signIn;
+  var signIn, devLogger;
   var url = 'https://foo.com';
 
   beforeEach(function(){
-    spyOn(Logger, 'warn');
+    devLogger = spyOn(Logger, 'warn');
     signIn = new Widget({
       baseUrl: url
     });
@@ -24,7 +24,7 @@ function (Widget, Expect, Logger) {
         See: https://developer.okta.com/code/javascript/okta_sign-in_widget#cdn
       `;
 
-      expect(Logger.warn).toHaveBeenCalledWith(debugMessage);
+      expect(devLogger).toHaveBeenCalledWith(debugMessage);
     });
   });
 

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -8,7 +8,7 @@ function (Widget, Expect, Logger) {
   var signIn, devLogger;
   var url = 'https://foo.com';
 
-  beforeEach(function(){
+  beforeEach(function () {
     devLogger = spyOn(Logger, 'warn');
     signIn = new Widget({
       baseUrl: url

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -5,11 +5,11 @@ define([
   'util/Logger'
 ],
 function (Widget, Expect, Logger) {
-  var signIn, devLogger;
+  var signIn;
   var url = 'https://foo.com';
 
   beforeEach(function () {
-    devLogger = spyOn(Logger, 'warn');
+    spyOn(Logger, 'warn');
     signIn = new Widget({
       baseUrl: url
     });
@@ -24,7 +24,7 @@ function (Widget, Expect, Logger) {
         See: https://developer.okta.com/code/javascript/okta_sign-in_widget#cdn
       `;
 
-      expect(devLogger).toHaveBeenCalledWith(debugMessage);
+      expect(Logger.warn).toHaveBeenCalledWith(debugMessage);
     });
   });
 

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -31,8 +31,7 @@ function (Q, _, $, OktaAuth, SharedUtil, Util, RecoveryChallengeForm, Beacon, Ex
       el: $sandbox,
       baseUrl: baseUrl,
       features: { securityImage: true },
-      authClient: authClient,
-      globalSuccessFn: function () {}
+      authClient: authClient
     }, settings));
     var form = new RecoveryChallengeForm($sandbox);
     var beacon = new Beacon($sandbox);

--- a/test/unit/spec/RecoveryLoading_spec.js
+++ b/test/unit/spec/RecoveryLoading_spec.js
@@ -27,8 +27,7 @@ function (Q, _, $, OktaAuth, Util, Beacon, RecoveryFormView, PrimaryAuthFormView
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
-      authClient: authClient,
-      globalSuccessFn: function () {}
+      authClient: authClient
     }, settings));
     var beacon = new Beacon($sandbox);
     var form = new RecoveryFormView($sandbox);

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -31,8 +31,7 @@ function (Q, _, $, OktaAuth, SharedUtil, Util, RecoveryQuestionForm, Beacon, Exp
       el: $sandbox,
       baseUrl: baseUrl,
       features: { securityImage: true },
-      authClient: authClient,
-      globalSuccessFn: function () {}
+      authClient: authClient
     }, settings));
     var form = new RecoveryQuestionForm($sandbox);
     var beacon = new Beacon($sandbox);

--- a/test/unit/spec/RefreshAuthState_spec.js
+++ b/test/unit/spec/RefreshAuthState_spec.js
@@ -27,7 +27,6 @@ function (Q, _, $, OktaAuth, Util, Beacon, FormView, Expect,
       el: $sandbox,
       baseUrl: baseUrl,
       authClient: authClient,
-      globalSuccessFn: function () {},
       features: {
         securityImage: true
       }

--- a/test/unit/spec/UnlockAccount_spec.js
+++ b/test/unit/spec/UnlockAccount_spec.js
@@ -30,7 +30,6 @@ function (Q, _, $, OktaAuth, Util, AccountRecoveryForm, Beacon, Expect, Router,
       el: $sandbox,
       baseUrl: baseUrl,
       authClient: authClient,
-      globalSuccessFn: function () {},
       'features.router': startRouter
     }, settings));
     var form = new AccountRecoveryForm($sandbox);

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -3,8 +3,9 @@
 var path          = require('path');
 var _             = require('underscore');
 var commonConfig  = require('./webpack.common.config');
-var testConfig    = commonConfig('main-tests.js');
 var plugins       = require('./buildtools/webpack/plugins');
+var testConfig    = commonConfig('main-tests.js');
+
 
 testConfig.entry = ['babel-polyfill', './src/util/RegisterInputs.js', './target/js/test/unit/main.js'];
 testConfig.output.path = path.resolve(__dirname, 'target/test/unit');


### PR DESCRIPTION
### Description
In the past, we've seen a number of developers omit adding `success` or `error` handlers when rendering the Widget.

Previously, an error was thrown to the console when a `success` handler was **not** provided. If an `error` handler was missing, the developer would not be notified of any error caught by the Widget's `globalErrorFn`.

```javascript
const signIn = new OktaSignIn({ baseUrl: 'https://{yourOktaDomain}' });
signIn.renderEl({
  el: '#widget-container'
},
function success(res) {
  console.log(`Response: ${res}`);
});
// If a recoverable error occurs, this error will be lost
```

This PR adds a **default** `success` handler (see flows below) and a **default** `error` handler to enhance the Widget's DX:

```javascript
const signIn = new OktaSignIn({ baseUrl: 'https://{yourOktaDomain}' });
signIn.renderEl({ el: '#widget-container' });

// Errors are passed via console warning messages
```

#### Default `success` handler
For various [OpenID Connect](https://github.com/okta/okta-signin-widget/#openid-connect) flows, the Widget never enters the `success` handler, redirecting the end-user to another application path.

See these sample applications as a reference: [Angular](https://github.com/okta/samples-js-angular/blob/master/custom-login/src/app/login/login.component.ts#L51-L62), [React](https://github.com/okta/samples-js-react/blob/master/custom-login/src/Login.jsx#L47-L58), [Vue](https://github.com/okta/samples-js-vue/blob/master/custom-login/src/components/Login.vue#L53-L64).

From a high-level:
- `mysite.com/login`
  - When the Widget is configured with `display: page`, it will initiate the OAuth 2.0 redirect flow
- :leftwards_arrow_with_hook: Redirect to app
- `mysite.com/callback`
  - Handle token parsing from `redirectUri`

#### Default `error` handler
We use a custom `Logger` class to output errors thrown by the Widget if the `error` handler is not provided. This is intended for running in **development** mode, as when the Widget is built for production, the `Logger.warn` messages will be stripped out.

### Resolves
[OKTA-171139](https://oktainc.atlassian.net/browse/OKTA-171139)

> See this Wiki for more details: [Improving Sign-In Widget DX](https://oktawiki.atlassian.net/wiki/spaces/~nate.barbettini/pages/299368755/Improving+Sign-In+Widget+DX)