### PR TITLE
:arrow_up: Rev up version to handle @okta/ci-update-package upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Rev up version of okta-signin-widget to 2.11.0 to handle an implicit upgrade to @okta/ci-update-package that handles release NPM packages differently.

Resolves: OKTA-178456

Primary Reviewers:
@rchild-okta 
@okta/travisci 