### PR TITLE
Upgrade handlebars to 4.0.11 which is monolith using

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-runtime": "^6.26.0",
     "backbone": "1.2.1",
     "clipboard": "1.6.1",
-    "handlebars": "4.0.5",
+    "handlebars": "4.0.11",
     "jquery": "1.12.1",
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,9 +2592,9 @@ gzip-size@^5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
-handlebars@4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.5.tgz#92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7"
+handlebars@4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"


### PR DESCRIPTION
```
➜  loginpage git:(master) yarn install && yarn why handlebars
yarn install v1.7.0
warning ../../package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
✨  Done in 9.13s.
yarn why v1.7.0
warning ../../package.json: No license field
[1/4] 🤔  Why do we have the module "handlebars"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "handlebars@4.0.11"
info Has been hoisted to "handlebars"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "712MB"
info Disk size with unique dependencies: "1.02GB"
info Disk size with transitive dependencies: "1.14GB"
info Number of shared dependencies: 5
=> Found "@okta/courage#handlebars@2.0.0"
info This module exists because "@okta#courage" depends on it.
info Disk size without dependencies: "580MB"
info Disk size with unique dependencies: "788MB"
info Disk size with transitive dependencies: "920MB"
info Number of shared dependencies: 3
=> Found "@okta/okta-signin-widget#handlebars@4.0.5"
info This module exists because "@okta#okta-signin-widget" depends on it.
info Disk size without dependencies: "536MB"
info Disk size with unique dependencies: "864MB"
info Disk size with transitive dependencies: "996MB"
info Number of shared dependencies: 5
✨  Done in 0.73s.
```