### PR TITLE
Change the IDP discovery redirect to other IDP from GET to POST request.

### DIFF
--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -11,16 +11,15 @@
  */
 
 define([
-  'okta',
   'PrimaryAuthController',
   'models/PrimaryAuth',
   'views/idp-discovery/IDPDiscoveryForm',
   'models/IDPDiscovery',
-  'views/shared/Footer',
-  'util/BaseLoginController'
+  'util/BaseLoginController',
+  'util/Util'
 ],
-function (Okta, PrimaryAuthController, PrimaryAuthModel, IDPDiscoveryForm, IDPDiscoveryModel,
-          Footer, BaseLoginController) {
+function (PrimaryAuthController, PrimaryAuthModel, IDPDiscoveryForm, IDPDiscoveryModel,
+          BaseLoginController, Util) {
 
   return PrimaryAuthController.extend({
     className: 'idp-discovery',
@@ -65,6 +64,10 @@ function (Okta, PrimaryAuthController, PrimaryAuthModel, IDPDiscoveryForm, IDPDi
           this.options.appState.set('disableUsername', true);
           this.options.appState.trigger('navigate', 'signin');
         }
+      });
+
+      this.listenTo(this.model, 'goToOtherIdpAuth', function (url) {
+        Util.postToUrl(url, this.$el);
       });
     }
 

--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -67,7 +67,7 @@ function (PrimaryAuthController, PrimaryAuthModel, IDPDiscoveryForm, IDPDiscover
       });
 
       this.listenTo(this.model, 'goToOtherIdpAuth', function (url) {
-        Util.postToUrl(url, this.$el);
+        Util.redirectToUrlWithPost(url, this.$el);
       });
     }
 

