### PR TITLE
Send accept language header if widget configured with language.

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -324,10 +324,14 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, SharedUtil
       }
     },
 
-    setAuthClient: function (authClient) {
+    setAcceptLanguageHeader: function (authClient) {
       if (authClient && authClient.options && authClient.options.headers) {
         authClient.options.headers['Accept-Language'] = this.get('languageCode');
       }
+    },
+
+    setAuthClient: function (authClient) {
+      this.setAcceptLanguageHeader(authClient);
       this.authClient = authClient;
     },
 

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -325,6 +325,9 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, SharedUtil
     },
 
     setAuthClient: function (authClient) {
+      if (authClient && authClient.options && authClient.options.headers) {
+        authClient.options.headers['Accept-Language'] = this.get('languageCode');
+      }
       this.authClient = authClient;
     },
 

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -71,7 +71,7 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CourageLogger, Logger, Okta
     function setup(settings) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl});
+      var authClient = new OktaAuth({url: baseUrl, headers: {}});
       var eventSpy = jasmine.createSpy('eventSpy');
       var router = new Router(_.extend({
         el: $sandbox,
@@ -1119,6 +1119,45 @@ function (Okta, Q, Backbone, SharedUtil, CryptoUtil, CourageLogger, Logger, Okta
         .then(function(test){
           test.form.submit();
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
+        });
+      });
+
+      itp('Sends the default accept lang header en with API calls if widget is not configured with a language', function () {
+        return setupLanguage({})
+        .then(function (test) {
+          test.setNextResponse(resSuccess);
+          test.router.navigate('');
+          return Expect.waitForPrimaryAuth();
+        })
+        .then(function () {
+          var form = new PrimaryAuthForm($sandbox);
+          expect(form.isPrimaryAuth()).toBe(true);
+          form.setUsername('testuser');
+          form.setPassword('testpassword');
+          form.submit();
+          expect($.ajax.calls.mostRecent().args[0].headers['Accept-Language']).toBe('en');
+        });
+      });
+
+      itp('Sends the right accept lang header with API calls if widget is configured with a language', function () {
+        return setupLanguage({
+          mockLanguageRequest: 'ja',
+          settings: {
+            language: 'ja'
+          }
+        })
+        .then(function (test) {
+          test.setNextResponse(resSuccess);
+          test.router.navigate('');
+          return Expect.waitForPrimaryAuth();
+        })
+        .then(function () {
+          var form = new PrimaryAuthForm($sandbox);
+          expect(form.isPrimaryAuth()).toBe(true);
+          form.setUsername('testuser');
+          form.setPassword('testpassword');
+          form.submit();
+          expect($.ajax.calls.mostRecent().args[0].headers['Accept-Language']).toBe('ja');
         });
       });
     });


### PR DESCRIPTION
- When the widget is bootstrapped with a language in the config option, we want to send that language code as a part of the Accept-Language header while making API requests.
- This is so that the server returns an API error localized in the widgets configured language which can be different than the browser language setting.

Video shows before and after results 
https://okta.box.com/s/c7a0ztrdeo7c496575hkm6s7iagvk7yj

Resolves: OKTA-168338

@santhoshbalakrishnan @mauriciocastillosilva-okta @hor-kanchan-okta 