### PR TITLE
Use 'idempotent-babel-polyfill' instead of babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,11 +110,11 @@
   },
   "dependencies": {
     "@okta/okta-auth-js": "1.17.0",
-    "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.26.0",
     "backbone": "1.2.1",
     "clipboard": "1.6.1",
     "handlebars": "4.0.11",
+    "idempotent-babel-polyfill": "^6.26.0",
     "jquery": "1.12.1",
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.1",

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -43,7 +43,7 @@ entryConfig.plugins = plugins({ isProduction: false, analyzerFile: 'okta-sign-in
 
 // 2. cdnConfig
 var cdnConfig = config('okta-sign-in.min.js');
-cdnConfig.entry.unshift('babel-polyfill');
+cdnConfig.entry.unshift('idempotent-babel-polyfill');
 cdnConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in.min.analyzer' });
 
 // 3. noJqueryConfig


### PR DESCRIPTION
Babel-polyfill causes issues when it's instantiated more than once, e.g. when it's used with Webpack as well as an included package (see https://github.com/babel/babel-loader/issues/401). It looks like you partially addressed this with https://github.com/okta/okta-signin-widget/pull/353, but babel-polyfill still gets included in the js files that you serve on your CDN.

This PR replaces it with `idempotent-babel-polyfill`, which guards against requiring babel-polyfill multiple times.