### PR TITLE
Added iframe with src when creating - devicefingerprint flow

### DIFF
--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -32,12 +32,7 @@ define(['q', 'okta'], function (Q, Okta) {
 
       var deferred = Q.defer();
       var self = this;
-
-      // Create iframe
-      var $iframe = $('<iframe>', {
-        style: 'display: none;'
-      });
-      $iframe.appendTo(element);
+      var $iframe;
 
       function isWindowsPhone(userAgent) {
         return userAgent.match(/windows phone|iemobile|wpdesktop/i);
@@ -86,8 +81,12 @@ define(['q', 'okta'], function (Q, Okta) {
 
       // Attach listener
       window.addEventListener('message', onMessageReceivedFromOkta, false);
-      // Load devicefingerprint page inside the iframe
-      $iframe.attr('src', oktaDomainUrl + '/auth/services/devicefingerprint');
+      // Create and Load devicefingerprint page inside the iframe
+      $iframe = $('<iframe>', {
+        style: 'display: none;',
+        src: oktaDomainUrl + '/auth/services/devicefingerprint'
+      });
+      element.append($iframe);
 
       return deferred.promise;
     }


### PR DESCRIPTION
* Creating the iframe without source and appending to the dom causes  IE embedded browser to crash in office
    2016 and 2010. (We are adding src later as a attribute).
* Moved to creating iframe with source and appending.

Tested on chrome mac, IE 10, embedded browser. 

<img width="1420" alt="screen shot 2018-11-07 at 11 19 21 am" src="https://user-images.githubusercontent.com/17267130/48155534-0a390380-e280-11e8-8de7-af3296dae603.png">
<img width="1440" alt="screen shot 2018-11-07 at 11 19 44 am" src="https://user-images.githubusercontent.com/17267130/48155535-0a390380-e280-11e8-9e20-5c0d095798f9.png">
<img width="1317" alt="screen shot 2018-11-07 at 11 22 22 am" src="https://user-images.githubusercontent.com/17267130/48155536-0a390380-e280-11e8-9bd9-2faf594c83ff.png">
<img width="1309" alt="screen shot 2018-11-07 at 11 23 20 am" src="https://user-images.githubusercontent.com/17267130/48155537-0a390380-e280-11e8-8c84-7b50862963de.png">


![inexcelwin10](https://user-images.githubusercontent.com/17267130/48155553-11f8a800-e280-11e8-8d22-127b7fb93b73.gif)


