### PR TITLE
:bug: clear input field if changing RSA pin

### DIFF
--- a/src/EnrollOnPremController.js
+++ b/src/EnrollOnPremController.js
@@ -72,6 +72,16 @@ function (Okta, FormType, FormController, Footer, TextBox) {
         noButtonBar: true,
         autoSave: true,
         className: getClassName(provider),
+        initialize: function() {
+          this.listenTo(this.model, 'error', _.bind(function (source, error) {
+            if (error && error.status === 409) {
+              // 409 means we are in change pin, so we should clear out answer input
+              this.model.set('passCode', '');
+              this.$('.o-form-input-name-passCode input').val('');
+              this.$('.o-form-input-name-passCode input').focus();
+            }
+          }, this));
+        },
         formChildren: [
           FormType.Input({
             name: 'credentialId',

--- a/src/EnrollOnPremController.js
+++ b/src/EnrollOnPremController.js
@@ -76,8 +76,8 @@ function (Okta, FormType, FormController, Footer, TextBox) {
           this.listenTo(this.model, 'error', _.bind(function (source, error) {
             if (error && error.status === 409) {
               // 409 means we are in change pin, so we should clear out answer input
-              this.model.set('passCode', '');
               this.$('.o-form-input-name-passCode input').val('');
+              this.$('.o-form-input-name-passCode input').trigger('change');
               this.$('.o-form-input-name-passCode input').focus();
             }
           }, this));

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -55,8 +55,8 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
         this.listenTo(this.model, 'error', _.bind(function (source, error) {
           if (error && error.status === 409) {
             // 409 means we are in change pin, so we should clear out answer input
-            this.model.set('answer', '');
             this.$('.auth-passcode input').val('');
+            this.$('.auth-passcode input').trigger('change');
             this.$('.auth-passcode input').focus();
           }
         }, this));

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -50,6 +50,17 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
           type: 'checkbox'
         });
       }
+
+      if (this.model.get('provider') === 'RSA' || this.model.get('provider') === 'DEL_OATH') {
+        this.listenTo(this.model, 'error', _.bind(function (source, error) {
+          if (error && error.status === 409) {
+            // 409 means we are in change pin, so we should clear out answer input
+            this.model.set('answer', '');
+            this.$('.auth-passcode input').val('');
+            this.$('.auth-passcode input').focus();
+          }
+        }, this));
+      }
     }
 
   });

--- a/test/unit/helpers/xhr/RSA_ERROR_change_pin.js
+++ b/test/unit/helpers/xhr/RSA_ERROR_change_pin.js
@@ -1,0 +1,11 @@
+define({
+  'status': 409,
+  'responseType': 'json',
+  'response': {
+    'errorCode': 'E0000113',
+    'errorSummary': 'Enter a new PIN having from 4 to 8 digits:',
+    'errorLink': 'E0000113',
+    'errorId': 'errorId',
+    'errorCauses': []
+  }
+});

--- a/test/unit/spec/EnrollOnPrem_spec.js
+++ b/test/unit/spec/EnrollOnPrem_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 14] */
+/* eslint max-params: [2, 15] */
 define([
   'vendor/lib/q',
   'okta/underscore',
@@ -12,11 +12,12 @@ define([
   'helpers/xhr/MFA_ENROLL_allFactors',
   'helpers/xhr/MFA_ENROLL_allFactors_OnPrem',
   'helpers/xhr/MFA_ENROLL_ACTIVATE_OnPrem_error',
+  'helpers/xhr/RSA_ERROR_change_pin',
   'helpers/xhr/SUCCESS',
   'LoginRouter'
 ],
 function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
-          resAllFactors, resAllFactorsOnPrem, resEnrollError, resSuccess, Router) {
+          resAllFactors, resAllFactorsOnPrem, resEnrollError, resRSAChangePin, resSuccess, Router) {
 
   var itp = Expect.itp;
   var tick = Expect.tick;
@@ -161,6 +162,21 @@ function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
             expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
           });
         });
+        itp('clears passcode field if error is for PIN change', function () {
+          return setup()
+          .then(function (test) {
+            test.setNextResponse(resRSAChangePin);
+            test.form.setCredentialId('Username');
+            test.form.setCode(123);
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
+            expect(test.form.codeField().val()).toEqual('');
+          });
+        });
         itp('calls activate with the right params', function () {
           return setup().then(function (test) {
             $.ajax.calls.reset();
@@ -266,6 +282,21 @@ function (Q, _, $, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
             expect(test.form.hasErrors()).toBe(true);
             // Note: This will change when we get field specific error messages
             expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
+          });
+        });
+        itp('clears passcode field if error is for PIN change', function () {
+          return setupOnPrem()
+          .then(function (test) {
+            test.setNextResponse(resRSAChangePin);
+            test.form.setCredentialId('Username');
+            test.form.setCode(123);
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
+            expect(test.form.codeField().val()).toEqual('');
           });
         });
         itp('calls activate with the right params', function () {

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -37,6 +37,7 @@ define([
   'helpers/xhr/MFA_VERIFY_invalid_answer',
   'helpers/xhr/MFA_VERIFY_invalid_password',
   'helpers/xhr/MFA_VERIFY_totp_invalid_answer',
+  'helpers/xhr/RSA_ERROR_change_pin',
   'helpers/xhr/SMS_RESEND_error',
   'helpers/xhr/MFA_LOCKED_FAILED_ATEMPTS',
   'helpers/xhr/MFA_REQUIRED_policy_always',
@@ -80,6 +81,7 @@ function (Okta,
           resInvalid,
           resInvalidPassword,
           resInvalidTotp,
+          resRSAChangePin,
           resResendError,
           resMfaLocked,
           resMfaAlwaysPolicy,
@@ -923,6 +925,34 @@ function (Okta,
           })
           .then(function (test) {
             expectSetTransactionError(test.router, resInvalidTotp);
+          });
+        });
+        itp('clears input field value if error is for PIN change (RSA)', function () {
+          return setupRsaTOTP()
+          .then(function (test) {
+            test.setNextResponse(resRSAChangePin);
+            test.form.setAnswer('correct');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
+            expect(test.form.answerField().val()).toEqual('');
+          });
+        });
+        itp('clears input field value if error is for PIN change (On-Prem)', function () {
+          return setupOnPremTOTP()
+          .then(function (test) {
+            test.setNextResponse(resRSAChangePin);
+            test.form.setAnswer('correct');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
+            expect(test.form.answerField().val()).toEqual('');
           });
         });
       });


### PR DESCRIPTION
RSA returns a 409 error when changing the pin number. At this point we need to clear the input field so we don't have the previous value in it to avoid possible errors of users changing the pin to something different than intented

Resolves: OKTA-165849

![clearinputduringchangepin](https://user-images.githubusercontent.com/6979296/41686086-a1aa163e-7497-11e8-9449-7b43d2dce519.gif)
