### PR TITLE
:bug: fixes the validation error disappear quickly

### DIFF
--- a/src/ForgotPasswordController.js
+++ b/src/ForgotPasswordController.js
@@ -105,6 +105,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, Util, ContactSu
             name: 'username',
             input: TextBox,
             type: 'text',
+            inlineValidation: false,
             params: {
               innerTooltip: Okta.loc('password.forgot.email.or.username.tooltip', 'login'),
               icon: 'person-16-gray'

--- a/src/UnlockAccountController.js
+++ b/src/UnlockAccountController.js
@@ -103,6 +103,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, ContactSupport,
             name: 'username',
             input: TextBox,
             type: 'text',
+            inlineValidation: false,
             params: {
               innerTooltip: Okta.loc('account.unlock.email.or.username.tooltip', 'login'),
               icon: 'person-16-gray'


### PR DESCRIPTION
## Description

It's about timing.. 
Both inline validation and the 'send via email' button would trigger clear form error and validation.
Although inline validation comes a bit later (_.delay) and it supposes to work fine.
However the actual validation is throttled.

## Solution

There could be 2 possible solution

1. delay/throttle (200ms) the save event like what `BaseForm#save does`
2. disable the inline validation

I choose the 2nd since inline validation doesn't seem useful and don't want to introduce more timer.

## Screencasts

- https://okta.box.com/s/qx0jhm2xogoxnjgsmalrzv6588ur4y5a
