### PR TITLE
feat: Adds ready and afterRender events

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ You can learn more on the [Okta + JavaScript][lang-landing] page in our document
   - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   - [Feature flags](#feature-flags)
 - [Events](#events)
+  - [ready](#ready)
+  - [afterRender](#afterrender)
+  - [pageRendered](#pagerendered)
+  - [passwordRevealed](#passwordrevealed)
 - [Building the Widget](#building-the-widget)
   - [The `.widgetrc` config file](#the-widgetrc-config-file)
   - [Build and test commands](#build-and-test-commands)
@@ -354,30 +358,28 @@ Subscribe to an event published by the widget.
 
 - `event` - [Event](#events) to subscribe to
 - `callback` - Function to call when the event is triggered
-- `context` - Optional context to bind the callback to
 
 ```javascript
-signIn.on('pageRendered', function (data) {
-  console.log(data);
-});
+// Handle a 'ready' event using an onReady callback
+signIn.on('ready', onReady);
 ```
 
 ### off
 
 Unsubscribe from widget events. If no callback is provided, unsubscribes all listeners from the event.
 
-- `event` - Optional event to unsubscribe from
+- `event` - Optional [event](#events) to unsubscribe from
 - `callback` - Optional callback that was used to subscribe to the event
 
 ```javascript
 // Unsubscribe all listeners from all events
 signIn.off();
 
-// Unsubscribe all listeners that have been registered to the 'pageRendered' event
-signIn.off('pageRendered');
+// Unsubscribe all listeners that have been registered to the 'ready' event
+signIn.off('ready');
 
-// Unsubscribe the onPageRendered listener from the 'pageRendered' event
-signIn.off('pageRendered', onPageRendered);
+// Unsubscribe the onReady listener from the 'ready' event
+signIn.off('ready', onReady);
 ```
 
 ### getTransaction
@@ -1319,23 +1321,63 @@ features: {
 
 Events published by the widget. Subscribe to these events using [on](#onevent-callback-context).
 
-- **pageRendered** - triggered when the widget transitions to a new page, and animations have finished.
+### ready
 
-    ```javascript
-    // Overriding the "Back to Sign In" click action on the Forgot Password page
-    signIn.on('pageRendered', function (data) {
-      if (data.page !== 'forgot-password') {
-        return;
-      }
-      var backLink = document.getElementsByClassName('js-back')[0];
-      backLink.addEventListener('click', function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        // Custom link behavior
-      });
-    });
-    ```
-- **passwordRevealed** - triggered when the show password button is clicked.
+Triggered when the widget is ready to accept user input for the first time. Returns a `context` object containing the following properties:
+
+- **controller** - Current controller name
+
+```javascript
+signIn.on('ready', function (context) {
+  if (context.controller === 'primary-auth') {
+    // The primary authentication form is ready for user input
+  }
+});
+```
+
+### afterRender
+
+Triggered when the widget transitions to a new page and animations have finished. Returns a `context` object containing the following properties:
+
+- **controller** - Current controller name
+
+```javascript
+// Overriding the "Back to Sign In" click action on the Forgot Password page
+signIn.on('afterRender', function (context) {
+  if (context.controller !== 'forgot-password') {
+    return;
+  }
+  var backLink = document.getElementsByClassName('js-back')[0];
+  backLink.addEventListener('click', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    // Custom link behavior
+  });
+});
+```
+
+### pageRendered
+
+:warning: This event has been *deprecated*, please use [**afterRender**](#afterrender) instead.
+
+Triggered when the widget transitions to a new page and animations have finished.
+
+```javascript
+signIn.on('pageRendered', function (data) {
+  console.log(data);
+  // { page: 'forgot-password' }
+});
+```
+
+### passwordRevealed
+
+Triggered when the show password button is clicked.
+
+```javascript
+signIn.on('passwordRevealed', function () {
+  // Handle the event
+})
+```
 
 ## Building the Widget
 

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -100,7 +100,10 @@ define(['okta', 'q'], function (Okta, Q) {
 
     postRenderAnimation: function () {
       // Event triggered after a page is rendered along with the classname to identify the page
+      // TODO: Deprecate this event in the next major version in favor of 'afterRender'
       this.trigger('pageRendered', {page: this.className});
+
+      this.trigger('afterRender', { controller: this.className });
     }
   });
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -223,6 +223,11 @@ var OktaSignIn = (function () {
 
     // Triggers the event up the chain so it is available to the consumers of the widget.
     this.listenTo(LoginRouter.prototype, 'all', this.trigger);
+
+    // On the first afterRender event (usually when the Widget is ready) - emit a 'ready' event
+    this.once('afterRender', function (context) {
+      this.trigger('ready', context);
+    });
   }
 
   return OktaSignIn;

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -552,7 +552,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function (test) {
           expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
-          expect(test.renderSpy.calls.count()).toBe(2);
+          expect(test.renderSpy).toHaveBeenCalledTimes(2);
           expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
           expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
         });
@@ -943,7 +943,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForPrimaryAuth(test);
           })
           .then(function (test){
-            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy).toHaveBeenCalledTimes(1);
             expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
           });
       });
@@ -954,9 +954,9 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForPrimaryAuth(test);
           })
           .then(function (test){
-            expect(test.eventSpy.calls.count()).toBe(1);
+            expect(test.eventSpy).toHaveBeenCalledTimes(1);
             expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
-            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy).toHaveBeenCalledTimes(1);
             expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
           });
       });
@@ -970,8 +970,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForForgotPassword(test);
           })
           .then(function (test) {
-          // since the event is triggered from the success function of the animation
-          // as well as after render, we expect two calls
+            // since the event is triggered from the success function of the animation
+            // as well as after render, we expect two calls
             expect(test.eventSpy.calls.count()).toBe(2);
             expect(test.eventSpy.calls.allArgs()[0]).toEqual([{page: 'forgot-password'}]);
             expect(test.eventSpy.calls.allArgs()[1]).toEqual([{page: 'forgot-password'}]);
@@ -985,7 +985,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForPrimaryAuth(test);
           })
           .then(function (test) {
-            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy).toHaveBeenCalledTimes(1);
             expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
             Util.mockRouterNavigate(test.router);
             test.router.navigate('signin/forgot-password');
@@ -994,7 +994,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           .then(function (test) {
             // since the event is triggered from the success function of the animation
             // as well as after render, we expect two calls
-            expect(test.renderSpy.calls.count()).toBe(2);
+            expect(test.renderSpy).toHaveBeenCalledTimes(2);
             expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
           });
       });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -71,7 +71,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({url: baseUrl, headers: {}});
       var eventSpy = jasmine.createSpy('eventSpy');
-      var renderSpy = jasmine.createSpy('renderSpy');
+      var afterRenderHandler = jasmine.createSpy('afterRenderHandler');
       var router = new Router(_.extend({
         el: $sandbox,
         baseUrl: baseUrl,
@@ -79,7 +79,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       }, settings));
       Util.registerRouter(router);
       router.on('pageRendered', eventSpy);
-      router.on('afterRender', renderSpy);
+      router.on('afterRender', afterRenderHandler);
       spyOn(authClient.token, 'getWithoutPrompt').and.callThrough();
       spyOn(authClient.token.getWithRedirect, '_setLocation');
       return tick({
@@ -87,7 +87,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         ac: authClient,
         setNextResponse: setNextResponse,
         eventSpy: eventSpy,
-        renderSpy: renderSpy
+        afterRenderHandler: afterRenderHandler
       });
     }
 
