### PR TITLE
Moved rm -rf to rimraf for Windows builds to work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-signin-widget",
-  "version": "2.9.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1896,7 +1896,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.2.8"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3134,7 +3134,7 @@
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "rimraf": "2.6.2"
       }
     },
     "function-bind": {
@@ -3449,6 +3449,12 @@
             "sigmund": "1.0.1"
           }
         },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        },
         "underscore": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
@@ -3563,7 +3569,7 @@
         "grunt-lib-phantomjs": "1.1.0",
         "jasmine-core": "2.4.1",
         "lodash": "2.4.2",
-        "rimraf": "2.2.8",
+        "rimraf": "2.6.2",
         "sprintf-js": "1.0.3"
       },
       "dependencies": {
@@ -5277,7 +5283,7 @@
         "npmlog": "4.1.2",
         "osenv": "0.1.5",
         "request": "2.85.0",
-        "rimraf": "2.2.8",
+        "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
         "which": "1.0.9"
@@ -5985,7 +5991,7 @@
             "jsonfile": "2.4.0",
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
+            "rimraf": "2.6.2"
           }
         },
         "har-validator": {
@@ -7152,10 +7158,29 @@
       }
     },
     "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
     },
     "ripemd160": {
       "version": "0.2.0",
@@ -8220,7 +8245,7 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "2.2.8",
+            "rimraf": "2.6.2",
             "tmp": "0.0.24",
             "ws": "1.1.5",
             "xml2js": "0.4.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "./dist/js/okta-sign-in.entry.js",
   "scripts": {
-    "clean": "rm -rf target && rm -rf dist",
+    "clean": "rimraf target && rimraf dist",
     "lint:report": "grunt lint --checkstyle",
     "lint": "grunt lint",
     "test": "grunt test",
@@ -82,6 +82,7 @@
     "phantomjs": "1.9.20",
     "protractor": "5.2.2",
     "request-promise": "2.0.0",
+    "rimraf": "^2.6.2",
     "semver": "5.1.0",
     "time-grunt": "1.4.0",
     "wait-on": "2.0.2",


### PR DESCRIPTION
## Description

- Currently npm run clean uses `rm -rf`. This blocks us from building sign in widget repo on any Windows machine.

## Reviewers

- @rchild-okta 
- @jmelberg-okta 