### PR TITLE
Revert ":art: Upgrade backbone to 1.3.3 (#581)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@okta/okta-auth-js": "1.17.0",
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.26.0",
-    "backbone": "1.3.3",
+    "backbone": "1.2.1",
     "clipboard": "1.6.1",
     "handlebars": "4.0.11",
     "jquery": "1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,11 +955,11 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
-backbone@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.3.3.tgz#4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
+backbone@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.2.1.tgz#d7219c5ed49e5e131dbffaf25c96d6d2cc3ca03e"
   dependencies:
-    underscore ">=1.8.3"
+    underscore ">=1.7.0"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -7475,13 +7475,9 @@ underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@1.8.3:
+underscore@1.8.3, underscore@>=1.7.0:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-
-underscore@>=1.8.3:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This reverts commit a54a7a8683d489f714689621c75febceee3d2670.

## Description

- upgrade to 1.3.3 caused underscore has been bundled twice.
- looks like backbone depends on 'underscore >= 1.8.3' which will always try to pull latest '1.9.1' at this time
- but sign-in widget explicitly depends on underscore-1.8.3

revert changes and cycle back later (probably after jQuery work when we have better idea at either upgrade both or include both within courage bundle file)
