### PR TITLE
 :bug: Fixing setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,6 @@ cd ${OKTA_HOME}/${REPO}
 setup_service grunt
 setup_service bundler
 
-setup_service node v8.1.1
-
 # Install required dependencies
 npm install -g @okta/ci-update-package
 npm install -g @okta/ci-pkginfo


### PR DESCRIPTION
 No need to install node in setup script as CI is on 8.11.1

 RESOLVES: OKTA-183902

<img width="467" alt="screen shot 2018-08-09 at 8 09 24 pm" src="https://user-images.githubusercontent.com/17267130/43936997-270dc3e4-9c10-11e8-9a7e-8d1c506aeb09.png">
