### PR TITLE
:art: removes moment.locale files all together when generates bundles.

### DIFF
--- a/buildtools/webpack/plugins.js
+++ b/buildtools/webpack/plugins.js
@@ -3,10 +3,14 @@
 
 const { readFileSync } = require('fs');
 const { join } = require('path');
-const { DefinePlugin, BannerPlugin, optimize } = require('webpack');
+const { DefinePlugin, BannerPlugin, IgnorePlugin, optimize } = require('webpack');
 const { some } = require('underscore');
 
 const UglifyJsPlugin = optimize.UglifyJsPlugin;
+
+function emptyModule() {
+  return new IgnorePlugin(/^\.\/locale$/, /moment$/);
+}
 
 function devMode() {
   return new DefinePlugin({
@@ -72,10 +76,10 @@ function banner() {
 function plugins(options = {}) {
   if (options.isProduction) {
     // Uglify and add license header
-    return [ uglify(), banner() ];
+    return [ emptyModule(), uglify(), banner() ];
   }
   // Use DEBUG/development environment w/ console warnings
-  return [ devMode() ];
+  return [ emptyModule(), devMode() ];
 }
 
 module.exports = plugins;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "main": "./dist/js/okta-sign-in.entry.js",
   "scripts": {
-    "clean": "rimraf target && rimraf dist",
+    "clean": "rimraf target && rimraf dist && rimraf build2",
     "lint:report": "grunt lint --checkstyle",
     "lint": "grunt lint",
     "test": "grunt test",


### PR DESCRIPTION
## Before changes

```
-rw-r--r--   1 haisheng.wu  staff   911K Oct  1 11:48 okta-sign-in-no-jquery.js
-rw-r--r--   1 haisheng.wu  staff   5.8M Oct  1 11:48 okta-sign-in-no-jquery.js.map
-rw-r--r--   1 haisheng.wu  staff   1.6M Oct  1 11:48 okta-sign-in.entry.js
-rw-r--r--   1 haisheng.wu  staff   2.4M Oct  1 11:48 okta-sign-in.entry.js.map
-rw-r--r--   1 haisheng.wu  staff   2.6M Oct  1 11:48 okta-sign-in.js
-rw-r--r--   1 haisheng.wu  staff   3.6M Oct  1 11:48 okta-sign-in.js.map
-rw-r--r--   1 haisheng.wu  staff   1.0M Oct  1 11:48 okta-sign-in.min.js
-rw-r--r--   1 haisheng.wu  staff   6.6M Oct  1 11:48 okta-sign-in.min.js.map
```

## After changes

```
-rw-r--r--   1 haisheng.wu  staff   752K Oct  1 11:48 okta-sign-in-no-jquery.js
-rw-r--r--   1 haisheng.wu  staff   5.0M Oct  1 11:48 okta-sign-in-no-jquery.js.map
-rw-r--r--   1 haisheng.wu  staff   1.6M Oct  1 11:48 okta-sign-in.entry.js
-rw-r--r--   1 haisheng.wu  staff   2.4M Oct  1 11:48 okta-sign-in.entry.js.map
-rw-r--r--   1 haisheng.wu  staff   2.2M Oct  1 11:48 okta-sign-in.js
-rw-r--r--   1 haisheng.wu  staff   3.2M Oct  1 11:48 okta-sign-in.js.map
-rw-r--r--   1 haisheng.wu  staff   848K Oct  1 11:48 okta-sign-in.min.js
-rw-r--r--   1 haisheng.wu  staff   5.8M Oct  1 11:48 okta-sign-in.min.js.map
```

## A little more details from webpack-bundle-analyzer


