### PR TITLE
:seedling: Adds config option for relayState in PrimaryAuth

### DIFF
--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -142,6 +142,9 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       if (!this.settings.get('features.passwordlessAuth')) {
         signInArgs.password = this.get('password');
       }
+      if (this.settings.get('features.sendRelayStateInPrimaryAuth') && this.settings.get('relayState')) {
+        signInArgs.relayState = this.settings.get('relayState');
+      }
       return signInArgs;
     },
 

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -89,6 +89,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       'features.passwordlessAuth': ['boolean', false, false],
       'features.showPasswordToggleOnSignInPage': ['boolean', false, false],
       'features.trackTypingPattern': ['boolean', false, false],
+      'features.sendRelayStateInPrimaryAuth': ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -758,6 +758,117 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
       });
     });
 
+    Expect.describe('relayState', function () {
+      itp('is not sent by default in primaryAuth', function () {
+        return setup().then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setUsername('testuser');
+          test.form.setPassword('pass');
+          test.setNextResponse(resSuccess);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn',
+            data: {
+              username: 'testuser',
+              password: 'pass',
+              options: {
+                warnBeforePasswordExpired: true,
+                multiOptionalFactorEnroll: false
+              }
+            }
+          });
+        });
+      });
+
+      itp('is not sent if sendRelayStateInPrimaryAuth=false', function () {
+        return setup({
+          features: { sendRelayStateInPrimaryAuth: false },
+          relayState: '/test/path'
+        }).then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setUsername('testuser');
+          test.form.setPassword('pass');
+          test.setNextResponse(resSuccess);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn',
+            data: {
+              username: 'testuser',
+              password: 'pass',
+              options: {
+                warnBeforePasswordExpired: true,
+                multiOptionalFactorEnroll: false
+              }
+            }
+          });
+        });
+      });
+
+      itp('is not sent if relayState is empty, even if sendRelayStateInPrimaryAuth=true', function () {
+        return setup({
+          features: { sendRelayStateInPrimaryAuth: true }
+        }).then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setUsername('testuser');
+          test.form.setPassword('pass');
+          test.setNextResponse(resSuccess);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn',
+            data: {
+              username: 'testuser',
+              password: 'pass',
+              options: {
+                warnBeforePasswordExpired: true,
+                multiOptionalFactorEnroll: false
+              }
+            }
+          });
+        });
+      });
+
+      itp('is sent if sendRelayStateInPrimaryAuth=true and relayState is not empty', function () {
+        return setup({
+          features: { sendRelayStateInPrimaryAuth: true },
+          relayState: '/test/path'
+        }).then(function (test) {
+          $.ajax.calls.reset();
+          test.form.setUsername('testuser');
+          test.form.setPassword('pass');
+          test.setNextResponse(resSuccess);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.successSpy, test);
+        })
+        .then(function () {
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn',
+            data: {
+              username: 'testuser',
+              password: 'pass',
+              relayState: '/test/path',
+              options: {
+                warnBeforePasswordExpired: true,
+                multiOptionalFactorEnroll: false
+              }
+            }
+          });
+        });
+      });
+    });
+
     Expect.describe('transform username', function () {
       itp('calls the transformUsername function with the right parameters', function () {
         return setupWithTransformUsername().then(function (test) {
@@ -1088,7 +1199,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
           expect(ajaxArgs[0].headers['X-Typing-Pattern']).toBe(typingPattern);
         });
-      });      
+      });
     });
 
     Expect.describe('events', function () {
@@ -2133,7 +2244,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           test.form.facebookButton().click();
           expect(SharedUtil.redirect.calls.count()).toBe(1);
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
-            'https://foo.com/sso/idps/0oaidiw9udOSceD1234?' + 
+            'https://foo.com/sso/idps/0oaidiw9udOSceD1234?' +
             $.param({fromURI: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U'})
           );
         });


### PR DESCRIPTION
Added a new config option (sendRelayStateInPrimaryAuth) that when true, will add the relayState to the primary auth request data

Resolves: OKTA-193359

Note: this is intentionally not documented in README since it is not even Beta yet