@@ -552,9 +552,9 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         })
         .then(function (test) {
           expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
-          expect(test.renderSpy).toHaveBeenCalledTimes(2);
-          expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
-          expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
+          expect(test.afterRenderHandler).toHaveBeenCalledTimes(2);
+          expect(test.afterRenderHandler.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
+          expect(test.afterRenderHandler.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
         });
     });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
@@ -943,8 +943,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForPrimaryAuth(test);
           })
           .then(function (test){
-            expect(test.renderSpy).toHaveBeenCalledTimes(1);
-            expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+            expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterRenderHandler).toHaveBeenCalledWith({ controller: 'primary-auth' });
           });
       });
       itp('triggers both pageRendered and afterRender events when first controller is loaded', function () {
@@ -956,8 +956,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           .then(function (test){
             expect(test.eventSpy).toHaveBeenCalledTimes(1);
             expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
-            expect(test.renderSpy).toHaveBeenCalledTimes(1);
-            expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+            expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterRenderHandler).toHaveBeenCalledWith({ controller: 'primary-auth' });
           });
       });
       itp('triggers a pageRendered event when navigating to a new controller', function () {
@@ -985,8 +985,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             return Expect.waitForPrimaryAuth(test);
           })
           .then(function (test) {
-            expect(test.renderSpy).toHaveBeenCalledTimes(1);
-            expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
+            expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterRenderHandler.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
             Util.mockRouterNavigate(test.router);
             test.router.navigate('signin/forgot-password');
             return Expect.waitForForgotPassword(test);
@@ -994,8 +994,8 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           .then(function (test) {
             // since the event is triggered from the success function of the animation
             // as well as after render, we expect two calls
-            expect(test.renderSpy).toHaveBeenCalledTimes(2);
-            expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
+            expect(test.afterRenderHandler).toHaveBeenCalledTimes(2);
+            expect(test.afterRenderHandler.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
           });
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -71,6 +71,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({url: baseUrl, headers: {}});
       var eventSpy = jasmine.createSpy('eventSpy');
+      var renderSpy = jasmine.createSpy('renderSpy');
       var router = new Router(_.extend({
         el: $sandbox,
         baseUrl: baseUrl,
@@ -78,13 +79,15 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
       }, settings));
       Util.registerRouter(router);
       router.on('pageRendered', eventSpy);
+      router.on('afterRender', renderSpy);
       spyOn(authClient.token, 'getWithoutPrompt').and.callThrough();
       spyOn(authClient.token.getWithRedirect, '_setLocation');
       return tick({
         router: router,
         ac: authClient,
         setNextResponse: setNextResponse,
-        eventSpy: eventSpy
+        eventSpy: eventSpy,
+        renderSpy: renderSpy
       });
     }
 
@@ -539,6 +542,21 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         });
     });
