### PR TITLE
:bug: Fix issue with custom string overrides in registration form.

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -58,14 +58,6 @@ function (
     }
   });
 
-  var Form = Okta.Form.extend({
-    layout: 'o-form-theme',
-    autoSave: true,
-    noCancelButton: true,
-    title: Okta.loc('registration.form.title', 'login'),
-    save: Okta.loc('registration.form.submit', 'login')
-  });
-
   return BaseLoginController.extend({
     className: 'registration',
     initialize: function() {
@@ -190,6 +182,13 @@ function (
         // create model
         self.model = self.createRegistrationModel(modelProperties);
         // create form
+        var Form = Okta.Form.extend({
+          layout: 'o-form-theme',
+          autoSave: true,
+          noCancelButton: true,
+          title: Okta.loc('registration.form.title', 'login'),
+          save: Okta.loc('registration.form.submit', 'login')
+        });
         var form = new Form(self.toJSON());
         // add form
         self.add(form);

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -143,9 +143,33 @@ function (Q, _, $, OktaAuth, Backbone, Util, Expect, Beacon, RegForm, RegSchema,
           expect(test.form.titleText()).toEqual('Create Account');
         });
       });
+      itp('uses custom title', function () {
+        var config = {
+          'i18n': {
+            'en': {
+              'registration.form.title': 'Custom Form Title'
+            }
+          }
+        };
+        return setup(config).then(function (test) {
+          expect(test.form.titleText()).toEqual('Custom Form Title');
+        });
+      });
       itp('uses default for submit', function () {
         return setup().then(function (test) {
           expect(test.form.submitButtonText()).toEqual('Register');
+        });
+      });
+      itp('uses custom text for submit', function () {
+        var config = {
+          'i18n': {
+            'en': {
+              'registration.form.submit': 'Custom Register Button'
+            }
+          }
+        };
+        return setup(config).then(function (test) {
+          expect(test.form.submitButtonText()).toEqual('Custom Register Button');
         });
       });
       itp('policyid is retrieved from default org policy', function () {


### PR DESCRIPTION
- Widget allows users to provide text overrides by exposing an i18n object within the widget config. If an i18n object is set as a part of the config, the ideal flow in the widget should be.

1. Widget loads all the bundles for the property files based on a locale
2. Widget then substitutes any overrides made via the widget config for i18n keys.
3. A controller calls the localize i.e. `Okta.loc('registration.form.title', 'login')` method using a i18n key (registration.form.title ) and bundlename (login) that has a text with custom value that was set in step2.

- The current implementation in the registration controller had a bug where the registration form that was initialized (and along with it the strings that were overridden) before the widget finished the overrides for custom values (in step2), and hence we were not seeing the overrides being reflected on the UI.

- TLDR; step 3 was being called before step 2 in the registration controller.

- Moved the form initialization inside the `fetchInitialData` method which fetches the schema for the reg form.

Resolves: [OKTA-185215](https://oktainc.atlassian.net/browse/OKTA-185215)

@okta/idx @mauriciocastillosilva-okta 

Testing : 

![screen shot 2018-09-06 at 9 19 15 am](https://user-images.githubusercontent.com/23267876/45176055-bc424980-b1c3-11e8-8809-44f546b55686.png)

