### PR TITLE
feat: Adds new 'navigated' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,7 +1326,7 @@ Triggered when the widget transitions to a new page and animations have finished
 
 - **view** - Current page path
 - **controller** - Current controller name
-- **transaction** - Current authentication [transaction](https://github.com/okta/okta-auth-js/#transactionstatus) (if available)
+- **transaction** - Current [authentication transaction](https://developer.okta.com/docs/api/resources/authn#transaction-model) (if available)
 
 ```javascript
 signIn.on('navigated', function (context) {

--- a/README.md
+++ b/README.md
@@ -1332,7 +1332,14 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
       // {
       //   view: '/signin/verify/okta/push',
       //   controller: 'mfa-verify',
-      //   transaction: AuthTransaction
+      //   transaction: {
+      //     status: 'MFA_REQUIRED',
+      //     user: {
+      //       id: "00u..",
+      //       ...
+      //     }
+      //     ...
+      //   }
       // }
     });
     ```
@@ -1353,7 +1360,7 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
       });
     });
     ```
-- **pageRendered** (*Deprecated*) - triggered when the widget transitions to a new page and animations have finished.
+- **pageRendered** (*Deprecated in favor of **navigated***) - triggered when the widget transitions to a new page and animations have finished.
 
     ```javascript
     signIn.on('pageRendered', function (data) {

--- a/README.md
+++ b/README.md
@@ -1325,6 +1325,7 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
 Triggered when the widget transitions to a new page and animations have finished. Returns a `context` object containing the following properties:
 
 - **controller** - Current controller name
+- **stateToken** (*optional*) - An ephemeral token mapped to the current state of an authenticataion transaction.
 
 ```javascript
 // Overriding the "Back to Sign In" click action on the Forgot Password page
@@ -1337,6 +1338,43 @@ signIn.on('navigated', function (context) {
     e.preventDefault();
     e.stopPropagation();
     // Custom link behavior
+  });
+});
+```
+
+```javascript
+// Request authentication transaction information
+signIn.on('navigated', function (context) {
+  if (context.controller !== 'mfa-verify') {
+    return;
+  }
+  signIn.getTransaction(context.stateToken)
+  .then(function (transaction) {
+    console.log(transaction);
+    // {
+    //   status: 'MFA_REQUIRED',
+    //   user: {
+    //     id: '00ugti3kwafWJBRIY0g3',
+    //     profile: {
+    //       login: 'isaac@example.org',
+    //       ...
+    //     },
+    //   },
+    //   factors: [{
+    //     id: 'ufsigasO4dVUPM5O40g3',
+    //     provider: 'OKTA',
+    //     factorType: 'question',
+    //     profile: {
+    //       question: 'disliked_food',
+    //       questionText: 'What is the food you least liked as a child?'
+    //     },
+    //     verify: function(options) { /* returns another transaction */ }
+    //   }],
+    //   ...
+    // }
+  })
+  .catch(function (err) {
+    console.error(err);
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ You can learn more on the [Okta + JavaScript][lang-landing] page in our document
   - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   - [Feature flags](#feature-flags)
 - [Events](#events)
+  - [navigated](#navigated)
+  - [pageRendered](#pagerendered)
+  - [passwordRevealed](#passwordrevealed)
 - [Building the Widget](#building-the-widget)
   - [The `.widgetrc` config file](#the-widgetrc-config-file)
   - [Build and test commands](#build-and-test-commands)
@@ -354,23 +357,17 @@ Subscribe to an event published by the widget.
 
 - `event` - [Event](#events) to subscribe to
 - `callback` - Function to call when the event is triggered
-- `context` - Optional context to bind the callback to
 
 ```javascript
-signIn.on('navigated', function (context) {
-  console.log(context);
-  // {
-  //   view: '/',
-  //   controller: 'primary-auth'
-  // }
-});
+// Handle a 'navigated' event using an onNavigated callback
+signIn.on('navigated', onNavigated);
 ```
 
 ### off
 
 Unsubscribe from widget events. If no callback is provided, unsubscribes all listeners from the event.
 
-- `event` - Optional event to unsubscribe from
+- `event` - Optional [event](#events) to unsubscribe from
 - `callback` - Optional callback that was used to subscribe to the event
 
 ```javascript
@@ -1323,54 +1320,74 @@ features: {
 
 Events published by the widget. Subscribe to these events using [on](#onevent-callback-context).
 
-- **navigated** - triggered when the widget transitions to a new page and animations have finished.
+### navigated
 
-    ```javascript
-    signIn.on('navigated', function (context) {
-      // Assume view transitions between Primary Auth and MFA Push
-      console.log(context);
-      // {
-      //   view: '/signin/verify/okta/push',
-      //   controller: 'mfa-verify',
-      //   transaction: {
-      //     status: 'MFA_REQUIRED',
-      //     user: {
-      //       id: "00u..",
-      //       ...
-      //     }
-      //     ...
-      //   }
-      // }
-    });
-    ```
+Triggered when the widget transitions to a new page and animations have finished. Returns a `context` object containing the following properties:
 
-    To perform logic based on a specific controller:
+- **view** - Current page path
+- **controller** - Current controller name
+- **transaction** - Current authentication [transaction](https://github.com/okta/okta-auth-js/#transactionstatus) (if available)
 
-    ```javascript
-    // Overriding the "Back to Sign In" click action on the Forgot Password page
-    signIn.on('navigated', function (context) {
-      if (context.controller !== 'forgot-password') {
-        return;
-      }
-      var backLink = document.getElementsByClassName('js-back')[0];
-      backLink.addEventListener('click', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        // Custom link behavior
-      });
-    });
-    ```
-- **pageRendered** (*Deprecated in favor of **navigated***) - triggered when the widget transitions to a new page and animations have finished.
+```javascript
+signIn.on('navigated', function (context) {
+  // Assume view transitions between Primary Auth and MFA Push
+  console.log(context);
+  // {
+  //   view: '/signin/verify/okta/push',
+  //   controller: 'mfa-verify',
+  //   transaction: {
+  //     status: 'MFA_REQUIRED',
+  //     user: {
+  //       id: "00u..",
+  //       ...
+  //     }
+  //     ...
+  //   }
+  // }
+});
+```
 
-    ```javascript
-    signIn.on('pageRendered', function (data) {
-      console.log(data);
-      // {
-      //  page: 'forgot-password'
-      // }
-    });
-    ```
-- **passwordRevealed** - triggered when the show password button is clicked.
+To perform logic based on a specific controller:
+
+```javascript
+// Overriding the "Back to Sign In" click action on the Forgot Password page
+signIn.on('navigated', function (context) {
+  if (context.controller !== 'forgot-password') {
+    return;
+  }
+  var backLink = document.getElementsByClassName('js-back')[0];
+  backLink.addEventListener('click', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    // Custom link behavior
+  });
+});
+```
+
+### pageRendered
+
+:warning: This event has been *deprecated*, please use [**navigated**](#navigated) instead.
+
+Triggered when the widget transitions to a new page and animations have finished.
+
+```javascript
+signIn.on('pageRendered', function (data) {
+  console.log(data);
+  // {
+  //  page: 'forgot-password'
+  // }
+});
+```
+
+### passwordRevealed
+
+Triggered when the show password button is clicked.
+
+```javascript
+signIn.on('passwordRevealed', function () {
+  // Handle the event
+})
+```
 
 ## Building the Widget
 

--- a/README.md
+++ b/README.md
@@ -1325,7 +1325,6 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
 Triggered when the widget transitions to a new page and animations have finished. Returns a `context` object containing the following properties:
 
 - **controller** - Current controller name
-- **stateToken** (*optional*) - An ephemeral token mapped to the current state of an authenticataion transaction.
 
 ```javascript
 // Overriding the "Back to Sign In" click action on the Forgot Password page
@@ -1338,43 +1337,6 @@ signIn.on('navigated', function (context) {
     e.preventDefault();
     e.stopPropagation();
     // Custom link behavior
-  });
-});
-```
-
-```javascript
-// Request authentication transaction information
-signIn.on('navigated', function (context) {
-  if (context.controller !== 'mfa-verify') {
-    return;
-  }
-  signIn.getTransaction(context.stateToken)
-  .then(function (transaction) {
-    console.log(transaction);
-    // {
-    //   status: 'MFA_REQUIRED',
-    //   user: {
-    //     id: '00ugti3kwafWJBRIY0g3',
-    //     profile: {
-    //       login: 'isaac@example.org',
-    //       ...
-    //     },
-    //   },
-    //   factors: [{
-    //     id: 'ufsigasO4dVUPM5O40g3',
-    //     provider: 'OKTA',
-    //     factorType: 'question',
-    //     profile: {
-    //       question: 'disliked_food',
-    //       questionText: 'What is the food you least liked as a child?'
-    //     },
-    //     verify: function(options) { /* returns another transaction */ }
-    //   }],
-    //   ...
-    // }
-  })
-  .catch(function (err) {
-    console.error(err);
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1324,30 +1324,7 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
 
 Triggered when the widget transitions to a new page and animations have finished. Returns a `context` object containing the following properties:
 
-- **view** - Current page path
 - **controller** - Current controller name
-- **transaction** - Current [authentication transaction](https://developer.okta.com/docs/api/resources/authn#transaction-model) (if available)
-
-```javascript
-signIn.on('navigated', function (context) {
-  // Assume view transitions between Primary Auth and MFA Push
-  console.log(context);
-  // {
-  //   view: '/signin/verify/okta/push',
-  //   controller: 'mfa-verify',
-  //   transaction: {
-  //     status: 'MFA_REQUIRED',
-  //     user: {
-  //       id: "00u..",
-  //       ...
-  //     }
-  //     ...
-  //   }
-  // }
-});
-```
-
-To perform logic based on a specific controller:
 
 ```javascript
 // Overriding the "Back to Sign In" click action on the Forgot Password page

--- a/README.md
+++ b/README.md
@@ -357,8 +357,12 @@ Subscribe to an event published by the widget.
 - `context` - Optional context to bind the callback to
 
 ```javascript
-signIn.on('pageRendered', function (data) {
-  console.log(data);
+signIn.on('navigated', function (context) {
+  console.log(context);
+  // {
+  //   view: '/',
+  //   controller: 'primary-auth'
+  // }
 });
 ```
 
@@ -373,11 +377,11 @@ Unsubscribe from widget events. If no callback is provided, unsubscribes all lis
 // Unsubscribe all listeners from all events
 signIn.off();
 
-// Unsubscribe all listeners that have been registered to the 'pageRendered' event
-signIn.off('pageRendered');
+// Unsubscribe all listeners that have been registered to the 'navigated' event
+signIn.off('navigated');
 
-// Unsubscribe the onPageRendered listener from the 'pageRendered' event
-signIn.off('pageRendered', onPageRendered);
+// Unsubscribe the onNavigated listener from the 'navigated' event
+signIn.off('navigated', onNavigated);
 ```
 
 ### getTransaction
@@ -1319,12 +1323,26 @@ features: {
 
 Events published by the widget. Subscribe to these events using [on](#onevent-callback-context).
 
-- **pageRendered** - triggered when the widget transitions to a new page, and animations have finished.
+- **navigated** - triggered when the widget transitions to a new page and animations have finished.
+
+    ```javascript
+    signIn.on('navigated', function (context) {
+      // Assume view transitions between Primary Auth and MFA Push
+      console.log(context);
+      // {
+      //   view: '/signin/verify/okta/push',
+      //   controller: 'mfa-verify',
+      //   transaction: AuthTransaction
+      // }
+    });
+    ```
+
+    To perform logic based on a specific controller:
 
     ```javascript
     // Overriding the "Back to Sign In" click action on the Forgot Password page
-    signIn.on('pageRendered', function (data) {
-      if (data.page !== 'forgot-password') {
+    signIn.on('navigated', function (context) {
+      if (context.controller !== 'forgot-password') {
         return;
       }
       var backLink = document.getElementsByClassName('js-back')[0];
@@ -1333,6 +1351,16 @@ Events published by the widget. Subscribe to these events using [on](#onevent-ca
         e.stopPropagation();
         // Custom link behavior
       });
+    });
+    ```
+- **pageRendered** (*Deprecated*) - triggered when the widget transitions to a new page and animations have finished.
+
+    ```javascript
+    signIn.on('pageRendered', function (data) {
+      console.log(data);
+      // {
+      //  page: 'forgot-password'
+      // }
     });
     ```
 - **passwordRevealed** - triggered when the show password button is clicked.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/* global module, __dirname */
 const path = require('path');
 const webpackConfig = require('./webpack.test.config.js');
 const karmaOverrides = require('./test/unit/karma/karma-overrides');

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -126,6 +126,7 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
       lastAuthResponse: ['object', true, {}],
       transaction: 'object',
       transactionError: 'object',
+      stateToken: 'string',
       username: 'string',
       factors: 'object',
       policy: 'object',

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -126,7 +126,6 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
       lastAuthResponse: ['object', true, {}],
       transaction: 'object',
       transactionError: 'object',
-      stateToken: 'string',
       username: 'string',
       factors: 'object',
       policy: 'object',

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -101,8 +101,12 @@ define(['okta', 'q'], function (Okta, Q) {
     postRenderAnimation: function() {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
+
+      // If a stateToken exists, return it in the event context
+      var transaction = this.options.appState.get('transaction') && this.options.appState.get('transaction').data;
       this.trigger('navigated', {
-        controller: this.className
+        controller: this.className,
+        stateToken: transaction && transaction.stateToken
       });
     }
   });

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -101,10 +101,11 @@ define(['okta', 'q'], function (Okta, Q) {
     postRenderAnimation: function() {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
+      var transaction = this.options.appState.get('transaction');
       var context = {
         view: window.location.pathname,
         controller: this.className,
-        transaction: this.options.appState.get('transaction')
+        transaction: transaction && transaction.data
       };
       this.trigger('navigated', context);
     }

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -101,13 +101,9 @@ define(['okta', 'q'], function (Okta, Q) {
     postRenderAnimation: function() {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
-      var transaction = this.options.appState.get('transaction');
-      var context = {
-        view: window.location.pathname,
-        controller: this.className,
-        transaction: transaction && transaction.data
-      };
-      this.trigger('navigated', context);
+      this.trigger('navigated', {
+        controller: this.className
+      });
     }
   });
 

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -101,6 +101,12 @@ define(['okta', 'q'], function (Okta, Q) {
     postRenderAnimation: function() {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
+      var context = {
+        view: window.location.pathname,
+        controller: this.className,
+        transaction: this.options.appState.get('transaction')
+      };
+      this.trigger('navigated', _.pick(context, _.identity));
     }
   });
 

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -52,6 +52,9 @@ define(['okta', 'q'], function (Okta, Q) {
     addModelListeners: function(model) {
       var setTransactionHandler = _.bind(function (transaction) {
         this.options.appState.set('transaction', transaction);
+        if (transaction && transaction.data) {
+          this.options.appState.set('stateToken', transaction.data.stateToken);
+        }
       }, this);
       var transactionErrorHandler = _.bind(function (err) {
         this.options.appState.set('transactionError', err);
@@ -102,11 +105,9 @@ define(['okta', 'q'], function (Okta, Q) {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
 
-      // If a stateToken exists, return it in the event context
-      var transaction = this.options.appState.get('transaction') && this.options.appState.get('transaction').data;
       this.trigger('navigated', {
         controller: this.className,
-        stateToken: transaction && transaction.stateToken
+        stateToken: this.options.appState.get('stateToken')
       });
     }
   });

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -106,7 +106,7 @@ define(['okta', 'q'], function (Okta, Q) {
         controller: this.className,
         transaction: this.options.appState.get('transaction')
       };
-      this.trigger('navigated', _.pick(context, _.identity));
+      this.trigger('navigated', context);
     }
   });
 

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -100,6 +100,7 @@ define(['okta', 'q'], function (Okta, Q) {
 
     postRenderAnimation: function() {
       // Event triggered after a page is rendered along with the classname to identify the page
+      // TODO: Deprecate this event in the next major version in favor of 'navigated'
       this.trigger('pageRendered', {page: this.className});
 
       this.trigger('navigated', { controller: this.className });

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -52,9 +52,6 @@ define(['okta', 'q'], function (Okta, Q) {
     addModelListeners: function(model) {
       var setTransactionHandler = _.bind(function (transaction) {
         this.options.appState.set('transaction', transaction);
-        if (transaction && transaction.data) {
-          this.options.appState.set('stateToken', transaction.data.stateToken);
-        }
       }, this);
       var transactionErrorHandler = _.bind(function (err) {
         this.options.appState.set('transactionError', err);
@@ -105,10 +102,7 @@ define(['okta', 'q'], function (Okta, Q) {
       // Event triggered after a page is rendered along with the classname to identify the page
       this.trigger('pageRendered', {page: this.className});
 
-      this.trigger('navigated', {
-        controller: this.className,
-        stateToken: this.options.appState.get('stateToken')
-      });
+      this.trigger('navigated', { controller: this.className });
     }
   });
 

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -553,16 +553,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       .then(function (test) {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         expect(test.navigatedSpy.calls.count()).toBe(2);
-        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
-          view: '/context.html',
-          controller: 'refresh-auth-state',
-          transaction: undefined
-        }]);
-        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
-          view: '/context.html',
-          controller: 'primary-auth',
-          transaction: resUnauthenticated.response
-        }]);
+        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
+        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
       });
     });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
@@ -952,11 +944,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test){
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({
-            view: '/context.html',
-            controller: 'primary-auth',
-            transaction: undefined
-          });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
       });
       itp('triggers both pageRendered and navigated events when first controller is loaded', function() {
@@ -969,11 +957,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.eventSpy.calls.count()).toBe(1);
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({
-            view: '/context.html',
-            controller: 'primary-auth',
-            transaction: undefined
-          });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
       });
       itp('triggers a pageRendered event when navigating to a new controller', function() {
@@ -1002,11 +986,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test) {
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
-            view: '/context.html',
-            controller: 'primary-auth',
-            transaction: undefined
-          }]);
+          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
@@ -1015,11 +995,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           // since the event is triggered from the success function of the animation
           // as well as after render, we expect two calls
           expect(test.navigatedSpy.calls.count()).toBe(2);
-          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
-            view: '/context.html',
-            controller: 'forgot-password',
-            transaction: undefined
-          }]);
+          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
         });
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -561,11 +561,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
           view: '/context.html',
           controller: 'primary-auth',
-          transaction: jasmine.objectContaining({
-            status: 'UNAUTHENTICATED',
-            authenticate: jasmine.any(Function),
-            data: jasmine.objectContaining(resUnauthenticated.response)
-          })
+          transaction: resUnauthenticated.response
         }]);
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -562,7 +562,9 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           view: '/context.html',
           controller: 'primary-auth',
           transaction: jasmine.objectContaining({
-            status: 'UNAUTHENTICATED'
+            status: 'UNAUTHENTICATED',
+            authenticate: jasmine.any(Function),
+            data: jasmine.objectContaining(resUnauthenticated.response)
           })
         }]);
       });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -542,6 +542,30 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
     });
+    itp('triggers a "navigated" event when routing to default route and when status is UNAUTHENTICATED', function () {
+      return setup({ stateToken: 'aStateToken' })
+      .then(function (test) {
+        Util.mockRouterNavigate(test.router);
+        test.setNextResponse(resUnauthenticated);
+        test.router.navigate('/app/sso');
+        return Expect.waitForPrimaryAuth(test);
+      })
+      .then(function (test) {
+        expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
+        expect(test.navigatedSpy.calls.count()).toBe(2);
+        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
+          view: '/context.html',
+          controller: 'refresh-auth-state'
+        }]);
+        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
+          view: '/context.html',
+          controller: 'primary-auth',
+          transaction: jasmine.objectContaining({
+            status: 'UNAUTHENTICATED'
+          })
+        }]);
+      });
+    });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
       Util.mockDuo();
       return setup()

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -555,7 +555,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         expect(test.navigatedSpy.calls.count()).toBe(2);
         expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
           view: '/context.html',
-          controller: 'refresh-auth-state'
+          controller: 'refresh-auth-state',
+          transaction: undefined
         }]);
         expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
           view: '/context.html',
@@ -955,7 +956,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.navigatedSpy.calls.count()).toBe(1);
           expect(test.navigatedSpy).toHaveBeenCalledWith({
             view: '/context.html',
-            controller: 'primary-auth'
+            controller: 'primary-auth',
+            transaction: undefined
           });
         });
       });
@@ -971,7 +973,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.navigatedSpy.calls.count()).toBe(1);
           expect(test.navigatedSpy).toHaveBeenCalledWith({
             view: '/context.html',
-            controller: 'primary-auth'
+            controller: 'primary-auth',
+            transaction: undefined
           });
         });
       });
@@ -1003,7 +1006,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.navigatedSpy.calls.count()).toBe(1);
           expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
             view: '/context.html',
-            controller: 'primary-auth'
+            controller: 'primary-auth',
+            transaction: undefined
           }]);
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
@@ -1015,7 +1019,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.navigatedSpy.calls.count()).toBe(2);
           expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
             view: '/context.html',
-            controller: 'forgot-password'
+            controller: 'forgot-password',
+            transaction: undefined
           }]);
         });
       });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -71,6 +71,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({url: baseUrl, headers: {}});
       var eventSpy = jasmine.createSpy('eventSpy');
+      var navigatedSpy = jasmine.createSpy('navigatedSpy');
       var router = new Router(_.extend({
         el: $sandbox,
         baseUrl: baseUrl,
@@ -78,13 +79,15 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       }, settings));
       Util.registerRouter(router);
       router.on('pageRendered', eventSpy);
+      router.on('navigated', navigatedSpy);
       spyOn(authClient.token, 'getWithoutPrompt').and.callThrough();
       spyOn(authClient.token.getWithRedirect, '_setLocation');
       return tick({
         router: router,
         ac: authClient,
         setNextResponse: setNextResponse,
-        eventSpy: eventSpy
+        eventSpy: eventSpy,
+        navigatedSpy: navigatedSpy
       });
     }
 
@@ -918,6 +921,36 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
         });
       });
+      itp('triggers a navigated event when first controller is loaded', function() {
+        return setup()
+        .then(function (test) {
+          test.router.primaryAuth();
+          return Expect.waitForPrimaryAuth(test);
+        })
+        .then(function(test){
+          expect(test.navigatedSpy.calls.count()).toBe(1);
+          expect(test.navigatedSpy).toHaveBeenCalledWith({
+            view: '/context.html',
+            controller: 'primary-auth'
+          });
+        });
+      });
+      itp('triggers both pageRendered and navigated events when first controller is loaded', function() {
+        return setup()
+        .then(function (test) {
+          test.router.primaryAuth();
+          return Expect.waitForPrimaryAuth(test);
+        })
+        .then(function(test){
+          expect(test.eventSpy.calls.count()).toBe(1);
+          expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
+          expect(test.navigatedSpy.calls.count()).toBe(1);
+          expect(test.navigatedSpy).toHaveBeenCalledWith({
+            view: '/context.html',
+            controller: 'primary-auth'
+          });
+        });
+      });
       itp('triggers a pageRendered event when navigating to a new controller', function() {
         return setup()
         .then(function (test) {
@@ -933,6 +966,33 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.eventSpy.calls.count()).toBe(2);
           expect(test.eventSpy.calls.allArgs()[0]).toEqual([{page: 'forgot-password'}]);
           expect(test.eventSpy.calls.allArgs()[1]).toEqual([{page: 'forgot-password'}]);
+        });
+      });
+      itp('triggers a navigated event when navigating to a new controller', function() {
+        return setup()
+        .then(function (test) {
+          // Test navigation from primary Auth to Forgot password page
+          test.router.primaryAuth();
+          return Expect.waitForPrimaryAuth(test);
+        })
+        .then(function(test) {
+          expect(test.navigatedSpy.calls.count()).toBe(1);
+          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{
+            view: '/context.html',
+            controller: 'primary-auth'
+          }]);
+          Util.mockRouterNavigate(test.router);
+          test.router.navigate('signin/forgot-password');
+          return Expect.waitForForgotPassword(test);
+        })
+        .then(function (test) {
+          // since the event is triggered from the success function of the animation
+          // as well as after render, we expect two calls
+          expect(test.navigatedSpy.calls.count()).toBe(2);
+          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{
+            view: '/context.html',
+            controller: 'forgot-password'
+          }]);
         });
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -553,8 +553,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       .then(function (test) {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         expect(test.navigatedSpy.calls.count()).toBe(2);
-        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
-        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
+        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state', stateToken: undefined }]);
+        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth', stateToken: 'aStateToken' }]);
       });
     });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
@@ -944,7 +944,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test){
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth', stateToken: undefined });
         });
       });
       itp('triggers both pageRendered and navigated events when first controller is loaded', function() {
@@ -957,7 +957,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.eventSpy.calls.count()).toBe(1);
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth', stateToken: undefined });
         });
       });
       itp('triggers a pageRendered event when navigating to a new controller', function() {
@@ -986,7 +986,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test) {
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
+          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth', stateToken: undefined }]);
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
@@ -995,7 +995,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           // since the event is triggered from the success function of the animation
           // as well as after render, we expect two calls
           expect(test.navigatedSpy.calls.count()).toBe(2);
-          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
+          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password', stateToken: undefined }]);
         });
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -553,8 +553,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       .then(function (test) {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         expect(test.navigatedSpy.calls.count()).toBe(2);
-        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state', stateToken: undefined }]);
-        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth', stateToken: 'aStateToken' }]);
+        expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
+        expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
       });
     });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
@@ -944,7 +944,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test){
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth', stateToken: undefined });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
       });
       itp('triggers both pageRendered and navigated events when first controller is loaded', function() {
@@ -957,7 +957,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.eventSpy.calls.count()).toBe(1);
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth', stateToken: undefined });
+          expect(test.navigatedSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
       });
       itp('triggers a pageRendered event when navigating to a new controller', function() {
@@ -986,7 +986,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function(test) {
           expect(test.navigatedSpy.calls.count()).toBe(1);
-          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth', stateToken: undefined }]);
+          expect(test.navigatedSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
@@ -995,7 +995,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           // since the event is triggered from the success function of the animation
           // as well as after render, we expect two calls
           expect(test.navigatedSpy.calls.count()).toBe(2);
-          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password', stateToken: undefined }]);
+          expect(test.navigatedSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
         });
       });
     });


### PR DESCRIPTION
### Description

Renames `pageRendered` event to `navigated`, and returns the following `context` information:

```javascript
signIn.on('navigated', (context) => {
  // Assume view transitions between Primary Auth and MFA Push
  console.log(context);
  /**
   * {
   *   controller: 'mfa-verify'
   * }
   */
});
```

> Note: Since there is no *good* way to deprecate events, we're going to label the existing `pageRendered` event as deprecated.