+    itp('triggers an afterRender event when routing to default route and when status is UNAUTHENTICATED', function () {
+      return setup({ stateToken: 'aStateToken' })
+        .then(function (test) {
+          Util.mockRouterNavigate(test.router);
+          test.setNextResponse(resUnauthenticated);
+          test.router.navigate('/app/sso');
+          return Expect.waitForPrimaryAuth(test);
+        })
+        .then(function (test) {
+          expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
+          expect(test.renderSpy.calls.count()).toBe(2);
+          expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
+          expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
+        });
+    });
     itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
       Util.mockDuo();
       return setup()
@@ -918,6 +936,30 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
           });
       });
+      itp('triggers an afterRender event when first controller is loaded', function () {
+        return setup()
+          .then(function (test) {
+            test.router.primaryAuth();
+            return Expect.waitForPrimaryAuth(test);
+          })
+          .then(function (test){
+            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+          });
+      });
+      itp('triggers both pageRendered and afterRender events when first controller is loaded', function () {
+        return setup()
+          .then(function (test) {
+            test.router.primaryAuth();
+            return Expect.waitForPrimaryAuth(test);
+          })
+          .then(function (test){
+            expect(test.eventSpy.calls.count()).toBe(1);
+            expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth'});
+            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy).toHaveBeenCalledWith({ controller: 'primary-auth' });
+          });
+      });
       itp('triggers a pageRendered event when navigating to a new controller', function () {
         return setup()
           .then(function (test) {
@@ -933,6 +975,27 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
             expect(test.eventSpy.calls.count()).toBe(2);
             expect(test.eventSpy.calls.allArgs()[0]).toEqual([{page: 'forgot-password'}]);
             expect(test.eventSpy.calls.allArgs()[1]).toEqual([{page: 'forgot-password'}]);
+          });
+      });
+      itp('triggers an afterRender event when navigating to a new controller', function () {
+        return setup()
+          .then(function (test) {
+            // Test navigation from primary Auth to Forgot password page
+            test.router.primaryAuth();
+            return Expect.waitForPrimaryAuth(test);
+          })
+          .then(function (test) {
+            expect(test.renderSpy.calls.count()).toBe(1);
+            expect(test.renderSpy.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
+            Util.mockRouterNavigate(test.router);
+            test.router.navigate('signin/forgot-password');
+            return Expect.waitForForgotPassword(test);
+          })
+          .then(function (test) {
+            // since the event is triggered from the success function of the animation
+            // as well as after render, we expect two calls
+            expect(test.renderSpy.calls.count()).toBe(2);
+            expect(test.renderSpy.calls.allArgs()[1]).toEqual([{ controller: 'forgot-password' }]);
           });
       });
     });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -3,9 +3,10 @@ define([
   'okta',
   'widget/OktaSignIn',
   'helpers/util/Expect',
-  'util/Logger'
+  'util/Logger',
+  'sandbox'
 ],
-function (Okta, Widget, Expect, Logger) {
+function (Okta, Widget, Expect, Logger, $sandbox) {
   var signIn;
   var url = 'https://foo.com';
   var { $ } = Okta;
@@ -122,6 +123,41 @@ function (Okta, Widget, Expect, Logger) {
             });
             done();
           });
