### PR TITLE
:art: Fixes flaky unit test

### DIFF
--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -152,13 +152,6 @@ define([
     return fn.wait(condition, resolveValue);
   };
 
-  fn.waitForEnrollChoices = function (resolveValue) {
-    var condition = function () {
-      return $('.enroll-choices').length > 0;
-    };
-    return fn.wait(condition, resolveValue);
-  };
-
   fn.wait = function (condition, resolveValue, timeout) {
     function check(success, fail, triesLeft) {
       if (condition()) {

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -139,7 +139,7 @@ define([
   };
 
   /**
-   * Use this function to wait for a error view which has top level class '.okta-form-infobox-error'.
+   * Use this function to wait for an error view which has top level class '.okta-form-infobox-error'.
    */
   fn.waitForFormError = function (form, resolveValue) {
     var condition = function () {
@@ -149,7 +149,7 @@ define([
   };
 
   /**
-   * Use this function to wait for a error view which has top level class '.okta-infobox-error'.
+   * Use this function to wait for an error view which has top level class '.okta-infobox-error'.
    */
   fn.waitForFormErrorBox = function (form, resolveValue) {
     var condition = function () {

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -86,6 +86,10 @@ define([
 
   fn.fitp = runTest.bind({}, fit);
 
+  /**
+   * @deprecated This is very hacky rather solving the actual reason of flakiness.
+   *             Please slack eng-ui and think twice before you want to use this function.
+   */
   fn.tick = function (returnVal) {
     var deferred = Q.defer();
     // Using four setTimeouts to remove flakiness (some tests need an extra

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -138,6 +138,9 @@ define([
     return fn.wait(condition, resolveValue);
   };
 
+  /**
+   * Use this function to wait for a error view which has top level class '.okta-form-infobox-error'.
+   */
   fn.waitForFormError = function (form, resolveValue) {
     var condition = function () {
       return form.hasErrors();
@@ -145,6 +148,9 @@ define([
     return fn.wait(condition, resolveValue);
   };
 
+  /**
+   * Use this function to wait for a error view which has top level class '.okta-infobox-error'.
+   */
   fn.waitForFormErrorBox = function (form, resolveValue) {
     var condition = function () {
       return form.errorBox().length > 0;

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -87,8 +87,8 @@ define([
   fn.fitp = runTest.bind({}, fit);
 
   /**
-   * @deprecated This is very hacky rather solving the actual reason of flakiness.
-   *             Please slack eng-ui and think twice before you want to use this function.
+   * @deprecated This function is non deterministic and can affect the output of the tests
+   *             Instead use any of the Expect.wait* functions.
    */
   fn.tick = function (returnVal) {
     var deferred = Q.defer();
@@ -141,6 +141,20 @@ define([
   fn.waitForFormError = function (form, resolveValue) {
     var condition = function () {
       return form.hasErrors();
+    };
+    return fn.wait(condition, resolveValue);
+  };
+
+  fn.waitForFormErrorBox = function (form, resolveValue) {
+    var condition = function () {
+      return form.errorBox().length > 0;
+    };
+    return fn.wait(condition, resolveValue);
+  };
+
+  fn.waitForEnrollChoices = function (resolveValue) {
+    var condition = function () {
+      return $('.enroll-choices').length > 0;
     };
     return fn.wait(condition, resolveValue);
   };

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -862,7 +862,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             Expect.isVisible(test.linkSentConfirmation.smsSentMsg());
             expect(test.linkSentConfirmation.getMsgText().indexOf('+14152554668') >= 0).toBe(true);
             test.originalAjax = Util.resumeEnrollFactorPoll(test.ac, test.originalAjax, resAllFactors);
-            return tick(test);
+            return Expect.wait(() => $('.enroll-choices').length > 0, test);
           })
           .then(function (test) {
             expect(test.linkSentConfirmation.smsSentMsg().length).toBe(0);

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -862,7 +862,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             Expect.isVisible(test.linkSentConfirmation.smsSentMsg());
             expect(test.linkSentConfirmation.getMsgText().indexOf('+14152554668') >= 0).toBe(true);
             test.originalAjax = Util.resumeEnrollFactorPoll(test.ac, test.originalAjax, resAllFactors);
-            return Expect.wait(() => $('.enroll-choices').length > 0, test);
+            return Expect.waitForEnrollChoices(test);
           })
           .then(function (test) {
             expect(test.linkSentConfirmation.smsSentMsg().length).toBe(0);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -850,7 +850,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
               state: OIDC_STATE
             }
           });
-          return tick();
+          return Expect.waitForSpyCall(successSpy);
         })
         .then(function () {
           expect(successSpy.calls.count()).toBe(1);

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -2849,14 +2849,10 @@ function (Okta,
           .then(function (test) {
             test.setNextResponse(resChallengeWindowsHello);
             test.form.submit();
-            return Expect.waitForSpyCall(webauthn.getAssertion, test);
+            return Expect.waitForFormErrorBox(test.form, test);
           })
           .then(function (test) {
-            return Expect.wait(() => {
-              return test.form.errorBox().length > 0;
-            }, test);
-          })
-          .then(function (test) {
+            expect(webauthn.getAssertion.calls.count()).toBe(1);
             expect(test.form.errorBox().length).toBe(1);
             expect(test.form.errorBox().text().trim())
               .toBe('Windows Hello is not configured. Select the Start button, ' +
@@ -2871,14 +2867,10 @@ function (Okta,
           .then(function (test) {
             test.setNextResponse(resChallengeWindowsHello);
             test.form.submit();
-            return Expect.waitForSpyCall(webauthn.getAssertion, test);
+            return Expect.waitForFormErrorBox(test.form, test);
           })
           .then(function (test) {
-            return Expect.wait(() => {
-              return test.form.errorBox().length > 0;
-            }, test);
-          })
-          .then(function (test) {
+            expect(webauthn.getAssertion.calls.count()).toBe(1);
             expect(test.form.errorBox().length).toBe(1);
             expect(test.form.errorBox().text().trim())
               .toBe('Your Windows Hello enrollment does not match our records. ' +

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -2852,7 +2852,15 @@ function (Okta,
             return Expect.waitForSpyCall(webauthn.getAssertion, test);
           })
           .then(function (test) {
-            expect(test.form.el('o-form-error-html').length).toBe(1);
+            return Expect.wait(() => {
+              return test.form.errorBox().length > 0;
+            }, test);
+          })
+          .then(function (test) {
+            expect(test.form.errorBox().length).toBe(1);
+            expect(test.form.errorBox().text().trim())
+              .toBe('Windows Hello is not configured. Select the Start button, ' +
+                    'then select Settings > Accounts > Sign-in to configure Windows Hello.');
             expect($.ajax.calls.count()).toBe(2);
           });
         });

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -2319,7 +2319,6 @@ function (Okta,
             });
             itp('starts poll after a delay of 6000ms', function () {
               var callAfterTimeoutStub;
-
               return setupOktaPush()
               .then(function (test) {
                 spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function(pullPromiseResolver) {


### PR DESCRIPTION
- Fixes several flakiness in `MfaVerify_spec.js`, `EnrollTotpController_spec.js`, `LoginRouter_spec.js`.
- Add `deprecate` annotation to `tick` help function