### PR TITLE
Passing along login_hint for all idps rather than just SAML

### DIFF
--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -71,9 +71,7 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums) {
                   redirectToIdp: function (redirectUrl) {
                     if(res.links && res.links[0] && res.links[0].href) {
                       var queryParams = {fromURI: redirectUrl};
-                      if (res.links[0].properties && res.links[0].properties['okta:idp:type'] === 'SAML2') {
-                        queryParams['login_hint'] = username;
-                      }
+                      queryParams['login_hint'] = username;
                       var url = res.links[0].href + Util.getUrlQueryString(queryParams);
                       Util.redirect(url);
                     }

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1107,7 +1107,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, B
             expect(redirectToIdp).toEqual(jasmine.any(Function));
             redirectToIdp('https://foo.com');
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
-              'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com'
+              'http://demo.okta1.com:1802/login/sso_iwa?fromURI=https%3A%2F%2Ffoo.com&login_hint=testuser%40clouditude.net'
             );
           });
       });


### PR DESCRIPTION
We would like to pass along the login_hint value for more than just SAML idps

@okta/idx 
@nikhilvenkatraman-okta 