### PR TITLE
Remove loaded language bunlde on sign in widget remove

### DIFF
--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -301,6 +301,7 @@ function (Okta, Backbone, BrowserFeatures, RefreshAuthStateController, Settings,
     remove: function () {
       this.controller.remove();
       this.header.$el.remove();
+      Bundles.remove();
       Backbone.history.stop();
     }
 

--- a/src/util/Bundles.js
+++ b/src/util/Bundles.js
@@ -207,6 +207,10 @@ define([
       return this.currentLanguage === language;
     },
 
+    remove: function () {
+      this.currentLanguage = null;
+    },
+
     loadLanguage: function (language, overrides, assets) {
       var parsedOverrides = parseOverrides(overrides);
       var lowerCaseLanguage = language.toLowerCase();

--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -9,7 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-/* global browser, element, by, oktaSignIn */
+/* global browser, element, by, oktaSignIn, options, OktaSignIn */
 var util = require('../util/util');
 
 describe('Basic flows', function() {
@@ -23,7 +23,9 @@ describe('Basic flows', function() {
   it('can hide, show, remove, and start a widget', function() {
     // Ensure the widget exists
     var el = element(by.css('#okta-sign-in'));
+    var signInTitle = element(by.css('[data-se="o-form-head"]'));
     expect(el.isDisplayed()).toBe(true);
+    expect(signInTitle.getText()).toBe('Sign In');
 
     // Ensure the widget can hide
     browser.executeScript('oktaSignIn.hide()');
@@ -39,12 +41,20 @@ describe('Basic flows', function() {
 
     // Ensure a new widget can be created
     function createWidget() {
+      options.i18n = {
+        en: {
+          'primaryauth.title': 'Sign In to Acme'
+        }
+      };
+      // eslint-disable-next-line no-global-assign
+      oktaSignIn = new OktaSignIn(options);
       oktaSignIn.renderEl({
         el: '#okta-login-container'
       }, function() {});
     }
     browser.executeScript(createWidget);
     expect(el.isDisplayed()).toBe(true);
+    expect(signInTitle.getText()).toBe('Sign In to Acme');
   });
 
 });


### PR DESCRIPTION
This allows for changing of i18n strings after signInWidget.remove(); has been called.

Writing e2e test on top of @joelfranusic-okta 's PR: https://github.com/okta/okta-signin-widget/pull/446