### PR TITLE
:fire: Removes authClient until 2.0 is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,20 +330,6 @@ signIn.off('pageRendered');
 signIn.off('pageRendered', onPageRendered);
 ```
 
-## authClient
-
-Returns the underlying `@okta/okta-auth-js` object used by the widget. See [AuthJS](https://github.com/okta/okta-auth-js#api) for a list of available methods.
-
-```javascript
-// Check for an existing authClient transaction
-var exists = signIn.authClient.tx.exists();
-if (exists) {
-  console.log('A session exists!');
-} else {
-  console.log('A session does not exist.');
-};
-```
-
 ## session.get(callback)
 
 Gets the active session, or returns `{status:inactive}` on error or no active session.

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -134,7 +134,6 @@ var OktaSignIn = (function () {
     return {
       renderEl: render,
       signOut: closeSession,
-      authClient: authClient,
       idToken: {
         refresh: refreshIdToken
       },

--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -47,24 +47,4 @@ describe('Basic flows', function() {
     expect(el.isDisplayed()).toBe(true);
   });
 
-  it('can call authClient methods', function() {
-    // Ensure the widget exists
-    var el = element(by.css('#okta-sign-in'));
-    expect(el.isDisplayed()).toBe(true);
-
-    function getToken() {
-      return oktaSignIn.authClient.tokenManager.get('idToken');
-    }
-
-    // Set a fake token into localStorage
-    var token = JSON.stringify({
-      idToken: { foo: 'bar' }
-    });
-    browser.executeScript(`window.localStorage.setItem('okta-token-storage', '${token}');`);
-
-    // Retrieve the token
-    browser.executeScript(getToken).then(function(storedToken) {
-      expect(storedToken).toEqual({foo: 'bar'});
-    });
-  });
 });

--- a/test/e2e/specs/dev_spec.js
+++ b/test/e2e/specs/dev_spec.js
@@ -47,24 +47,4 @@ describe('Dev Mode flows', function() {
     expect(el.isDisplayed()).toBe(true);
   });
 
-  it('can call authClient methods', function() {
-    // Ensure the widget exists
-    var el = element(by.css('#okta-sign-in'));
-    expect(el.isDisplayed()).toBe(true);
-
-    function getToken() {
-      return oktaSignIn.authClient.tokenManager.get('idToken');
-    }
-
-    // Set a fake token into localStorage
-    var token = JSON.stringify({
-      idToken: { foo: 'bar' }
-    });
-    browser.executeScript(`window.localStorage.setItem('okta-token-storage', '${token}');`);
-
-    // Retrieve the token
-    browser.executeScript(getToken).then(function(storedToken) {
-      expect(storedToken).toEqual({foo: 'bar'});
-    });
-  });
 });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -36,10 +36,6 @@ function (Widget, Expect, Logger) {
       it('has a signOut method', function () {
         expect(signIn.signOut).toBeDefined();
       });
-      it('has an authClient object', function () {
-        expect(signIn.authClient).toBeDefined();
-        expect(signIn.authClient.options.url).toEqual(url);
-      });
       it('has a tokenManager method', function () {
         expect(signIn.tokenManager).toBeDefined();
       });


### PR DESCRIPTION
Exposing the `authClient` can be problematic to the Widget as breaking changes are introduced in `okta-auth-js` over the next month.

This change will be revisited in the future.