### PR TITLE
use new endpoint to social auth when none OIDC mode

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -20,9 +20,10 @@ define([
   'util/Util',
   'util/Logger',
   'util/OAuth2Util',
+  'shared/util/Util',
   'json!config/config'
 ],
-function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
+function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, SharedUtil, config) {
 
   var DEFAULT_LANGUAGE = 'en';
 
@@ -31,6 +32,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       oauthRedirectTpl = Okta.tpl('{{origin}}');
 
   var _ = Okta._,
+      $ = Okta.$,
       ConfigError = Errors.ConfigError,
       UnsupportedBrowserError = Errors.UnsupportedBrowserError;
 
@@ -275,7 +277,16 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
               },
               click: function (e) {
                 e.preventDefault();
-                OAuth2Util.getTokens(self, {idp: idp.id});
+                if (self.get('oauth2Enabled')) {
+                  OAuth2Util.getTokens(self, {idp: idp.id});
+                } else {
+                  const baseUrl = self.get('baseUrl');
+                  const params = $.param({
+                    fromURI: self.get('relayState'),
+                  });
+                  const targetUri = `${baseUrl}/sso/idps/${idp.id}?${params}`;
+                  SharedUtil.redirect(targetUri);
+                }
               }
             };
             buttonArray.push(socialAuthButton);

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -149,6 +149,19 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
     });
   }
 
+  function setupSocialNoneOIDCMode(settings) {
+    Util.mockOIDCStateGenerator();
+    return setup(_.extend({
+      redirectUri: 'https://0.0.0.0:9999',
+      idps: [
+        {
+          type: 'FACEBOOK',
+          id: '0oaidiw9udOSceD1234'
+        }
+      ]
+    }, settings));
+  }
+
   function setupAdditionalAuthButton() {
     var settings = {
       customButtons: [
@@ -1985,6 +1998,21 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthFo
             'scope=openid%20email%20profile',
             'External Identity Provider User Authentication',
             'toolbar=no, scrollbars=yes, resizable=yes, top=100, left=500, width=600, height=600'
+          );
+        });
+      });
+      itp('navigate to "/sso/idp/:id" at none OIDC mode when an idp button is clicked', function () {
+        spyOn(SharedUtil, 'redirect');
+        const opt = {
+          relayState: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U',
+        };
+
+        return setupSocialNoneOIDCMode(opt).then(function (test) {
+          test.form.facebookButton().click();
+          expect(SharedUtil.redirect.calls.count()).toBe(1);
+          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+            'https://foo.com/sso/idps/0oaidiw9udOSceD1234?' + 
+            $.param({fromURI: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U'})
           );
         });
       });


### PR DESCRIPTION
## Description

- social login today only works in OIDC mode which doesn't well support the customization signin page.
- a new endpoint was added last week (/sso/idp/:id) to allow social idp to be used as standard IdP, meaning could be used at none OIDC mode.
- this commit is to implement social login using the new endpoint at none OIDC mode

## Video

- https://okta.box.com/s/kvxc3dmsfn4071os9tp4itrspa5nckuh

## JIRA

- [OKTA-159649](https://oktainc.atlassian.net/browse/OKTA-159649)