--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -70,6 +70,7 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums, Util) {
       authClient.webfinger(webfingerArgs)
       .then(_.bind(function(res) {
         if(res) {
+          var that = this;
           if(res.links && res.links[0] && res.links[0].properties['okta:idp:type'] === 'OKTA') {
             this.trigger('goToPrimaryAuth');
           }
@@ -83,7 +84,7 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums, Util) {
                       queryParams['login_hint'] = username;
                     }
                     var url = res.links[0].href + Util.getUrlQueryString(queryParams);
-                    Util.redirect(url);
+                    that.trigger('goToOtherIdpAuth', url);
                   }
                 }
               }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -112,7 +112,7 @@ define(['okta', 'util/Logger'], function (Okta, Logger) {
   // what it does is actually create a hidden form
   // and fill values from the url (base url, query parameters)
   // and submit the form.
-  Util.postToUrl = function (url, $el) {
+  Util.redirectToUrlWithPost = function (url, $el) {
     var parts = url.split('?'),
         baseUrl = parts[0],
         queryString = parts[1],

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -22,7 +22,7 @@ define(['okta', 'util/Logger'], function (Okta, Logger) {
     '<input type="hidden" name="{{name}}" value="{{value}}">' +
     '{{/each}}'+
     '</form>');
-  
+
   Util.hasTokensInHash = function (hash) {
     return /((id|access)_token=)/i.test(hash);
   };
@@ -117,10 +117,9 @@ define(['okta', 'util/Logger'], function (Okta, Logger) {
         baseUrl = parts[0],
         queryString = parts[1],
         queryParams,
-        form;
-    var formData = {
-      action: baseUrl
-    };
+        form,
+        formData = { action: baseUrl };
+
     if (queryString) {
       queryParams = queryString.split('&');
       formData.inputs = _.map(queryParams, function (param) {

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1018,7 +1018,9 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
         });
       });
       itp('redirects to idp for SAML idps', function () {
-        spyOn(SharedUtil, 'redirect');
+        spyOn(IDPDiscovery.prototype, 'trigger').and.callThrough();
+        spyOn(LoginUtil, 'postToUrl');
+
         return setup()
         .then(function (test) {
           test.setNextWebfingerResponse(resSuccessSAML);
@@ -1030,13 +1032,19 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           var redirectToIdp = test.successSpy.calls.mostRecent().args[0].idpDiscovery.redirectToIdp;
           expect(redirectToIdp).toEqual(jasmine.any(Function));
           redirectToIdp('https://foo.com');
-          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+          expect(IDPDiscovery.prototype.trigger).toHaveBeenCalledWith(
+            'goToOtherIdpAuth',
             'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4?fromURI=https%3A%2F%2Ffoo.com&login_hint=testuser%40clouditude.net'
+          );
+          expect(LoginUtil.postToUrl).toHaveBeenCalledWith(
+            'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4?fromURI=https%3A%2F%2Ffoo.com&login_hint=testuser%40clouditude.net',
+            test.router.controller.$el
           );
         });
       });
       itp('redirects to idp for idps other than okta/saml', function () {
-        spyOn(SharedUtil, 'redirect');
+        spyOn(IDPDiscovery.prototype, 'trigger').and.callThrough();
+        spyOn(LoginUtil, 'postToUrl');
         return setup()
         .then(function (test) {
           test.setNextWebfingerResponse(resSuccessIWA);
@@ -1048,8 +1056,13 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
           var redirectToIdp = test.successSpy.calls.mostRecent().args[0].idpDiscovery.redirectToIdp;
           expect(redirectToIdp).toEqual(jasmine.any(Function));
           redirectToIdp('https://foo.com');
-          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+          expect(IDPDiscovery.prototype.trigger).toHaveBeenCalledWith(
+            'goToOtherIdpAuth',
             'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com'
+          );
+          expect(LoginUtil.postToUrl).toHaveBeenCalledWith(
+            'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com',
+            test.router.controller.$el
           );
         });
       });

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1019,7 +1019,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
       });
       itp('redirects to idp for SAML idps', function () {
         spyOn(IDPDiscovery.prototype, 'trigger').and.callThrough();
-        spyOn(LoginUtil, 'postToUrl');
+        spyOn(LoginUtil, 'redirectToUrlWithPost');
 
         return setup()
         .then(function (test) {
@@ -1036,7 +1036,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
             'goToOtherIdpAuth',
             'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4?fromURI=https%3A%2F%2Ffoo.com&login_hint=testuser%40clouditude.net'
           );
-          expect(LoginUtil.postToUrl).toHaveBeenCalledWith(
+          expect(LoginUtil.redirectToUrlWithPost).toHaveBeenCalledWith(
             'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4?fromURI=https%3A%2F%2Ffoo.com&login_hint=testuser%40clouditude.net',
             test.router.controller.$el
           );
@@ -1044,7 +1044,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
       });
       itp('redirects to idp for idps other than okta/saml', function () {
         spyOn(IDPDiscovery.prototype, 'trigger').and.callThrough();
-        spyOn(LoginUtil, 'postToUrl');
+        spyOn(LoginUtil, 'redirectToUrlWithPost');
         return setup()
         .then(function (test) {
           test.setNextWebfingerResponse(resSuccessIWA);
@@ -1060,7 +1060,7 @@ function (_, $, Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryF
             'goToOtherIdpAuth',
             'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com'
           );
-          expect(LoginUtil.postToUrl).toHaveBeenCalledWith(
+          expect(LoginUtil.redirectToUrlWithPost).toHaveBeenCalledWith(
             'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com',
             test.router.controller.$el
           );

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -1,5 +1,7 @@
 /* eslint max-len: [2, 140] */
-define(['util/Util', 'util/Logger'], function (Util, Logger) {
+define(['okta', 'util/Util', 'util/Logger'], function (Okta, Util, Logger) {
+
+  var $ = Okta.$;
 
   describe('util/Util', function () {
 
@@ -130,6 +132,41 @@ define(['util/Util', 'util/Logger'], function (Util, Logger) {
         Logger.warn.calls.reset();
         Util.debugMessage(debugMessage);
         expect(Logger.warn).toHaveBeenCalledWith('\nMulti-line\nString\nMessage\n');
+      });
+    });
+
+    describe('postToUrl', function () {
+      beforeEach(function () {
+        spyOn($.fn, 'submit');
+      });
+
+      it('post the from only when no query parameters', function () {
+        var container = $('<div/>');
+
+        Util.postToUrl('http://test.abc.com/', container);
+        expect(container.children().size()).toBe(1);
+
+        var form = $(container.children()[0]);
+        expect(form[0].outerHTML).toBe(
+          '<form method="POST" action="http://test.abc.com/" style="display:none;"></form>'
+        );
+        expect(form.submit.calls.count()).toBe(1);
+      });
+
+      it('post the from when has query parameters', function () {
+        var container = $('<div/>');
+
+        Util.postToUrl('http://test.foo.com?aa=12&bb=34', container);
+        expect(container.children().size()).toBe(1);
+
+        var form = $(container.children()[0]);
+        expect(form[0].outerHTML).toBe(
+          '<form method="POST" action="http://test.foo.com" style="display:none;">'+
+          '<input type="hidden" name="aa" value="12">' +
+          '<input type="hidden" name="bb" value="34">' +
+          '</form>'
+        );
+        expect(form.submit.calls.count()).toBe(1);
       });
     });
 

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -140,7 +140,7 @@ define(['okta', 'util/Util', 'util/Logger'], function (Okta, Util, Logger) {
         spyOn($.fn, 'submit');
       });
 
-      it('post the from only when no query parameters', function () {
+      it('post the from when no query parameters', function () {
         var container = $('<div/>');
 
         Util.postToUrl('http://test.abc.com/', container);

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -135,15 +135,15 @@ define(['okta', 'util/Util', 'util/Logger'], function (Okta, Util, Logger) {
       });
     });
 
-    describe('postToUrl', function () {
+    describe('redirectToUrlWithPost', function () {
       beforeEach(function () {
         spyOn($.fn, 'submit');
       });
 
-      it('post the from when no query parameters', function () {
+      it('post the form without query parameters', function () {
         var container = $('<div/>');
 
-        Util.postToUrl('http://test.abc.com/', container);
+        Util.redirectToUrlWithPost('http://test.abc.com/', container);
         expect(container.children().size()).toBe(1);
 
         var form = $(container.children()[0]);
@@ -153,10 +153,10 @@ define(['okta', 'util/Util', 'util/Logger'], function (Okta, Util, Logger) {
         expect(form.submit.calls.count()).toBe(1);
       });
 
-      it('post the from when has query parameters', function () {
+      it('post the form with query parameters', function () {
         var container = $('<div/>');
 
-        Util.postToUrl('http://test.foo.com?aa=12&bb=34', container);
+        Util.redirectToUrlWithPost('http://test.foo.com?aa=12&bb=34', container);
         expect(container.children().size()).toBe(1);
 
         var form = $(container.children()[0]);


### PR DESCRIPTION
In IDP Discovery flow, the endpoint to next IdP could be very long (typically a inbound SAML request).
Therefore, instead of doing GET (browser redirect) which has length limit, we changed to POST.

for OKTA-182115

- @mauriciocastillosilva-okta @santhoshbalakrishnan 
- @yuliu-okta  @federations-okta 