### PR TITLE
:bug: Fixes the webpack3 config naming for module.rules

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -63,7 +63,7 @@ module.exports = (config) => {
 
   // instrument code for coverage report
   if (config.reporters.includes('coverage')) {
-    const rules = options.webpack.module.loaders;
+    const rules = options.webpack.module.rules;
     const babelRule = rules.find(rule => rule.loader === 'babel-loader');
     babelRule.query.plugins = babelRule.query.plugins.concat(['babel-plugin-istanbul']);
   }

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -39,14 +39,6 @@ entryConfig.externals = {
   'u2f-api-polyfill': true,
   'underscore': true
 };
-// Add transform-runtime
-entryConfig.module.loaders = entryConfig.module.loaders || [];
-const loader = entryConfig.module.loaders.find(item =>
-  item.loader === 'babel-loader');
-if (loader) {
-  loader.query.plugins = loader.query.plugins || [];
-  loader.query.plugins.push('transform-runtime');
-}
 entryConfig.plugins = plugins({ isProduction: false, analyzerFile: 'okta-sign-in.entry.analyzer' });
 
 // 2. cdnConfig


### PR DESCRIPTION
- After upgrade to webpack3, the naming for module loaders is `module.rules`.