### PR TITLE
:bug: Prevents XSS when hovering over help icons

### DIFF
--- a/src/EnrollOnPremController.js
+++ b/src/EnrollOnPremController.js
@@ -89,7 +89,7 @@ function (Okta, FormType, FormController, Footer, TextBox) {
             type: 'text',
             placeholder: Okta.loc('enroll.onprem.username.placeholder', 'login', [vendorName]),
             params: {
-              innerTooltip: Okta.loc('enroll.onprem.username.tooltip', 'login', [vendorName])
+              innerTooltip: Okta.loc('enroll.onprem.username.tooltip', 'login', [_.escape(vendorName)])
             }
           }),
           FormType.Input({
@@ -98,7 +98,7 @@ function (Okta, FormType, FormController, Footer, TextBox) {
             type: 'password',
             placeholder: Okta.loc('enroll.onprem.passcode.placeholder', 'login', [vendorName]),
             params: {
-              innerTooltip: Okta.loc('enroll.onprem.passcode.tooltip', 'login', [vendorName])
+              innerTooltip: Okta.loc('enroll.onprem.passcode.tooltip', 'login', [_.escape(vendorName)])
             }
           }),
           FormType.Toolbar({

--- a/test/unit/helpers/dom/EnrollTokenFactorForm.js
+++ b/test/unit/helpers/dom/EnrollTokenFactorForm.js
@@ -47,7 +47,15 @@ define(['./Form'], function (Form) {
 
     backLink: function () {
       return this.el('back-link');
-    }
+    },
+
+    credIdTooltipText: function () {
+      return this.tooltipText(CRED_ID_FIELD);
+    },
+
+    codeTooltipText: function () {
+      return this.tooltipText(CODE_FIELD);
+    },
 
   });
 


### PR DESCRIPTION
Resolves: OKTA-175902

NOTE: This is for the sign-in-widget side of changes. (From the JIRA - Escape the values that are controlled by the user in the UI) The other recommendation will be taken care of in a separate PR for okta-core.

<img width="639" alt="screen shot 2018-07-10 at 3 35 47 pm" src="https://user-images.githubusercontent.com/26014318/42541419-175b87ae-8457-11e8-8332-befd88e772ad.png">

<img width="608" alt="screen shot 2018-07-10 at 3 35 51 pm" src="https://user-images.githubusercontent.com/26014318/42541420-1b3d1d42-8457-11e8-8bca-7a3c12eab0ce.png">
