### PR TITLE
Okta 186322 Remove the call to processCreds at IdP discovery form submit

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function (grunt) {
         'test/unit/helpers/**/*.js',
         'test/**/**/*.js',
         '!test/e2e/react-app/**/*.js',
+        '!test/e2e/angular-app/**/*.js',
         '!test/unit/helpers/xhr/*.js',
         '!test/unit/vendor/*.js',
         'webpack.*.js'

--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -25,13 +25,7 @@ define([
     saveId: 'idp-discovery-submit',
 
     initialize: function () {
-      this.listenTo(this, 'save', function () {
-        var creds = {
-          username: this.model.get('username')
-        };
-        this.settings.processCreds(creds)
-        .then(_.bind(this.model.save, this.model));
-      });
+      this.listenTo(this, 'save', _.bind(this.model.save, this.model));
       this.stateEnableChange();
     },
 

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -115,8 +115,10 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
   }
 
   function waitForWebfingerCall(test) {
-    //wait for the webfinger call
-    return Expect.waitForSpyCall(test.ac.webfinger, test);
+    return tick() // wait for the webfinger call cycle finish (promise -> then -> final)
+    .then(function () {
+      return Expect.waitForSpyCall(test.ac.webfinger, test);
+    });
   }
 
   function transformUsername(name) {
@@ -912,7 +914,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           });
         });
       });
-      itp('calls processCreds function before saving a model', function () {
+      itp('does not call processCreds function before saving a model', function () {
         var processCredsSpy = jasmine.createSpy('processCreds');
         return setup({
           processCreds: processCredsSpy
@@ -924,54 +926,8 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           return waitForWebfingerCall(test);
         })
         .then(function(test) {
-          expect(processCredsSpy.calls.count()).toBe(1);
-          expect(processCredsSpy).toHaveBeenCalledWith({
-            username: 'testuser@clouditude.net'
-          });
+          expect(processCredsSpy.calls.count()).toBe(0);
           expect(test.ac.webfinger).toHaveBeenCalled();
-        });
-      });
-      itp('calls async processCreds function before saving a model', function () {
-        var processCredsSpy = jasmine.createSpy('processCreds');
-        return setup({
-          'processCreds': function(creds, callback) {
-            processCredsSpy(creds, callback);
-            callback();
-          }
-        })
-        .then(function (test) {
-          test.form.setUsername('testuser@clouditude.net');
-          test.setNextWebfingerResponse(resSuccess);
-          test.form.submit();
-          return waitForWebfingerCall(test);
-        })
-        .then(function(test) {
-          expect(processCredsSpy.calls.count()).toBe(1);
-          expect(processCredsSpy).toHaveBeenCalledWith({
-            username: 'testuser@clouditude.net'
-          }, jasmine.any(Function));
-          expect(test.ac.webfinger).toHaveBeenCalled();
-        });
-      });
-      itp('calls async processCreds function and can prevent saving a model', function () {
-        var processCredsSpy = jasmine.createSpy('processCreds');
-        return setup({
-          'processCreds': function(creds, callback) {
-            processCredsSpy(creds, callback);
-          }
-        })
-        .then(function (test) {
-          test.form.setUsername('testuser@clouditude.net');
-          test.setNextWebfingerResponse(resSuccess);
-          test.form.submit();
-          return Expect.waitForSpyCall(processCredsSpy, test);
-        })
-        .then(function(test) {
-          expect(processCredsSpy.calls.count()).toBe(1);
-          expect(processCredsSpy).toHaveBeenCalledWith({
-            username: 'testuser@clouditude.net',
-          }, jasmine.any(Function));
-          expect(test.ac.webfinger).not.toHaveBeenCalled();
         });
       });
       itp('sets rememberMe cookie if rememberMe is enabled and checked on submit', function () {


### PR DESCRIPTION
`processCreds` hook is intend to record Username/Password. 
The use case from monolith is for ChromeBook [OKTA-69142](https://oktainc.atlassian.net/browse/OKTA-69142).
However, the IdP Discovery (identity first flow) only has username but not password and doesn't need to invoke the `processCreds` function.

cc @federations-okta 