### PR TITLE
:warning: Temporarily disable flakey tests

### DIFF
--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -1170,7 +1170,8 @@ function (Okta,
             });
           });
         });
-        itp('posts resend if send code button is clicked second time', function () {
+        // See OKTA-179504
+        xit('posts resend if send code button is clicked second time', function () {
           Util.speedUpPolling();
           return setupSMS().then(function (test) {
             test.setNextResponse(resChallengeSms);
@@ -2895,7 +2896,8 @@ function (Okta,
           });
         });
 
-        itp('calls u2f.sign and verifies factor when rememberDevice set to true', function () {
+        // See OKTA-179504
+        xit('calls u2f.sign and verifies factor when rememberDevice set to true', function () {
           var signStub = function (appId, nonce, registeredKeys, callback) {
             callback({
               keyHandle: 'someKeyHandle',


### PR DESCRIPTION
### Description
Temporarily disables specific MFA Verify tests due to unexpected failures/successes.

Tracking under [OKTA-179504](https://oktainc.atlassian.net/browse/OKTA-179504)

> Odd behavior:
> When `posts resend if send code button is clicked second time` would fail, it would occasionally cause `calls u2f.sign and verifies factor when rememberDevice set to true` to succeed.