+      });
+    });
+
+    Expect.describe('events', function () {
+      afterEach(function () {
+        signIn.remove();
+        signIn.off();
+      });
+      it('triggers an afterRender event when the Widget renders a page', function (done) {
+        signIn.on('afterRender', function (context) {
+          expect(context).toEqual({ controller: 'primary-auth' });
+          done();
+        });
+        signIn.renderEl({ el: $sandbox });
+      });
+      it('triggers a ready event when the Widget is loaded for the first time', function (done) {
+        signIn.on('ready', function (context) {
+          expect(context).toEqual({ controller: 'primary-auth' });
+          done();
+        });
+        signIn.renderEl({ el: $sandbox });
+      });
+      it('does not trigger a ready event twice', function (done) {
+        signIn.on('ready', function (context) {
+          expect(context).toEqual({ controller: 'primary-auth' });
+          // Navigate directly to forgot-password page
+          var forgotPasswordLink = document.getElementsByClassName('link js-forgot-password');
+          forgotPasswordLink[0].click();
+        });
+        signIn.on('afterRender', function (context) {
+          if (context.controller === 'forgot-password') {
+            done();
+          }
+        });
+        signIn.renderEl({ el: '#sandbox' });
       });
     });
   });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -145,6 +145,28 @@ function (Okta, Widget, Expect, Logger, $sandbox) {
         });
         signIn.renderEl({ el: $sandbox });
       });
+      it('triggers a ready event when the Widget is loaded with a recoveryToken', function (done) {
+        signIn = new Widget({
+          baseUrl: url,
+          recoveryToken: 'foo'
+        });
+        signIn.on('ready', function (context) {
+          expect(context).toEqual({ controller: 'recovery-loading' });
+          done();
+        });
+        signIn.renderEl({ el: $sandbox });
+      });
+      it('triggers a ready event when the Widget is loaded with using idpDiscovery', function (done) {
+        signIn = new Widget({
+          baseUrl: url,
+          features: { idpDiscovery: true }
+        });
+        signIn.on('ready', function (context) {
+          expect(context).toEqual({ controller: 'idp-discovery' });
+          done();
+        });
+        signIn.renderEl({ el: $sandbox });
+      });
       it('does not trigger a ready event twice', function (done) {
         signIn.on('ready', function (context) {
           expect(context).toEqual({ controller: 'primary-auth' });


### PR DESCRIPTION
### Description

Begins implementation around the new design pattern for events. This PR introduces a new event `ready` and renames the existing event `pageRendered` to `afterRender`.

The new event design adheres to the following naming conventions:

- All standard events are triggered **before** the DOM has rendered, and allows developer to "hook into" our controller as a blocking operation. This naming convention will adhere to all events, excluding any obvious outliers. For example, `ready`.
- If an event is prefixed with `after`, the DOM has rendered and the Widget has completed all controller and view logic. This will allow developers to update the UI, log messages, and/or navigate elsewhere under specific scenarios.

### Reviewers

- @haishengwu-okta 
- @manueltanzi-okta 
- @nbarbettini 

