### PR TITLE
Use form submit for redirects

### DIFF
--- a/src/CustomPasswordExpiredController.js
+++ b/src/CustomPasswordExpiredController.js
@@ -14,12 +14,12 @@ define([
   'okta',
   'util/FormController',
   'util/FormType',
+  'util/RedirectUtil',
   'views/expired-password/Footer'
 ],
-function (Okta, FormController, FormType, Footer) {
+function (Okta, FormController, FormType, RedirectUtil, Footer) {
 
   var _ = Okta._;
-  var { Util } = Okta.internal.util;
 
   return FormController.extend({
     className: 'custom-password-expired',
@@ -58,7 +58,7 @@ function (Okta, FormController, FormType, Footer) {
             className: 'button button-primary button-wide',
             attributes: {'data-se': 'custom-button'},
             click: function () {
-              Util.redirect(this.options.appState.get('passwordExpiredLinkUrl'));
+              RedirectUtil.setWindowLocationTo(this.options.appState.get('passwordExpiredLinkUrl'));
             }
           })
         ];

--- a/src/EnrollCustomFactorController.js
+++ b/src/EnrollCustomFactorController.js
@@ -13,12 +13,12 @@
 define([
   'okta',
   'util/FormController',
+  'util/RedirectUtil',
   'views/enroll-factors/Footer'
 ],
-function (Okta, FormController, Footer) {
+function (Okta, FormController, RedirectUtil, Footer) {
 
   var _ = Okta._;
-  var { Util } = Okta.internal.util;
 
   return FormController.extend({
     className: 'enroll-custom-factor',
@@ -38,7 +38,7 @@ function (Okta, FormController, Footer) {
               setTransaction(trans);
               var url = this.appState.get('enrollCustomFactorRedirectUrl');
               if(url !== null) {
-                Util.redirect(url);
+                RedirectUtil.setWindowLocationTo(url);
               }
             })
             .fail(function (err) {

--- a/src/VerifyCustomFactorController.js
+++ b/src/VerifyCustomFactorController.js
@@ -14,12 +14,12 @@ define([
   'okta',
   'util/FormController',
   'views/shared/FooterSignout',
-  'util/FactorUtil'
+  'util/FactorUtil',
+  'util/RedirectUtil',
 ],
-function (Okta, FormController, FooterSignout, FactorUtil) {
+function (Okta, FormController, FooterSignout, FactorUtil, RedirectUtil) {
 
   var _ = Okta._;
-  var { Util } = Okta.internal.util;
 
   return FormController.extend({
 
@@ -52,7 +52,7 @@ function (Okta, FormController, FooterSignout, FactorUtil) {
               setTransaction(trans);
               var url = this.appState.get('verifyCustomFactorRedirectUrl');
               if(url !== null) {
-                Util.redirect(url);
+                RedirectUtil.setWindowLocationTo(url);
               }
             })
             .fail(function (err) {

--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -14,9 +14,10 @@ define([
   'okta',
   'models/PrimaryAuth',
   'util/CookieUtil',
-  'util/Enums'
+  'util/Enums',
+  'util/RedirectUtil'
 ],
-function (Okta, PrimaryAuthModel, CookieUtil, Enums) {
+function (Okta, PrimaryAuthModel, CookieUtil, Enums, RedirectUtil) {
 
   var { Util } = Okta.internal.util;
   var _ = Okta._;
@@ -75,7 +76,7 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums) {
                         queryParams['login_hint'] = username;
                       }
                       var url = res.links[0].href + Util.getUrlQueryString(queryParams);
-                      Util.redirect(url);
+                      RedirectUtil.redirectTo(url);
                     }
                   }
                 }

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -18,11 +18,10 @@ define([
   'util/Util',
   'util/Logger',
   'util/OAuth2Util',
+  'util/RedirectUtil',
   'config/config.json'
 ],
-function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
-
-  var SharedUtil = Okta.internal.util.Util;
+function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, RedirectUtil, config) {
 
   var DEFAULT_LANGUAGE = 'en';
 
@@ -286,7 +285,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
                     fromURI: self.get('relayState'),
                   });
                   const targetUri = `${baseUrl}/sso/idps/${idp.id}?${params}`;
-                  SharedUtil.redirect(targetUri);
+                  RedirectUtil.setWindowLocationTo(targetUri);
                 }
               }
             };

--- a/src/util/RedirectUtil.js
+++ b/src/util/RedirectUtil.js
@@ -1,0 +1,61 @@
+/*!
+ * Copyright (c) 2015-2018, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define(function () {
+  var fn = {};
+
+  /**
+   * Redirects the browser to a new URL by directly setting window.location.
+   */
+  fn.setWindowLocationTo = function (url) {
+    window.location = url;
+  };
+
+  /**
+   * Redirects the browser to a new URL without using window.location.
+   */
+  fn.redirectTo = function (url) {
+    var form = this.buildDynamicForm(url);
+    document.body.appendChild(form);
+    form.submit();
+  };
+
+  fn.buildDynamicForm = function (url) {
+    var form = document.createElement('form');
+    form.method = 'get';
+    form.setAttribute('style', 'display: none;');
+
+    var chunks = (url || '').split('?');
+    var targetUrl = chunks[0];
+    var query = chunks[1];
+
+    form.action = targetUrl;
+
+    if (query && query.length) {
+      var queryParts = query.split('&');
+
+      for (var i = 0; i < queryParts.length; i++) {
+        var input = document.createElement('input');
+        var parameterParts = queryParts[i].split('=');
+
+        input.name = parameterParts[0];
+        input.value = decodeURIComponent(parameterParts[1]);
+        input.type = 'hidden';
+        form.appendChild(input);    
+      }
+    }
+
+    return form;
+  };
+
+  return fn;
+});

--- a/src/util/RedirectUtil.js
+++ b/src/util/RedirectUtil.js
@@ -30,14 +30,13 @@ define(function () {
   };
 
   fn.buildDynamicForm = function (url) {
-    var form = document.createElement('form');
-    form.method = 'get';
-    form.setAttribute('style', 'display: none;');
-
     var chunks = (url || '').split('?');
     var targetUrl = chunks[0];
     var query = chunks[1];
-
+    
+    var form = document.createElement('form');
+    form.method = 'get';
+    form.setAttribute('style', 'display: none;');
     form.action = targetUrl;
 
     if (query && query.length) {

--- a/src/util/RedirectUtil.js
+++ b/src/util/RedirectUtil.js
@@ -30,9 +30,16 @@ define(function () {
   };
 
   fn.buildDynamicForm = function (url) {
-    var chunks = (url || '').split('?');
-    var targetUrl = chunks[0];
-    var query = chunks[1];
+    var splitOnFragment = (url || '').split('#');
+    var fragment = splitOnFragment[1];
+    
+    var splitOnQuery = (splitOnFragment[0] || '').split('?');
+    var query = splitOnQuery[1];
+
+    var targetUrl = splitOnQuery[0];
+    if (fragment) {
+      targetUrl += '#' + fragment;
+    }
     
     var form = document.createElement('form');
     form.method = 'get';
@@ -43,17 +50,21 @@ define(function () {
       var queryParts = query.split('&');
 
       for (var i = 0; i < queryParts.length; i++) {
-        var input = document.createElement('input');
         var parameterParts = queryParts[i].split('=');
-
-        input.name = parameterParts[0];
-        input.value = decodeURIComponent(parameterParts[1]);
-        input.type = 'hidden';
-        form.appendChild(input);    
+        var input = this.buildInputForParameter(parameterParts[0], parameterParts[1]);
+        form.appendChild(input);
       }
     }
 
     return form;
+  };
+
+  fn.buildInputForParameter = function (name, value) {
+    var input = document.createElement('input');
+    input.name = name;
+    input.value = decodeURIComponent(value);
+    input.type = 'hidden';
+    return input;
   };
 
   return fn;

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -15,13 +15,13 @@ define([
   'okta',
   './OAuth2Util',
   './Util',
+  './RedirectUtil',
   './Enums',
   './BrowserFeatures',
   './Errors',
   './ErrorCodes'
 ],
-function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
-  var { Util: CourageUtil } = Okta.internal.util;
+function (Okta, OAuth2Util, Util, RedirectUtil, Enums, BrowserFeatures, Errors, ErrorCodes) {
   var fn = {};
 
   var verifyUrlTpl = Okta.tpl('signin/verify/{{provider}}/{{factorType}}');
@@ -137,7 +137,7 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
         successData.stepUp = {
           url: targetUrl,
           finish: function () {
-            CourageUtil.redirect(targetUrl);
+            RedirectUtil.redirectTo(targetUrl);
           }
         };
       } else {
@@ -146,11 +146,13 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
         successData.session = {
           token: res.sessionToken,
           setCookieAndRedirect: function (redirectUrl) {
-            CourageUtil.redirect(sessionCookieRedirectTpl({
+            var url = sessionCookieRedirectTpl({
               baseUrl: router.settings.get('baseUrl'),
               token: encodeURIComponent(res.sessionToken),
               redirectUrl: encodeURIComponent(redirectUrl)
-            }));
+            });
+
+            RedirectUtil.redirectTo(url);
           }
         };
       }

--- a/src/views/expired-password/Footer.js
+++ b/src/views/expired-password/Footer.js
@@ -10,9 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/Enums'], function (Okta, Enums) {
-
-  var { Util } = Okta.internal.util;
+define(['okta', 'util/Enums', 'util/RedirectUtil'], function (Okta, Enums, RedirectUtil) {
 
   return Okta.View.extend({
     template: '\
@@ -33,7 +31,7 @@ define(['okta', 'util/Enums'], function (Okta, Enums) {
         })
           .then(function () {
             if (self.settings.get('signOutLink')) {
-              Util.redirect(self.settings.get('signOutLink'));
+              RedirectUtil.setWindowLocationTo(self.settings.get('signOutLink'));
             } else {
               self.state.set('navigateDir', Enums.DIRECTION_BACK);
               self.options.appState.trigger('navigate', '');

--- a/src/views/shared/Footer.js
+++ b/src/views/shared/Footer.js
@@ -11,11 +11,11 @@
  */
 
 define([
-  'okta'
+  'okta',
+  'util/RedirectUtil'
 ],
-function (Okta) {
+function (Okta, RedirectUtil) {
 
-  var { Util } = Okta.internal.util;
   var compile = Okta.Handlebars.compile;
   var _ = Okta._;
 
@@ -91,7 +91,7 @@ function (Okta) {
 
         var customResetPasswordPage = this.settings.get('helpLinks.forgotPassword');
         if (customResetPasswordPage) {
-          Util.redirect(customResetPasswordPage);
+          RedirectUtil.setWindowLocationTo(customResetPasswordPage);
         }
         else {
           this.options.appState.trigger('navigate', 'signin/forgot-password');
@@ -105,7 +105,7 @@ function (Okta) {
 
         var customUnlockPage = this.settings.get('helpLinks.unlock');
         if (customUnlockPage) {
-          Util.redirect(customUnlockPage);
+          RedirectUtil.setWindowLocationTo(customUnlockPage);
         }
         else {
           this.options.appState.trigger('navigate', 'signin/unlock');

--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -10,9 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/Enums'], function (Okta, Enums) {
+define(['okta', 'util/Enums', 'util/RedirectUtil'], function (Okta, Enums, RedirectUtil) {
 
-  var { Util } = Okta.internal.util;
   var _ = Okta._;
 
   return Okta.View.extend({
@@ -31,7 +30,7 @@ define(['okta', 'util/Enums'], function (Okta, Enums) {
         })
           .then(function () {
             if (self.settings.get('signOutLink')) {
-              Util.redirect(self.settings.get('signOutLink'));
+              RedirectUtil.setWindowLocationTo(self.settings.get('signOutLink'));
             } else {
               self.state.set('navigateDir', Enums.DIRECTION_BACK);
               self.options.appState.trigger('navigate', '');

--- a/test/unit/spec/EnrollCustomFactor_spec.js
+++ b/test/unit/spec/EnrollCustomFactor_spec.js
@@ -1,8 +1,8 @@
 /* eslint max-params:[2, 14] */
 define([
-  'okta',
   '@okta/okta-auth-js/jquery',
   'util/Util',
+  'util/RedirectUtil',
   'helpers/mocks/Util',
   'helpers/dom/EnrollCustomFactorForm',
   'helpers/dom/Beacon',
@@ -15,9 +15,9 @@ define([
   'helpers/xhr/NO_PERMISSION_error',
   'helpers/xhr/SUCCESS'
 ],
-function (Okta,
-  OktaAuth,
+function (OktaAuth,
   LoginUtil,
+  RedirectUtil,
   Util,
   Form,
   Beacon,
@@ -29,8 +29,7 @@ function (Okta,
   responseMfaEnrollActivateCustomOidc,
   resNoPermissionError,
   responseSuccess) {
-
-  var SharedUtil = Okta.internal.util.Util;
+  
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -110,14 +109,14 @@ function (Okta,
         });
 
         itp('redirects to third party when Enroll button is clicked', function () {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           return setup().then(function (test) {
             test.setNextResponse([responseMfaEnrollActivateCustomSaml, responseSuccess]);
             test.form.submit();
-            return Expect.waitForSpyCall(SharedUtil.redirect);
+            return Expect.waitForSpyCall(RedirectUtil.setWindowLocationTo);
           })
             .then(function () {
-              expect(SharedUtil.redirect).toHaveBeenCalledWith(
+              expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith(
                 'http://rain.okta1.com:1802/policy/mfa-saml-idp-redirect?okta_key=mfa.redirect.id'
               );
             });
@@ -180,14 +179,14 @@ function (Okta,
         });
 
         itp('redirects to third party when Enroll button is clicked', function () {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           return setup(true).then(function (test) {
             test.setNextResponse([responseMfaEnrollActivateCustomOidc, responseSuccess]);
             test.form.submit();
-            return Expect.waitForSpyCall(SharedUtil.redirect);
+            return Expect.waitForSpyCall(RedirectUtil.setWindowLocationTo);
           })
             .then(function () {
-              expect(SharedUtil.redirect).toHaveBeenCalledWith(
+              expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith(
                 'http://rain.okta1.com:1802/policy/mfa-oidc-idp-redirect?okta_key=mfa.redirect.id'
               );
             });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -3,6 +3,7 @@ define([
   'okta',
   'q',
   'util/Logger',
+  'util/RedirectUtil',
   '@okta/okta-auth-js/jquery',
   'helpers/mocks/Util',
   'helpers/util/Expect',
@@ -29,13 +30,12 @@ define([
   'helpers/xhr/labels_login_ja',
   'helpers/xhr/labels_country_ja'
 ],
-function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
+function (Okta, Q, Logger, RedirectUtil, OktaAuth, Util, Expect, Router,
   $sandbox, PrimaryAuthForm, IDPDiscoveryForm, RecoveryForm, MfaVerifyForm, EnrollCallForm,
   resSuccess, resRecovery, resMfa, resMfaRequiredDuo, resMfaRequiredOktaVerify, resMfaChallengeDuo,
   resMfaChallengePush, resMfaEnroll, errorInvalidToken, resUnauthenticated, resSuccessStepUp,
   Errors, BrowserFeatures, labelsLoginJa, labelsCountryJa) {
 
-  var SharedUtil = Okta.internal.util.Util;
   var CourageLogger = Okta.internal.util.Logger;
   var {_, $, Backbone} = Okta;
 
@@ -273,7 +273,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         });
     });
     itp('has a success callback which correctly implements the setCookieAndRedirect function', function () {
-      spyOn(SharedUtil, 'redirect');
+      spyOn(RedirectUtil, 'redirectTo');
       var successSpy = jasmine.createSpy('successSpy');
       return setup({ globalSuccessFn: successSpy })
         .then(function (test) {
@@ -284,14 +284,14 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
         .then(function () {
           var setCookieAndRedirect = successSpy.calls.mostRecent().args[0].session.setCookieAndRedirect;
           setCookieAndRedirect('http://baz.com/foo');
-          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+          expect(RedirectUtil.redirectTo).toHaveBeenCalledWith(
             'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
           '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
           );
         });
     });
     itp('for SESSION_STEP_UP type, success callback data contains the target resource url and a finish function', function () {
-      spyOn(SharedUtil, 'redirect');
+      spyOn(RedirectUtil, 'redirectTo');
       var successSpy = jasmine.createSpy('successSpy');
       return setup({ stateToken: 'aStateToken', globalSuccessFn: successSpy })
         .then(function (test) {
@@ -305,7 +305,7 @@ function (Okta, Q, Logger, OktaAuth, Util, Expect, Router,
           var finish = successSpy.calls.mostRecent().args[0].stepUp.finish;
           expect(finish).toEqual(jasmine.any(Function));
           finish();
-          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+          expect(RedirectUtil.redirectTo).toHaveBeenCalledWith(
             'http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken'
           );
         });

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -4,6 +4,7 @@ define([
   'q',
   'duo',
   '@okta/okta-auth-js/jquery',
+  'util/RedirectUtil',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/MfaVerifyForm',
@@ -47,6 +48,7 @@ function (Okta,
   Q,
   Duo,
   OktaAuth,
+  RedirectUtil,
   LoginUtil,
   Util,
   MfaVerifyForm,
@@ -87,7 +89,6 @@ function (Okta,
   labelsCountryJa) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
   var factors = {
@@ -559,7 +560,7 @@ function (Okta,
           function () {
             return setupSecurityQuestion({ signOutLink: 'http://www.goodbye.com' })
               .then(function (test) {
-                spyOn(SharedUtil, 'redirect');
+                spyOn(RedirectUtil, 'setWindowLocationTo');
                 $.ajax.calls.reset();
                 test.setNextResponse(resSuccess);
                 test.form.signoutLink($sandbox).click();
@@ -573,7 +574,7 @@ function (Okta,
                     stateToken: 'testStateToken'
                   }
                 });
-                expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+                expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('http://www.goodbye.com');
               });
           });
 
@@ -3207,14 +3208,14 @@ function (Okta,
           });
         });
         itp('redirects to third party when Verify button is clicked', function () {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           return setupCustomSAMLFactor().then(function (test) {
             test.setNextResponse([resChallengeCustomSAMLFactor, resSuccess]);
             test.form.submit();
-            return Expect.waitForSpyCall(SharedUtil.redirect);
+            return Expect.waitForSpyCall(RedirectUtil.setWindowLocationTo);
           })
             .then(function () {
-              expect(SharedUtil.redirect).toHaveBeenCalledWith(
+              expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith(
                 'http://rain.okta1.com:1802/policy/mfa-saml-idp-redirect?okta_key=mfa.redirect.id'
               );
             });
@@ -3292,14 +3293,14 @@ function (Okta,
           });
         });
         itp('redirects to third party when Verify button is clicked', function () {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           return setupCustomOIDCFactor().then(function (test) {
             test.setNextResponse([resChallengeCustomOIDCFactor, resSuccess]);
             test.form.submit();
-            return Expect.waitForSpyCall(SharedUtil.redirect);
+            return Expect.waitForSpyCall(RedirectUtil.setWindowLocationTo);
           })
             .then(function () {
-              expect(SharedUtil.redirect).toHaveBeenCalledWith(
+              expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith(
                 'http://rain.okta1.com:1802/policy/mfa-oidc-idp-redirect?okta_key=mfa.redirect.id'
               );
             });

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -3,6 +3,7 @@ define([
   'okta',
   '@okta/okta-auth-js/jquery',
   'util/Util',
+  'util/RedirectUtil',
   'helpers/mocks/Util',
   'helpers/dom/PasswordExpiredForm',
   'helpers/dom/Beacon',
@@ -17,12 +18,11 @@ define([
   'helpers/xhr/CUSTOM_PASSWORD_EXPIRED',
   'helpers/xhr/SUCCESS'
 ],
-function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, Router,
+function (Okta, OktaAuth, LoginUtil, RedirectUtil, Util, PasswordExpiredForm, Beacon, Expect, Router,
   $sandbox, resPassWarn, resPassExpired, resErrorComplexity,
   resErrorOldPass, resCustomPassWarn, resCustomPassExpired, resSuccess) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -167,7 +167,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       });
       itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
         return setup().then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           $.ajax.calls.reset();
           test.setNextResponse(resSuccess);
           test.form.signout();
@@ -187,7 +187,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       itp('has a signout link which cancels the current stateToken and redirects to the provided signout url',
         function () {
           return setup({ signOutLink: 'http://www.goodbye.com' }).then(function (test) {
-            spyOn(SharedUtil, 'redirect');
+            spyOn(RedirectUtil, 'setWindowLocationTo');
             $.ajax.calls.reset();
             test.setNextResponse(resSuccess);
             test.form.signout();
@@ -201,7 +201,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
                   stateToken: 'testStateToken'
                 }
               });
-              expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+              expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('http://www.goodbye.com');
             });
         });
       itp('calls processCreds function before saving a model', function () {
@@ -430,10 +430,10 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
         });
       });
       itp('redirect is called with the correct arg on custom button click', function () {
-        spyOn(SharedUtil, 'redirect');
+        spyOn(RedirectUtil, 'setWindowLocationTo');
         return setupCustomExpiredPassword().then(function (test) {
           test.form.clickCustomButton();
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('https://www.twitter.com');
+          expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('https://www.twitter.com');
         });
       });
 
@@ -564,10 +564,10 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
         });
       });
       itp('redirect is called with the correct arg on custom button click', function () {
-        spyOn(SharedUtil, 'redirect');
+        spyOn(RedirectUtil, 'setWindowLocationTo');
         return setupCustomExpiredPasswordWarn(4).then(function (test) {
           test.form.clickCustomButton();
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('https://www.google.com');
+          expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('https://www.google.com');
         });
       });
 

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -3,6 +3,7 @@ define([
   'okta',
   '@okta/okta-auth-js/jquery',
   'util/Util',
+  'util/RedirectUtil',
   'helpers/mocks/Util',
   'helpers/dom/PasswordResetForm',
   'helpers/dom/Beacon',
@@ -15,11 +16,10 @@ define([
   'helpers/xhr/200',
   'helpers/xhr/SUCCESS'
 ],
-function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect, Router,
+function (Q, Okta, OktaAuth, LoginUtil, RedirectUtil, Util, PasswordResetForm, Beacon, Expect, Router,
   $sandbox, resPasswordReset, resPasswordResetWithComplexity, resError, res200, resSuccess) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -149,7 +149,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
-            spyOn(SharedUtil, 'redirect');
+            spyOn(RedirectUtil, 'setWindowLocationTo');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
@@ -165,7 +165,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
                 stateToken: 'testStateToken'
               }
             });
-            expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+            expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });
 

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -3,6 +3,7 @@ define([
   'q',
   '@okta/okta-auth-js/jquery',
   'util/Util',
+  'util/RedirectUtil',
   'okta',
   'helpers/mocks/Util',
   'helpers/dom/AuthContainer',
@@ -28,13 +29,12 @@ define([
   'helpers/xhr/PASSWORDLESS_UNAUTHENTICATED',
   'sandbox'
 ],
-function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Beacon, PrimaryAuth,
+function (Q, OktaAuth, LoginUtil, RedirectUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Beacon, PrimaryAuth,
   Router, BrowserFeatures, Errors, DeviceFingerprint, TypingUtil, Expect, resSecurityImage,
   resSecurityImageFail, resSuccess, resUnauthenticated, resLockedOut, resPwdExpired, resUnauthorized,
   resNonJson, resInvalidText, resThrottle, resPasswordlessUnauthenticated, $sandbox) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -425,13 +425,13 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
       });
       itp('has the correct help link url', function () {
         return setup().then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           expect(test.form.helpLinkHref()).toBe('https://foo.com/help/login');
         });
       });
       itp('has a custom help link url when available', function () {
         return setup({ 'helpLinks.help': 'https://bar.com' }).then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           expect(test.form.helpLinkHref()).toBe('https://bar.com');
         });
       });
@@ -487,15 +487,15 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
       });
       itp('navigates to custom forgot password page when available', function () {
         return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
+          expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('https://foo.com');
         });
       });
       itp('does not navigate to custom forgot password page when link disabled and clicked', function () {
         return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
@@ -504,7 +504,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
         }).then(function (test) {
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
-          expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
+          expect(RedirectUtil.setWindowLocationTo).not.toHaveBeenCalledWith('https://foo.com');
         });
       });
       itp('unlock link is hidden on load', function () {
@@ -545,10 +545,10 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           'helpLinks.unlock': 'https://foo.com',
           'features.selfServiceUnlock': true
         }).then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           test.form.helpFooter().click();
           test.form.unlockLink().click();
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
+          expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('https://foo.com');
         });
       });
       itp('does not navigate to custom unlock page when link disabled and clicked', function () {
@@ -556,7 +556,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           'helpLinks.unlock': 'https://foo.com',
           'features.selfServiceUnlock': true
         }).then(function (test) {
-          spyOn(SharedUtil, 'redirect');
+          spyOn(RedirectUtil, 'setWindowLocationTo');
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
@@ -565,7 +565,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
         }).then(function (test) {
           test.form.helpFooter().click();
           test.form.unlockLink().click();
-          expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
+          expect(RedirectUtil.setWindowLocationTo).not.toHaveBeenCalledWith('https://foo.com');
         });
       });
       itp('does not show unlock link if feature is off', function () {
@@ -2144,15 +2144,15 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
         });
       });
       itp('navigate to "/sso/idp/:id" at none OIDC mode when an idp button is clicked', function () {
-        spyOn(SharedUtil, 'redirect');
+        spyOn(RedirectUtil, 'setWindowLocationTo');
         const opt = {
           relayState: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U',
         };
 
         return setupSocialNoneOIDCMode(opt).then(function (test) {
           test.form.facebookButton().click();
-          expect(SharedUtil.redirect.calls.count()).toBe(1);
-          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+          expect(RedirectUtil.setWindowLocationTo.calls.count()).toBe(1);
+          expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith(
             'https://foo.com/sso/idps/0oaidiw9udOSceD1234?' +
             $.param({fromURI: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U'})
           );

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -2,6 +2,7 @@
 define([
   'okta',
   '@okta/okta-auth-js/jquery',
+  'util/RedirectUtil',
   'helpers/mocks/Util',
   'helpers/dom/RecoveryChallengeForm',
   'helpers/dom/Beacon',
@@ -14,11 +15,10 @@ define([
   'helpers/xhr/200',
   'helpers/xhr/SUCCESS'
 ],
-function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
+function (Okta, OktaAuth, RedirectUtil, Util, RecoveryChallengeForm, Beacon, Expect, Router,
   $sandbox, resChallenge, resResendError, resVerifyError, res200, resSuccess) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -95,7 +95,7 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
-            spyOn(SharedUtil, 'redirect');
+            spyOn(RedirectUtil, 'setWindowLocationTo');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
@@ -111,7 +111,7 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
                 stateToken: 'testStateToken'
               }
             });
-            expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+            expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });
     itp('has a text field to enter the recovery sms code', function () {

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -2,6 +2,7 @@
 define([
   'okta',
   '@okta/okta-auth-js/jquery',
+  'util/RedirectUtil',
   'helpers/mocks/Util',
   'helpers/dom/RecoveryQuestionForm',
   'helpers/dom/Beacon',
@@ -14,11 +15,10 @@ define([
   'helpers/xhr/SUCCESS',
   'helpers/xhr/SUCCESS_unlock'
 ],
-function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
+function (Okta, OktaAuth, RedirectUtil, Util, RecoveryQuestionForm, Beacon, Expect, Router,
   $sandbox, resRecovery, resError, res200, resSuccess, resSuccessUnlock) {
 
   var { _, $ } = Okta;
-  var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -87,7 +87,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
-            spyOn(SharedUtil, 'redirect');
+            spyOn(RedirectUtil, 'setWindowLocationTo');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
@@ -103,7 +103,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
                 stateToken: 'testStateToken'
               }
             });
-            expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
+            expect(RedirectUtil.setWindowLocationTo).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });
     itp('sets the correct title for a forgotten password flow', function () {

--- a/test/unit/spec/RedirectUtil_spec.js
+++ b/test/unit/spec/RedirectUtil_spec.js
@@ -35,21 +35,20 @@ function (RedirectUtil) {
         return frame;
       }
 
-      var wait = 200; // ms
-
       it('should redirect to a path', function (done) {
         var url = window.location.origin + '/path';
 
         var form = RedirectUtil.buildDynamicForm(url);
         var frame = createTestIframe();
         frame.contentDocument.body.appendChild(form);
-        form.submit();
     
-        setTimeout(() => {
+        frame.addEventListener('load', function () {
           expect(frame.contentWindow.location.pathname).toBe('/path');
           expect(frame.contentWindow.location.search).toBe('');
           done();
-        }, wait);
+        });
+
+        form.submit();
       });
 
       it('should redirect to a path and query', function (done) {
@@ -58,13 +57,14 @@ function (RedirectUtil) {
         var form = RedirectUtil.buildDynamicForm(url);
         var frame = createTestIframe();
         frame.contentDocument.body.appendChild(form);
-        form.submit();
     
-        setTimeout(() => {
+        frame.addEventListener('load', function () {
           expect(frame.contentWindow.location.pathname).toBe('/path/too');
           expect(frame.contentWindow.location.search).toBe('?foo=bar&baz=1');
           done();
-        }, wait);
+        });
+
+        form.submit();
       });
 
       it('should redirect to a URL containing an escaped URL', function (done) {
@@ -73,13 +73,14 @@ function (RedirectUtil) {
         var form = RedirectUtil.buildDynamicForm(url);
         var frame = createTestIframe();
         frame.contentDocument.body.appendChild(form);
-        form.submit();
     
-        setTimeout(() => {
+        frame.addEventListener('load', function () {
           expect(frame.contentWindow.location.pathname).toBe('/redirect');
           expect(frame.contentWindow.location.search).toBe('?dest=https%3A%2F%2Fexample.com&foo=bar');
           done();
-        }, wait);
+        });
+
+        form.submit();
       });
 
       it('should redirect to a path with a query containing multiple same-named parameters', function (done) {
@@ -88,13 +89,14 @@ function (RedirectUtil) {
         var form = RedirectUtil.buildDynamicForm(url);
         var frame = createTestIframe();
         frame.contentDocument.body.appendChild(form);
-        form.submit();
     
-        setTimeout(() => {
+        frame.addEventListener('load', function () {
           expect(frame.contentWindow.location.pathname).toBe('/path/too');
           expect(frame.contentWindow.location.search).toBe('?foo=bar&baz=1&foo=two');
           done();
-        }, 1000);
+        });
+
+        form.submit();
       });
 
       it('should redirect to a path and preserve a fragment', function (done) {
@@ -103,14 +105,15 @@ function (RedirectUtil) {
         var form = RedirectUtil.buildDynamicForm(url);
         var frame = createTestIframe();
         frame.contentDocument.body.appendChild(form);
-        form.submit();
-    
-        setTimeout(() => {
+
+        frame.addEventListener('load', function () {
           expect(frame.contentWindow.location.pathname).toBe('/path');
           expect(frame.contentWindow.location.hash).toBe('#baz');
           expect(frame.contentWindow.location.search).toBe('?foo=bar');
           done();
-        }, wait);
+        });
+
+        form.submit();
       });
     });
   });

--- a/test/unit/spec/RedirectUtil_spec.js
+++ b/test/unit/spec/RedirectUtil_spec.js
@@ -35,7 +35,7 @@ function (RedirectUtil) {
         return frame;
       }
 
-      var wait = 25;
+      var wait = 200; // ms
 
       it('should redirect to a path', function (done) {
         var url = window.location.origin + '/path';
@@ -93,6 +93,22 @@ function (RedirectUtil) {
         setTimeout(() => {
           expect(frame.contentWindow.location.pathname).toBe('/path/too');
           expect(frame.contentWindow.location.search).toBe('?foo=bar&baz=1&foo=two');
+          done();
+        }, 1000);
+      });
+
+      it('should redirect to a path and preserve a fragment', function (done) {
+        var url = window.location.origin + '/path?foo=bar#baz';
+
+        var form = RedirectUtil.buildDynamicForm(url);
+        var frame = createTestIframe();
+        frame.contentDocument.body.appendChild(form);
+        form.submit();
+    
+        setTimeout(() => {
+          expect(frame.contentWindow.location.pathname).toBe('/path');
+          expect(frame.contentWindow.location.hash).toBe('#baz');
+          expect(frame.contentWindow.location.search).toBe('?foo=bar');
           done();
         }, wait);
       });

--- a/test/unit/spec/RedirectUtil_spec.js
+++ b/test/unit/spec/RedirectUtil_spec.js
@@ -1,0 +1,101 @@
+define([
+  'util/RedirectUtil'
+],
+function (RedirectUtil) {
+
+  describe('util/RedirectUtil', function () {
+
+    describe('buildDynamicForm', function() {
+      it('returns an element', function() {
+        var form = RedirectUtil.buildDynamicForm('https://example.com');
+        expect(form).not.toBeUndefined();
+      });
+
+      it('returns a form whose method is GET', function() {
+        var form = RedirectUtil.buildDynamicForm('https://example.com/path?foo=bar');
+        expect(form.method).toBe('get');
+      });
+
+      it('returns a form whose action is the URL minus query', function() {
+        var form = RedirectUtil.buildDynamicForm('https://example.com/path?foo=bar');
+        expect(form.action).toBe('https://example.com/path');
+      });
+    });
+
+    describe('buildDynamicForm redirection', function() {
+      function createTestIframe() {
+        var frame = document.createElement('iframe');
+        frame.style = 'display: none;';
+        document.body.appendChild(frame);
+
+        frame.contentDocument.open();
+        frame.contentDocument.write("<html><body></body></html>");
+        frame.contentDocument.close();
+        
+        return frame;
+      }
+
+      var wait = 25;
+
+      it("should redirect to a path", function (done) {
+        var url = window.location.origin + '/path';
+
+        var form = RedirectUtil.buildDynamicForm(url);
+        var frame = createTestIframe();
+        frame.contentDocument.body.appendChild(form);
+        form.submit();
+    
+        setTimeout(() => {
+          expect(frame.contentWindow.location.pathname).toBe('/path');
+          expect(frame.contentWindow.location.search).toBe('');
+          done();
+        }, wait);
+      });
+
+      it("should redirect to a path and query", function (done) {
+        var url = window.location.origin + '/path/too?foo=bar&baz=1';
+
+        var form = RedirectUtil.buildDynamicForm(url);
+        var frame = createTestIframe();
+        frame.contentDocument.body.appendChild(form);
+        form.submit();
+    
+        setTimeout(() => {
+          expect(frame.contentWindow.location.pathname).toBe('/path/too');
+          expect(frame.contentWindow.location.search).toBe('?foo=bar&baz=1');
+          done();
+        }, wait);
+      });
+
+      it("should redirect to a URL containing an escaped URL", function (done) {
+        var url = window.location.origin + '/redirect?dest=https%3A%2F%2Fexample.com&foo=bar';
+
+        var form = RedirectUtil.buildDynamicForm(url);
+        var frame = createTestIframe();
+        frame.contentDocument.body.appendChild(form);
+        form.submit();
+    
+        setTimeout(() => {
+          expect(frame.contentWindow.location.pathname).toBe('/redirect');
+          expect(frame.contentWindow.location.search).toBe('?dest=https%3A%2F%2Fexample.com&foo=bar');
+          done();
+        }, wait);
+      });
+
+      it("should redirect to a path with a query containing multiple same-named parameters", function (done) {
+        var url = window.location.origin + '/path/too?foo=bar&baz=1&foo=two';
+
+        var form = RedirectUtil.buildDynamicForm(url);
+        var frame = createTestIframe();
+        frame.contentDocument.body.appendChild(form);
+        form.submit();
+    
+        setTimeout(() => {
+          expect(frame.contentWindow.location.pathname).toBe('/path/too');
+          expect(frame.contentWindow.location.search).toBe('?foo=bar&baz=1&foo=two');
+          done();
+        }, wait);
+      });
+    })
+  });
+});

--- a/test/unit/spec/RedirectUtil_spec.js
+++ b/test/unit/spec/RedirectUtil_spec.js
@@ -5,31 +5,31 @@ function (RedirectUtil) {
 
   describe('util/RedirectUtil', function () {
 
-    describe('buildDynamicForm', function() {
-      it('returns an element', function() {
+    describe('buildDynamicForm', function () {
+      it('returns an element', function () {
         var form = RedirectUtil.buildDynamicForm('https://example.com');
         expect(form).not.toBeUndefined();
       });
 
-      it('returns a form whose method is GET', function() {
+      it('returns a form whose method is GET', function () {
         var form = RedirectUtil.buildDynamicForm('https://example.com/path?foo=bar');
         expect(form.method).toBe('get');
       });
 
-      it('returns a form whose action is the URL minus query', function() {
+      it('returns a form whose action is the URL minus query', function () {
         var form = RedirectUtil.buildDynamicForm('https://example.com/path?foo=bar');
         expect(form.action).toBe('https://example.com/path');
       });
     });
 
-    describe('buildDynamicForm redirection', function() {
-      function createTestIframe() {
+    describe('buildDynamicForm redirection', function () {
+      function createTestIframe () {
         var frame = document.createElement('iframe');
         frame.style = 'display: none;';
         document.body.appendChild(frame);
 
         frame.contentDocument.open();
-        frame.contentDocument.write("<html><body></body></html>");
+        frame.contentDocument.write('<html><body></body></html>');
         frame.contentDocument.close();
         
         return frame;
@@ -37,7 +37,7 @@ function (RedirectUtil) {
 
       var wait = 25;
 
-      it("should redirect to a path", function (done) {
+      it('should redirect to a path', function (done) {
         var url = window.location.origin + '/path';
 
         var form = RedirectUtil.buildDynamicForm(url);
@@ -52,7 +52,7 @@ function (RedirectUtil) {
         }, wait);
       });
 
-      it("should redirect to a path and query", function (done) {
+      it('should redirect to a path and query', function (done) {
         var url = window.location.origin + '/path/too?foo=bar&baz=1';
 
         var form = RedirectUtil.buildDynamicForm(url);
@@ -67,7 +67,7 @@ function (RedirectUtil) {
         }, wait);
       });
 
-      it("should redirect to a URL containing an escaped URL", function (done) {
+      it('should redirect to a URL containing an escaped URL', function (done) {
         var url = window.location.origin + '/redirect?dest=https%3A%2F%2Fexample.com&foo=bar';
 
         var form = RedirectUtil.buildDynamicForm(url);
@@ -82,7 +82,7 @@ function (RedirectUtil) {
         }, wait);
       });
 
-      it("should redirect to a path with a query containing multiple same-named parameters", function (done) {
+      it('should redirect to a path with a query containing multiple same-named parameters', function (done) {
         var url = window.location.origin + '/path/too?foo=bar&baz=1&foo=two';
 
         var form = RedirectUtil.buildDynamicForm(url);
@@ -96,6 +96,6 @@ function (RedirectUtil) {
           done();
         }, wait);
       });
-    })
+    });
   });
 });


### PR DESCRIPTION
This PR:

* Replaces `window.location` with a dynamic form submit for a few redirect calls within the critical login path
* Makes it clearer in code where the Widget modifies `window.location`
* Adds tests

Needs to be reviewed, and also squashed!