### PR TITLE
Upgrade Courage and i18n versions

### DIFF
--- a/packages/@okta/courage-dist/okta.js
+++ b/packages/@okta/courage-dist/okta.js
@@ -1,4 +1,4 @@
-/*! THIS FILE IS GENERATED FROM PACKAGE @okta/courage@4.4.0 */
+/*! THIS FILE IS GENERATED FROM PACKAGE @okta/courage@4.6.0-beta.2098.gc581fa3 */
 module.exports =
 /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
@@ -62,635 +62,658 @@ module.exports =
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 34);
+/******/ 	return __webpack_require__(__webpack_require__.s = 33);
 /******/ })
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint @okta/okta/enforce-requirejs-names: 0, @okta/okta/no-specific-methods: 0, @okta/okta/no-specific-modules: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(36),
-  __webpack_require__(17)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (underscore, Handlebars) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_underscore__ = __webpack_require__(35);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_underscore___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_underscore__);
+/* eslint @okta/okta/enforce-requirejs-names: 0, @okta/okta/no-specific-methods: 0, @okta/okta/no-specific-modules: 0 */
 
-  var _ = underscore.noConflict();
 
-  _.mixin({
 
-    resultCtx: function (object, property, context, defaultValue) {
-      var value = _.isObject(object) ? object[property] : void 0;
-      if (_.isFunction(value)) {
-        value = value.call(context || object);
-      }
-      if (value) {
-        return value;
-      }
-      else {
-        return !_.isUndefined(defaultValue) ? defaultValue : value;
-      }
-    },
+const _ = __WEBPACK_IMPORTED_MODULE_1_underscore___default.a.noConflict();
 
-    isInteger: function (x) {
-      return _.isNumber(x) && (x % 1 === 0);
-    },
+_.mixin({
+  resultCtx: function (object, property, context, defaultValue) {
+    let value = _.isObject(object) ? object[property] : void 0;
 
-    template: function (source, data) {
-      var template = Handlebars.compile(source);
-      return data ? template(data) : function (data) { return template(data); };
+    if (_.isFunction(value)) {
+      value = value.call(context || object);
     }
+    if (value) {
+      return value;
+    } else {
+      return !_.isUndefined(defaultValue) ? defaultValue : value;
+    }
+  },
 
-  });
+  isInteger: function (x) {
+    return _.isNumber(x) && x % 1 === 0;
+  },
 
-  return _;
+  template: function (source, data) {
+    const template = __WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.compile(source);
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+    return data
+      ? template(data)
+      : function (data) {
+        return template(data);
+      };
+  }
+});
+
+/* harmony default export */ __webpack_exports__["default"] = (_);
 
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(5),
-  __webpack_require__(3),
-  __webpack_require__(22)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Backbone, TemplateUtil, View) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_backbone__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__framework_View__ = __webpack_require__(21);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__ = __webpack_require__(3);
 
-  // add `broadcast` and `listen` functionality to all views
-  // We use one event emitter per all views
-  // This means we need to be very careful with event names
 
-  var eventBus = _.clone(Backbone.Events);
+
+
+
+const eventBus = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Events);
+
+// add `broadcast` and `listen` functionality to all views
+// We use one event emitter per all views
+// This means we need to be very careful with event names
+
+const proto = {
+  constructor: function () {
+    __WEBPACK_IMPORTED_MODULE_2__framework_View__["a" /* default */].apply(this, arguments);
+    this.module && this.$el.attr('data-view', this.module.id);
+  },
 
   /**
-   * See {@link src/framework/View} for more detail and examples from the base class.
-   * @class module:Okta.View
-   * @extends src/framework/View
+   * @deprecated Use {@link #removeChildren}
    */
+  empty: function () {
+    return this.removeChildren();
+  },
 
-  /** @lends module:Okta.View.prototype */
-  var proto = {
+  compileTemplate: __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl,
 
-    constructor: function () {
-      View.apply(this, arguments);
-      this.module && this.$el.attr('data-view', this.module.id);
-    },
+  /**
+   *
+   * Broadcasts a global event that all views and controllers can subscribe to
+   * for framework use only - prefer using a shared model
+   *
+   * @param {String} eventName A unique identifier for the event
+   * @param {...String} param Parameter to pass with the event (can pass more than one parameter)
+   * @deprecated For internal use only
+   * @private
+   */
+  broadcast: function () {
+    eventBus.trigger.apply(eventBus, arguments);
+    return this;
+  },
 
-    /**
-     * @deprecated Use {@link #removeChildren}
-     */
-    empty: function () {
-      return this.removeChildren();
-    },
+  /**
+   * Subscribe to broadcast events
+   * for framework use only - prefer using a shared model
+   *
+   * @param {String} eventName The event identifier to subscribe
+   * @param {Function} fn The callback function to invoke
+   * @deprecated For internal use only
+   * @private
+   */
+  listen: function (name, fn) {
+    eventBus.off(name, fn);
+    this.listenTo(eventBus, name, fn);
+    return this;
+  },
 
-    compileTemplate: TemplateUtil.tpl,
+  /**
+   * Shows a notification box
+   * @param {String} level success / warning / error
+   * @param {String} message The message to display
+   * @param {Object} [options]
+   * @param {Number} [options.width] Set a custom width
+   * @param {String} [options.title] Set a custom title
+   * @param {Boolean} [options.hide=true] Do we want to auto-hide this notification?
+   * @param {Boolean} [options.dismissable] Show a dismiss button
+   * @example
+   * view.notify('success', 'Group created successfully');
+   */
+  notify: function (level, message, options) {
+    this.broadcast('notification', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults({ message: message, level: level }, options));
+    return this;
+  },
 
-    /**
-     *
-     * Broadcasts a global event that all views and controllers can subscribe to
-     * for framework use only - prefer using a shared model
-     *
-     * @param {String} eventName A unique identifier for the event
-     * @param {...String} param Parameter to pass with the event (can pass more than one parameter)
-     * @deprecated For internal use only
-     * @private
-     */
-    broadcast: function () {
-      eventBus.trigger.apply(eventBus, arguments);
-      return this;
-    },
+  /**
+   * Shows a confirmation dialog
+   *
+   * The main difference between this and the native javascript `confirm` method
+   * Is this method is non blocking (note the callback pattern).
+   *
+   * The callback function will run in the context (`this`) of the invoking view.
+   *
+   * @param {String} [title] The title of the confirmation dialog
+   * @param {String} [message] The message of the confirmation dialog
+   * @param {Function} [okfn] The callback to run when the user hits "OK" (runs in the context of the invoking view)
+   * @param {Function} [cancelfn] The callback to run when the user hits "Cancel"
+   *        (runs in the context of the invoking view)
+   * @example
+   * view.confirm('Delete Group', 'Are you sure you want to delete the selected group?', function () {
+   *   model.destroy();
+   * });
+   *
+   * // title will be auto-set to "Okta"
+   * view.confirm('Are you sure you want to delete the selected group?', function () {
+   *   model.destroy();
+   * });
+   *
+   * view.confirm({
+   *   title: 'Delete Group', //=> Modal title
+   *   subtitle: 'Are you sure you want to delete the selected group?', //=> Modal subtitle
+   *   content: '<h3 color="red">THIS WILL DELETE THE GROUP!</h3>', //=> A template or a view to add to the modal
+   *   save: 'Delete Group', //=> Button label
+   *   ok: _.bind(model.save, model) // Callback function on hitting "ok" button
+   *   cancel: 'Cancel', //=> Button label
+   *   cancelFn: _.bind(model.destroy, model) // Callback function on hitting "cancel" button
+   * });
+   */
+  confirm: function (title, message, okfn, cancelfn) {
+    let options;
+    /* eslint max-statements: [2, 12] */
 
-    /**
-     * Subscribe to broadcast events
-     * for framework use only - prefer using a shared model
-     *
-     * @param {String} eventName The event identifier to subscribe
-     * @param {Function} fn The callback function to invoke
-     * @deprecated For internal use only
-     * @private
-     */
-    listen: function (name, fn) {
-      eventBus.off(name, fn);
-      this.listenTo(eventBus, name, fn);
-      return this;
-    },
-
-    /**
-     * Shows a notification box
-     * @param {String} level success / warning / error
-     * @param {String} message The message to display
-     * @param {Object} [options]
-     * @param {Number} [options.width] Set a custom width
-     * @param {String} [options.title] Set a custom title
-     * @param {Boolean} [options.hide=true] Do we want to auto-hide this notification?
-     * @param {Boolean} [options.dismissable] Show a dismiss button
-     * @example
-     * view.notify('success', 'Group created successfully');
-     */
-    notify: function (level, message, options) {
-      this.broadcast('notification', _.defaults({message: message, level: level}, options));
-      return this;
-    },
-
-    /**
-     * Shows a confirmation dialog
-     *
-     * The main difference between this and the native javascript `confirm` method
-     * Is this method is non blocking (note the callback pattern).
-     *
-     * The callback function will run in the context (`this`) of the invoking view.
-     *
-     * @param {String} [title] The title of the confirmation dialog
-     * @param {String} [message] The message of the confirmation dialog
-     * @param {Function} [okfn] The callback to run when the user hits "OK" (runs in the context of the invoking view)
-     * @param {Function} [cancelfn] The callback to run when the user hits "Cancel"
-     *        (runs in the context of the invoking view)
-     * @example
-     * view.confirm('Delete Group', 'Are you sure you want to delete the selected group?', function () {
-     *   model.destroy();
-     * });
-     *
-     * // title will be auto-set to "Okta"
-     * view.confirm('Are you sure you want to delete the selected group?', function () {
-     *   model.destroy();
-     * });
-     *
-     * view.confirm({
-     *   title: 'Delete Group', //=> Modal title
-     *   subtitle: 'Are you sure you want to delete the selected group?', //=> Modal subtitle
-     *   content: '<h3 color="red">THIS WILL DELETE THE GROUP!</h3>', //=> A template or a view to add to the modal
-     *   save: 'Delete Group', //=> Button label
-     *   ok: _.bind(model.save, model) // Callback function on hitting "ok" button
-     *   cancel: 'Cancel', //=> Button label
-     *   cancelFn: _.bind(model.destroy, model) // Callback function on hitting "cancel" button
-     * });
-     */
-    confirm: function (title, message, okfn, cancelfn) {
-      /* eslint max-statements: [2, 12] */
-
-      var options;
-      if (typeof title == 'object') {
-        options = title;
-      }
-      else {
-        if (arguments.length == 2 && _.isFunction(message)) {
-          options = {
-            title: 'Okta',
-            subtitle: title,
-            ok: message
-          };
-        }
-        else {
-          options = {
-            title: title,
-            subtitle: message,
-            ok: okfn,
-            cancelFn: cancelfn
-          };
-        }
-      }
-      if (_.isFunction(options.ok)) {
-        options.ok = _.bind(options.ok, this);
-      }
-      if (_.isFunction(options.cancelFn)) {
-        options.cancelFn = _.bind(options.cancelFn, this);
-      }
-      this.broadcast('confirmation', options);
-      return this;
-    },
-
-    /**
-     * Shows an alert box
-     *
-     * The main difference between this and the native javascript `alert` method
-     * Is this method is non blocking.
-     *
-     * @param {String} message The message
-     * @example
-     * view.alert('Mission complete');
-     */
-    alert: function (params) {
-      if (_.isString(params)) {
-        params = {
-          subtitle: params
+    if (typeof title === 'object') {
+      options = title;
+    } else {
+      if (arguments.length === 2 && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(message)) {
+        options = {
+          title: 'Okta',
+          subtitle: title,
+          ok: message
+        };
+      } else {
+        options = {
+          title: title,
+          subtitle: message,
+          ok: okfn,
+          cancelFn: cancelfn
         };
       }
-      this.confirm(_.extend({}, params, {
-        noCancelButton: true
-      }));
-      return this;
     }
-  };
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(options.ok)) {
+      options.ok = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(options.ok, this);
+    }
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(options.cancelFn)) {
+      options.cancelFn = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(options.cancelFn, this);
+    }
+    this.broadcast('confirmation', options);
+    return this;
+  },
 
-  return View.extend(proto, /** @lends View.prototype */ {
+  /**
+   * Shows an alert box
+   *
+   * The main difference between this and the native javascript `alert` method
+   * Is this method is non blocking.
+   *
+   * @param {String} message The message
+   * @example
+   * view.alert('Mission complete');
+   */
+  alert: function (params) {
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(params)) {
+      params = {
+        subtitle: params
+      };
+    }
+    this.confirm(
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, params, {
+        noCancelButton: true
+      })
+    );
+    return this;
+  }
+};
+
+/**
+ * See {@link src/framework/View} for more detail and examples from the base class.
+ * @class module:Okta.View
+ * @extends src/framework/View
+ */
+
+/** @lends module:Okta.View.prototype */
+
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_2__framework_View__["a" /* default */].extend(
+  proto,
+  /** @lends View.prototype */ {
     /** @method */
     decorate: function (TargetView) {
-      var View = TargetView.extend({});
-      _.defaults(View.prototype, proto);
-      return View;
-    }
-  });
+      const BaseViewView = TargetView.extend({});
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults(BaseViewView.prototype, proto);
+      return BaseViewView;
+    }
+  }
+));
 
 
 /***/ }),
 /* 2 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint-disable @okta/okta/enforce-requirejs-names, @okta/okta/no-specific-modules */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(10)], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($) {
-  $.ajaxSetup({
-    beforeSend: function (xhr) {
-      xhr.setRequestHeader('X-Okta-XsrfToken', $('#_xsrfToken').text());
-    },
-    converters: {
-      'text secureJSON': function (str) {
-        if (str.substring(0, 11) === 'while(1){};') {
-          str = str.substring(11);
-        }
-        return JSON.parse(str);
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_jquery__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_jquery___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_jquery__);
+/* eslint-disable @okta/okta/enforce-requirejs-names, @okta/okta/no-specific-modules */
+
+
+__WEBPACK_IMPORTED_MODULE_0_jquery___default.a.ajaxSetup({
+  beforeSend: function (xhr) {
+    xhr.setRequestHeader('X-Okta-XsrfToken', __WEBPACK_IMPORTED_MODULE_0_jquery___default()('#_xsrfToken').text());
+  },
+  converters: {
+    'text secureJSON': function (str) {
+      if (str.substring(0, 11) === 'while(1){};') {
+        str = str.substring(11);
       }
+      return JSON.parse(str);
     }
-  });
+  }
+});
 
-  // Selenium Hook
-  // Widget such as autocomplete and autosuggest needs to be triggered from the running version of jQuery.
-  // We have 2 versions of jQuery running in parallel and they don't share the same events bus
-  window.jQueryCourage = $;
-  return $;
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+// Selenium Hook
+// Widget such as autocomplete and autosuggest needs to be triggered from the running version of jQuery.
+// We have 2 versions of jQuery running in parallel and they don't share the same events bus
+window.jQueryCourage = __WEBPACK_IMPORTED_MODULE_0_jquery___default.a;
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_0_jquery___default.a);
 
 
 /***/ }),
 /* 3 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint @okta/okta/enforce-requirejs-names: 0, @okta/okta/no-specific-methods: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(18)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Handlebars) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
+/* eslint @okta/okta/no-specific-methods: 0 */
 
+
+
+/**
+ * @class module:Okta.internal.util.TemplateUtil
+ * @hideconstructor
+ */
+/* harmony default export */ __webpack_exports__["default"] = ({
   /**
-   * @class module:Okta.internal.util.TemplateUtil
-   * @hideconstructor
+   * Compiles a Handlebars template
+   * @static
+   * @method
    */
-  return /** @lends module:Okta.internal.util.TemplateUtil */ {
-
-    /**
-     * Compiles a Handlebars template
-     * @static
-     * @method
-     */
-    tpl: _.memoize(function (tpl) {
-      /* eslint okta/no-specific-methods: 0 */
-      return Handlebars.compile(tpl);
-    })
-
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  tpl: __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].memoize(function (tpl) {
+    /* eslint okta/no-specific-methods: 0 */
+    return __WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.compile(tpl);
+  })
+});
 
 
 /***/ }),
 /* 4 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(37),
-  __webpack_require__(13)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, Bundles) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles__ = __webpack_require__(39);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles__);
 
-  var entityMap = {
-    '&amp;': '&',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    '&#39;': '\'',
-    '&#039;': '\'',
-    '&#x2F;': '/'
-  };
 
-  /* eslint max-len: 0*/
-  var emailValidator = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@(?!-)((\[?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\]?)|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-  /**
-   * Handy utility functions to handle strings.
-   *
-   * @class module:Okta.internal.util.StringUtil
-   * @hideconstructor
-   */
-  var StringUtil = /** @lends module:Okta.internal.util.StringUtil */ {
-    /** @static */
-    sprintf: function () {
-      /* eslint max-statements: [2, 11] */
 
-      var args = Array.prototype.slice.apply(arguments),
-          value = args.shift(),
-          oldValue = value;
+const entityMap = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': '\'',
+  '&#039;': '\'',
+  '&#x2F;': '/'
+};
+const emailValidator = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@(?!-)((\[?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\]?)|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-      function triggerError() {
-        throw new Error('Mismatch number of variables: ' + arguments[0] + ', ' + JSON.stringify(args));
-      }
+/* eslint max-len: 0*/
 
-      for (var i = 0, l = args.length; i < l; i++) {
-        var entity = args[i];
-        value = value.replace('{' + i + '}', entity);
-        if (entity === undefined || entity === null || value === oldValue) {
-          triggerError();
-        }
-        oldValue = value;
-      }
+const StringUtil = /** @lends module:Okta.internal.util.StringUtil */ {
+  /** @static */
+  sprintf: function () {
+    const args = Array.prototype.slice.apply(arguments);
+    let value = args.shift();
+    let oldValue = value;
+    /* eslint max-statements: [2, 13] */
 
-      if (/\{[\d+]\}/.test(value)) {
-        triggerError();
-      }
-
-      return value;
-    },
-
-    /**
-     * Converts a URI encoded query string into a hash map
-     * @param  {String} query The query string
-     * @return {Object} The map
-     * @static
-     * @example
-     * StringUtil.parseQuery('foo=bar&baz=qux') // {foo: 'bar', baz: 'qux'}
-     */
-    parseQuery: function (query) {
-      var params = {};
-      var pairs = decodeURIComponent(query.replace(/\+/g, ' ')).split('&');
-      for (var i = 0; i < pairs.length; i++) {
-        var pair = pairs[i];
-        var data = pair.split('=');
-        params[data.shift()] = data.join('=');
-      }
-      return params;
-    },
-
-    /** @static */
-    encodeJSObject: function (jsObj) {
-      return encodeURIComponent(JSON.stringify(jsObj));
-    },
-
-    /** @static */
-    decodeJSObject: function (jsObj) {
-      try {
-        return JSON.parse(decodeURIComponent(jsObj));
-      } catch (e) {
-        return null;
-      }
-    },
-
-    /** @static */
-    unescapeHtml: function (string) {
-      return String(string).replace(/&[\w#\d]{2,};/g, function (s) {
-        return entityMap[s] || s;
-      });
-    },
-
-    /**
-     * Translate a key to the localized value
-     * @static
-     * @param  {String} key The key
-     * @param  {String} [bundle="messages"] The name of the i18n bundle. Defaults to the first bundle in the list.
-     * @param  {Array} [params] A list of parameters to apply as tokens to the i18n value
-     * @return {String} The localized value
-     */
-    localize: function (key, bundleName, params) {
-      /* eslint complexity: [2, 7] */
-      var bundle = bundleName ? Bundles[bundleName] : Bundles[_.keys(Bundles)[0]];
-
-      if (!bundle) {
-        return 'L10N_ERROR[' + (bundleName) + ']';
-      }
-
-      var value = bundle[key];
-
-      try {
-        params = params && params.slice ? params.slice(0) : [];
-        params.unshift(value);
-        value = StringUtil.sprintf.apply(null, params);
-      }
-      catch (e) {
-        value = null;
-      }
-
-      return value || 'L10N_ERROR[' + key + ']';
-    },
-
-    /**
-    * Convert a string to a float if valid, otherwise return the string.
-    * Valid numbers may contain a negative sign and a decimal point.
-    * @static
-    * @param {String} string The string to convert to a number
-    * @return {String|Number} Returns a number if the string can be casted, otherwise returns the original string
-    */
-    parseFloat: function (string) {
-      var number = +string;
-      return typeof string == 'string' && number === parseFloat(string) ? number : string;
-    },
-
-    /**
-     * Convert a string to an integer if valid, otherwise return the string
-     * @static
-     * @param {String} string The string to convert to an integer
-     * @return {String|integer} Returns an integer if the string can be casted, otherwise, returns the original string
-     */
-    parseInt: function (string) {
-      var int = +string;
-      return _.isString(string) && int === parseInt(string, 10) ? int : string;
-    },
-
-    /**
-     * Convert a string to an object if valid, otherwise return the string
-     * @static
-     * @param {String} string The string to convert to an object
-     * @return {String|object} Returns an object if the string can be casted, otherwise, returns the original string
-     */
-    parseObject: function (string) {
-      if (!_.isString(string)) {
-        return string;
-      }
-
-      try {
-        var object = JSON.parse(string);
-        return $.isPlainObject(object) ? object : string;
-      } catch (e) {
-        return string;
-      }
-    },
-
-    /**
-     * Returns a random string from [a-z][A-Z][0-9] of a given length
-     * @static
-     * @param {Number} length The length of the random string.
-     * @return {String} Returns a random string from [a-z][A-Z][0-9] of a given length
-     */
-    randomString: function (length) {
-      var characters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-
-      if (length === undefined) {
-        length = _.random(characters.length);
-      } else if (length === 0) {
-        return '';
-      }
-
-      var stringArray = [];
-      while (length--) {
-        stringArray.push(characters[_.random(characters.length - 1)]);
-      }
-      return stringArray.join('');
-    },
-
-    /**
-     * Returns if a str ends with another string
-     * @static
-     * @param {String} str The string to search
-     * @param {String} ends The string it should end with
-     *
-     * @return {Boolean} Returns if the str ends with ends
-     */
-    endsWith: function (str, ends) {
-      str += '';
-      ends += '';
-      return str.length >= ends.length && str.substring(str.length - ends.length) === ends;
-    },
-
-    /** @static */
-    isEmail: function (str) {
-      var target = $.trim(str);
-      return !_.isEmpty(target) && emailValidator.test(target);
+    function triggerError() {
+      throw new Error('Mismatch number of variables: ' + arguments[0] + ', ' + JSON.stringify(args));
     }
 
-  };
+    for (var i = 0, l = args.length; i < l; i++) {
+      const entity = args[i];
 
-  return StringUtil;
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+      value = value.replace('{' + i + '}', entity);
+      if (entity === undefined || entity === null || value === oldValue) {
+        triggerError();
+      }
+      oldValue = value;
+    }
+
+    if (/\{[\d+]\}/.test(value)) {
+      triggerError();
+    }
+
+    return value;
+  },
+
+  /**
+   * Converts a URI encoded query string into a hash map
+   * @param  {String} query The query string
+   * @return {Object} The map
+   * @static
+   * @example
+   * StringUtil.parseQuery('foo=bar&baz=qux') // {foo: 'bar', baz: 'qux'}
+   */
+  parseQuery: function (query) {
+    const params = {};
+    const pairs = decodeURIComponent(query.replace(/\+/g, ' ')).split('&');
+
+    for (var i = 0; i < pairs.length; i++) {
+      const pair = pairs[i];
+      const data = pair.split('=');
+
+      params[data.shift()] = data.join('=');
+    }
+    return params;
+  },
+
+  /** @static */
+  encodeJSObject: function (jsObj) {
+    return encodeURIComponent(JSON.stringify(jsObj));
+  },
+
+  /** @static */
+  decodeJSObject: function (jsObj) {
+    try {
+      return JSON.parse(decodeURIComponent(jsObj));
+    } catch (e) {
+      return null;
+    }
+  },
+
+  /** @static */
+  unescapeHtml: function (string) {
+    return String(string).replace(/&[\w#\d]{2,};/g, function (s) {
+      return entityMap[s] || s;
+    });
+  },
+
+  /**
+   * Translate a key to the localized value
+   * @static
+   * @param  {String} key The key
+   * @param  {String} [bundle="messages"] The name of the i18n bundle. Defaults to the first bundle in the list.
+   * @param  {Array} [params] A list of parameters to apply as tokens to the i18n value
+   * @return {String} The localized value
+   */
+  localize: function (key, bundleName, params) {
+    const bundle = bundleName ? __WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles___default.a[bundleName] : __WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles___default.a[__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].keys(__WEBPACK_IMPORTED_MODULE_2_okta_i18n_bundles___default.a)[0]];
+    /* eslint complexity: [2, 7] */
+
+    if (!bundle) {
+      return 'L10N_ERROR[' + bundleName + ']';
+    }
+
+    let value = bundle[key];
+
+    try {
+      params = params && params.slice ? params.slice(0) : [];
+      params.unshift(value);
+      value = StringUtil.sprintf.apply(null, params);
+    } catch (e) {
+      value = null;
+    }
+
+    return value || 'L10N_ERROR[' + key + ']';
+  },
+
+  /**
+   * Convert a string to a float if valid, otherwise return the string.
+   * Valid numbers may contain a negative sign and a decimal point.
+   * @static
+   * @param {String} string The string to convert to a number
+   * @return {String|Number} Returns a number if the string can be casted, otherwise returns the original string
+   */
+  parseFloat: function (string) {
+    const number = +string;
+
+    return typeof string === 'string' && number === parseFloat(string) ? number : string;
+  },
+
+  /**
+   * Convert a string to an integer if valid, otherwise return the string
+   * @static
+   * @param {String} string The string to convert to an integer
+   * @return {String|integer} Returns an integer if the string can be casted, otherwise, returns the original string
+   */
+  parseInt: function (string) {
+    const int = +string;
+
+    return __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].isString(string) && int === parseInt(string, 10) ? int : string;
+  },
+
+  /**
+   * Convert a string to an object if valid, otherwise return the string
+   * @static
+   * @param {String} string The string to convert to an object
+   * @return {String|object} Returns an object if the string can be casted, otherwise, returns the original string
+   */
+  parseObject: function (string) {
+    if (!__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].isString(string)) {
+      return string;
+    }
+
+    try {
+      const object = JSON.parse(string);
+
+      return __WEBPACK_IMPORTED_MODULE_0__jquery_wrapper__["default"].isPlainObject(object) ? object : string;
+    } catch (e) {
+      return string;
+    }
+  },
+
+  /**
+   * Returns a random string from [a-z][A-Z][0-9] of a given length
+   * @static
+   * @param {Number} length The length of the random string.
+   * @return {String} Returns a random string from [a-z][A-Z][0-9] of a given length
+   */
+  randomString: function (length) {
+    const characters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
+
+    if (length === undefined) {
+      length = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].random(characters.length);
+    } else if (length === 0) {
+      return '';
+    }
+
+    const stringArray = [];
+
+    while (length--) {
+      stringArray.push(characters[__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].random(characters.length - 1)]);
+    }
+    return stringArray.join('');
+  },
+
+  /**
+   * Returns if a str ends with another string
+   * @static
+   * @param {String} str The string to search
+   * @param {String} ends The string it should end with
+   *
+   * @return {Boolean} Returns if the str ends with ends
+   */
+  endsWith: function (str, ends) {
+    str += '';
+    ends += '';
+    return str.length >= ends.length && str.substring(str.length - ends.length) === ends;
+  },
+
+  /** @static */
+  isEmail: function (str) {
+    const target = __WEBPACK_IMPORTED_MODULE_0__jquery_wrapper__["default"].trim(str);
+
+    return !__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].isEmpty(target) && emailValidator.test(target);
+  }
+};
+
+/**
+ * Handy utility functions to handle strings.
+ *
+ * @class module:Okta.internal.util.StringUtil
+ * @hideconstructor
+ */
+
+/* harmony default export */ __webpack_exports__["default"] = (StringUtil);
 
 
 /***/ }),
 /* 5 */
 /***/ (function(module, exports) {
 
-module.exports = require("backbone");
+module.exports = require("handlebars");
 
 /***/ }),
 /* 6 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-var __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {
-
-  function log(level, args) {
-    if (window.console && window.okta && window.okta.debug) {
-      window.console[level].apply(window.console, args);
-    }
-  }
-
-  /**
-   * Utility library of logging functions.
-   * @class module:Okta.Logger
-   */
-  return /** @lends module:Okta.Logger */ {
-
-    /**
-     * See [console.trace](https://developer.mozilla.org/en-US/docs/Web/API/Console.trace)
-     * @static
-     */
-    trace: function () {
-      return log('trace', arguments);
-    },
-    /**
-     * See [console.dir](https://developer.mozilla.org/en-US/docs/Web/API/Console.dir)
-     * @static
-     */
-    dir: function () {
-      return log('dir', arguments);
-    },
-    /**
-     * See [console.time](https://developer.mozilla.org/en-US/docs/Web/API/Console.time)
-     * @static
-     */
-    time: function () {
-      return log('time', arguments);
-    },
-    /**
-     * See [console.timeEnd](https://developer.mozilla.org/en-US/docs/Web/API/Console.timeEnd)
-     * @static
-     */
-    timeEnd: function () {
-      return log('timeEnd', arguments);
-    },
-    /**
-     * See [console.group](https://developer.mozilla.org/en-US/docs/Web/API/Console.group)
-     * @static
-     */
-    group: function () {
-      return log('group', arguments);
-    },
-    /**
-     * See [console.groupEnd](https://developer.mozilla.org/en-US/docs/Web/API/Console.groupEnd)
-     * @static
-     */
-    groupEnd: function () {
-      return log('groupEnd', arguments);
-    },
-    /**
-     * See [console.assert](https://developer.mozilla.org/en-US/docs/Web/API/Console.assert)
-     * @static
-     */
-    assert: function () {
-      return log('assert', arguments);
-    },
-    /**
-     * See [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console.log)
-     * @static
-     */
-    log: function () {
-      return log('log', arguments);
-    },
-    /**
-     * See [console.info](https://developer.mozilla.org/en-US/docs/Web/API/Console.info)
-     * @static
-     */
-    info: function () {
-      return log('info', arguments);
-    },
-    /**
-     * See [console.warn](https://developer.mozilla.org/en-US/docs/Web/API/Console.warn)
-     * @static
-     */
-    warn: function () {
-      return log('warn', arguments);
-    },
-    /**
-     * See [console.error](https://developer.mozilla.org/en-US/docs/Web/API/Console.error)
-     * @static
-     */
-    error: function () {
-      return log('error', arguments);
-    }
-  };
-}).call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
+module.exports = require("backbone");
 
 /***/ }),
 /* 7 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-!(module.exports = {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+function log(level, args) {
+  if (window.console && window.okta && window.okta.debug) {
+    window.console[level].apply(window.console, args);
+  }
+}
+
+/**
+ * Utility library of logging functions.
+ * @class module:Okta.Logger
+ */
+/* harmony default export */ __webpack_exports__["default"] = ({
+  /**
+   * See [console.trace](https://developer.mozilla.org/en-US/docs/Web/API/Console.trace)
+   * @static
+   */
+  trace: function () {
+    return log('trace', arguments);
+  },
+  /**
+   * See [console.dir](https://developer.mozilla.org/en-US/docs/Web/API/Console.dir)
+   * @static
+   */
+  dir: function () {
+    return log('dir', arguments);
+  },
+  /**
+   * See [console.time](https://developer.mozilla.org/en-US/docs/Web/API/Console.time)
+   * @static
+   */
+  time: function () {
+    return log('time', arguments);
+  },
+  /**
+   * See [console.timeEnd](https://developer.mozilla.org/en-US/docs/Web/API/Console.timeEnd)
+   * @static
+   */
+  timeEnd: function () {
+    return log('timeEnd', arguments);
+  },
+  /**
+   * See [console.group](https://developer.mozilla.org/en-US/docs/Web/API/Console.group)
+   * @static
+   */
+  group: function () {
+    return log('group', arguments);
+  },
+  /**
+   * See [console.groupEnd](https://developer.mozilla.org/en-US/docs/Web/API/Console.groupEnd)
+   * @static
+   */
+  groupEnd: function () {
+    return log('groupEnd', arguments);
+  },
+  /**
+   * See [console.assert](https://developer.mozilla.org/en-US/docs/Web/API/Console.assert)
+   * @static
+   */
+  assert: function () {
+    return log('assert', arguments);
+  },
+  /**
+   * See [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console.log)
+   * @static
+   */
+  log: function () {
+    return log('log', arguments);
+  },
+  /**
+   * See [console.info](https://developer.mozilla.org/en-US/docs/Web/API/Console.info)
+   * @static
+   */
+  info: function () {
+    return log('info', arguments);
+  },
+  /**
+   * See [console.warn](https://developer.mozilla.org/en-US/docs/Web/API/Console.warn)
+   * @static
+   */
+  warn: function () {
+    return log('warn', arguments);
+  },
+  /**
+   * See [console.error](https://developer.mozilla.org/en-US/docs/Web/API/Console.error)
+   * @static
+   */
+  error: function () {
+    return log('error', arguments);
+  }
+});
+
+
+/***/ }),
+/* 8 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony default export */ __webpack_exports__["default"] = ({
   UP: 38,
   DOWN: 40,
   DEL: 46,
@@ -704,7 +727,7 @@ var __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_RESULT__ = (function ()
   SPACE: 32,
   BACKSPACE: 8,
   __isKey: function (e, key) {
-    return (e.which || e.keyCode) == this[key];
+    return (e.which || e.keyCode) === this[key];
   },
   isEnter: function (e) {
     return this.__isKey(e, 'ENTER');
@@ -717,838 +740,886 @@ var __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_RESULT__ = (function ()
   }
 });
 
-/***/ }),
-/* 8 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-params: [2, 6] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(4),
-  __webpack_require__(1),
-  __webpack_require__(7),
-  __webpack_require__(6),
-  __webpack_require__(23)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, StringUtil, BaseView, Keys, Logger, ViewUtil) {
-
-  var LABEL_OPTIONS = ['model', 'id', 'inputId', 'type', 'label', 'sublabel', 'tooltip', 'name'],
-
-      CONTAINER_OPTIONS = ['wide', 'multi', 'input', 'explain', 'customExplain', 'model', 'name', 'type', 'autoRender'],
-
-      WRAPPER_OPTIONS = ['model', 'name', 'label-top', 'readOnly', 'events', 'initialize', 'showWhen', 'bindings',
-        'render', 'className', 'data-se', 'toggleWhen'],
-
-      INPUT_OPTIONS = ['model', 'name', 'inputId', 'type', // base options
-        'input', // custom input
-        'placeholder', 'label', // labels
-        'readOnly', 'read', 'disabled', 'readModeString', // modes
-        'options', // select/radio
-        'deps', // used to specify inputs that have dependencies and show a callout to user on select
-        'from', 'to', // model transformers,
-        'autoRender', // model attributes change event to trigger rerendering of the input
-        'inlineValidation', // control inline validating against the model on focus lost
-        'validateOnlyIfDirty', // check if field has been interacted with and then validate
-        'ariaLabel', // 508 compliance for inputs that do not have label associated with them
-        'params'], // widgets params - for input specific widgets
-
-      OTHER_OPTIONS = ['errorField'];
-
-  var ALL_OPTIONS = _.uniq(_.union(LABEL_OPTIONS, CONTAINER_OPTIONS, WRAPPER_OPTIONS, INPUT_OPTIONS, OTHER_OPTIONS));
-
-  var SAVE_BUTTON_PHASES = [
-    '•         ',
-    '•  •      ',
-    '•  •  •   ',
-    '•  •  •  •',
-    '   •  •  •',
-    '      •  •',
-    '         •',
-    '          ',
-    '          ',
-    '          '
-  ];
-
-  function decorateDoWhen(doWhen) {
-    if (doWhen && !doWhen['__edit__']) {
-      return _.extend({'__edit__': _.constant(true)}, doWhen);
-    }
-  }
-
-  function createButton(options) {
-
-    options = _.pick(options || {}, 'action', 'id', 'className', 'text', 'type');
-
-    var timeoutId, intervalId, phaseCount;
-
-    return BaseView.extend({
-      tagName: 'input',
-      className: 'button',
-      events: {
-        'click': function () {
-          if (options.action && !this.disabled()) {
-            options.action.call(this);
-          }
-        },
-        'keyup': function (e) {
-          if (Keys.isEnter(e) && options.action && !this.disabled()) {
-            options.action.call(this);
-          }
-        }
-      },
-
-      disabled: function () {
-        return this.$el.prop('disabled') === true;
-      },
-
-      disable: function () {
-        this.$el.prop('disabled', true);
-        this.$el.addClass('btn-disabled');
-      },
-
-      enable: function () {
-        this.$el.prop('disabled', false);
-        this.$el.removeClass('btn-disabled');
-      },
-
-      initialize: function () {
-        var self = this;
-
-        this.$el.attr('type', options.type == 'save' ? 'submit' : 'button');
-        this.$el.val(options.text);
-        if (options.id) {
-          this.$el.attr('id', options.id);
-        }
-        if (options.className) {
-          this.$el.addClass(options.className);
-        }
-        if (options.type) {
-          this.$el.attr('data-type', options.type);
-        }
-
-        this.$el.mousedown(function () {
-          self.model.set('__pending__', true);
-        });
-
-        this.$el.mouseup(function () {
-          self.model.set('__pending__', false);
-        });
-
-        this.listenTo(this.model, 'form:set-saving-state', function () {
-          this.disable();
-          if (options.type == 'save') {
-            timeoutId = setTimeout(_.bind(this.__changeSaveText, this), 1000);
-          }
-        });
-        this.listenTo(this.model, 'form:clear-saving-state', function () {
-          this.enable();
-          if (options.type == 'save') {
-            clearTimeout(timeoutId);
-            clearInterval(intervalId);
-            this.$el.val(options.text);
-          }
-        });
-      },
-
-      __changeSaveText: function () {
-        phaseCount = 0;
-        intervalId = setInterval(_.bind(this.__showLoadingText, this), 200);
-      },
-
-      __showLoadingText: function () {
-        this.$el.val(SAVE_BUTTON_PHASES[phaseCount++ % SAVE_BUTTON_PHASES.length]);
-      }
-    });
-  }
-
-  function validateInput(options, model) {
-    /* eslint max-statements: 0, complexity: 0 */
-
-    options || (options = {});
-
-    if (options.type == 'label') {
-      if (!options.label) {
-        Logger.warn('A label input must have a "label" parameter', options);
-      }
-      return;
-    }
-
-    if (options.type == 'button') {
-      if (!options.title && !options.icon) {
-        Logger.warn('A button input must have a "title" and/or an "icon" parameter', options);
-      }
-      if (!options.click && !options.href) {
-        Logger.warn('A button input must have a "click" and/or an "href" parameter', options);
-      }
-      return;
-    }
-
-    if (!options.name && !options.input) {
-      Logger.warn('Missing "name" or "input" parameters', options);
-    }
-
-    if (_.isArray(options.name) && _.isArray(options.input)) {
-      throw new Error('Not allowed to have both "name" and "input" defined as array.');
-    }
-
-    if (options.type != 'list' && options.name && (model && model.allows)) {
-      var names = [];
-      if (_.isArray(options.name)) {
-        names = options.name;
-      } else {
-        names.push(options.name);
-      }
-      _.each(names, function (name) {
-        if (!model.allows(name)) {
-          throw new Error('field not allowed: ' + options.name);
-        }
-      });
-    }
-
-    if (_.isArray(options.input) && options.type != 'list') {
-      _.each(options.input, function (input) {
-        validateInput(input, model);
-      });
-    }
-
-    var keys = _.keys(options),
-        intersection = _.intersection(keys, ALL_OPTIONS);
-
-    if (_.size(intersection) != _.size(options)) {
-      var fields = _.clone(ALL_OPTIONS);
-      fields.unshift(keys);
-      Logger.warn('Invalid input parameters', _.without.apply(null, fields), options);
-    }
-  }
-
-  function generateInputOptions(options, form, createFn) {
-    options = _.clone(options);
-
-    if (_.contains(['list', 'group'], options.type)) {
-      options.params = _.defaults({
-        create: createFn,
-        inputs: _.map(_.isArray(options.input) ? options.input : [options.input], function (input) {
-          return _.first(generateInputOptions(input, form, createFn));
-        })
-      }, options.params || {});
-      delete options.input;
-    }
-
-    var inputs = _.isArray(options.input) ? _.clone(options.input) : [options];
-
-    return _.map(inputs, function (input) {
-      var target = _.defaults({model: form.model}, input, _.omit(options, 'input', 'inputs'), form.options, {
-        id: _.uniqueId('input'),
-        readOnly: form.isReadOnly(),
-        read: form.hasReadMode()
-      });
-      if (form.isReadOnly()) {
-        target.read = target.readOnly = true;
-      }
-      return target;
-    });
-
-  }
-
-  return {
-
-    LABEL_OPTIONS: LABEL_OPTIONS,
-    CONTAINER_OPTIONS: CONTAINER_OPTIONS,
-    WRAPPER_OPTIONS: WRAPPER_OPTIONS,
-    INPUT_OPTIONS: INPUT_OPTIONS,
-
-    generateInputOptions: generateInputOptions,
-
-    changeEventString: function (fieldNames) {
-      return 'change:' + fieldNames.join(' change:');
-    },
-
-    createReadFormButton: function (options) {
-
-      var action, text, ariaLabel;
-      if (options.type == 'cancel') {
-        text = ariaLabel = StringUtil.localize('oform.cancel', 'courage');
-        action = function () {
-          this.model.trigger('form:cancel');
-        };
-      }
-      else {
-        text = StringUtil.localize('oform.edit', 'courage');
-        ariaLabel = text + ' ' + options.formTitle;
-        action = function () {
-          this.model.set('__edit__', true);
-        };
-      }
-
-      return BaseView.extend({
-        tagName: 'a',
-        attributes: {
-          href: '#',
-          'aria-label': ariaLabel
-        },
-        template: function () {
-          return _.escape(text);
-        },
-        events: {
-          click: function (e) {
-            e.preventDefault();
-            action.call(this);
-          }
-        }
-      });
-
-    },
-
-    createButton: function (options) {
-      options = _.clone(options);
-      switch (options.type) {
-      case 'save':
-        _.defaults(options, {className: 'button-primary'});
-        break;
-      case 'cancel':
-        _.defaults(options, {
-          text: StringUtil.localize('oform.cancel', 'courage'),
-          action: function () {
-            this.model.trigger('form:cancel');
-          }
-        });
-        break;
-      case 'previous':
-        _.defaults(options, {
-          text: StringUtil.localize('oform.previous', 'courage'),
-          action: function () {
-            this.model.trigger('form:previous');
-          }
-        });
-        break;
-      }
-      return createButton(options);
-    },
-
-    validateInput: validateInput,
-
-    /**
-     * Applies a show-when logic on a view instance.
-     * The show-when is a map of a model field name -> a boolean or a function that returns a boolean.
-     * The view will toggle based on the field value.
-     *
-     * @param  {Okta.View} view a view instance that has a this.model attached to it
-     * @param  {Object} showWhen
-     */
-    applyShowWhen: function (view, showWhen) {
-      var toggleAndResize = function (bool) {
-        return function () {
-          // The `toggle` is here since an event may be triggered before the el is in the DOM
-          // and in that case slide events may not function as expected.
-          view.$el.toggle(bool);
-          view.model.trigger('form:resize');
-        };
-      };
-
-      ViewUtil.applyDoWhen(view, decorateDoWhen(showWhen), function (bool, options) {
-        if (!options.animate) {
-          view.$el.toggle(bool);
-        }
-        else {
-          view.$el['slide' + (bool ? 'Down' : 'Up')](200, toggleAndResize(bool));
-        }
-      });
-    },
-
-    applyToggleWhen: function (view, toggleWhen) {
-      ViewUtil.applyDoWhen(view, decorateDoWhen(toggleWhen), function (bool, options) {
-        view.$el.toggle(bool);
-        view.model.trigger('form:resize');
-        if (options.animate) {
-          view.render();
-        }
-      });
-    }
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
 
 /***/ }),
 /* 9 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint-env es6 */
-/* eslint max-statements: [2, 17], max-len: [2, 160], max-params: [2, 6] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(1),
-  __webpack_require__(64),
-  __webpack_require__(21),
-  __webpack_require__(4)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, BaseView, Callout, ButtonFactory, StringUtil) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_Keys__ = __webpack_require__(8);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_Logger__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__util_ViewUtil__ = __webpack_require__(24);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__BaseView__ = __webpack_require__(1);
+/* eslint max-params: [2, 6] */
 
-  /**
-   * @class BaseInput
-   * @private
-   * An abstract object that defines an input for {@link Okta.Form}
-   *
-   * BaseInputs are typically not created directly, but being passed to {@link Okta.Form#addInput}
-   * @extends Okta.View
-   */
 
-  return BaseView.extend({
 
-    tagName: 'span',
 
-    attributes: function () {
-      return {
-        'data-se': 'o-form-input-' + this.getNameString()
-      };
-    },
 
-    /**
-    * default placeholder text when options.placeholder is not defined
-    */
-    defaultPlaceholder: '',
 
-    constructor: function (options) {
-      /* eslint complexity: [2, 7] */
-      options = _.defaults(
-        options || {},
-        {
-          inputId: options.id || _.uniqueId('input'),
-          placeholder: this.defaultPlaceholder,
-          inlineValidation: true,
-          validateOnlyIfDirty: false
+const LABEL_OPTIONS = ['model', 'id', 'inputId', 'type', 'label', 'sublabel', 'tooltip', 'name'];
+const CONTAINER_OPTIONS = ['wide', 'multi', 'input', 'explain', 'customExplain', 'model', 'name', 'type', 'autoRender'];
+const WRAPPER_OPTIONS = [
+  'model',
+  'name',
+  'label-top',
+  'readOnly',
+  'events',
+  'initialize',
+  'showWhen',
+  'bindings',
+  'render',
+  'className',
+  'data-se',
+  'toggleWhen',
+];
+const INPUT_OPTIONS = [
+  'model',
+  'name',
+  'inputId',
+  'type', // base options
+  'input', // custom input
+  'placeholder',
+  'label', // labels
+  'readOnly',
+  'read',
+  'disabled',
+  'readModeString', // modes
+  'options', // select/radio
+  'deps', // used to specify inputs that have dependencies and show a callout to user on select
+  'from',
+  'to', // model transformers,
+  'autoRender', // model attributes change event to trigger rerendering of the input
+  'inlineValidation', // control inline validating against the model on focus lost
+  'validateOnlyIfDirty', // check if field has been interacted with and then validate
+  'ariaLabel', // 508 compliance for inputs that do not have label associated with them
+  'params',
+];
+const // widgets params - for input specific widgets
+
+      OTHER_OPTIONS = ['errorField'];
+
+const ALL_OPTIONS = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniq(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].union(LABEL_OPTIONS, CONTAINER_OPTIONS, WRAPPER_OPTIONS, INPUT_OPTIONS, OTHER_OPTIONS));
+
+const SAVE_BUTTON_PHASES = [
+  '•         ',
+  '•  •      ',
+  '•  •  •   ',
+  '•  •  •  •',
+  '   •  •  •',
+  '      •  •',
+  '         •',
+  '          ',
+  '          ',
+  '          ',
+];
+
+function decorateDoWhen(doWhen) {
+  if (doWhen && !doWhen['__edit__']) {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({ __edit__: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].constant(true) }, doWhen);
+  }
+}
+
+function createButton(options) {
+  options = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].pick(options || {}, 'action', 'id', 'className', 'text', 'type');
+
+  let timeoutId;
+  let intervalId;
+  let phaseCount;
+
+  return __WEBPACK_IMPORTED_MODULE_5__BaseView__["default"].extend({
+    tagName: 'input',
+    className: 'button',
+    events: {
+      click: function () {
+        if (options.action && !this.disabled()) {
+          options.action.call(this);
         }
-      );
-
-      delete options.id;
-
-      // decorate the `enable` and `disable` and toggle the `o-form-disabled` class.
-      // so we wont need to worry about this when overriding the methods
-      var self = this;
-      _.each({enable: 'removeClass', disable: 'addClass'}, function (method, action) {
-        self[action] = _.wrap(self[action], function (fn) {
-          fn.apply(self, arguments);
-          self.$el[method]('o-form-disabled');
-        });
-      });
-
-      BaseView.call(this, options);
-
-      if (_.result(options, 'readOnly') !== true && _.result(options, 'read') === true) {
-        this.listenTo(this.model, 'change:__edit__', this.render);
-      }
-
-      if (_.isFunction(this.focus)) {
-        this.focus = _.debounce(_.bind(this.focus, this), 50);
-      }
-
-      // Enable inline validation if this is not the first field in the form.
-      if (!_.result(options, 'validateOnlyIfDirty')) {
-        this.addInlineValidation();
-      }
-
-      this.addModelListeners();
-      this.$el.addClass('o-form-input-name-' + this.getNameString());
-    },
-
-    addAriaLabel: function () {
-      var ariaLabel = this.options.ariaLabel;
-      if (ariaLabel) {
-        this.$(':input').attr('aria-label', ariaLabel);
-      }
-    },
-
-    addInlineValidation: function () {
-      if (_.result(this.options, 'inlineValidation')) {
-        this.$el.on('focusout', ':input', _.bind(this.validate, this));
-      }
-    },
-
-    toModelValue: function () {
-      var value = this.val();
-      if (_.isFunction(this.to)) {
-        value = this.to.call(this, value);
-      }
-      if (_.isFunction(this.options.to)) {
-        value = this.options.to.call(this, value);
-      }
-      return value;
-    },
-
-    __getDependencyCalloutBtn: function (btnConfig) {
-      var self = this;
-      var btnOptions = _.clone(btnConfig);
-      // add onfocus listener to re-evaluate depedency when callout button is clicked
-      var originalClick = btnOptions.click || function () {};
-      btnOptions.click = function () {
-        $(window).one('focus.dependency', function () {
-          self.__showInputDependencies();
-        });
-        originalClick.call(self);
-      };
-      var CalloutBtn = BaseView.extend({
-        children: [
-          ButtonFactory.create(btnOptions)
-        ]
-      });
-      return new CalloutBtn();
-    },
-
-    getCalloutParent: function () {
-      return this.$('input[value="' + this.getModelValue() + '"]').parent();
-    },
-
-    __getCalloutMsgContainer: function (calloutMsg) {
-      return BaseView.extend({
-        template: '\
-        <span class="o-form-explain">\
-           {{msg}}\
-        </span>\
-        ',
-        getTemplateData: function () {
-          return {
-            msg: calloutMsg
-          };
-        }
-      });
-    },
-
-    showCallout: function (calloutConfig, dependencyResolved) {
-      var callout = _.clone(calloutConfig);
-      callout.className = 'dependency-callout';
-      if (callout.btn) {
-        callout.content = this.__getDependencyCalloutBtn(callout.btn);
-        delete callout.btn;
-      }
-      var dependencyCallout = Callout.create(callout);
-      if (!dependencyResolved) {
-        dependencyCallout.add(this.__getCalloutMsgContainer(StringUtil.localize('dependency.callout.msg', 'courage')));
-      }
-      var calloutParent = this.getCalloutParent();
-      calloutParent.append(dependencyCallout.render().el);
-      if (callout.type == 'success') {
-        _.delay(function () {
-          // fade out success callout
-          dependencyCallout.$el.fadeOut(800);
-        }, 1000);
-      }
-    },
-
-    removeCallout: function () {
-      this.$el.find('.dependency-callout').remove();
-    },
-
-    __evaluateCalloutObject: function (dependencyResolved, calloutTitle) {
-      var defaultCallout;
-      if (dependencyResolved) {
-        defaultCallout = {
-          title: StringUtil.localize('dependency.action.completed', 'courage'),
-          size: 'large',
-          type: 'success'
-        };
-      } else {
-        defaultCallout = {
-          title: StringUtil.localize('dependency.action.required', 'courage', [calloutTitle]),
-          size: 'large',
-          type: 'warning'
-        };
-      }
-      return defaultCallout;
-    },
-
-    __handleDependency: function (result, callout) {
-      var self = this;
-      var calloutConfig = _.isFunction(callout) ? callout(result) : _.extend({}, callout, self.__evaluateCalloutObject(result.resolved, callout.title));
-      // remove existing callouts if any
-      self.removeCallout();
-      self.showCallout(calloutConfig, result.resolved);
-    },
-
-    __showInputDependencies: function () {
-      var self = this;
-      var fieldDependency = self.options.deps[self.getModelValue()];
-      if (fieldDependency && _.isFunction(fieldDependency.func)) {
-        fieldDependency.func()
-          .done(function (data) {
-            self.__handleDependency({resolved: true, data: data}, fieldDependency.callout);
-          })
-          .fail(function (data) {
-            self.__handleDependency({resolved: false, data: data}, fieldDependency.callout);
-          });
-      } else {
-        self.removeCallout();
-      }
-    },
-
-    _isEdited: false,
-    /**
-     * updates the model with the input's value
-     */
-    update: function () {
-      if (!this._isEdited && _.result(this.options, 'validateOnlyIfDirty')) {
-        this._isEdited = true;
-        this.addInlineValidation();
-      }
-      this.model.set(this.options.name, this.toModelValue());
-      if (this.options.deps) {
-        // check for dependencies
-        this.__showInputDependencies();
-      }
-    },
-
-    /**
-     * Is the input in edit mode
-     * @return {Boolean}
-     */
-    isEditMode: function () {
-      var ret = !_.result(this.options, 'readOnly') &&
-        (_.result(this.options, 'read') !== true || this.model.get('__edit__') === true);
-      return ret;
-    },
-
-    /**
-     * Renders the input
-     * @readonly
-     */
-    render: function () {
-      this.preRender();
-      var params = this.options.params;
-      this.options.params = _.resultCtx(this.options, 'params', this);
-
-      if (this.isEditMode()) {
-        this.editMode();
-        if (_.resultCtx(this.options, 'disabled', this)) {
-          this.disable();
-        } else {
-          this.enable();
-        }
-      }
-      else {
-        this.readMode();
-      }
-
-      this.options.params = params;
-      this.addAriaLabel();
-      this.postRender();
-
-      return this;
-    },
-
-    /**
-     * checks if the current value in the model is valid for this field
-     */
-    validate: function () {
-      if (!this.model.get('__pending__') && this.isEditMode() && _.isFunction(this.model.validateField)) {
-        var validationError = this.model.validateField(this.options.name);
-        if (validationError) {
-          _.delay(function () {
-            this.model.trigger('form:clear-error:' + this.options.name);
-            this.model.trigger('invalid', this.model, validationError, false);
-          }.bind(this), 100);
+      },
+      keyup: function (e) {
+        if (__WEBPACK_IMPORTED_MODULE_1__util_Keys__["default"].isEnter(e) && options.action && !this.disabled()) {
+          options.action.call(this);
         }
       }
     },
 
-    /**
-    * Add model event listeners
-    */
-    addModelListeners: function () {
-      this.listenTo(this.model, 'form:field-error', function (name) {
-        if (this.options.name === name) {
-          this.__markError();
-        }
-      });
-      this.listenTo(this.model, 'form:clear-errors change:' + this.options.name, this.__clearError);
-      this.listenTo(this.model, 'form:clear-error:' + this.options.name, this.__clearError);
+    disabled: function () {
+      return this.$el.prop('disabled') === true;
     },
 
-    /**
-    * The value of the input
-    * @return {Mixed}
-    */
-    val: function () {
-      throw new Error('val() is an abstract method');
-    },
-
-    /**
-    * Set focus on the input
-    */
-    focus: function () {
-      throw new Error('focus() is an abstract method');
-    },
-
-    /**
-    * Default value in read mode
-    * When model has no value for the field
-    */
-    defaultValue: function () {
-      return '';
-    },
-
-    /**
-    * Renders the input in edit mode
-    */
-    editMode: function () {
-      var options = _.extend({}, this.options, {
-        value: this.getModelValue()
-      });
-      this.$el.html(this.template(options));
-      this.options.multi && this.$el.removeClass('margin-r');
-      return this;
-    },
-
-    /**
-    * Renders the readable value of the input in read mode
-    */
-    readMode: function () {
-      this.$el.text(this.getReadModeString());
-      this.$el.removeClass('error-field');
-      this.options.multi && this.$el.addClass('margin-r');
-      return this;
-    },
-
-    getReadModeString: function () {
-      var readModeStr = _.resultCtx(this.options, 'readModeString', this);
-      if (readModeStr) {
-        return readModeStr;
-      }
-      return this.toStringValue();
-    },
-
-    /**
-     * The model value off the field associated with the input
-     * @return {Mixed}
-     */
-    getModelValue: function () {
-      var value = this.model.get(this.options.name);
-
-      if (_.isFunction(this.from)) {
-        value = this.from.call(this, value);
-      }
-      if (_.isFunction(this.options.from)) {
-        value = this.options.from.call(this, value);
-      }
-      return value;
-    },
-
-    /*
-    * convenience method to get the textual value from the model
-    * will return the textual label rather than value in case of select/radio
-    * @return {String}
-    */
-    toStringValue: function () {
-      var value = this.getModelValue();
-      if (this.options.options) { // dropdown or radio
-        value = this.options.options[value];
-      }
-      return value || this.defaultValue();
-    },
-
-    /**
-     * Triggers a form:resize event in order to tell dialogs content size has changed
-     */
-    resize: function () {
-      this.model.trigger('form:resize');
-    },
-
-    /**
-     * Disable the input
-     */
     disable: function () {
-      this.$(':input').prop('disabled', true);
+      this.$el.prop('disabled', true);
+      this.$el.addClass('btn-disabled');
     },
 
-    /**
-     * Enable the input
-     */
     enable: function () {
-      this.$(':input').prop('disabled', false);
+      this.$el.prop('disabled', false);
+      this.$el.removeClass('btn-disabled');
     },
 
-    /**
-     * Change the type of the input field. (e.g., text <--> password)
-     * @param type
-     */
-    changeType: function (type) {
-      this.$(':input').prop('type', type);
-      // Update the options so that it keeps the uptodate state
-      this.options.type = type;
-    },
+    initialize: function () {
+      const self = this;
 
-    getNameString: function () {
-      if (_.isArray(this.options.name)) {
-        return this.options.name.join('-');
+      this.$el.attr('type', options.type === 'save' ? 'submit' : 'button');
+      this.$el.val(options.text);
+      if (options.id) {
+        this.$el.attr('id', options.id);
       }
-      return this.options.name;
+      if (options.className) {
+        this.$el.addClass(options.className);
+      }
+      if (options.type) {
+        this.$el.attr('data-type', options.type);
+      }
+
+      this.$el.mousedown(function () {
+        self.model.set('__pending__', true);
+      });
+
+      this.$el.mouseup(function () {
+        self.model.set('__pending__', false);
+      });
+
+      this.listenTo(this.model, 'form:set-saving-state', function () {
+        this.disable();
+        if (options.type === 'save') {
+          timeoutId = setTimeout(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].bind(this.__changeSaveText, this), 1000);
+        }
+      });
+      this.listenTo(this.model, 'form:clear-saving-state', function () {
+        this.enable();
+        if (options.type === 'save') {
+          clearTimeout(timeoutId);
+          clearInterval(intervalId);
+          this.$el.val(options.text);
+        }
+      });
     },
 
-    /**
-     * Get parameters, computing _.result
-     * @param  {[type]} options alternative options
-     * @return {Object} the params
-     */
-    getParams: function (options) {
-      var opts = options || this.options || {};
-      return _.clone(_.resultCtx(opts, 'params', this) || {});
+    __changeSaveText: function () {
+      phaseCount = 0;
+      intervalId = setInterval(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].bind(this.__showLoadingText, this), 200);
     },
 
-    /**
-     * get a parameter from options.params, compute _.result when needed.
-     * @param  {String} key
-     * @param  {Object} defaultValue
-     * @return {Object} the params
-     */
-    getParam: function (key, defaultValue) {
-      var result = _.resultCtx(this.getParams(), key, this);
-      return !_.isUndefined(result) ? result : defaultValue;
-    },
+    __showLoadingText: function () {
+      this.$el.val(SAVE_BUTTON_PHASES[phaseCount++ % SAVE_BUTTON_PHASES.length]);
+    }
+  });
+}
 
-    /**
-     * Get a parameter from options.params or if empty, object attribute.
-     *
-     * @param  {String} key
-     * @return {Object} the param or attribute
-     */
-    getParamOrAttribute: function (key) {
-      return this.getParam(key) || _.result(this, key);
-    },
+function validateInput(options, model) {
+  /* eslint max-statements: 0, complexity: 0 */
 
-    __markError: function () {
-      this.$el.addClass('o-form-has-errors');
-    },
+  options || (options = {});
 
-    __clearError: function () {
-      this.$el.removeClass('o-form-has-errors');
+  if (options.type === 'label') {
+    if (!options.label) {
+      __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('A label input must have a "label" parameter', options);
+    }
+    return;
+  }
+
+  if (options.type === 'button') {
+    if (!options.title && !options.icon) {
+      __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('A button input must have a "title" and/or an "icon" parameter', options);
+    }
+    if (!options.click && !options.href) {
+      __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('A button input must have a "click" and/or an "href" parameter', options);
+    }
+    return;
+  }
+
+  if (!options.name && !options.input) {
+    __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('Missing "name" or "input" parameters', options);
+  }
+
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.name) && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.input)) {
+    throw new Error('Not allowed to have both "name" and "input" defined as array.');
+  }
+
+  if (options.type !== 'list' && options.name && model && model.allows) {
+    let names = [];
+
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.name)) {
+      names = options.name;
+    } else {
+      names.push(options.name);
+    }
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(names, function (name) {
+      if (!model.allows(name)) {
+        throw new Error('field not allowed: ' + options.name);
+      }
+    });
+  }
+
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.input) && options.type !== 'list') {
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(options.input, function (input) {
+      validateInput(input, model);
+    });
+  }
+
+  const keys = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].keys(options);
+
+  const intersection = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].intersection(keys, ALL_OPTIONS);
+
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(intersection) !== __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(options)) {
+    const fields = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(ALL_OPTIONS);
+
+    fields.unshift(keys);
+    __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('Invalid input parameters', __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].without.apply(null, fields), options);
+  }
+}
+
+function generateInputOptions(options, form, createFn) {
+  options = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(options);
+
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(['list', 'group'], options.type)) {
+    options.params = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(
+      {
+        create: createFn,
+        inputs: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.input) ? options.input : [options.input], function (input) {
+          return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].first(generateInputOptions(input, form, createFn));
+        })
+      },
+      options.params || {}
+    );
+    delete options.input;
+  }
+
+  const inputs = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(options.input) ? __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(options.input) : [options];
+
+  return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(inputs, function (input) {
+    const target = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults({ model: form.model }, input, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(options, 'input', 'inputs'), form.options, {
+      id: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniqueId('input'),
+      readOnly: form.isReadOnly(),
+      read: form.hasReadMode()
+    });
+
+    if (form.isReadOnly()) {
+      target.read = target.readOnly = true;
+    }
+    return target;
+  });
+}
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  LABEL_OPTIONS: LABEL_OPTIONS,
+  CONTAINER_OPTIONS: CONTAINER_OPTIONS,
+  WRAPPER_OPTIONS: WRAPPER_OPTIONS,
+  INPUT_OPTIONS: INPUT_OPTIONS,
+
+  generateInputOptions: generateInputOptions,
+
+  changeEventString: function (fieldNames) {
+    return 'change:' + fieldNames.join(' change:');
+  },
+
+  createReadFormButton: function (options) {
+    let action;
+    let text;
+    let ariaLabel;
+
+    if (options.type === 'cancel') {
+      text = ariaLabel = __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('oform.cancel', 'courage');
+      action = function () {
+        this.model.trigger('form:cancel');
+      };
+    } else {
+      text = __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('oform.edit', 'courage');
+      ariaLabel = text + ' ' + options.formTitle;
+      action = function () {
+        this.model.set('__edit__', true);
+      };
     }
 
-  });
+    return __WEBPACK_IMPORTED_MODULE_5__BaseView__["default"].extend({
+      tagName: 'a',
+      attributes: {
+        href: '#',
+        'aria-label': ariaLabel
+      },
+      template: function () {
+        return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].escape(text);
+      },
+      events: {
+        click: function (e) {
+          e.preventDefault();
+          action.call(this);
+        }
+      }
+    });
+  },
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  createButton: function (options) {
+    options = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(options);
+    switch (options.type) {
+    case 'save':
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options, { className: 'button-primary' });
+      break;
+    case 'cancel':
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options, {
+        text: __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('oform.cancel', 'courage'),
+        action: function () {
+          this.model.trigger('form:cancel');
+        }
+      });
+      break;
+    case 'previous':
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options, {
+        text: __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('oform.previous', 'courage'),
+        action: function () {
+          this.model.trigger('form:previous');
+        }
+      });
+      break;
+    }
+    return createButton(options);
+  },
+
+  validateInput: validateInput,
+
+  /**
+   * Applies a show-when logic on a view instance.
+   * The show-when is a map of a model field name -> a boolean or a function that returns a boolean.
+   * The view will toggle based on the field value.
+   *
+   * @param  {Okta.View} view a view instance that has a this.model attached to it
+   * @param  {Object} showWhen
+   */
+  applyShowWhen: function (view, showWhen) {
+    const toggleAndResize = function (bool) {
+      return function () {
+        // The `toggle` is here since an event may be triggered before the el is in the DOM
+        // and in that case slide events may not function as expected.
+        view.$el.toggle(bool);
+        view.model.trigger('form:resize');
+      };
+    };
+
+    __WEBPACK_IMPORTED_MODULE_4__util_ViewUtil__["a" /* default */].applyDoWhen(view, decorateDoWhen(showWhen), function (bool, options) {
+      if (!options.animate) {
+        view.$el.toggle(bool);
+      } else {
+        view.$el['slide' + (bool ? 'Down' : 'Up')](200, toggleAndResize(bool));
+      }
+    });
+  },
+
+  applyToggleWhen: function (view, toggleWhen) {
+    __WEBPACK_IMPORTED_MODULE_4__util_ViewUtil__["a" /* default */].applyDoWhen(view, decorateDoWhen(toggleWhen), function (bool, options) {
+      view.$el.toggle(bool);
+      view.model.trigger('form:resize');
+      if (options.animate) {
+        view.render();
+      }
+    });
+  }
+});
 
 
 /***/ }),
 /* 10 */
-/***/ (function(module, exports) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = require("jquery");
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_ButtonFactory__ = __webpack_require__(28);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__components_Callout__ = __webpack_require__(70);
+/* eslint-env es6 */
+/* eslint max-statements: [2, 17], max-len: [2, 160], max-params: [2, 6] */
+
+
+
+
+
+
+
+/**
+ * @class BaseInput
+ * @private
+ * An abstract object that defines an input for {@link Okta.Form}
+ *
+ * BaseInputs are typically not created directly, but being passed to {@link Okta.Form#addInput}
+ * @extends Okta.View
+ */
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend({
+  tagName: 'span',
+
+  attributes: function () {
+    return {
+      'data-se': 'o-form-input-' + this.getNameString()
+    };
+  },
+
+  /**
+   * default placeholder text when options.placeholder is not defined
+   */
+  defaultPlaceholder: '',
+
+  constructor: function (options) {
+    /* eslint complexity: [2, 7] */
+    options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults(options || {}, {
+      inputId: options.id || __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].uniqueId('input'),
+      placeholder: this.defaultPlaceholder,
+      inlineValidation: true,
+      validateOnlyIfDirty: false
+    });
+
+    delete options.id;
+
+    // decorate the `enable` and `disable` and toggle the `o-form-disabled` class.
+    // so we wont need to worry about this when overriding the methods
+    const self = this;
+
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each({ enable: 'removeClass', disable: 'addClass' }, function (method, action) {
+      self[action] = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].wrap(self[action], function (fn) {
+        fn.apply(self, arguments);
+        self.$el[method]('o-form-disabled');
+      });
+    });
+
+    __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].call(this, options);
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(options, 'readOnly') !== true && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(options, 'read') === true) {
+      this.listenTo(this.model, 'change:__edit__', this.render);
+    }
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.focus)) {
+      this.focus = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].debounce(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.focus, this), 50);
+    }
+
+    // Enable inline validation if this is not the first field in the form.
+    if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(options, 'validateOnlyIfDirty')) {
+      this.addInlineValidation();
+    }
+
+    this.addModelListeners();
+    this.$el.addClass('o-form-input-name-' + this.getNameString());
+  },
+
+  addAriaLabel: function () {
+    const ariaLabel = this.options.ariaLabel;
+
+    if (ariaLabel) {
+      this.$(':input').attr('aria-label', ariaLabel);
+    }
+  },
+
+  addInlineValidation: function () {
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this.options, 'inlineValidation')) {
+      this.$el.on('focusout', ':input', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.validate, this));
+    }
+  },
+
+  toModelValue: function () {
+    let value = this.val();
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.to)) {
+      value = this.to.call(this, value);
+    }
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.options.to)) {
+      value = this.options.to.call(this, value);
+    }
+    return value;
+  },
+
+  __getDependencyCalloutBtn: function (btnConfig) {
+    const self = this;
+
+    const btnOptions = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(btnConfig);
+
+    const originalClick = btnOptions.click || function () {};
+    // add onfocus listener to re-evaluate depedency when callout button is clicked
+
+    btnOptions.click = function () {
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).one('focus.dependency', function () {
+        self.__showInputDependencies();
+      });
+      originalClick.call(self);
+    };
+    const BaseInputCalloutBtn = __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend({
+      children: [__WEBPACK_IMPORTED_MODULE_2__util_ButtonFactory__["default"].create(btnOptions)]
+    });
+
+    return new BaseInputCalloutBtn();
+  },
+
+  getCalloutParent: function () {
+    return this.$('input[value="' + this.getModelValue() + '"]').parent();
+  },
+
+  __getCalloutMsgContainer: function (calloutMsg) {
+    return __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend({
+      template: '\
+        <span class="o-form-explain">\
+           {{msg}}\
+        </span>\
+        ',
+      getTemplateData: function () {
+        return {
+          msg: calloutMsg
+        };
+      }
+    });
+  },
+
+  showCallout: function (calloutConfig, dependencyResolved) {
+    const callout = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(calloutConfig);
+
+    callout.className = 'dependency-callout';
+    if (callout.btn) {
+      callout.content = this.__getDependencyCalloutBtn(callout.btn);
+      delete callout.btn;
+    }
+    const dependencyCallout = __WEBPACK_IMPORTED_MODULE_5__components_Callout__["a" /* default */].create(callout);
+
+    if (!dependencyResolved) {
+      dependencyCallout.add(this.__getCalloutMsgContainer(__WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('dependency.callout.msg', 'courage')));
+    }
+    const calloutParent = this.getCalloutParent();
+
+    calloutParent.append(dependencyCallout.render().el);
+    if (callout.type === 'success') {
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].delay(function () {
+        // fade out success callout
+        dependencyCallout.$el.fadeOut(800);
+      }, 1000);
+    }
+  },
+
+  removeCallout: function () {
+    this.$el.find('.dependency-callout').remove();
+  },
+
+  __evaluateCalloutObject: function (dependencyResolved, calloutTitle) {
+    let defaultCallout;
+
+    if (dependencyResolved) {
+      defaultCallout = {
+        title: __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('dependency.action.completed', 'courage'),
+        size: 'large',
+        type: 'success'
+      };
+    } else {
+      defaultCallout = {
+        title: __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].localize('dependency.action.required', 'courage', [calloutTitle]),
+        size: 'large',
+        type: 'warning'
+      };
+    }
+    return defaultCallout;
+  },
+
+  __handleDependency: function (result, callout) {
+    const self = this;
+    const calloutConfig = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(callout)
+      ? callout(result)
+      : __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, callout, self.__evaluateCalloutObject(result.resolved, callout.title));
+
+    // remove existing callouts if any
+    self.removeCallout();
+    self.showCallout(calloutConfig, result.resolved);
+  },
+
+  __showInputDependencies: function () {
+    const self = this;
+    const fieldDependency = self.options.deps[self.getModelValue()];
+
+    if (fieldDependency && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(fieldDependency.func)) {
+      fieldDependency
+        .func()
+        .done(function (data) {
+          self.__handleDependency({ resolved: true, data: data }, fieldDependency.callout);
+        })
+        .fail(function (data) {
+          self.__handleDependency({ resolved: false, data: data }, fieldDependency.callout);
+        });
+    } else {
+      self.removeCallout();
+    }
+  },
+
+  _isEdited: false,
+  /**
+   * updates the model with the input's value
+   */
+  update: function () {
+    if (!this._isEdited && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this.options, 'validateOnlyIfDirty')) {
+      this._isEdited = true;
+      this.addInlineValidation();
+    }
+    this.model.set(this.options.name, this.toModelValue());
+    if (this.options.deps) {
+      // check for dependencies
+      this.__showInputDependencies();
+    }
+  },
+
+  /**
+   * Is the input in edit mode
+   * @return {Boolean}
+   */
+  isEditMode: function () {
+    const ret =
+      !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this.options, 'readOnly') &&
+      (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this.options, 'read') !== true || this.model.get('__edit__') === true);
+
+    return ret;
+  },
+
+  /**
+   * Renders the input
+   * @readonly
+   */
+  render: function () {
+    this.preRender();
+    const params = this.options.params;
+
+    this.options.params = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.options, 'params', this);
+
+    if (this.isEditMode()) {
+      this.editMode();
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.options, 'disabled', this)) {
+        this.disable();
+      } else {
+        this.enable();
+      }
+    } else {
+      this.readMode();
+    }
+
+    this.options.params = params;
+    this.addAriaLabel();
+    this.postRender();
+
+    return this;
+  },
+
+  /**
+   * checks if the current value in the model is valid for this field
+   */
+  validate: function () {
+    if (!this.model.get('__pending__') && this.isEditMode() && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.model.validateField)) {
+      const validationError = this.model.validateField(this.options.name);
+
+      if (validationError) {
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].delay(
+          function () {
+            this.model.trigger('form:clear-error:' + this.options.name);
+            this.model.trigger('invalid', this.model, validationError, false);
+          }.bind(this),
+          100
+        );
+      }
+    }
+  },
+
+  /**
+   * Add model event listeners
+   */
+  addModelListeners: function () {
+    this.listenTo(this.model, 'form:field-error', function (name) {
+      if (this.options.name === name) {
+        this.__markError();
+      }
+    });
+    this.listenTo(this.model, 'form:clear-errors change:' + this.options.name, this.__clearError);
+    this.listenTo(this.model, 'form:clear-error:' + this.options.name, this.__clearError);
+  },
+
+  /**
+   * The value of the input
+   * @return {Mixed}
+   */
+  val: function () {
+    throw new Error('val() is an abstract method');
+  },
+
+  /**
+   * Set focus on the input
+   */
+  focus: function () {
+    throw new Error('focus() is an abstract method');
+  },
+
+  /**
+   * Default value in read mode
+   * When model has no value for the field
+   */
+  defaultValue: function () {
+    return '';
+  },
+
+  /**
+   * Renders the input in edit mode
+   */
+  editMode: function () {
+    const options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, this.options, {
+      value: this.getModelValue()
+    });
+
+    this.$el.html(this.template(options));
+    this.options.multi && this.$el.removeClass('margin-r');
+    return this;
+  },
+
+  /**
+   * Renders the readable value of the input in read mode
+   */
+  readMode: function () {
+    this.$el.text(this.getReadModeString());
+    this.$el.removeClass('error-field');
+    this.options.multi && this.$el.addClass('margin-r');
+    return this;
+  },
+
+  getReadModeString: function () {
+    const readModeStr = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.options, 'readModeString', this);
+
+    if (readModeStr) {
+      return readModeStr;
+    }
+    return this.toStringValue();
+  },
+
+  /**
+   * The model value off the field associated with the input
+   * @return {Mixed}
+   */
+  getModelValue: function () {
+    let value = this.model.get(this.options.name);
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.from)) {
+      value = this.from.call(this, value);
+    }
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.options.from)) {
+      value = this.options.from.call(this, value);
+    }
+    return value;
+  },
+
+  /*
+  * convenience method to get the textual value from the model
+  * will return the textual label rather than value in case of select/radio
+  * @return {String}
+  */
+  toStringValue: function () {
+    let value = this.getModelValue();
+
+    if (this.options.options) {
+      // dropdown or radio
+      value = this.options.options[value];
+    }
+    return value || this.defaultValue();
+  },
+
+  /**
+   * Triggers a form:resize event in order to tell dialogs content size has changed
+   */
+  resize: function () {
+    this.model.trigger('form:resize');
+  },
+
+  /**
+   * Disable the input
+   */
+  disable: function () {
+    this.$(':input').prop('disabled', true);
+  },
+
+  /**
+   * Enable the input
+   */
+  enable: function () {
+    this.$(':input').prop('disabled', false);
+  },
+
+  /**
+   * Change the type of the input field. (e.g., text <--> password)
+   * @param type
+   */
+  changeType: function (type) {
+    this.$(':input').prop('type', type);
+    // Update the options so that it keeps the uptodate state
+    this.options.type = type;
+  },
+
+  getNameString: function () {
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(this.options.name)) {
+      return this.options.name.join('-');
+    }
+    return this.options.name;
+  },
+
+  /**
+   * Get parameters, computing _.result
+   * @param  {[type]} options alternative options
+   * @return {Object} the params
+   */
+  getParams: function (options) {
+    const opts = options || this.options || {};
+
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(opts, 'params', this) || {});
+  },
+
+  /**
+   * get a parameter from options.params, compute _.result when needed.
+   * @param  {String} key
+   * @param  {Object} defaultValue
+   * @return {Object} the params
+   */
+  getParam: function (key, defaultValue) {
+    const result = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.getParams(), key, this);
+
+    return !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(result) ? result : defaultValue;
+  },
+
+  /**
+   * Get a parameter from options.params or if empty, object attribute.
+   *
+   * @param  {String} key
+   * @return {Object} the param or attribute
+   */
+  getParamOrAttribute: function (key) {
+    return this.getParam(key) || __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, key);
+  },
+
+  __markError: function () {
+    this.$el.addClass('o-form-has-errors');
+  },
+
+  __clearError: function () {
+    this.$el.removeClass('o-form-has-errors');
+  }
+}));
+
 
 /***/ }),
 /* 11 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(39)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Model) {
-  /**
-   * Wrapper around the more generic {@link src/framework/Model} that
-   * contains Okta-specific logic.
-   * @class module:Okta.Model
-   * @extends src/framework/Model
-   */
-  return Model.extend(/** @lends module:Okta.Model.prototype */ {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__framework_Model__ = __webpack_require__(37);
 
+
+
+/**
+ * Wrapper around the more generic {@link src/framework/Model} that
+ * contains Okta-specific logic.
+ * @class module:Okta.Model
+ * @extends src/framework/Model
+ */
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_1__framework_Model__["a" /* default */].extend(
+  /** @lends module:Okta.Model.prototype */ {
     /**
      * Is the end point using the legacy "secureJSON" format
      * @type {Function|Boolean}
@@ -1556,311 +1627,344 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     secureJSON: false,
 
     _builtInLocalProps: {
-      '__edit__': 'boolean',
-      '__pending__': 'boolean'
+      __edit__: 'boolean',
+      __pending__: 'boolean'
     },
 
     constructor: function () {
-      this.local = _.defaults({}, _.result(this, 'local'), this._builtInLocalProps);
+      this.local = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults({}, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'local'), this._builtInLocalProps);
 
-      if (_.result(this, 'secureJSON')) {
-        this.sync = _.wrap(this.sync, function (sync, method, model, options) {
-          return sync.call(this, method, model, _.extend({dataType: 'secureJSON'}, options));
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'secureJSON')) {
+        this.sync = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].wrap(this.sync, function (sync, method, model, options) {
+          return sync.call(this, method, model, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({ dataType: 'secureJSON' }, options));
         });
       }
 
-      Model.apply(this, arguments);
+      __WEBPACK_IMPORTED_MODULE_1__framework_Model__["a" /* default */].apply(this, arguments);
     }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+));
 
 
 /***/ }),
 /* 12 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, exports) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(4)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, StringUtil) {
-
-  var loc = StringUtil.localize;
-
-  var SchemaUtils = {
-    STRING: 'string',
-    NUMBER: 'number',
-    INTEGER: 'integer',
-    BOOLEAN: 'boolean',
-    OBJECT: 'object',
-    FORMATDISPLAYTYPE: {
-      'date-time': 'date',
-      'uri': 'uri',
-      'email': 'email',
-      'country-code': 'country-code',
-      'language-code': 'language-code',
-      'locale': 'locale',
-      'timezone': 'timezone',
-      'ref-id': 'reference'
-    },
-    ARRAYDISPLAYTYPE: {
-      'arrayofobject': 'arrayofobject',
-      'arrayofstring': 'arrayofstring',
-      'arrayofnumber': 'arrayofnumber',
-      'arrayofinteger': 'arrayofinteger',
-      'arrayofref-id': 'arrayofref-id'
-    },
-    DISPLAYTYPES: {
-      'date': {'type': 'string', 'format': 'date-time'},
-      'uri': {'type': 'string', 'format': 'uri'},
-      'email': {'type': 'string', 'format': 'email'},
-      'country-code': {'type': 'string', 'format': 'country-code'},
-      'language-code': {'type': 'string', 'format': 'language-code'},
-      'locale': {'type': 'string', 'format': 'locale'},
-      'timezone': {'type': 'string', 'format': 'timezone'},
-      'string': {'type': 'string'},
-      'number': {'type': 'number'},
-      'boolean': {'type': 'boolean'},
-      'integer': {'type': 'integer'},
-      'reference': {'type': 'string', 'format': 'ref-id'},
-      'arrayofobject': {'type': 'array', 'items': {'type': 'object'}},
-      'arrayofstring': {'type': 'array', 'items': {'type': 'string'}},
-      'arrayofnumber': {'type': 'array', 'items': {'type': 'number'}},
-      'arrayofinteger': {'type': 'array', 'items': {'type': 'integer'}},
-      'arrayofref-id': {'type': 'array', 'items': {'type': 'string', 'format': 'ref-id'}},
-      'image': {'type': 'image'},
-      'password': {'type': 'string'}
-    },
-    SUPPORTSMINMAX: [
-      'string',
-      'number',
-      'integer',
-      'password'
-    ],
-    SUPPORTENUM: [
-      'string',
-      'number',
-      'integer',
-      'object',
-      'arrayofstring',
-      'arrayofnumber',
-      'arrayofinteger',
-      'arrayofobject'
-    ],
-    DATATYPE: {
-      'string': 'string',
-      'number': 'number',
-      'boolean': 'boolean',
-      'integer': 'integer',
-      'date': 'datetime',
-      'object': 'object',
-      'arrayofobject': 'object array',
-      'arrayofstring': 'string array',
-      'arrayofnumber': 'number array',
-      'arrayofinteger': 'integer array',
-      'arrayofref-id': 'reference array',
-      'country-code': 'country code',
-      'language-code': 'language code',
-      'reference': 'reference',
-      'timezone': 'timezone',
-      'image': 'image'
-    },
-    MUTABILITY: {
-      READONLY: 'READ_ONLY',
-      WRITEONLY: 'WRITE_ONLY',
-      READWRITE: 'READ_WRITE',
-      IMMUTABLE: 'IMMUTABLE'
-    },
-    SCOPE: {
-      NONE: 'NONE',
-      SELF: 'SELF',
-      SYSTEM: 'SYSTEM'
-    },
-    DISPLAYSCOPE: {
-      SELF: 'User personal',
-      SYSTEM: 'System',
-      NA: 'None'
-    },
-    UNION: {
-      DISABLE: 'DISABLE',
-      ENABLE: 'ENABLE'
-    },
-    UNION_OPTIONS: {
-      'DISABLE': loc('universal-directory.profiles.attribute.form.union.enable.display', 'courage'),
-      'ENABLE': loc('universal-directory.profiles.attribute.form.union.disable.display', 'courage')
-    },
-    PERMISSION: {
-      HIDE: 'HIDE',
-      READ_ONLY: 'READ_ONLY',
-      WRITE_ONLY: 'WRITE_ONLY',
-      READ_WRITE: 'READ_WRITE'
-    },
-    ENDUSER_ATTRIBUTE_PERMISSION_OPTIONS: {
-      HIDE: loc('universal-directory.profiles.attribute.enduser.permission.hide', 'courage'),
-      READ_ONLY: loc('universal-directory.profiles.attribute.enduser.permission.readonly', 'courage'),
-      READ_WRITE: loc('universal-directory.profiles.attribute.enduser.permission.readwrite', 'courage')
-    },
-    ATTRIBUTE_LEVEL_MASTERING_OPTIONS: {
-      INHERIT: loc('universal-directory.profiles.attribute.master.inherit', 'courage'),
-      OKTA_MASTERED: loc('universal-directory.profiles.attribute.master.oktamastered', 'courage'),
-      OVERRIDE: loc('universal-directory.profiles.attribute.master.override', 'courage')
-    },
-    USERNAMETYPE: {
-      NONE: 'non-username',
-      OKTA_TO_APP: 'okta-to-app-username',
-      OKTA_TO_AD: 'okta-to-ad-username',
-      APP_TO_OKTA: 'app-to-okta-username',
-      IDP_TO_OKTA: 'idp-to-okta-username'
-    },
-    LOGINPATTERNFORMAT: {
-      EMAIL: 'EMAIL',
-      CUSTOM: 'CUSTOM',
-      NONE: 'NONE'
-    },
-
-    /*
-     * Get a display string for a schema attribute type.
-     * @param {String} type Type of an attribute
-     * @param {String} format Format of an attribute
-     * @param {String} itemType Item type of an attribute if an array
-     * @param {String} defaultValue The default value if an attribute type is undefined
-     * @return {String} the display value
-     */
-    getDisplayType: function (type, format, itemType, defaultValue) {
-      var displayType;
-      // type is undefined for
-      // - an un-mapped source attribute from mapping
-      // - an source attribute which is mapped to username target attribute
-      if (type) {
-        // format is only defined for complicated types (ex. reference, date time, array)
-        // not for simple types (ex. string, integer, boolean)
-        if (format) {
-          displayType = this.FORMATDISPLAYTYPE[format];
-        } else {
-          // itemType is only defined for array type
-          // to specify an array element type (ex. string, integer, number)
-          displayType = itemType ? this.ARRAYDISPLAYTYPE[type + 'of' + itemType] : type;
-        }
-      }
-      if (!displayType) {
-        displayType = typeof defaultValue == 'undefined' ? '' : defaultValue;
-      }
-      return displayType;
-    },
-
-    /*
-     * Get attribute mapping source attribute username type
-     * @param {String} mappingDirection
-     * @param {String} targetName The mapping target attribute name
-     * @param {String} appName The app name that's mapped to/from Okta
-     * @return {String} the source attribute username type value
-     */
-    getSourceUsernameType: function (mappingDirection, targetName, appName) {
-      /* eslint complexity: [2, 7] */
-      var sourceUsernameType = this.USERNAMETYPE.NONE;
-      if (mappingDirection === 'oktaToApp') {
-        if (targetName === 'userName') {
-          sourceUsernameType = this.USERNAMETYPE.OKTA_TO_APP;
-        } else if (targetName === 'cn') {
-          sourceUsernameType = this.USERNAMETYPE.OKTA_TO_AD;
-        }
-      } else if (mappingDirection === 'appToOkta' && targetName === 'login') {
-        if (appName === 'saml_idp') {
-          sourceUsernameType = this.USERNAMETYPE.IDP_TO_OKTA;
-        } else {
-          sourceUsernameType = this.USERNAMETYPE.APP_TO_OKTA;
-        }
-      }
-      return sourceUsernameType;
-    },
-
-    isArrayDataType: function (type) {
-      return _.contains(_.values(this.ARRAYDISPLAYTYPE), type);
-    },
-
-    isObjectDataType: function (type) {
-      return this.DATATYPE.object === type;
-    }
-  };
-
-  return SchemaUtils;
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
+module.exports = require("jquery");
 
 /***/ }),
 /* 13 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-var __WEBPACK_AMD_DEFINE_RESULT__;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__StringUtil__ = __webpack_require__(4);
 
-// TODO: maybe replaced by
-// https://github.com/Calvein/empty-module
-// https://github.com/crimx/empty-module-loader
-!(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {}).call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+
+const loc = __WEBPACK_IMPORTED_MODULE_1__StringUtil__["default"].localize;
+const SchemaUtils = {
+  STRING: 'string',
+  NUMBER: 'number',
+  INTEGER: 'integer',
+  BOOLEAN: 'boolean',
+  OBJECT: 'object',
+  FORMATDISPLAYTYPE: {
+    'date-time': 'date',
+    uri: 'uri',
+    email: 'email',
+    // TODO: settle on using EITHER underscores OR hyphens --- not both (OKTA-202818)
+    'country-code': 'country-code',
+    'language-code': 'language-code',
+    'country_code': 'country_code',
+    'language_code': 'language_code',
+    locale: 'locale',
+    timezone: 'timezone',
+    'ref-id': 'reference'
+  },
+  ARRAYDISPLAYTYPE: {
+    arrayofobject: 'arrayofobject',
+    arrayofstring: 'arrayofstring',
+    arrayofnumber: 'arrayofnumber',
+    arrayofinteger: 'arrayofinteger',
+    'arrayofref-id': 'arrayofref-id'
+  },
+  DISPLAYTYPES: {
+    date: { type: 'string', format: 'date-time' },
+    uri: { type: 'string', format: 'uri' },
+    email: { type: 'string', format: 'email' },
+    // TODO: Resolve inconsistencies in hyphens vs. underscores for these properties (OKTA-202818)
+    'country-code': { type: 'string', format: 'country-code' },
+    'language-code': { type: 'string', format: 'language-code' },
+    'country_code': { type: 'string' },
+    'language_code': { type: 'string' },
+    locale: { type: 'string', format: 'locale' },
+    timezone: { type: 'string', format: 'timezone' },
+    string: { type: 'string' },
+    number: { type: 'number' },
+    boolean: { type: 'boolean' },
+    integer: { type: 'integer' },
+    reference: { type: 'string', format: 'ref-id' },
+    arrayofobject: { type: 'array', items: { type: 'object' } },
+    arrayofstring: { type: 'array', items: { type: 'string' } },
+    arrayofnumber: { type: 'array', items: { type: 'number' } },
+    arrayofinteger: { type: 'array', items: { type: 'integer' } },
+    'arrayofref-id': { type: 'array', items: { type: 'string', format: 'ref-id' } },
+    image: { type: 'image' },
+    password: { type: 'string' }
+  },
+  SUPPORTSMINMAX: ['string', 'number', 'integer', 'password'],
+  SUPPORTENUM: [
+    'string',
+    'number',
+    'integer',
+    'object',
+    'arrayofstring',
+    'arrayofnumber',
+    'arrayofinteger',
+    'arrayofobject',
+  ],
+  DATATYPE: {
+    string: 'string',
+    number: 'number',
+    boolean: 'boolean',
+    integer: 'integer',
+    date: 'datetime',
+    object: 'object',
+    arrayofobject: 'object array',
+    arrayofstring: 'string array',
+    arrayofnumber: 'number array',
+    arrayofinteger: 'integer array',
+    'arrayofref-id': 'reference array',
+    // TODO: settle on using EITHER underscores OR hyphens --- not both (OKTA-202818)
+    'country-code': 'country code',
+    'language-code': 'language code',
+    'country_code': 'country code',
+    'language_code': 'language code',
+    reference: 'reference',
+    timezone: 'timezone',
+    image: 'image'
+  },
+  MUTABILITY: {
+    READONLY: 'READ_ONLY',
+    WRITEONLY: 'WRITE_ONLY',
+    READWRITE: 'READ_WRITE',
+    IMMUTABLE: 'IMMUTABLE'
+  },
+  SCOPE: {
+    NONE: 'NONE',
+    SELF: 'SELF',
+    SYSTEM: 'SYSTEM'
+  },
+  DISPLAYSCOPE: {
+    SELF: 'User personal',
+    SYSTEM: 'System',
+    NA: 'None'
+  },
+  UNION: {
+    DISABLE: 'DISABLE',
+    ENABLE: 'ENABLE'
+  },
+  UNION_OPTIONS: {
+    DISABLE: loc('universal-directory.profiles.attribute.form.union.enable.display', 'courage'),
+    ENABLE: loc('universal-directory.profiles.attribute.form.union.disable.display', 'courage')
+  },
+  PERMISSION: {
+    HIDE: 'HIDE',
+    READ_ONLY: 'READ_ONLY',
+    WRITE_ONLY: 'WRITE_ONLY',
+    READ_WRITE: 'READ_WRITE'
+  },
+  ENDUSER_ATTRIBUTE_PERMISSION_OPTIONS: {
+    HIDE: loc('universal-directory.profiles.attribute.enduser.permission.hide', 'courage'),
+    READ_ONLY: loc('universal-directory.profiles.attribute.enduser.permission.readonly', 'courage'),
+    READ_WRITE: loc('universal-directory.profiles.attribute.enduser.permission.readwrite', 'courage')
+  },
+  ATTRIBUTE_LEVEL_MASTERING_OPTIONS: {
+    INHERIT: loc('universal-directory.profiles.attribute.master.inherit', 'courage'),
+    OKTA_MASTERED: loc('universal-directory.profiles.attribute.master.oktamastered', 'courage'),
+    OVERRIDE: loc('universal-directory.profiles.attribute.master.override', 'courage')
+  },
+  USERNAMETYPE: {
+    NONE: 'non-username',
+    OKTA_TO_APP: 'okta-to-app-username',
+    OKTA_TO_AD: 'okta-to-ad-username',
+    APP_TO_OKTA: 'app-to-okta-username',
+    IDP_TO_OKTA: 'idp-to-okta-username'
+  },
+  LOGINPATTERNFORMAT: {
+    EMAIL: 'EMAIL',
+    CUSTOM: 'CUSTOM',
+    NONE: 'NONE'
+  },
+
+  /*
+   * Get a display string for a schema attribute type.
+   * @param {String} type Type of an attribute
+   * @param {String} format Format of an attribute
+   * @param {String} itemType Item type of an attribute if an array
+   * @param {String} defaultValue The default value if an attribute type is undefined
+   * @return {String} the display value
+   */
+  getDisplayType: function (type, format, itemType, defaultValue) {
+    let displayType;
+
+    // type is undefined for
+    // - an un-mapped source attribute from mapping
+    // - an source attribute which is mapped to username target attribute
+    if (type) {
+      // format is only defined for complicated types (ex. reference, date time, array)
+      // not for simple types (ex. string, integer, boolean)
+      if (format) {
+        displayType = this.FORMATDISPLAYTYPE[format];
+      } else {
+        // itemType is only defined for array type
+        // to specify an array element type (ex. string, integer, number)
+        displayType = itemType ? this.ARRAYDISPLAYTYPE[type + 'of' + itemType] : type;
+      }
+    }
+    if (!displayType) {
+      displayType = typeof defaultValue === 'undefined' ? '' : defaultValue;
+    }
+    return displayType;
+  },
+
+  /*
+   * Get attribute mapping source attribute username type
+   * @param {String} mappingDirection
+   * @param {String} targetName The mapping target attribute name
+   * @param {String} appName The app name that's mapped to/from Okta
+   * @return {String} the source attribute username type value
+   */
+  getSourceUsernameType: function (mappingDirection, targetName, appName) {
+    let sourceUsernameType = this.USERNAMETYPE.NONE;
+    /* eslint complexity: [2, 7] */
+
+    if (mappingDirection === 'oktaToApp') {
+      if (targetName === 'userName') {
+        sourceUsernameType = this.USERNAMETYPE.OKTA_TO_APP;
+      } else if (targetName === 'cn') {
+        sourceUsernameType = this.USERNAMETYPE.OKTA_TO_AD;
+      }
+    } else if (mappingDirection === 'appToOkta' && targetName === 'login') {
+      if (appName === 'saml_idp') {
+        sourceUsernameType = this.USERNAMETYPE.IDP_TO_OKTA;
+      } else {
+        sourceUsernameType = this.USERNAMETYPE.APP_TO_OKTA;
+      }
+    }
+    return sourceUsernameType;
+  },
+
+  isArrayDataType: function (type) {
+    return __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].contains(__WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].values(this.ARRAYDISPLAYTYPE), type);
+  },
+
+  isObjectDataType: function (type) {
+    return this.DATATYPE.object === type;
+  }
+};
+/* harmony default export */ __webpack_exports__["a"] = (SchemaUtils);
+
 
 /***/ }),
 /* 14 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(11)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Model) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__framework_Collection__ = __webpack_require__(36);
 
-  /**
-   * @class module:Okta.BaseModel
-   * @extends module:Okta.Model
-   * @deprecated Use {@link module:Okta.Model|Okta.Model} instead
-   * @example
-   * var Model = BaseModel.extend({
-   *   defaults: {
-   *     name: BaseModel.ComputedProperty(['fname', 'lname'], function (fname, lname) {
-   *       return fname + ' ' + lname;
-   *     })
-   *   }
-   * });
-   * var model = new Model({fname: 'Joe', lname: 'Doe'});
-   * model.get('name'); //=> "Joe Doe"
-   * model.toJSON(); //=> {fname: 'Joe', lname: 'Doe'}
-   *
-   * model.set('__private__', 'private property');
-   * model.get('__private__'); //=> "private property"
-   * model.toJSON(); //=> {fname: 'Joe', lname: 'Doe'}
-   */
 
-  var hasProps = function (model) {
-    var local = _.omit(model.local, _.keys(model._builtInLocalProps));
-    return _.size(model.props) + _.size(local) > 0;
-  };
 
-  var BaseModel = Model.extend(/** @lends module:Okta.BaseModel.prototype */ {
+/**
+ * Wrapper around the more generic {@link src/framework/Collection} that
+ * contains Okta-specific logic.
+ * @class module:Okta.Collection
+ * @extends src/framework/Collection
+ */
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_1__framework_Collection__["a" /* default */].extend(
+  /** @lends module:Okta.Collection.prototype */ {
+    /**
+     * Is the end point using the legacy "secureJSON" format
+     * @type {Function|Boolean}
+     */
+    secureJSON: false,
+
+    constructor: function () {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'secureJSON')) {
+        this.sync = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].wrap(this.sync, function (sync, method, collection, options) {
+          return sync.call(this, method, collection, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({ dataType: 'secureJSON' }, options));
+        });
+      }
+      __WEBPACK_IMPORTED_MODULE_1__framework_Collection__["a" /* default */].apply(this, arguments);
+    }
+  }
+));
+
+
+/***/ }),
+/* 15 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__Model__ = __webpack_require__(11);
+
+
+
+const hasProps = function (model) {
+  const local = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(model.local, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].keys(model._builtInLocalProps));
+
+  return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(model.props) + __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(local) > 0;
+};
+
+/**
+ * @class module:Okta.BaseModel
+ * @extends module:Okta.Model
+ * @deprecated Use {@link module:Okta.Model|Okta.Model} instead
+ * @example
+ * var Model = BaseModel.extend({
+ *   defaults: {
+ *     name: BaseModel.ComputedProperty(['fname', 'lname'], function (fname, lname) {
+ *       return fname + ' ' + lname;
+ *     })
+ *   }
+ * });
+ * var model = new Model({fname: 'Joe', lname: 'Doe'});
+ * model.get('name'); //=> "Joe Doe"
+ * model.toJSON(); //=> {fname: 'Joe', lname: 'Doe'}
+ *
+ * model.set('__private__', 'private property');
+ * model.get('__private__'); //=> "private property"
+ * model.toJSON(); //=> {fname: 'Joe', lname: 'Doe'}
+ */
+
+const BaseModelBaseModel = __WEBPACK_IMPORTED_MODULE_1__Model__["default"].extend(
+  /** @lends module:Okta.BaseModel.prototype */ {
     /**
      * @type {Boolean}
      */
     flat: false,
 
     constructor: function () {
-      Model.apply(this, arguments);
+      __WEBPACK_IMPORTED_MODULE_1__Model__["default"].apply(this, arguments);
       this.on('sync', this._setSynced);
     },
 
     allows: function () {
       if (hasProps(this)) {
-        return Model.prototype.allows.apply(this, arguments);
-      }
-      else {
+        return __WEBPACK_IMPORTED_MODULE_1__Model__["default"].prototype.allows.apply(this, arguments);
+      } else {
         return true;
       }
     },
 
     // bw compatibility support for old computed properties
     set: function (key, val) {
-      var attrs;
+      let attrs;
+
       if (typeof key === 'object') {
         attrs = key;
       } else {
@@ -1868,18 +1972,25 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
       }
 
       // computed properties
-      _(attrs).each(function (fn, attr) {
-        if (!fn || !_.isArray(fn.__attributes)) { return; }
-        this.on('change:' + fn.__attributes.join(' change:'), function () {
-          var val = this.get(attr);
-          if (val !== this['__schema__'].computedProperties[attr]) {
-            this['__schema__'].computedProperties[attr] = val;
-            this.trigger('change:' + attr, val);
-          }
-        }, this);
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])(attrs).each(function (fn, attr) {
+        if (!fn || !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(fn.__attributes)) {
+          return;
+        }
+        this.on(
+          'change:' + fn.__attributes.join(' change:'),
+          function () {
+            const val = this.get(attr);
+
+            if (val !== this['__schema__'].computedProperties[attr]) {
+              this['__schema__'].computedProperties[attr] = val;
+              this.trigger('change:' + attr, val);
+            }
+          },
+          this
+        );
       }, this);
 
-      return Model.prototype.set.apply(this, arguments);
+      return __WEBPACK_IMPORTED_MODULE_1__Model__["default"].prototype.set.apply(this, arguments);
     },
 
     /**
@@ -1890,9 +2001,10 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * @return {Mixed} The value of the model attribute
      */
     get: function () {
-      var value = Model.prototype.get.apply(this, arguments);
-      if (_.isFunction(value)) {
-        return value.apply(this, _.map(value.__attributes || [], this.get, this));
+      const value = __WEBPACK_IMPORTED_MODULE_1__Model__["default"].prototype.get.apply(this, arguments);
+
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(value)) {
+        return value.apply(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(value.__attributes || [], this.get, this));
       }
       return value;
     },
@@ -1918,11 +2030,11 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      */
     toJSON: function (options) {
       options || (options = {});
-      var res = Model.prototype.toJSON.apply(this, arguments);
+      const res = __WEBPACK_IMPORTED_MODULE_1__Model__["default"].prototype.toJSON.apply(this, arguments);
 
       // cleanup computed properties
-      _(res).each(function (value, key) {
-        if (typeof value == 'function') {
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])(res).each(function (value, key) {
+        if (typeof value === 'function') {
           if (options.verbose) {
             res[key] = this.get(key);
           } else {
@@ -1933,7 +2045,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
 
       // cleanup private properties
       if (!options.verbose) {
-        _(res).each(function (value, key) {
+        Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])(res).each(function (value, key) {
           if (/^__\w+__$/.test(key)) {
             delete res[key];
           }
@@ -1944,9 +2056,10 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     },
 
     sanitizeAttributes: function (attributes) {
-      var attrs = {};
-      _.each(attributes, function (value, key) {
-        if (!_.isFunction(value)) {
+      const attrs = {};
+
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(attributes, function (value, key) {
+        if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(value)) {
           attrs[key] = value;
         }
       });
@@ -1959,18 +2072,19 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     },
 
     clear: function (options) {
-      var attrs = {};
-      _.each(this.sanitizeAttributes(this.attributes), function (value, key) {
+      const attrs = {};
+
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(this.sanitizeAttributes(this.attributes), function (value, key) {
         attrs[key] = void 0;
       });
-      return this.set(attrs, _.extend({}, options, {unset: true}));
+      return this.set(attrs, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, options, { unset: true }));
     },
 
     /**
      * @private
      */
     _setSynced: function (newModel) {
-      this._syncedData = newModel && _.isFunction(newModel.toJSON) ? newModel.toJSON() : {};
+      this._syncedData = newModel && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(newModel.toJSON) ? newModel.toJSON() : {};
     },
 
     /**
@@ -1981,9 +2095,10 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     },
 
     isSynced: function () {
-      return _.isEqual(this._getSynced(), this.toJSON());
+      return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEqual(this._getSynced(), this.toJSON());
     }
-  }, /** @lends module:Okta.BaseModel.prototype */ {
+  },
+  /** @lends module:Okta.BaseModel.prototype */ {
     /**
      * @static
      *
@@ -2008,1250 +2123,1339 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * @deprecated Use {@link #derived} instead
      */
     ComputedProperty: function () {
-      var args = _.toArray(arguments);
-      var fn = args.pop();
+      const args = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].toArray(arguments);
+
+      const fn = args.pop();
+
       fn.__attributes = args.pop();
       return fn;
     }
-  });
-
-  return BaseModel;
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 15 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(40)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Collection) {
-  /**
-   * Wrapper around the more generic {@link src/framework/Collection} that
-   * contains Okta-specific logic.
-   * @class module:Okta.Collection
-   * @extends src/framework/Collection
-   */
-  return Collection.extend(/** @lends module:Okta.Collection.prototype */ {
-
-    /**
-     * Is the end point using the legacy "secureJSON" format
-     * @type {Function|Boolean}
-     */
-    secureJSON: false,
-
-    constructor: function () {
-      if (_.result(this, 'secureJSON')) {
-        this.sync = _.wrap(this.sync, function (sync, method, collection, options) {
-          return sync.call(this, method, collection, _.extend({dataType: 'secureJSON'}, options));
-        });
-      }
-      Collection.apply(this, arguments);
-    }
-
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+);
+/* harmony default export */ __webpack_exports__["default"] = (BaseModelBaseModel);
 
 
 /***/ }),
 /* 16 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(1)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__views_BaseView__ = __webpack_require__(1);
 
-  return {
-    redirect: function (url) {
-      window.location = url;
-    },
 
-    reloadPage: function () {
-      window.location.reload();
-    },
+/* harmony default export */ __webpack_exports__["default"] = ({
+  redirect: function (url) {
+    window.location = url;
+  },
 
-    constantError: function (errorMessage) {
-      return function () {
-        throw new Error(errorMessage);
-      };
-    },
+  reloadPage: function () {
+    window.location.reload();
+  },
 
-    /**
-     * Simply convert an URL query key value pair object into an URL query string.
-     * Remember NOT to escape the query string when using this util.
-     * example:
-     * input: {userId: 123, instanceId: undefined, expand: 'schema,app'}
-     * output: '?userId=123&expand=schema,app'
-     */
-    getUrlQueryString: function (queries) {
-      _.isObject(queries) || (queries = {});
-      var queriesString = _.without(_.map(queries, function (value, key) {
+  constantError: function (errorMessage) {
+    return function () {
+      throw new Error(errorMessage);
+    };
+  },
+
+  /**
+   * Simply convert an URL query key value pair object into an URL query string.
+   * Remember NOT to escape the query string when using this util.
+   * example:
+   * input: {userId: 123, instanceId: undefined, expand: 'schema,app'}
+   * output: '?userId=123&expand=schema,app'
+   */
+  getUrlQueryString: function (queries) {
+    __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isObject(queries) || (queries = {});
+
+    const queriesString = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].without(
+      __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].map(queries, function (value, key) {
         if (value !== undefined && value !== null) {
           return key + '=' + encodeURIComponent(value);
         }
-      }), undefined).join('&');
-      return _.isEmpty(queriesString) ? '' : '?' + queriesString;
-    },
+      }),
+      undefined
+    ).join('&');
 
-    isABaseView(obj) {
-      return obj instanceof BaseView || obj.prototype instanceof BaseView || obj === BaseView;
-    }
-  };
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+    return __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isEmpty(queriesString) ? '' : '?' + queriesString;
+  },
+
+  isABaseView(obj) {
+    return obj instanceof __WEBPACK_IMPORTED_MODULE_1__views_BaseView__["default"] || obj.prototype instanceof __WEBPACK_IMPORTED_MODULE_1__views_BaseView__["default"] || obj === __WEBPACK_IMPORTED_MODULE_1__views_BaseView__["default"];
+  }
+});
 
 
 /***/ }),
 /* 17 */
-/***/ (function(module, exports) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = require("handlebars");
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseCollection__ = __webpack_require__(14);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__BaseModel__ = __webpack_require__(15);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__util_Logger__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__views_forms_helpers_EnumTypeHelper__ = __webpack_require__(18);
+/* eslint max-statements: [2, 16], complexity: [2, 8], max-params: [2, 8] */
+
+
+
+
+
+
+
+
+const loc = __WEBPACK_IMPORTED_MODULE_6__util_StringUtil__["default"].localize;
+const STRING = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].STRING;
+const NUMBER = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].NUMBER;
+const INTEGER = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].INTEGER;
+const OBJECT = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].OBJECT;
+
+const getArrayTypeName = function (type, elementType) {
+  return type + 'of' + elementType;
+};
+
+const SchemaPropertySubSchema = __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].extend({
+  defaults: {
+    description: undefined,
+    minLength: undefined,
+    maxLength: undefined,
+    format: undefined
+  },
+  parse: function (resp) {
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(resp.format)) {
+      const matcher = /^\/(.+)\/$/.exec(resp.format);
+
+      if (matcher) {
+        resp.format = matcher[1];
+      }
+    }
+    return resp;
+  }
+});
+const SchemaPropertySubSchemaCollection = __WEBPACK_IMPORTED_MODULE_2__BaseCollection__["default"].extend({
+  model: SchemaPropertySubSchema
+});
+const SchemaPropertySubSchemaAllOfCollection = SchemaPropertySubSchemaCollection.extend({
+  _type: 'allOf'
+});
+const SchemaPropertySubSchemaOneOfCollection = SchemaPropertySubSchemaCollection.extend({
+  _type: 'oneOf'
+});
+const SchemaPropertySubSchemaNoneOfCollection = SchemaPropertySubSchemaCollection.extend({
+  _type: 'noneOf'
+});
+const constraintTypeErrorMessages = {
+  string: loc('schema.validation.field.value.must.string', 'courage'),
+  number: loc('schema.validation.field.value.must.number', 'courage'),
+  integer: loc('schema.validation.field.value.must.integer', 'courage'),
+  object: loc('schema.validation.field.value.must.object', 'courage')
+};
+const loginFormatNonePattern = '.+';
+const escapedLoginCharsRe = /[^a-zA-Z0-9-]/;
+const SchemaPropertySchemaProperty = __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].extend({
+  constraintHandlers: {
+    between: '_checkBetweenConstraints',
+    greaterThan: '_checkGreaterThanConstraint',
+    lessThan: '_checkLessThanConstraint',
+    equals: '_checkEqualsConstraint'
+  },
+
+  idAttribute: 'name',
+
+  local: {
+    __oneOf__: {
+      type: 'array',
+      minItems: 1
+    }
+  },
+
+  defaults: {
+    // OKTA-28445, set empty string by default as the key for each property when syncing with server
+    // so that server can respond with error when a name is not provided
+    name: '',
+    title: undefined,
+    type: undefined,
+    description: undefined,
+    required: false,
+    format: undefined,
+    // choose disable option be default.
+    union: undefined,
+    subSchemas: undefined,
+    settings: { permissions: { SELF: __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].PERMISSION.READ_ONLY } },
+    __isSensitive__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['settings'], function (settings) {
+      return !!(settings && settings.sensitive);
+    }),
+    __userPermission__: __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].PERMISSION.READ_ONLY,
+    __displayType__: undefined,
+    __displayTypeLabel__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].DATATYPE[displayType] || displayType;
+    }),
+    __supportsMinMax__: false,
+    // use the private naming convention for these computed properties,
+    // to deal with the complexity in cloning schema with properties (toJSON({verbose: true})),
+    // to make sure these attributes are being excluded from api request
+    __isReadOnly__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['mutability'], function (mutability) {
+      return mutability === __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].MUTABILITY.READONLY;
+    }),
+    __isWriteOnly__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['mutability'], function (mutability) {
+      return mutability === __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].MUTABILITY.WRITEONLY;
+    }),
+    __displayScope__: undefined,
+    __isScopeSelf__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['scope'], function (scope) {
+      return scope === __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SCOPE.SELF;
+    }),
+    __isNoneScopeArrayType__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__isScopeSelf__', '__displayType__'], function (
+      isScopeSelf,
+      displayType
+    ) {
+      return !isScopeSelf && __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].isArrayDataType(displayType);
+    }),
+    __isImported__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['externalName'], function (externalName) {
+      return !!externalName;
+    }),
+    __isFromBaseSchema__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__schemaMeta__'], function (schemaMeta) {
+      return schemaMeta && schemaMeta.name === 'base';
+    }),
+    // Only UI can turn on __enumDefined__ and reprocess the enum/oneOf value; otherwise,
+    // it should leave existing value untouch
+    __enumDefined__: false,
+    __supportEnum__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].contains(__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SUPPORTENUM, displayType);
+    }),
+    __isNumberTypeEnum__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].contains([__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].NUMBER, __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].ARRAYDISPLAYTYPE.arrayofnumber], displayType);
+    }),
+    __isIntegerTypeEnum__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].contains([__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].INTEGER, __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].ARRAYDISPLAYTYPE.arrayofinteger], displayType);
+    }),
+    __isObjectTypeEnum__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].contains([__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].OBJECT, __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].ARRAYDISPLAYTYPE.arrayofobject], displayType);
+    }),
+    __isStringTypeEnum__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__displayType__'], function (displayType) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].contains([__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].STRING, __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].ARRAYDISPLAYTYPE.arrayofstring], displayType);
+    }),
+    __enumConstraintType__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(
+      ['__isStringTypeEnum__', '__isNumberTypeEnum__', '__isIntegerTypeEnum__', '__isObjectTypeEnum__'],
+      function (isStringType, isNumberType, isIntegerType, isObjectType) {
+        if (isStringType) {
+          return STRING;
+        }
+        if (isNumberType) {
+          return NUMBER;
+        }
+        if (isIntegerType) {
+          return INTEGER;
+        }
+        if (isObjectType) {
+          return OBJECT;
+        }
+      }
+    ),
+    __isEnumDefinedAndSupported__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__enumDefined__', '__supportEnum__'], function (
+      enumDefined,
+      supportEnum
+    ) {
+      return enumDefined && supportEnum;
+    }),
+    __isLoginOfBaseSchema__: __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].ComputedProperty(['__isFromBaseSchema__', 'name'], function (
+      isFromBaseSchema,
+      name
+    ) {
+      return isFromBaseSchema && name === 'login';
+    })
+  },
+
+  initialize: function () {
+    __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].prototype.initialize.apply(this, arguments);
+    this.listenTo(this, 'change:__displayType__', this._updateTypeFormatConstraints);
+    this.listenTo(this, 'change:type change:format change:items', this._updateDisplayType);
+    this.listenTo(this, 'change:__minVal__ change:__maxVal__', this._updateMinMax);
+    this.listenTo(this, 'change:__equals__', this._convertEqualsToMinMax);
+    this.listenTo(this, 'change:__constraint__', this._setConstraintText);
+    this._setConstraintText();
+    this._setLoginPattern();
+  },
+
+  parse: function (resp) {
+    /* eslint complexity: [2, 9] */
+    resp = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(resp);
+
+    if (resp.type === 'object' && resp.extendedType === 'image') {
+      resp.type = 'image';
+    }
+    resp['__displayType__'] = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].getDisplayType(
+      resp.type,
+      resp.format,
+      resp.items ? (resp.items.format ? resp.items.format : resp.items.type) : undefined
+    );
+    this._setRangeConstraints(resp);
+    resp['__supportsMinMax__'] = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SUPPORTSMINMAX.indexOf(resp['__displayType__']) !== -1;
+    resp['__displayScope__'] = __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].DISPLAYSCOPE[resp.scope] || __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].DISPLAYSCOPE.NA;
+    if (resp.settings && resp.settings.permissions && resp.settings.permissions.SELF) {
+      resp['__userPermission__'] = resp.settings.permissions.SELF;
+    }
+    this._setMasterOverride(resp);
+    this._setSubSchemas(resp);
+    return resp;
+  },
+
+  validate: function () {
+    const enumValidationError = this._validateEnumOneOf();
+
+    if (enumValidationError) {
+      return enumValidationError;
+    }
+
+    if (!this.get('__supportsMinMax__') || !this.get('__constraint__')) {
+      return undefined;
+    }
+
+    const constraitType = this.get('__constraint__');
+    const constraitHandler = this[this.constraintHandlers[constraitType]];
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(constraitHandler)) {
+      return constraitHandler.call(this);
+    } else {
+      __WEBPACK_IMPORTED_MODULE_4__util_Logger__["default"].warn('No constraint handler found for: ' + constraitType);
+      return undefined;
+    }
+  },
+
+  _checkBetweenConstraints: function () {
+    const minVal = this.get('__minVal__');
+    const maxVal = this.get('__maxVal__');
+
+    if (!minVal && !maxVal) {
+      return;
+    }
+    if (!minVal) {
+      return { __minVal__: 'Min value is required' };
+    }
+    if (!maxVal) {
+      return { __maxVal__: 'Max value is required' };
+    }
+
+    let val = this._checkIntegerConstraints('__minVal__', 'Min value');
+
+    if (val) {
+      return val;
+    }
+    val = this._checkIntegerConstraints('__maxVal__', 'Max value');
+    if (val) {
+      return val;
+    }
+    if (+minVal >= +maxVal) {
+      return { __maxVal__: 'Max val must be greater than min val' };
+    }
+  },
+
+  _checkGreaterThanConstraint: function () {
+    const minVal = this.get('__minVal__');
+
+    if (!minVal) {
+      return;
+    }
+
+    const val = this._checkIntegerConstraints('__minVal__', 'Min value');
+
+    if (val) {
+      return val;
+    }
+  },
+
+  _checkLessThanConstraint: function () {
+    const maxVal = this.get('__maxVal__');
+
+    if (!maxVal) {
+      return;
+    }
+
+    const val = this._checkIntegerConstraints('__maxVal__', 'Max value');
+
+    if (val) {
+      return val;
+    }
+  },
+
+  _checkEqualsConstraint: function () {
+    const equals = this.get('__equals__');
+
+    if (!equals) {
+      return;
+    }
+
+    const val = this._checkIntegerConstraints('__equals__', 'Constraint');
+
+    if (val) {
+      return val;
+    }
+  },
+
+  _checkIntegerConstraints: function (field, name) {
+    const val = this.get(field);
+    const error = {};
+
+    if (isNaN(val)) {
+      error[field] = name + ' must be a number';
+      return error;
+    }
+    if (+val < 0) {
+      error[field] = name + ' must be greater than 0';
+      return error;
+    }
+  },
+
+  _setMasterOverride: function (resp) {
+    if (resp.settings && resp.settings.masterOverride && resp.settings.masterOverride) {
+      const masterOverrideValue = resp.settings.masterOverride.value;
+
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(masterOverrideValue) && !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(masterOverrideValue)) {
+        resp['__masterOverrideType__'] = 'OVERRIDE';
+        resp['__masterOverrideValue__'] = masterOverrideValue || [];
+      } else {
+        resp['__masterOverrideType__'] = resp.settings.masterOverride.type;
+      }
+    } else {
+      resp['__masterOverrideType__'] = 'INHERIT';
+    }
+  },
+
+  _setRangeConstraints: function (resp) {
+    /* eslint complexity: [2, 11] */
+    if (resp['__displayType__'] === STRING) {
+      resp['__minVal__'] = resp.minLength;
+      resp['__maxVal__'] = resp.maxLength;
+    } else if (resp['__displayType__'] === INTEGER || resp['__displayType__'] === NUMBER) {
+      resp['__minVal__'] = resp.minimum;
+      resp['__maxVal__'] = resp.maximum;
+    }
+    if (resp['__minVal__'] && resp['__maxVal__']) {
+      if (resp['__minVal__'] === resp['__maxVal__']) {
+        resp['__constraint__'] = 'equals';
+        resp['__equals__'] = resp['__minVal__'];
+      } else {
+        resp['__constraint__'] = 'between';
+      }
+    } else if (!resp['__minVal__'] && resp['__maxVal__']) {
+      resp['__constraint__'] = 'lessThan';
+    } else if (!resp['__maxVal__'] && resp['__minVal__']) {
+      resp['__constraint__'] = 'greaterThan';
+    }
+  },
+
+  _setSubSchemas: function (resp) {
+    if (resp.allOf) {
+      resp['subSchemas'] = new SchemaPropertySubSchemaAllOfCollection(resp.allOf, { parse: true });
+    } else if (resp.oneOf) {
+      resp['subSchemas'] = new SchemaPropertySubSchemaOneOfCollection(resp.oneOf, { parse: true });
+    } else if (resp.noneOf) {
+      resp['subSchemas'] = new SchemaPropertySubSchemaNoneOfCollection(resp.noneOf, { parse: true });
+    }
+  },
+
+  _setLoginPattern: function () {
+    if (!this.get('__isLoginOfBaseSchema__')) {
+      return;
+    }
+
+    const pattern = this.get('pattern');
+
+    if (pattern === loginFormatNonePattern) {
+      this.set('__loginFormatRestriction__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.NONE);
+    } else if (pattern) {
+      this.set('__loginFormatRestriction__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.CUSTOM);
+      this.set('__loginFormatRestrictionCustom__', this._extractLoginPattern(pattern));
+    } else {
+      this.set('__loginFormatRestriction__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.EMAIL);
+    }
+  },
+
+  _updateDisplayType: function () {
+    const type = this.get('type');
+
+    if (type === STRING && this.get('format')) {
+      this.set('__displayType__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].FORMATDISPLAYTYPE[this.get('format')]);
+    } else {
+      const items = this.get('items');
+      const arraytype = items && (items.format ? items.format : items.type);
+
+      if (type && arraytype) {
+        this.set('__displayType__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].ARRAYDISPLAYTYPE[getArrayTypeName(type, arraytype)]);
+      } else {
+        this.set('__displayType__', type);
+      }
+    }
+  },
+
+  _validateEnumOneOf: function () {
+    if (!this.get('__isEnumDefinedAndSupported__')) {
+      return;
+    }
+
+    const enumOneOf = this.get('__oneOf__') || [];
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(enumOneOf)) {
+      return { __oneOf__: loc('model.validation.field.blank', 'courage') };
+    }
+
+    if (!this._isValidateOneOfConstraint(enumOneOf)) {
+      const constraintType = this.get('__enumConstraintType__');
+      const errorTypeMsg = constraintTypeErrorMessages[constraintType];
+
+      return { __oneOf__: errorTypeMsg };
+    }
+  },
+
+  _isValidateOneOfConstraint: function (values) {
+    const constraintType = this.get('__enumConstraintType__');
+
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].all(values, function (value) {
+      return __WEBPACK_IMPORTED_MODULE_7__views_forms_helpers_EnumTypeHelper__["a" /* default */].isConstraintValueMatchType(value.const, constraintType);
+    });
+  },
+
+  toJSON: function () {
+    let json = __WEBPACK_IMPORTED_MODULE_3__BaseModel__["default"].prototype.toJSON.apply(this, arguments);
+
+    json.settings = { permissions: {} };
+    json.settings.permissions['SELF'] = this.get('__userPermission__');
+
+    // omit "sensitive" filed will have default it value to false.
+    if (this.get('__isSensitive__')) {
+      json.settings.sensitive = this.get('__isSensitive__');
+    }
+    if (this.get('type') === 'image') {
+      json.type = 'object';
+      json.extendedType = 'image';
+    }
+
+    json = this._enumAssignment(json);
+    json = this._attributeOverrideToJson(json);
+    json = this._normalizeUnionValue(json);
+    json = this._patternAssignment(json);
+    return json;
+  },
+
+  _attributeOverrideToJson: function (json) {
+    const masterOverrideType = this.get('__masterOverrideType__');
+    const masterOverrideValue = this.get('__masterOverrideValue__');
+
+    if (masterOverrideType === 'OKTA_MASTERED') {
+      json.settings.masterOverride = { type: 'OKTA_MASTERED' };
+    } else if (masterOverrideType === 'OVERRIDE') {
+      json.settings.masterOverride = { type: 'ORDERED_LIST', value: [] };
+      if (masterOverrideValue instanceof __WEBPACK_IMPORTED_MODULE_2__BaseCollection__["default"]) {
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(masterOverrideValue.toJSON(), function (overrideProfile) {
+          json.settings.masterOverride.value.push(overrideProfile.id);
+        });
+      } else if (masterOverrideValue instanceof Array) {
+        json.settings.masterOverride.value = masterOverrideValue;
+      }
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(json.settings.masterOverride.value)) {
+        delete json.settings.masterOverride;
+      }
+    }
+
+    if (masterOverrideType === 'INHERIT') {
+      delete json.settings.masterOverride;
+    }
+    return json;
+  },
+
+  /**
+   * Only allow set "union" value when isScopeSelf is NONE and displayType is
+   * array of (string/number/integer), otherwise reset to default.
+   *
+   * @see /universal-directory/shared/views/components/UnionGroupValuesRadio.js
+   */
+  _normalizeUnionValue: function (json) {
+    if (!this.get('__isNoneScopeArrayType__')) {
+      json['union'] = undefined;
+    }
+
+    return json;
+  },
+
+  _enumAssignment: function (json) {
+    if (!this.get('__isEnumDefinedAndSupported__')) {
+      return json;
+    }
+
+    // backfill empty title by constraint
+
+    const enumOneOf = this._getEnumOneOfWithTitleCheck();
+
+    if (this.get('type') === 'array') {
+      delete json.items.enum;
+      json.items.oneOf = enumOneOf;
+    } else {
+      delete json.enum;
+      json.oneOf = enumOneOf;
+    }
+
+    return json;
+  },
+
+  _patternAssignment: function (json) {
+    if (!this.get('__isLoginOfBaseSchema__') || !this.get('__loginFormatRestriction__')) {
+      return json;
+    }
+
+    switch (this.get('__loginFormatRestriction__')) {
+    case __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.EMAIL:
+      delete json.pattern;
+      break;
+    case __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.CUSTOM:
+      json.pattern = this._buildLoginPattern(this.get('__loginFormatRestrictionCustom__'));
+      break;
+    case __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].LOGINPATTERNFORMAT.NONE:
+      json.pattern = loginFormatNonePattern;
+      break;
+    }
+
+    return json;
+  },
+
+  /**
+   * Character should be escaped except letters, digits and hyphen
+   */
+  _escapedRegexChar: function (pattern, index) {
+    const char = pattern.charAt(index);
+
+    if (escapedLoginCharsRe.test(char)) {
+      return '\\' + char;
+    }
+
+    return char;
+  },
+
+  _buildLoginPattern: function (pattern) {
+    let result = '';
+
+    for (var i = 0; i < pattern.length; i++) {
+      result = result + this._escapedRegexChar(pattern, i);
+    }
+
+    return '[' + result + ']+';
+  },
+
+  _extractLoginPattern: function (pattern) {
+    const re = /^\[(.*)\]\+/;
+    const matches = pattern.match(re);
+
+    return matches ? matches[1].replace(/\\(.)/g, '$1') : pattern;
+  },
+
+  _getEnumOneOfWithTitleCheck: function () {
+    const enumOneOf = this.get('__oneOf__');
+
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(enumOneOf, function (value) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(value.title) !== '') {
+        return value;
+      }
+
+      value.title = !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(value.const) ? JSON.stringify(value.const) : value.const;
+
+      return value;
+    });
+  },
+
+  _updateTypeFormatConstraints: function () {
+    const displayType = this.get('__displayType__');
+
+    // OKTA-31952 reset format according to its displayType
+    this.unset('format', { silent: true });
+    this.unset('items', { silent: true });
+    this.set(__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].DISPLAYTYPES[displayType]);
+    if (displayType !== NUMBER && displayType !== INTEGER) {
+      this.unset('minimum');
+      this.unset('maximum');
+    }
+    if (displayType !== STRING) {
+      this.unset('minLength');
+      this.unset('maxLength');
+    }
+
+    this.unset('__minVal__');
+    this.unset('__maxVal__');
+    this.unset('__equals__');
+    this.set('__supportsMinMax__', __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SUPPORTSMINMAX.indexOf(this.get('__displayType__')) !== -1);
+  },
+
+  _updateMinMax: function () {
+    let min;
+    let max;
+    const displayType = this.get('__displayType__');
+
+    if (displayType === STRING) {
+      min = 'minLength';
+      max = 'maxLength';
+    } else if (displayType === INTEGER || displayType === NUMBER) {
+      min = 'minimum';
+      max = 'maximum';
+    }
+
+    if (this.get('__minVal__')) {
+      this.set(min, parseInt(this.get('__minVal__'), 10));
+    } else {
+      this.unset(min);
+    }
+
+    if (this.get('__maxVal__')) {
+      this.set(max, parseInt(this.get('__maxVal__'), 10));
+    } else {
+      this.unset(max);
+    }
+  },
+
+  _convertEqualsToMinMax: function () {
+    const equals = this.get('__equals__');
+
+    if (equals) {
+      this.set('__minVal__', equals);
+      this.set('__maxVal__', equals);
+    }
+  },
+
+  /*
+   Normally we would use a derived property here but derived properties do not work with the model Clone function
+   so we use this workaround instead.
+   */
+  _setConstraintText: function () {
+    const constraint = this.get('__constraint__');
+    const min = this.get('__minVal__');
+    const max = this.get('__maxVal__');
+    const equals = this.get('__equals__');
+
+    switch (constraint) {
+    case 'between':
+      this.set('__constraintText__', 'Between ' + min + ' and ' + max);
+      break;
+    case 'greaterThan':
+      this.set('__constraintText__', 'Greater than ' + min);
+      break;
+    case 'lessThan':
+      this.set('__constraintText__', 'Less than ' + max);
+      break;
+    case 'equals':
+      this.set('__constraintText__', 'Equals ' + equals);
+      break;
+    default:
+      this.set('__constraintText__', '');
+      break;
+    }
+  },
+
+  cleanup: function () {
+    if (this.get('__constraint__') === 'lessThan') {
+      this.unset('__minVal__');
+    } else if (this.get('__constraint__') === 'greaterThan') {
+      this.unset('__maxVal__');
+    }
+    if (this.get('scope') !== __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SCOPE.SYSTEM) {
+      if (this.get('__isScopeSelf__') === true) {
+        this.set({ scope: __WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SCOPE.SELF }, { silent: true });
+      } else {
+        this.unset('scope');
+      }
+    }
+  },
+
+  /**
+   * Since there is not an dedicated attribute to flag enum type,
+   * use enum values to determine whether the property is enum type or not.
+   */
+  isEnumType: function () {
+    return !!this.getEnumValues();
+  },
+
+  getEnumValues: function () {
+    return (
+      this.get('oneOf') ||
+      this.get('enum') ||
+      (this.get('items') && this.get('items')['oneOf']) ||
+      (this.get('items') && this.get('items')['enum'])
+    );
+  },
+
+  detectHasEnumDefined: function () {
+    const enumValues = this.getEnumValues();
+
+    if (!enumValues) {
+      return;
+    }
+
+    this.set('__oneOf__', __WEBPACK_IMPORTED_MODULE_7__views_forms_helpers_EnumTypeHelper__["a" /* default */].convertToOneOf(enumValues));
+    this.set('__enumDefined__', true);
+  }
+});
+const SchemaPropertySchemaProperties = __WEBPACK_IMPORTED_MODULE_2__BaseCollection__["default"].extend({
+  model: SchemaPropertySchemaProperty,
+  clone: function () {
+    return new this.constructor(this.toJSON({ verbose: true }), { parse: true });
+  },
+  areAllReadOnly: function () {
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].all(this.pluck('__isReadOnly__'));
+  },
+  createModelProperties: function () {
+    return this.reduce(function (p, schemaProperty) {
+      const type = schemaProperty.get('type');
+
+      p[schemaProperty.id] = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].DISPLAYTYPES[type]);
+      if (__WEBPACK_IMPORTED_MODULE_5__util_SchemaUtil__["a" /* default */].SUPPORTSMINMAX.indexOf(type) !== -1) {
+        p[schemaProperty.id].minLength = schemaProperty.get('minLength');
+        p[schemaProperty.id].maxLength = schemaProperty.get('maxLength');
+      }
+      if (type === 'string') {
+        p[schemaProperty.id].format = schemaProperty.get('format');
+      }
+      return p;
+    }, {});
+  }
+});
+/* harmony default export */ __webpack_exports__["default"] = ({
+  Model: SchemaPropertySchemaProperty,
+  Collection: SchemaPropertySchemaProperties
+});
+
 
 /***/ }),
 /* 18 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint @okta/okta/enforce-requirejs-names: 0, @okta/okta/no-specific-modules: 0, max-params: 0, max-statements: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(17),
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(4),
-  __webpack_require__(38),
-  __webpack_require__(13)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (Handlebars, _, $, StringUtil, markdownToHtml, moment) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__ = __webpack_require__(4);
+/* eslint max-statements: 0 */
 
-  var CACHE_BUST_URL_PREFIX = '/assets';
 
-  function formatDate(format, dateInISOString) {
-    return moment.utc(dateInISOString).utcOffset('-07:00').format(format);
+
+
+const NAME = 'name';
+const ENUM_KEY_PREFIX = '_enum_';
+
+/**
+ * Generate Input Options in order to create an input in an Form for Enum type attribute.
+ * @param {Object} config informations for creating input options
+ *   config.name        schema property name
+ *   config.title       schema property title
+ *   config.readOnly    create an read only input?
+ *   config.explain     sub-title to the input
+ *   config.enumValues  list of enum values for creating input options (Dropdown/SimpleCheckBoxSet)
+ *   config.displayType display type of schema property
+ *
+ * @return {Object} inputOptions options for create an Input view. (Dropdown/SimpleCheckBoxSet)
+ *
+ */
+function getEnumInputOptions(config) {
+  const enumOneOf = convertToOneOf(config.enumValues);
+  const inputOptions = {
+    name: config.name,
+    label: config.title,
+    readOnly: config.readOnly,
+    customExplain: config.explain,
+    params: { enumOneOf: enumOneOf },
+    options: getDropdownOptionsFromOneOf(enumOneOf)
+  };
+
+  // input type
+  if (__WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__["a" /* default */].isArrayDataType(config.displayType)) {
+    inputOptions.type = 'checkboxset';
+    inputOptions.to = valuesToEnumObjects;
+    inputOptions.from = enumObjectsToValues;
+  } else {
+    inputOptions.type = 'select';
+    inputOptions.to = valueToEnumObject;
+    inputOptions.from = enumObjectToValue;
   }
 
-  function trim(str) {
-    return str && str.replace(/^\s+|\s+$/g, '');
+  inputOptions.input = null;
+  return inputOptions;
+}
+
+function getDropdownOptions(values) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(values) ? getDropdownOptionsFromOneOf(convertToOneOf(values)) : {};
+}
+
+function getDropdownOptionsFromOneOf(values) {
+  if (!isOneOfEnumObject(values)) {
+    return {};
   }
 
-  function prependCachebustPrefix(path) {
-    if (path.indexOf(CACHE_BUST_URL_PREFIX) === 0) {
-      return path;
-    }
-    return CACHE_BUST_URL_PREFIX + path;
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].reduce(
+    values,
+    function (options, value, index) {
+      options[convertIndexToEnumIndex(index)] = value.title;
+      return options;
+    },
+    {}
+  );
+}
+
+function convertToOneOf(values) {
+  // assume this is a legacy enum array and convert to oneOf object
+  if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].all(values, __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].isPlainObject)) {
+    return convertEnumToOneOf(values);
+
+    // we assume object without const and title is an enum object which need special conversion
+  } else if (!isOneOfEnumObject(values)) {
+    return convertEnumObjectToOneOf(values);
   }
 
-  Handlebars.registerHelper('i18n', function (options) {
-    var params,
-        key = trim(options.hash.code),
-        bundle = trim(options.hash.bundle),
-        args = trim(options.hash['arguments']);
+  return values;
+}
 
-    if (args) {
-      params = _.map(trim(args).split(';'), function (param) {
-        param = trim(param);
-        var val,
-            data = this;
-        /*
-         * the context(data) may be a deep object, ex {user: {name: 'John', gender: 'M'}}
-         * arguments may be 'user.name'
-         * return data['user']['name']
-         */
-        _.each(param.split('.'), function (p) {
-          val = val ? val[p] : data[p];
-        });
-        return val;
-      }, this);
-    }
+function isOneOfEnumObject(values) {
+  return (
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(values) &&
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].all(values, function (value) {
+      return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].has(value, 'const') && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].has(value, 'title');
+    })
+  );
+}
 
-    return StringUtil.localize(key, bundle, params);
+function convertEnumToOneOf(values) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(values, function (value) {
+    return {
+      const: value,
+      title: valueToTitle(value)
+    };
   });
+}
 
-  Handlebars.registerHelper('xsrfTokenInput', function () {
-    return new Handlebars.SafeString('<input type="hidden" class="hide" name="_xsrfToken" ' +
-           'value="' + $('#_xsrfToken').text() + '">');
+function valueToTitle(value) {
+  if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(value)) {
+    return JSON.stringify(value);
+  }
+
+  if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(value)) {
+    return value + '';
+  }
+
+  return value;
+}
+
+function convertEnumObjectToOneOf(values) {
+  const findKey = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].partial(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].has, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"], NAME);
+  // If all object found the key NAME, use the NAME's value as display name
+
+  if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].all(values, findKey)) {
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].chain(values)
+      .filter(function (value) {
+        return __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].isPlainObject(value) && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].has(value, NAME);
+      })
+      .map(function (value) {
+        return { const: value, title: value[NAME] };
+      })
+      .value();
+  }
+
+  // Assume a legacy object array does not need special handling and just convert to const/title enum
+  return convertEnumToOneOf(values);
+}
+
+function convertIndexToEnumIndex(index) {
+  return `${ENUM_KEY_PREFIX}${index}`;
+}
+
+function enumObjectToValue(obj) {
+  const index = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].findIndex(this.options.params.enumOneOf, function (oneOfObj) {
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(obj) ? __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEqual(oneOfObj.const, obj) : oneOfObj.const === obj;
   });
+  // Cannot rely on comparator in findIndex when compare objects so need special handling
 
-  Handlebars.registerHelper('img', function (options) {
-    /*global okta */
-    var cdn = (typeof okta != 'undefined' && okta.cdnUrlHostname || '');
-    var hash = _.pick(options.hash, ['src', 'alt', 'width', 'height', 'class', 'title']);
-    hash.src = '' + cdn + prependCachebustPrefix(hash.src);
-    var attrs = _.map(hash, function (value, attr) {
-      return attr + '="' + Handlebars.Utils.escapeExpression(value) + '"';
-    });
-    return new Handlebars.SafeString('<img ' + attrs.join(' ') + '/>');
-  });
+  return index > -1 ? convertIndexToEnumIndex(index) : obj;
+}
 
-  Handlebars.registerHelper('shortDate', _.partial(formatDate, 'MMM Do'));
-  Handlebars.registerHelper('mediumDate', _.partial(formatDate, 'MMMM DD, YYYY'));
-  Handlebars.registerHelper('longDate', _.partial(formatDate, 'MMMM DD, YYYY, h:mma'));
-  Handlebars.registerHelper('formatDate', formatDate);
+function valueToEnumObject(val) {
+  if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(val) || val.indexOf(ENUM_KEY_PREFIX) !== 0) {
+    return val;
+  }
 
+  const index = val.replace(ENUM_KEY_PREFIX, '');
+  const enumValue =
+    this.options.params && __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(this.options.params.enumOneOf) ? this.options.params.enumOneOf[index] : null;
 
-  Handlebars.registerHelper('markdown', function (mdText) {
-    return markdownToHtml(Handlebars, mdText);
-  });
+  // @see `getEnumInputOptions` how enumValues has been set.
 
-  return Handlebars;
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].has(enumValue, 'const') ? enumValue.const : enumValue;
+}
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+function valuesToEnumObjects(values) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(values, valueToEnumObject.bind(this));
+}
+
+function enumObjectsToValues(values) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(values, enumObjectToValue.bind(this));
+}
+
+function isStringConstraint(value) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(value) && __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(value) !== '';
+}
+
+function isNumberConstraint(value) {
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(value) || __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(__WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].parseFloat(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(value)));
+}
+
+function isIntegerConstraint(value) {
+  const integer = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(value) ? value : __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].parseInt(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(value));
+
+  return typeof integer === 'number' && isFinite(integer) && Math.floor(integer) === integer;
+}
+
+function isObjectConstraint(value) {
+  if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(value) && !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(value)) {
+    return true;
+  }
+
+  const object = __WEBPACK_IMPORTED_MODULE_3__util_StringUtil__["default"].parseObject(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(value));
+
+  return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(object) && !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(object);
+}
+
+function isConstraintValueMatchType(value, type) {
+  switch (type) {
+  case __WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__["a" /* default */].STRING:
+    return isStringConstraint(value);
+  case __WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__["a" /* default */].NUMBER:
+    return isNumberConstraint(value);
+  case __WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__["a" /* default */].INTEGER:
+    return isIntegerConstraint(value);
+  case __WEBPACK_IMPORTED_MODULE_2__util_SchemaUtil__["a" /* default */].OBJECT:
+    return isObjectConstraint(value);
+  }
+}
+
+/* harmony default export */ __webpack_exports__["a"] = ({
+  getEnumInputOptions: getEnumInputOptions,
+  getDropdownOptions: getDropdownOptions,
+  convertToOneOf: convertToOneOf,
+  isConstraintValueMatchType: isConstraintValueMatchType
+});
 
 
 /***/ }),
 /* 19 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-statements: [2, 15], complexity: [2, 8], max-params: [2, 8] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(15),
-  __webpack_require__(14),
-  __webpack_require__(6),
-  __webpack_require__(12),
-  __webpack_require__(4),
-  __webpack_require__(20)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, BaseCollection, BaseModel, Logger, SchemaUtil, StringUtil, EnumTypeHelper) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_backbone__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__Logger__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__SettingsModel__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__views_components_ConfirmationDialog__ = __webpack_require__(41);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__views_components_Notification__ = __webpack_require__(51);
+/* eslint max-len: [2, 150], max-params: [2, 7] */
 
-  var loc = StringUtil.localize;
 
-  var STRING = SchemaUtil.STRING,
-      NUMBER = SchemaUtil.NUMBER,
-      INTEGER = SchemaUtil.INTEGER,
-      OBJECT = SchemaUtil.OBJECT;
 
-  var getArrayTypeName = function (type, elementType) {
-    return type + 'of' + elementType;
-  };
 
-  var SubSchema = BaseModel.extend({
-    defaults: {
-      description: undefined,
-      minLength: undefined,
-      maxLength: undefined,
-      format: undefined
-    },
-    parse: function (resp) {
-      if (_.isString(resp.format)) {
-        var matcher = /^\/(.+)\/$/.exec(resp.format);
-        if (matcher) {
-          resp.format = matcher[1];
-        }
-      }
-      return resp;
-    }
-  });
 
-  var SubSchemaCollection = BaseCollection.extend({
-    model: SubSchema
-  });
 
-  var SubSchemaAllOfCollection = SubSchemaCollection.extend({
-    _type: 'allOf'
-  });
 
-  var SubSchemaOneOfCollection = SubSchemaCollection.extend({
-    _type: 'oneOf'
-  });
 
-  var SubSchemaNoneOfCollection = SubSchemaCollection.extend({
-    _type: 'noneOf'
-  });
+function getRoute(router, route) {
+  const root = __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].result(router, 'root') || '';
 
-  var constraintTypeErrorMessages = {
-    string: loc('schema.validation.field.value.must.string', 'courage'),
-    number: loc('schema.validation.field.value.must.number', 'courage'),
-    integer: loc('schema.validation.field.value.must.integer', 'courage'),
-    object: loc('schema.validation.field.value.must.object', 'courage')
-  };
+  if (root && __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].isString(route)) {
+    return [root, route].join('/').replace(/\/{2,}/g, '/');
+  }
+  return route;
+}
 
-  var loginFormatNonePattern = '.+';
+/**
+ * BaseRouter is a standard [Backbone.Router](http://backbonejs.org/#Router)
+ * with a few additions:
+ * - Explicit mapping between routes and controllers
+ * - Support for rendering notification and confirmation dialogs
+ *
+ * Checkout the [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World)
+ * for a step-by-step guide to using this.
+ *
+ * @class module:Okta.Router
+ * @extends external:Backbone.Router
+ * @param {Object} options options hash
+ * @param {String} options.el a jQuery selector string stating where to attach the controller in the DOM
+ */
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Router.extend(
+  /** @lends module:Okta.Router.prototype */ {
+    /**
+     * The root URL for the router. When setting {@link http://backbonejs.org/#Router-routes|routes},
+     * it will be prepended to each route.
+     * @type {String|Function}
+     */
+    root: '',
 
-  var escapedLoginCharsRe = /[^a-zA-Z0-9-]/;
+    listen: __WEBPACK_IMPORTED_MODULE_6__views_components_Notification__["a" /* default */].prototype.listen,
 
-  var SchemaProperty = BaseModel.extend({
-
-    constraintHandlers: {
-      between: '_checkBetweenConstraints',
-      greaterThan: '_checkGreaterThanConstraint',
-      lessThan: '_checkLessThanConstraint',
-      equals: '_checkEqualsConstraint'
-    },
-
-    idAttribute: 'name',
-
-    local: {
-      '__oneOf__': {
-        type: 'array',
-        minItems: 1
-      }
-    },
-
-    defaults: {
-      // OKTA-28445, set empty string by default as the key for each property when sycn with server
-      // so that server can respond with error when a name is not provided
-      name: '',
-      title: undefined,
-      type: undefined,
-      description: undefined,
-      required: false,
-      format: undefined,
-      // choose disable option be default.
-      union: undefined,
-      subSchemas: undefined,
-      settings: {permissions: {SELF: SchemaUtil.PERMISSION.READ_ONLY}},
-      '__isSensitive__': BaseModel.ComputedProperty(['settings'], function (settings) {
-        return !!(settings && settings.sensitive);
-      }),
-      '__userPermission__': SchemaUtil.PERMISSION.READ_ONLY,
-      '__displayType__': undefined,
-      '__displayTypeLabel__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return SchemaUtil.DATATYPE[displayType] || displayType;
-      }),
-      '__supportsMinMax__': false,
-      // use the private naming convention for these computed properties,
-      // to deal with the complexity in cloning schema with properties (toJSON({verbose: true})),
-      // to make sure these attributes are being excluded from api request
-      '__isReadOnly__': BaseModel.ComputedProperty(['mutability'], function (mutability) {
-        return mutability === SchemaUtil.MUTABILITY.READONLY;
-      }),
-      '__isWriteOnly__': BaseModel.ComputedProperty(['mutability'], function (mutability) {
-        return mutability === SchemaUtil.MUTABILITY.WRITEONLY;
-      }),
-      '__displayScope__': undefined,
-      '__isScopeSelf__': BaseModel.ComputedProperty(['scope'], function (scope) {
-        return scope === SchemaUtil.SCOPE.SELF;
-      }),
-      '__isNoneScopeArrayType__': BaseModel.ComputedProperty(
-        ['__isScopeSelf__', '__displayType__'],
-        function (isScopeSelf, displayType) {
-          return !isScopeSelf && SchemaUtil.isArrayDataType(displayType);
-        }),
-      '__isImported__': BaseModel.ComputedProperty(['externalName'], function (externalName) {
-        return !!externalName;
-      }),
-      '__isFromBaseSchema__': BaseModel.ComputedProperty(['__schemaMeta__'], function (schemaMeta) {
-        return schemaMeta && schemaMeta.name === 'base';
-      }),
-      // Only UI can turn on __enumDefined__ and reprocess the enum/oneOf value; otherwise,
-      // it should leave existing value untouch
-      '__enumDefined__': false,
-      '__supportEnum__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return _.contains(SchemaUtil.SUPPORTENUM, displayType);
-      }),
-      '__isNumberTypeEnum__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return _.contains([SchemaUtil.NUMBER, SchemaUtil.ARRAYDISPLAYTYPE.arrayofnumber], displayType);
-      }),
-      '__isIntegerTypeEnum__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return _.contains([SchemaUtil.INTEGER, SchemaUtil.ARRAYDISPLAYTYPE.arrayofinteger], displayType);
-      }),
-      '__isObjectTypeEnum__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return _.contains([SchemaUtil.OBJECT, SchemaUtil.ARRAYDISPLAYTYPE.arrayofobject], displayType);
-      }),
-      '__isStringTypeEnum__': BaseModel.ComputedProperty(['__displayType__'], function (displayType) {
-        return _.contains([SchemaUtil.STRING, SchemaUtil.ARRAYDISPLAYTYPE.arrayofstring], displayType);
-      }),
-      '__enumConstraintType__': BaseModel.ComputedProperty(
-        ['__isStringTypeEnum__', '__isNumberTypeEnum__', '__isIntegerTypeEnum__', '__isObjectTypeEnum__'],
-        function (isStringType, isNumberType, isIntegerType, isObjectType) {
-          if (isStringType) {
-            return STRING;
-          }
-          if (isNumberType) {
-            return NUMBER;
-          }
-          if (isIntegerType) {
-            return INTEGER;
-          }
-          if (isObjectType) {
-            return OBJECT;
-          }
-        }),
-      '__isEnumDefinedAndSupported__': BaseModel.ComputedProperty(
-        ['__enumDefined__', '__supportEnum__'],
-        function (enumDefined, supportEnum) {
-          return enumDefined && supportEnum;
-        }),
-      '__isLoginOfBaseSchema__': BaseModel.ComputedProperty(
-        ['__isFromBaseSchema__', 'name'], function (isFromBaseSchema, name) {
-          return isFromBaseSchema && name === 'login';
-        })
-    },
-
-    initialize: function () {
-      BaseModel.prototype.initialize.apply(this, arguments);
-      this.listenTo(this, 'change:__displayType__', this._updateTypeFormatConstraints);
-      this.listenTo(this, 'change:type change:format change:items', this._updateDisplayType);
-      this.listenTo(this, 'change:__minVal__ change:__maxVal__', this._updateMinMax);
-      this.listenTo(this, 'change:__equals__', this._convertEqualsToMinMax);
-      this.listenTo(this, 'change:__constraint__', this._setConstraintText);
-      this._setConstraintText();
-      this._setLoginPattern();
-    },
-
-    parse: function (resp) {
-      /* eslint complexity: [2, 9] */
-      resp = _.clone(resp);
-
-      if (resp.type === 'object' && resp.extendedType === 'image') {
-        resp.type = 'image';
-      }
-      resp['__displayType__'] = SchemaUtil.getDisplayType(
-        resp.type, resp.format, resp.items ? (
-          resp.items.format ? resp.items.format : resp.items.type
-        ) : undefined
-      );
-      this._setRangeConstraints(resp);
-      resp['__supportsMinMax__'] = SchemaUtil.SUPPORTSMINMAX.indexOf(resp['__displayType__']) != -1;
-      resp['__displayScope__'] = SchemaUtil.DISPLAYSCOPE[resp.scope] || SchemaUtil.DISPLAYSCOPE.NA;
-      if (resp.settings && resp.settings.permissions && resp.settings.permissions.SELF) {
-        resp['__userPermission__'] = resp.settings.permissions.SELF;
-      }
-      this._setMasterOverride(resp);
-      this._setSubSchemas(resp);
-      return resp;
-    },
-
-    validate: function () {
-      var enumValidationError = this._validateEnumOneOf();
-
-      if (enumValidationError) {
-        return enumValidationError;
+    constructor: function (options) {
+      options || (options = {});
+      this.el = options.el;
+      this.settings = new __WEBPACK_IMPORTED_MODULE_4__SettingsModel__["a" /* default */](__WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].omit(options, 'el'));
+      if (options.root) {
+        this.root = options.root;
       }
 
-      if (!this.get('__supportsMinMax__') || !this.get('__constraint__')) {
-        return undefined;
-      }
+      __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Router.apply(this, arguments);
 
-      var constraitType = this.get('__constraint__'),
-          constraitHandler = this[this.constraintHandlers[constraitType]];
-
-      if (_.isFunction(constraitHandler)) {
-        return constraitHandler.call(this);
-      } else {
-        Logger.warn('No constraint handler found for: ' + constraitType);
-        return undefined;
-      }
-    },
-
-    _checkBetweenConstraints: function () {
-      var minVal = this.get('__minVal__'),
-          maxVal = this.get('__maxVal__');
-
-      if (!minVal && !maxVal) {
-        return;
-      }
-      if (!minVal) {
-        return {'__minVal__': 'Min value is required'};
-      }
-      if (!maxVal) {
-        return {'__maxVal__': 'Max value is required'};
-      }
-      var val = this._checkIntegerConstraints('__minVal__', 'Min value');
-      if (val) {
-        return val;
-      }
-      val = this._checkIntegerConstraints('__maxVal__', 'Max value');
-      if (val) {
-        return val;
-      }
-      if (+minVal >= +maxVal) {
-        return {'__maxVal__': 'Max val must be greater than min val'};
-      }
-    },
-
-    _checkGreaterThanConstraint: function () {
-      var minVal = this.get('__minVal__');
-      if (!minVal) {
-        return;
-      }
-      var val = this._checkIntegerConstraints('__minVal__', 'Min value');
-      if (val) {
-        return val;
-      }
-    },
-
-    _checkLessThanConstraint: function () {
-      var maxVal = this.get('__maxVal__');
-      if (!maxVal) {
-        return;
-      }
-      var val = this._checkIntegerConstraints('__maxVal__', 'Max value');
-      if (val) {
-        return val;
-      }
-    },
-
-    _checkEqualsConstraint: function () {
-      var equals = this.get('__equals__');
-      if (!equals) {
-        return;
-      }
-      var val = this._checkIntegerConstraints('__equals__', 'Constraint');
-      if (val) {
-        return val;
-      }
-    },
-
-    _checkIntegerConstraints: function (field, name) {
-      var val = this.get(field);
-
-      var error = {};
-      if (isNaN(val)) {
-        error[field] = name + ' must be a number';
-        return error;
-      }
-      if (+val < 0) {
-        error[field] = name + ' must be greater than 0';
-        return error;
-      }
-    },
-
-    _setMasterOverride: function (resp) {
-      if (resp.settings && resp.settings.masterOverride && resp.settings.masterOverride) {
-        var masterOverrideValue = resp.settings.masterOverride.value;
-        if (_.isArray(masterOverrideValue) && !_.isEmpty(masterOverrideValue)) {
-          resp['__masterOverrideType__'] = 'OVERRIDE';
-          resp['__masterOverrideValue__'] = masterOverrideValue || [];
-        } else {
-          resp['__masterOverrideType__'] = resp.settings.masterOverride.type;
-        }
-      } else {
-        resp['__masterOverrideType__'] = 'INHERIT';
-      }
-    },
-
-    _setRangeConstraints: function (resp) {
-      /* eslint complexity: [2, 11] */
-      if (resp['__displayType__'] == STRING) {
-        resp['__minVal__'] = resp.minLength;
-        resp['__maxVal__'] = resp.maxLength;
-      } else if (resp['__displayType__'] == INTEGER || resp['__displayType__'] == NUMBER) {
-        resp['__minVal__'] = resp.minimum;
-        resp['__maxVal__'] = resp.maximum;
-      }
-      if (resp['__minVal__'] && resp['__maxVal__']) {
-        if (resp['__minVal__'] === resp['__maxVal__']) {
-          resp['__constraint__'] = 'equals';
-          resp['__equals__'] = resp['__minVal__'];
-        } else {
-          resp['__constraint__'] = 'between';
-        }
-      } else if (!resp['__minVal__'] && resp['__maxVal__']) {
-        resp['__constraint__'] = 'lessThan';
-      } else if (!resp['__maxVal__'] && resp['__minVal__']) {
-        resp['__constraint__'] = 'greaterThan';
-      }
-    },
-
-    _setSubSchemas: function (resp) {
-      if (resp.allOf) {
-        resp['subSchemas'] = new SubSchemaAllOfCollection(resp.allOf, { parse: true});
-      } else if (resp.oneOf) {
-        resp['subSchemas'] = new SubSchemaOneOfCollection(resp.oneOf, { parse: true});
-      } else if (resp.noneOf) {
-        resp['subSchemas'] = new SubSchemaNoneOfCollection(resp.noneOf, { parse: true});
-      }
-    },
-
-    _setLoginPattern: function () {
-      if (!this.get('__isLoginOfBaseSchema__')) {
-        return;
-      }
-
-      var pattern = this.get('pattern');
-      if (pattern === loginFormatNonePattern) {
-        this.set('__loginFormatRestriction__', SchemaUtil.LOGINPATTERNFORMAT.NONE);
-      } else if (pattern) {
-        this.set('__loginFormatRestriction__', SchemaUtil.LOGINPATTERNFORMAT.CUSTOM);
-        this.set('__loginFormatRestrictionCustom__', this._extractLoginPattern(pattern));
-      } else {
-        this.set('__loginFormatRestriction__', SchemaUtil.LOGINPATTERNFORMAT.EMAIL);
-      }
-    },
-
-    _updateDisplayType: function () {
-      var type = this.get('type');
-      if (type === STRING && this.get('format')) {
-        this.set('__displayType__', SchemaUtil.FORMATDISPLAYTYPE[this.get('format')]);
-      } else {
-        var items = this.get('items');
-        var arraytype = items && (items.format ? items.format : items.type);
-        if (type && arraytype) {
-          this.set('__displayType__', SchemaUtil.ARRAYDISPLAYTYPE[getArrayTypeName(type, arraytype)]);
-        } else {
-          this.set('__displayType__', type);
-        }
-      }
-    },
-
-    _validateEnumOneOf: function () {
-      if (!this.get('__isEnumDefinedAndSupported__')) {
-        return;
-      }
-
-      var enumOneOf = this.get('__oneOf__') || [];
-
-      if (_.isEmpty(enumOneOf)) {
-        return { '__oneOf__': loc('model.validation.field.blank', 'courage') };
-      }
-
-      if (!this._isValidateOneOfConstraint(enumOneOf)) {
-        var constraintType = this.get('__enumConstraintType__'),
-            errorTypeMsg = constraintTypeErrorMessages[constraintType];
-
-        return { '__oneOf__': errorTypeMsg };
-      }
-    },
-
-    _isValidateOneOfConstraint: function (values) {
-      var constraintType = this.get('__enumConstraintType__');
-
-      return _.all(values, function (value) {
-        return EnumTypeHelper.isConstraintValueMatchType(value.const, constraintType);
-      });
-    },
-
-    toJSON: function () {
-      var json = BaseModel.prototype.toJSON.apply(this, arguments);
-
-      json.settings = {permissions: {}};
-      json.settings.permissions['SELF'] = this.get('__userPermission__');
-
-      // omit "sensitive" filed will have default it value to false.
-      if (this.get('__isSensitive__')) {
-        json.settings.sensitive = this.get('__isSensitive__');
-      }
-      if (this.get('type') === 'image') {
-        json.type = 'object';
-        json.extendedType = 'image';
-      }
-
-      json = this._enumAssignment(json);
-      json = this._attributeOverrideToJson(json);
-      json = this._normalizeUnionValue(json);
-      json = this._patternAssignment(json);
-      return json;
-    },
-
-    _attributeOverrideToJson: function (json) {
-      var masterOverrideType = this.get('__masterOverrideType__'),
-          masterOverrideValue = this.get('__masterOverrideValue__');
-      if (masterOverrideType === 'OKTA_MASTERED') {
-        json.settings.masterOverride = {type: 'OKTA_MASTERED'};
-      } else if (masterOverrideType === 'OVERRIDE') {
-        json.settings.masterOverride = {type: 'ORDERED_LIST', value: []};
-        if (masterOverrideValue instanceof BaseCollection) {
-          _.each(masterOverrideValue.toJSON(), function (overrideProfile) {
-            json.settings.masterOverride.value.push(overrideProfile.id);
-          });
-        } else if (masterOverrideValue instanceof Array) {
-          json.settings.masterOverride.value = masterOverrideValue;
-        }
-        if (_.isEmpty(json.settings.masterOverride.value)) {
-          delete json.settings.masterOverride;
-        }
-      }
-
-      if (masterOverrideType === 'INHERIT') {
-        delete json.settings.masterOverride;
-      }
-      return json;
+      this.listen('notification', this._notify);
+      this.listen('confirmation', this._confirm);
     },
 
     /**
-     * Only allow set "union" value when isScopeSelf is NONE and displayType is
-     * array of (string/number/integer), otherwise reset to default.
+     * Fires up a confirmation dialog
      *
-     * @see /universal-directory/shared/views/components/UnionGroupValuesRadio.js
+     * @param  {Object} options Options Hash
+     * @param  {String} options.title The title
+     * @param  {String} options.subtitle The explain text
+     * @param  {String} options.save The text for the save button
+     * @param  {Function} options.ok The callback function to run when hitting "OK"
+     * @param  {String} options.cancel The text for the cancel button
+     * @param  {Function} options.cancelFn The callback function to run when hitting "Cancel"
+     * @param  {Boolean} options.noCancelButton Don't render the cancel button (useful for alert dialogs)
+     *
+     * @private
+     *
+     * @return {Okta.View} the dialog view
      */
-    _normalizeUnionValue: function (json) {
+    _confirm: function (options) {
+      options || (options = {});
+      const Dialog = __WEBPACK_IMPORTED_MODULE_5__views_components_ConfirmationDialog__["a" /* default */].extend(
+        __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].pick(options, 'title', 'subtitle', 'save', 'ok', 'cancel', 'cancelFn', 'noCancelButton', 'content', 'danger')
+      );
+      const dialog = new Dialog({ model: this.settings });
+      // The model is here because itsa part of the BaseForm paradigm.
+      // It will be ignored in the context of a confirmation dialog.
 
-      if (!this.get('__isNoneScopeArrayType__')) {
-        json['union'] = undefined;
-      }
-
-      return json;
-    },
-
-    _enumAssignment: function (json) {
-      if (!this.get('__isEnumDefinedAndSupported__')) {
-        return json;
-      }
-
-      // backfill empty title by constraint
-      var enumOneOf = this._getEnumOneOfWithTitleCheck();
-
-      if (this.get('type') === 'array') {
-        delete json.items.enum;
-        json.items.oneOf = enumOneOf;
-      } else {
-        delete json.enum;
-        json.oneOf = enumOneOf;
-      }
-
-      return json;
-    },
-
-    _patternAssignment: function (json) {
-      if (!this.get('__isLoginOfBaseSchema__') || !this.get('__loginFormatRestriction__')) {
-        return json;
-      }
-
-      switch (this.get('__loginFormatRestriction__')) {
-      case SchemaUtil.LOGINPATTERNFORMAT.EMAIL:
-        delete json.pattern;
-        break;
-      case SchemaUtil.LOGINPATTERNFORMAT.CUSTOM:
-        json.pattern = this._buildLoginPattern(this.get('__loginFormatRestrictionCustom__'));
-        break;
-      case SchemaUtil.LOGINPATTERNFORMAT.NONE:
-        json.pattern = loginFormatNonePattern;
-        break;
-      }
-
-      return json;
+      dialog.render();
+      return dialog; // test hook
     },
 
     /**
-     * Character should be escaped except letters, digits and hyphen
+     * Fires up a notification banner
+     *
+     * @param  {Object} options Options Hash
+     * @return {Okta.View} the notification view
+     * @private
      */
-    _escapedRegexChar: function (pattern, index) {
-      var char = pattern.charAt(index);
+    _notify: function (options) {
+      const notification = new __WEBPACK_IMPORTED_MODULE_6__views_components_Notification__["a" /* default */](options);
 
-      if (escapedLoginCharsRe.test(char)) {
-        return '\\' + char;
-      }
-
-      return char;
+      Object(__WEBPACK_IMPORTED_MODULE_1__jquery_wrapper__["default"])('#content').prepend(notification.render().el);
+      return notification; // test hook
     },
 
-    _buildLoginPattern: function (pattern) {
-      var result = '';
-
-      for (var i = 0; i < pattern.length; i++) {
-        result = result + this._escapedRegexChar(pattern, i);
-      }
-
-      return '[' + result + ']+';
+    /**
+     * Renders a Controller
+     * This will initialize new instance of a controller and call render on it
+     *
+     * @param  {Okta.Controller} Controller The controller Class we which to render
+     * @param  {Object} [options] Extra options to the controller constructor
+     */
+    render: function (Controller, options) {
+      this.unload();
+      options = __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].extend(__WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].pick(this, 'settings', 'el'), options || {});
+      this.controller = new Controller(options);
+      this.controller.render();
     },
 
-    _extractLoginPattern: function (pattern) {
-      var re = /^\[(.*)\]\+/,
-          matches = pattern.match(re);
-      return matches ? matches[1].replace(/\\(.)/g, '$1') : pattern;
-    },
+    /**
+     * Starts the backbone history object
+     *
+     * Waits for the dom to be ready before calling `Backbone.history.start()` (IE issue).
+     *
+     * See [Backbone History](http://backbonejs.org/#History) for more information.
+     */
+    start: function () {
+      const args = arguments;
 
-    _getEnumOneOfWithTitleCheck: function () {
-      var enumOneOf = this.get('__oneOf__');
-
-      return _.map(enumOneOf, function (value) {
-        if ($.trim(value.title) !== '') {
-          return value;
+      Object(__WEBPACK_IMPORTED_MODULE_1__jquery_wrapper__["default"])(function () {
+        if (__WEBPACK_IMPORTED_MODULE_0_backbone___default.a.History.started) {
+          __WEBPACK_IMPORTED_MODULE_3__Logger__["default"].error('History has already been started');
+          return;
         }
-
-        value.title = !_.isString(value.const) ? JSON.stringify(value.const) : value.const;
-
-        return value;
+        __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.history.start.apply(__WEBPACK_IMPORTED_MODULE_0_backbone___default.a.history, args);
       });
     },
 
-    _updateTypeFormatConstraints: function () {
-      var displayType = this.get('__displayType__');
-      // OKTA-31952 reset format according to its displayType
-      this.unset('format', {silent: true});
-      this.unset('items', {silent: true});
-      this.set(SchemaUtil.DISPLAYTYPES[displayType]);
-      if (displayType != NUMBER && displayType != INTEGER) {
-        this.unset('minimum');
-        this.unset('maximum');
-      }
-      if (displayType != STRING) {
-        this.unset('minLength');
-        this.unset('maxLength');
-      }
-
-      this.unset('__minVal__');
-      this.unset('__maxVal__');
-      this.unset('__equals__');
-      this.set('__supportsMinMax__', SchemaUtil.SUPPORTSMINMAX.indexOf(this.get('__displayType__')) != -1);
-    },
-
-    _updateMinMax: function () {
-      var min,
-          max,
-          displayType = this.get('__displayType__');
-
-      if (displayType === STRING) {
-        min = 'minLength';
-        max = 'maxLength';
-      } else if (displayType == INTEGER || displayType == NUMBER) {
-        min = 'minimum';
-        max = 'maximum';
-      }
-
-      if (this.get('__minVal__')) {
-        this.set(min, parseInt(this.get('__minVal__'), 10));
-      } else {
-        this.unset(min);
-      }
-
-      if (this.get('__maxVal__')) {
-        this.set(max, parseInt(this.get('__maxVal__'), 10));
-      } else {
-        this.unset(max);
-      }
-    },
-
-    _convertEqualsToMinMax: function () {
-      var equals = this.get('__equals__');
-      if (equals) {
-        this.set('__minVal__', equals);
-        this.set('__maxVal__', equals);
-      }
-    },
-
-    /*
-     Normally we would use a derived property here but derived properties do not work with the model Clone function
-     so we use this workaround instead.
-     */
-    _setConstraintText: function () {
-      var constraint = this.get('__constraint__'),
-          min = this.get('__minVal__'),
-          max = this.get('__maxVal__'),
-          equals = this.get('__equals__');
-
-      switch (constraint) {
-      case 'between':
-        this.set('__constraintText__', 'Between ' + min + ' and ' + max);
-        break;
-      case 'greaterThan':
-        this.set('__constraintText__', 'Greater than ' + min);
-        break;
-      case 'lessThan':
-        this.set('__constraintText__', 'Less than ' + max);
-        break;
-      case 'equals':
-        this.set('__constraintText__', 'Equals ' + equals);
-        break;
-      default:
-        this.set('__constraintText__', '');
-        break;
-      }
-    },
-
-    cleanup: function () {
-      if (this.get('__constraint__') === 'lessThan') {
-        this.unset('__minVal__');
-      } else if (this.get('__constraint__') === 'greaterThan') {
-        this.unset('__maxVal__');
-      }
-      if (this.get('scope') !== SchemaUtil.SCOPE.SYSTEM) {
-        if (this.get('__isScopeSelf__') === true) {
-          this.set({'scope': SchemaUtil.SCOPE.SELF}, {silent: true});
-        } else {
-          this.unset('scope');
-        }
-      }
-    },
-
     /**
-     * Since there is not an dedicated attribute to flag enum type,
-     * use enum values to determine whether the property is enum type or not.
+     * Removes active controller and frees up event listeners
      */
-    isEnumType: function () {
-      return !!this.getEnumValues();
-    },
-
-    getEnumValues: function () {
-      return this.get('oneOf') ||
-             this.get('enum') ||
-             (this.get('items') && this.get('items')['oneOf']) ||
-             (this.get('items') && this.get('items')['enum']);
-    },
-
-    detectHasEnumDefined: function () {
-      var enumValues = this.getEnumValues();
-
-      if (!enumValues) {
-        return;
+    unload: function () {
+      if (this.controller) {
+        this.stopListening(this.controller);
+        this.stopListening(this.controller.state);
+        this.controller.remove();
       }
-
-      this.set('__oneOf__', EnumTypeHelper.convertToOneOf(enumValues));
-      this.set('__enumDefined__', true);
-    }
-
-  });
-
-  var SchemaProperties = BaseCollection.extend({
-    model: SchemaProperty,
-    clone: function () {
-      return new this.constructor(this.toJSON({verbose: true}), {parse: true});
     },
-    areAllReadOnly: function () {
-      return _.all(this.pluck('__isReadOnly__'));
+
+    route: function (route, name, callback) {
+      return __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Router.prototype.route.call(this, getRoute(this, route), name, callback);
     },
-    createModelProperties: function () {
-      return this.reduce(function (p, schemaProperty) {
-        var type = schemaProperty.get('type');
-        p[schemaProperty.id] = _.clone(SchemaUtil.DISPLAYTYPES[type]);
-        if (SchemaUtil.SUPPORTSMINMAX.indexOf(type) != -1) {
-          p[schemaProperty.id].minLength = schemaProperty.get('minLength');
-          p[schemaProperty.id].maxLength = schemaProperty.get('maxLength');
-        }
-        if (type === 'string') {
-          p[schemaProperty.id].format = schemaProperty.get('format');
-        }
-        return p;
-      }, {});
+
+    navigate: function (fragment, options) {
+      return __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Router.prototype.navigate.call(this, getRoute(this, fragment), options);
     }
-  });
-
-  return {
-    Model: SchemaProperty,
-    Collection: SchemaProperties
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+));
 
 
 /***/ }),
 /* 20 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-statements: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(12),
-  __webpack_require__(4)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, SchemaUtil, StringUtil) {
-  var NAME = 'name',
-      ENUM_KEY_PREFIX = '_enum_';
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__models_Model__ = __webpack_require__(11);
+
+
+
+/**
+ * @class SettingsModel
+ * @extends {Okta.Model}
+ * @private
+ */
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_1__models_Model__["default"].extend({
+  local: function () {
+    const settings = (window.okta && window.okta.settings) || {};
+
+    return {
+      orgId: ['string', false, settings.orgId],
+      orgName: ['string', false, settings.orgName],
+      serverStatus: ['string', false, settings.serverStatus],
+      persona: ['string', false, settings.persona],
+      isDeveloperConsole: ['boolean', false, settings.isDeveloperConsole],
+      isPreview: ['boolean', false, settings.isPreview],
+      permissions: ['array', true, settings.permissions || []]
+    };
+  },
+
+  extraProperties: true,
+
+  constructor: function () {
+    this.features = window._features || [];
+    __WEBPACK_IMPORTED_MODULE_1__models_Model__["default"].apply(this, arguments);
+  },
 
   /**
-   * Generate Input Options in order to create an input in an Form for Enum type attribute.
-   * @param {Object} config informations for creating input options
-   *   config.name        schema property name
-   *   config.title       schema property title
-   *   config.readOnly    create an read only input?
-   *   config.explain     sub-title to the input
-   *   config.enumValues  list of enum values for creating input options (Dropdown/SimpleCheckBoxSet)
-   *   config.displayType display type of schema property
-   *
-   * @return {Object} inputOptions options for create an Input view. (Dropdown/SimpleCheckBoxSet)
-   *
+   * Checks if the user have a feature flag enabled (Based of the org level feature flag)
+   * @param  {String}  feature Feature name
+   * @return {Boolean}
    */
-  function getEnumInputOptions(config) {
-    var enumOneOf = convertToOneOf(config.enumValues),
-        inputOptions = {
-          name: config.name,
-          label: config.title,
-          readOnly: config.readOnly,
-          customExplain: config.explain,
-          params: {enumOneOf: enumOneOf},
-          options: getDropdownOptionsFromOneOf(enumOneOf)
-        };
-
-    // input type
-    if (SchemaUtil.isArrayDataType(config.displayType)) {
-      inputOptions.type = 'checkboxset';
-      inputOptions.to = valuesToEnumObjects;
-      inputOptions.from = enumObjectsToValues;
-    } else {
-      inputOptions.type = 'select';
-      inputOptions.to = valueToEnumObject;
-      inputOptions.from = enumObjectToValue;
+  hasFeature: function (feature) {
+    if (window._possibleFeatures
+          && !__WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].contains(window._possibleFeatures, feature)
+          && window.okta
+          && window.okta.logHasFeatureError) {
+      window.okta.logHasFeatureError(feature);
     }
+    return __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].contains(this.features, feature);
+  },
 
-    inputOptions.input = null;
-    return inputOptions;
+  /**
+   * Checks if any of the given feature flags are enabled (Based of the org level feature flags)
+   * @param  {Array}  featureArray Features names
+   * @return {Boolean} true if any of the give features are enabled. False otherwise
+   */
+  hasAnyFeature: function (featureArray) {
+    return __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].some(featureArray, this.hasFeature, this);
+  },
+
+  /**
+   * Checks if the user have a specific permission (based on data passed from JSP)
+   * @param  {String}  permission Permission name
+   * @return {Boolean}
+   */
+  hasPermission: function (permission) {
+    return __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].contains(this.get('permissions'), permission);
   }
-
-  function getDropdownOptions(values) {
-    return _.isArray(values) ? getDropdownOptionsFromOneOf(convertToOneOf(values)) : {};
-  }
-
-  function getDropdownOptionsFromOneOf(values) {
-    if (!isOneOfEnumObject(values)) {
-      return {};
-    }
-
-    return _.reduce(values, function (options, value, index) {
-      options[convertIndexToEnumIndex(index)] = value.title;
-      return options;
-    }, {});
-  }
-
-  function convertToOneOf(values) {
-    // assume this is a legacy enum array and convert to oneOf object
-    if (!_.all(values, $.isPlainObject)) {
-      return convertEnumToOneOf(values);
-
-      // we assume object without const and title is an enum object which need special conversion
-    } else if (!isOneOfEnumObject(values)) {
-      return convertEnumObjectToOneOf(values);
-    }
-
-    return values;
-  }
-
-  function isOneOfEnumObject(values) {
-    return _.isArray(values) && _.all(values, function (value) {
-      return _.has(value, 'const') && _.has(value, 'title');
-    });
-  }
-
-  function convertEnumToOneOf(values) {
-    return _.map(values, function (value) {
-      return {
-        const: value,
-        title: valueToTitle(value)
-      };
-    });
-  }
-
-  function valueToTitle(value) {
-    if (_.isObject(value)) {
-      return JSON.stringify(value);
-    }
-
-    if (_.isNumber(value)) {
-      return value + '';
-    }
-
-    return value;
-  }
-
-  function convertEnumObjectToOneOf(values) {
-    // If all object found the key NAME, use the NAME's value as display name
-    var findKey = _.partial(_.has, _, NAME);
-    if (_.all(values, findKey)) {
-      return _.chain(values)
-        .filter(function (value) { return $.isPlainObject(value) && _.has(value, NAME); })
-        .map(function (value) { return {const: value, title: value[NAME]}; })
-        .value();
-    }
-
-    // Assume a legacy object array does not need special handling and just convert to const/title enum
-    return convertEnumToOneOf(values);
-  }
-
-  function convertIndexToEnumIndex(index) {
-    return `${ENUM_KEY_PREFIX}${index}`;
-  }
-
-  function enumObjectToValue(obj) {
-    // Cannot rely on comparator in findIndex when compare objects so need special handling
-    var index = _.findIndex(this.options.params.enumOneOf, function (oneOfObj) {
-      return _.isObject(obj) ? _.isEqual(oneOfObj.const, obj) : oneOfObj.const === obj;
-    });
-
-    return index > -1 ? convertIndexToEnumIndex(index) : obj;
-  }
-
-  function valueToEnumObject(val) {
-    if (!_.isString(val) || val.indexOf(ENUM_KEY_PREFIX) !== 0) {
-      return val;
-    }
-
-    var index = val.replace(ENUM_KEY_PREFIX, '');
-
-    // @see `getEnumInputOptions` how enumValues has been set.
-    var enumValue = this.options.params && _.isArray(this.options.params.enumOneOf) ?
-      this.options.params.enumOneOf[index] : null;
-
-    return _.has(enumValue, 'const') ? enumValue.const : enumValue;
-  }
-
-  function valuesToEnumObjects(values) {
-    return _.map(values, valueToEnumObject.bind(this));
-  }
-
-  function enumObjectsToValues(values) {
-    return _.map(values, enumObjectToValue.bind(this));
-  }
-
-  function isStringConstraint(value) {
-    return _.isString(value) && $.trim(value) !== '';
-  }
-
-  function isNumberConstraint(value) {
-    return _.isNumber(value) || _.isNumber(StringUtil.parseFloat($.trim(value)));
-  }
-
-  function isIntegerConstraint(value) {
-    var integer = _.isNumber(value) ? value : StringUtil.parseInt($.trim(value));
-
-    return typeof integer === 'number' && isFinite(integer) && Math.floor(integer) === integer;
-  }
-
-  function isObjectConstraint(value) {
-    if (_.isObject(value) && !_.isArray(value)) {
-      return true;
-    }
-
-    var object = StringUtil.parseObject($.trim(value));
-    return _.isObject(object) && !_.isArray(object);
-  }
-
-  function isConstraintValueMatchType(value, type) {
-    switch (type) {
-    case SchemaUtil.STRING: return isStringConstraint(value);
-    case SchemaUtil.NUMBER: return isNumberConstraint(value);
-    case SchemaUtil.INTEGER: return isIntegerConstraint(value);
-    case SchemaUtil.OBJECT: return isObjectConstraint(value);
-    }
-  }
-
-  return {
-    getEnumInputOptions: getEnumInputOptions,
-    getDropdownOptions: getDropdownOptions,
-    convertToOneOf: convertToOneOf,
-    isConstraintValueMatchType: isConstraintValueMatchType
-  };
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+}));
 
 
 /***/ }),
 /* 21 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(42)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseButtonLink) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_backbone__);
 
-  /**
-   * A factory method wrapper for {@link BaseButtonLink} creation
-   * @class module:Okta.internal.util.ButtonFactory
-   */
 
-  function normalizeEvents(options) {
-    var events = _.extend(options.click ? {click: options.click} : {}, options.events || {}),
-        target = {};
-    _.each(events, function (fn, eventName) {
-      target[eventName] = function (e) {
-        if (!options.href) {
-          e.preventDefault();
-          e.stopPropagation();
+
+
+var CHILDREN = '__children__',
+    RENDERED = '__rendered__',
+    PARENT = '__parent__',
+    CHILD_DEFINITIONS = '__children_definitions__',
+    ADD_TO_CONTAINER = '__add_to_container__';
+
+function getIndex(container, view) {
+  for (var i = 0; i < container[CHILDREN].length; i++) {
+    if (view.cid === container[CHILDREN][i].cid) {
+      return i;
+    }
+  }
+}
+
+function noop() { }
+
+function doRender(view) {
+  view[RENDERED] = true;
+
+  var html = view.renderTemplate(view.template);
+  if (html) {
+    view.$el.html(html);
+  }
+  else if (view.length) {
+    view.$el.empty();
+  }
+
+  view.each(function (view) {
+    view[ADD_TO_CONTAINER]();
+  });
+}
+
+function subscribeEvents(view) {
+  var isEventPropertyRe = /^(?!(?:delegate|undelegate|_))([a-zA-Z0-9]+)(?:Events)$/;
+  __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].allKeys(view), function (key) {
+    var matchKeys = key.match(isEventPropertyRe);
+    if (!matchKeys) {
+      return;
+    }
+    var bindings = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(view, key),
+        entity = view.options[matchKeys[1]] || view[matchKeys[1]];
+    if (!entity || !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(bindings) || !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(entity.trigger)) {
+      return;
+    }
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(bindings, function (callback, event) {
+      var callbacks = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(callback) ? [callback] : __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].reduce(callback.split(/\s+/), function (arr, name) {
+        if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(view[name])) {
+          arr.push(view[name]);
         }
-        fn.apply(this, arguments);
-      };
-    });
-    return target;
-  }
-
-  return /** @lends module:Okta.internal.util.ButtonFactory */ {
-    /**
-     * Creates a {@link module:Okta.internal.views.components.BaseButtonLink|BaseButtonLink}.
-     * @param  {Object} options Options hash
-     * @param  {String} [options.title] The button text
-     * @param  {String} [options.icon]
-     * CSS class for the icon to display. See [Style guide](http://rain.okta1.com:1802/su/dev/style-guide#icons)
-     * @param {String} [options.href] The button link
-     * @param {Function} [options.click] On click callback
-     * @param {Object} [options.events] a [Backbone events](http://backbonejs.org/#View-delegateEvents) hash
-     * @returns {module:Okta.internal.views.components.BaseButtonLink} BaseButtonLink prototype ("class")
-     */
-    create: function (options) {
-      options = _.clone(options);
-      options.attrs = options.attributes;
-      delete options.attributes;
-
-      return BaseButtonLink.extend(_.extend(options, {
-        events: normalizeEvents(options)
-      }));
-    }
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 22 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(5)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
-				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  }
-  /* global module, exports */
-  else if (typeof require === 'function' && typeof exports === 'object') {
-    module.exports = factory(require('okta/underscore'), require('backbone'));
-  }
-  else {
-    root.Archer || (root.Archer = {});
-    root.Archer.View = factory(root._, root.Backbone);
-  }
-}(this, function (_, Backbone) {
-
-  var CHILDREN = '__children__',
-      RENDERED = '__rendered__',
-      PARENT = '__parent__',
-      CHILD_DEFINITIONS = '__children_definitions__',
-      ADD_TO_CONTAINER = '__add_to_container__';
-
-  function getIndex(container, view) {
-    for (var i = 0; i < container[CHILDREN].length; i++) {
-      if (view.cid === container[CHILDREN][i].cid) {
-        return i;
-      }
-    }
-  }
-
-  function noop() {}
-
-  function doRender(view) {
-    view[RENDERED] = true;
-
-    var html = view.renderTemplate(view.template);
-    if (html) {
-      view.$el.html(html);
-    }
-    else if (view.length) {
-      view.$el.empty();
-    }
-
-    view.each(function (view) {
-      view[ADD_TO_CONTAINER]();
-    });
-  }
-
-  function subscribeEvents(view) {
-    var isEventPropertyRe = /^(?!(?:delegate|undelegate|_))([a-zA-Z0-9]+)(?:Events)$/;
-    _.each(_.allKeys(view), function (key) {
-      var matchKeys = key.match(isEventPropertyRe);
-      if (!matchKeys) {
-        return;
-      }
-      var bindings = _.result(view, key),
-          entity = view.options[matchKeys[1]] || view[matchKeys[1]];
-      if (!entity || !_.isObject(bindings) || !_.isFunction(entity.trigger)) {
-        return;
-      }
-      _.each(bindings, function (callback, event) {
-        var callbacks = _.isFunction(callback) ? [callback] : _.reduce(callback.split(/\s+/), function (arr, name) {
-          if (_.isFunction(view[name])) {
-            arr.push(view[name]);
-          }
-          return arr;
-        }, []);
-        _.each(callbacks, function (cb) {
-          view.listenTo(entity, event, cb);
-        });
+        return arr;
+      }, []);
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(callbacks, function (cb) {
+        view.listenTo(entity, event, cb);
       });
     });
-  }
+  });
+}
 
-  /**
+/**
    * A View operates on a string template, an token based template, or a model based template, with a few added hooks.
    * It provides a collection of child views, when a child view could be a View or another View.
    * Conceptually, if we were in a file system, the View is a folder, when the concrete child views are files,
@@ -3278,9 +3482,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    *   children: [[HeaderView, 'header'], [ContentView, 'article'], [FooterView, 'footer']]
    * });
    */
-  var View = Backbone.View.extend(/** @lends src/framework/View.prototype */ {
+var View = __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.View.extend(/** @lends src/framework/View.prototype */ {
 
-    /**
+  /**
      * An object listing events and callback bind to this.{entity}
      * @name *Events
      * @memberof src/framework/View
@@ -3326,43 +3530,43 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * });
      */
 
-    constructor: function (options) {
-      /* eslint max-statements: [2, 17] */
-      this.options = options || {};
-      _.extend(this, _.pick(this.options, 'state', 'settings'));
+  constructor: function (options) {
+    /* eslint max-statements: [2, 17] */
+    this.options = options || {};
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].pick(this.options, 'state', 'settings'));
 
-      // init per-instance children collection
-      this[CHILDREN] = [];
-      this[RENDERED] = false;
-      this[PARENT] = null;
-      this[CHILD_DEFINITIONS] = this.children;
+    // init per-instance children collection
+    this[CHILDREN] = [];
+    this[RENDERED] = false;
+    this[PARENT] = null;
+    this[CHILD_DEFINITIONS] = this.children;
 
-      // we want to make sure initialize is triggered *after* we append the views from the `this.views` array
-      var initialize = this.initialize;
-      this.initialize = noop;
+    // we want to make sure initialize is triggered *after* we append the views from the `this.views` array
+    var initialize = this.initialize;
+    this.initialize = noop;
 
-      Backbone.View.apply(this, arguments);
+    __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.View.apply(this, arguments);
 
-      _.each(_.result(this, CHILD_DEFINITIONS), function (childDefinition) {
-        this.add.apply(this, _.isArray(childDefinition) ? childDefinition : [childDefinition]);
-      }, this);
-      delete this[CHILD_DEFINITIONS];
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, CHILD_DEFINITIONS), function (childDefinition) {
+      this.add.apply(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(childDefinition) ? childDefinition : [childDefinition]);
+    }, this);
+    delete this[CHILD_DEFINITIONS];
 
-      if (this.autoRender && this.model) {
-        var event = _.isArray(this.autoRender) ? _.map(this.autoRender, function (field) {
-          return 'change:' + field;
-        }).join(' ') : 'change';
-        this.listenTo(this.model, event, function () {
-          this.render();
-        });
-      }
+    if (this.autoRender && this.model) {
+      var event = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.autoRender) ? __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(this.autoRender, function (field) {
+        return 'change:' + field;
+      }).join(' ') : 'change';
+      this.listenTo(this.model, event, function () {
+        this.render();
+      });
+    }
 
-      this.initialize = initialize;
-      this.initialize.apply(this, arguments);
-      subscribeEvents(this);
-    },
+    this.initialize = initialize;
+    this.initialize.apply(this, arguments);
+    subscribeEvents(this);
+  },
 
-    /**
+  /**
      * Unregister view from container
      * Note: this will not remove the view from the dom
      * and will not call the `remove` method on the view
@@ -3370,20 +3574,20 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * @param {src/framework/View} view the view to unregister
      * @private
      */
-    unregister: function (view) {
+  unregister: function (view) {
 
-      this.stopListening(view);
-      var viewIndex = getIndex(this, view);
-      // viewIndex is undefined when the view is not found (may have been removed)
-      // check if it is undefined to prevent unexpected thing to happen
-      // array.splice(undefined, x) removes the first x element(s) from the array
-      // this protects us against issues when calling `remove` on a child view multiple times
-      if (_.isNumber(viewIndex)) {
-        this[CHILDREN].splice(viewIndex, 1);
-      }
-    },
+    this.stopListening(view);
+    var viewIndex = getIndex(this, view);
+    // viewIndex is undefined when the view is not found (may have been removed)
+    // check if it is undefined to prevent unexpected thing to happen
+    // array.splice(undefined, x) removes the first x element(s) from the array
+    // this protects us against issues when calling `remove` on a child view multiple times
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNumber(viewIndex)) {
+      this[CHILDREN].splice(viewIndex, 1);
+    }
+  },
 
-    /**
+  /**
      * Should we auto render the view upon model change. Boolean or array of field names to listen to.
      * @type {Boolean|Array}
      * @deprecated Instead, please use modelEvents
@@ -3392,9 +3596,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *   change:name: 'render'
      * }
      */
-    autoRender: false,
+  autoRender: false,
 
-    /**
+  /**
      *
      * When the template is an underscore template, the render method will pass the options has to the template
      * And the associated model, if exists, when it will prefer the model over the options in case of a conflict.
@@ -3405,9 +3609,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *   template: '<p class="name">{{name}}</p>'
      * };
      */
-    template: null,
+  template: null,
 
-    /**
+  /**
      * A list of child view definitions to be passed to {@link #add this.add()}.
      * Note: these definitions will be added **before** the {@link #constructor initiliaze} method invokes.
      * @type {(Array|Function)}
@@ -3430,9 +3634,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *    }
      *  })
      */
-    children: [],
+  children: [],
 
-    /**
+  /**
      * Add a child view to the container.
      * If the container is already rendered, will also render the view  and append it to the DOM.
      * Otherwise will render and append once the container is rendered.
@@ -3482,141 +3686,141 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *
      * var container - new View({name: 'John Doe'});
      */
-    add: function (view, selector, bubble, prepend, extraOptions) {
-      /* eslint max-statements: [2, 28], complexity: [2, 9] */
+  add: function (view, selector, bubble, prepend, extraOptions) {
+    /* eslint max-statements: [2, 28], complexity: [2, 9] */
 
-      var options = {},
-          args = _.toArray(arguments);
+    var options = {},
+        args = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].toArray(arguments);
 
-      if (_.isObject(selector)) {
-        options = selector;
-        selector = options.selector;
-        bubble = options.bubble;
-        prepend = options.prepend;
-        extraOptions = options.options;
-      }
-      else if (_.isObject(bubble)) {
-        options = bubble;
-        bubble = options.bubble;
-        prepend = options.prepend;
-        extraOptions = options.options;
-      }
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(selector)) {
+      options = selector;
+      selector = options.selector;
+      bubble = options.bubble;
+      prepend = options.prepend;
+      extraOptions = options.options;
+    }
+    else if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(bubble)) {
+      options = bubble;
+      bubble = options.bubble;
+      prepend = options.prepend;
+      extraOptions = options.options;
+    }
 
-      if (_.isString(view)) {
-        view = (function (template) {
-          return View.extend({
-            constructor: function () {
-              try {
-                var $el = Backbone.$(template);
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(view)) {
+      view = (function (template) {
+        return View.extend({
+          constructor: function () {
+            try {
+              var $el = __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.$(template);
 
-                if ($el.length != 1) { throw 'invalid Element'; }
+              if ($el.length != 1) { throw 'invalid Element'; }
 
-                var unescapingRexExp = /&(\w+|#x\d+);/g;
-                var elementUnescapedOuterHTMLLength = $el.prop('outerHTML').replace(unescapingRexExp, ' ').length;
-                var templateUnescapedLength = template.replace(unescapingRexExp, ' ').length;
+              var unescapingRexExp = /&(\w+|#x\d+);/g;
+              var elementUnescapedOuterHTMLLength = $el.prop('outerHTML').replace(unescapingRexExp, ' ').length;
+              var templateUnescapedLength = template.replace(unescapingRexExp, ' ').length;
 
-                if (elementUnescapedOuterHTMLLength !== templateUnescapedLength) { throw 'invalid Element'; }
+              if (elementUnescapedOuterHTMLLength !== templateUnescapedLength) { throw 'invalid Element'; }
 
-                this.template = $el.html();
-                this.el = $el.empty()[0];
-              }
-              catch (e) { // not a valid html tag.
-                this.template = template;
-              }
-              View.apply(this, arguments);
+              this.template = $el.html();
+              this.el = $el.empty()[0];
             }
-          });
-        }(view));
-      }
-
-      if (view.prototype && view.prototype instanceof View) {
-        /* eslint new-cap: 0 */
-        var viewOptions = _.omit(_.extend({}, this.options, extraOptions), 'el');
-        args[0] = new view(viewOptions);
-        return this.add.apply(this, args);
-      }
-
-      // prevent dups
-      if (_.isNumber(getIndex(this, view))) {
-        throw new Error('Duplicate child');
-      }
-
-      view[PARENT] = this;
-
-      // make the view responsible for adding itself to the parent:
-      // * register the selector in the closure
-      // * register a reference the parent in the closure
-      view[ADD_TO_CONTAINER] = (function (selector) {
-        return function () {
-          if (selector && view[PARENT].$(selector).length != 1) {
-            throw new Error('Invalid selector: ' + selector);
+            catch (e) { // not a valid html tag.
+              this.template = template;
+            }
+            View.apply(this, arguments);
           }
-          var $el = selector ? this[PARENT].$(selector) : this[PARENT].$el;
-          this.render();
-          // we need to delegate events in case
-          // the view was added and removed before
-          this.delegateEvents();
-
-          // this[PARENT].at(index).$el.before(this.el);
-          prepend ? $el.prepend(this.el) : $el.append(this.el);
-        };
-      }).call(view, selector);
-
-      // if flag to bubble events is set
-      // proxy all child view events
-      if (bubble) {
-        this.listenTo(view, 'all', function () {
-          this.trigger.apply(this, arguments);
         });
-      }
+      }(view));
+    }
 
-      // add to the dom if `render` has been called
-      if (this.rendered()) {
-        view[ADD_TO_CONTAINER]();
-      }
+    if (view.prototype && view.prototype instanceof View) {
+      /* eslint new-cap: 0 */
+      var viewOptions = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, this.options, extraOptions), 'el');
+      args[0] = new view(viewOptions);
+      return this.add.apply(this, args);
+    }
 
-      // add view to child views collection
-      this[CHILDREN].push(view);
+    // prevent dups
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNumber(getIndex(this, view))) {
+      throw new Error('Duplicate child');
+    }
 
-      return this;
+    view[PARENT] = this;
 
-    },
+    // make the view responsible for adding itself to the parent:
+    // * register the selector in the closure
+    // * register a reference the parent in the closure
+    view[ADD_TO_CONTAINER] = (function (selector) {
+      return function () {
+        if (selector && view[PARENT].$(selector).length != 1) {
+          throw new Error('Invalid selector: ' + selector);
+        }
+        var $el = selector ? this[PARENT].$(selector) : this[PARENT].$el;
+        this.render();
+        // we need to delegate events in case
+        // the view was added and removed before
+        this.delegateEvents();
 
-    /**
+        // this[PARENT].at(index).$el.before(this.el);
+        prepend ? $el.prepend(this.el) : $el.append(this.el);
+      };
+    }).call(view, selector);
+
+    // if flag to bubble events is set
+    // proxy all child view events
+    if (bubble) {
+      this.listenTo(view, 'all', function () {
+        this.trigger.apply(this, arguments);
+      });
+    }
+
+    // add to the dom if `render` has been called
+    if (this.rendered()) {
+      view[ADD_TO_CONTAINER]();
+    }
+
+    // add view to child views collection
+    this[CHILDREN].push(view);
+
+    return this;
+
+  },
+
+  /**
      * Remove all children from container
      */
-    removeChildren: function () {
-      this.each(function (view) {
-        view.remove();
-      });
-      return this;
-    },
+  removeChildren: function () {
+    this.each(function (view) {
+      view.remove();
+    });
+    return this;
+  },
 
-    /**
+  /**
      *  Removes a view from the DOM, and calls stopListening to remove any bound events that the view has listenTo'd.
      *  Also removes all childern of the view if any, and removes itself from its parent view(s)
      */
-    remove: function () {
-      this.removeChildren();
-      if (this[PARENT]) {
-        this[PARENT].unregister(this);
-      }
-      return Backbone.View.prototype.remove.apply(this, arguments);
-    },
+  remove: function () {
+    this.removeChildren();
+    if (this[PARENT]) {
+      this[PARENT].unregister(this);
+    }
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.View.prototype.remove.apply(this, arguments);
+  },
 
-    /**
+  /**
      * Compile the template to function you can apply tokens on on render time.
      * Uses the underscore tempalting engine by default
      * @protected
      * @param  {String} template
      * @return {Function} a compiled template
      */
-    compileTemplate: function (template) {
-      /* eslint  @okta/okta/no-specific-methods: 0*/
-      return _.template(template);
-    },
+  compileTemplate: function (template) {
+    /* eslint  @okta/okta/no-specific-methods: 0*/
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].template(template);
+  },
 
-    /**
+  /**
      * Render a template with `this.model` and `this.options` as parameters
      * preferring the model over the options.
      *
@@ -3624,57 +3828,57 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * @return {String} An HTML string
      * @protected
      */
-    renderTemplate: function (template) {
-      if (_.isString(template)) {
-        template = this.compileTemplate(template);
-      }
-      if (_.isFunction(template)) {
-        return template(this.getTemplateData());
-      }
-    },
+  renderTemplate: function (template) {
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(template)) {
+      template = this.compileTemplate(template);
+    }
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(template)) {
+      return template(this.getTemplateData());
+    }
+  },
 
-    /**
+  /**
      * The data hash passed to the compiled template
      * @return {Object}
      * @protected
      */
-    getTemplateData: function () {
-      var modelData = this.model && this.model.toJSON({verbose: true}) || {};
-      var options = _.omit(this.options, ['state', 'settings', 'model', 'collection']);
-      return _.defaults({}, modelData, options);
-    },
+  getTemplateData: function () {
+    var modelData = this.model && this.model.toJSON({ verbose: true }) || {};
+    var options = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(this.options, ['state', 'settings', 'model', 'collection']);
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults({}, modelData, options);
+  },
 
-    /**
+  /**
      * Renders the template to `$el` and append all children in order
      * {@link #template View.template}
      */
-    render: function () {
-      this.preRender();
-      doRender(this);
-      this.postRender();
-      return this;
-    },
+  render: function () {
+    this.preRender();
+    doRender(this);
+    this.postRender();
+    return this;
+  },
 
-    /**
+  /**
      * Pre render routine. Will be called right *before* the logic in {@link #render} is executed
      * @method
      */
-    preRender: noop,
+  preRender: noop,
 
-    /**
+  /**
      * Post render routine. Will be called right *after* the logic in {@link #render} is executed
      * @method
      */
-    postRender: noop,
+  postRender: noop,
 
-    /**
+  /**
      * Was this instance rendered
      */
-    rendered: function () {
-      return this[RENDERED];
-    },
+  rendered: function () {
+    return this[RENDERED];
+  },
 
-    /**
+  /**
      * Get all direct child views.
      * @returns {src/framework/View[]}
      * @example
@@ -3683,55 +3887,55 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * }).render();
      * container.getChildren() //=> [view1, view2];
      */
-    getChildren: function () {
-      return this.toArray();
-    },
+  getChildren: function () {
+    return this.toArray();
+  },
 
-    /**
+  /**
      * Get a child by index
      * @param {number} index
      * @returns {src/framework/View} The child view
      */
-    at: function (index) {
-      return this.getChildren()[index];
-    },
+  at: function (index) {
+    return this.getChildren()[index];
+  },
 
-    /**
+  /**
      * Invokes a method on all children down the tree
      *
      * @param {String} method The method to invoke
      */
-    invoke: function (methodName) {
-      var args = _.toArray(arguments);
-      this.each(function (child) {
-        // if child has children, bubble down the tree
-        if (child.size()) {
-          child.invoke.apply(child, args);
-        }
-        // run the function on the child
-        if (_.isFunction(child[methodName])) {
-          child[methodName].apply(child, args.slice(1));
-        }
-      });
-      return this;
-    }
-  });
+  invoke: function (methodName) {
+    var args = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].toArray(arguments);
+    this.each(function (child) {
+      // if child has children, bubble down the tree
+      if (child.size()) {
+        child.invoke.apply(child, args);
+      }
+      // run the function on the child
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(child[methodName])) {
+        child[methodName].apply(child, args.slice(1));
+      }
+    });
+    return this;
+  }
+});
 
-  // Code borrowed from Backbone.js source
-  // Underscore methods that we want to implement on the Container.
-  var methods = ['each', 'map', 'reduce', 'reduceRight', 'find', 'filter', 'reject', 'every',
-    'some', 'contains', 'toArray', 'size', 'first', 'initial', 'rest', 'last', 'without',
-    'indexOf', 'shuffle', 'lastIndexOf', 'isEmpty', 'chain', 'where', 'findWhere'];
+// Code borrowed from Backbone.js source
+// Underscore methods that we want to implement on the Container.
+var methods = ['each', 'map', 'reduce', 'reduceRight', 'find', 'filter', 'reject', 'every',
+  'some', 'contains', 'toArray', 'size', 'first', 'initial', 'rest', 'last', 'without',
+  'indexOf', 'shuffle', 'lastIndexOf', 'isEmpty', 'chain', 'where', 'findWhere'];
 
-  _.each(methods, function (method) {
-    View.prototype[method] = function () {
-      var args = _.toArray(arguments);
-      args.unshift(_.toArray(this[CHILDREN]));
-      return _[method].apply(_, args);
-    };
-  }, this);
+__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(methods, function (method) {
+  View.prototype[method] = function () {
+    var args = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].toArray(arguments);
+    args.unshift(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].toArray(this[CHILDREN]));
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"][method].apply(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"], args);
+  };
+}, this);
 
-  /**
+/**
    * See [_.each](http://underscorejs.org/#each)
    * @name each
    * @memberof src/framework/View
@@ -3740,7 +3944,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} iterator
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.map](http://underscorejs.org/#map)
    * @name map
    * @memberof src/framework/View
@@ -3749,7 +3953,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} iterator
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.reduce](http://underscorejs.org/#reduce)
    * @name reduce
    * @memberof src/framework/View
@@ -3760,7 +3964,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Object} [context]
    */
 
-  /**
+/**
    * See [_.reduceRight](http://underscorejs.org/#reduceRight)
    * @name reduceRight
    * @memberof src/framework/View
@@ -3770,7 +3974,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Mixed} memo
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.find](http://underscorejs.org/#find)
    * @name find
    * @memberof src/framework/View
@@ -3779,7 +3983,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} predicate
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.filter](http://underscorejs.org/#filter)
    * @name filter
    * @memberof src/framework/View
@@ -3788,7 +3992,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} predicate
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.reject](http://underscorejs.org/#reject)
    * @name reject
    * @memberof src/framework/View
@@ -3797,7 +4001,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} predicate
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.every](http://underscorejs.org/#every)
    * @name every
    * @memberof src/framework/View
@@ -3806,7 +4010,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} [predicate]
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.some](http://underscorejs.org/#some)
    * @name some
    * @memberof src/framework/View
@@ -3815,7 +4019,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Function} [predicate]
    * @param {Object} [context]
    */
-  /**
+/**
    * See [_.contains](http://underscorejs.org/#contains)
    * @name contains
    * @memberof src/framework/View
@@ -3823,21 +4027,21 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Mixed} value
    */
-  /**
+/**
    * See [_.toArray](http://underscorejs.org/#toArray)
    * @name toArray
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.size](http://underscorejs.org/#size)
    * @name size
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.first](http://underscorejs.org/#first)
    * @name first
    * @memberof src/framework/View
@@ -3845,7 +4049,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Number} [n]
    */
-  /**
+/**
    * See [_.initial](http://underscorejs.org/#initial)
    * @name initial
    * @memberof src/framework/View
@@ -3853,7 +4057,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Number} [n]
    */
-  /**
+/**
    * See [_.last](http://underscorejs.org/#last)
    * @name last
    * @memberof src/framework/View
@@ -3861,7 +4065,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Number} [n]
    */
-  /**
+/**
    * See [_.rest](http://underscorejs.org/#rest)
    * @name rest
    * @memberof src/framework/View
@@ -3869,14 +4073,14 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Number} [index]
    */
-  /**
+/**
    * See [_.without](http://underscorejs.org/#without)
    * @name without
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.indexOf](http://underscorejs.org/#indexOf)
    * @name indexOf
    * @memberof src/framework/View
@@ -3885,14 +4089,14 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Mixed} value
    * @param {Boolean} [isSorted]
    */
-  /**
+/**
    * See [_.shuffle](http://underscorejs.org/#shuffle)
    * @name shuffle
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.shuffle](http://underscorejs.org/#lastIndexOf)
    * @name lastIndexOf
    * @memberof src/framework/View
@@ -3901,21 +4105,21 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Mixed} value
    * @param {Number} [fromIndex]
    */
-  /**
+/**
    * See [_.isEmpty](http://underscorejs.org/#isEmpty)
    * @name isEmpty
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.chain](http://underscorejs.org/#chain)
    * @name chain
    * @memberof src/framework/View
    * @method
    * @instance
    */
-  /**
+/**
    * See [_.where](http://underscorejs.org/#where)
    * @name where
    * @memberof src/framework/View
@@ -3923,7 +4127,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @instance
    * @param {Object} properties
    */
-  /**
+/**
    * See [_.findWhere](http://underscorejs.org/#findWhere)
    * @name findWhere
    * @memberof src/framework/View
@@ -3932,315 +4136,59 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * @param {Object} properties
    */
 
-  return View;
+/* harmony default export */ __webpack_exports__["a"] = (View);
 
-}));
 
+/***/ }),
+/* 22 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+var __WEBPACK_AMD_DEFINE_RESULT__;
+
+// TODO: maybe replaced by
+// https://github.com/Calvein/empty-module
+// https://github.com/crimx/empty-module-loader
+!(__WEBPACK_AMD_DEFINE_RESULT__ = (function () {}).call(exports, __webpack_require__, exports, module),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 /***/ }),
 /* 23 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_) {
-
-  function changeEventString(doWhen) {
-    return 'change:' + _.keys(doWhen).join(' change:');
-  }
-
-  function calcDoWhen(value, key) {
-    var modelValue = this.model.get(key);
-    if (_.isFunction(value)) {
-      return value.call(this, modelValue);
-    }
-    else {
-      return value == modelValue;
-    }
-  }
-
-  function _doWhen(view, doWhen, fn) {
-    var toggle = _.bind(fn, view, view, doWhen);
-
-    view.render = _.wrap(view.render, function (render) {
-      var val = render.call(view);
-      toggle({animate: false});
-      return val;
-    });
-
-    view.listenTo(view.model, changeEventString(doWhen), function () {
-      toggle({animate: true});
-    });
-  }
-
-  return {
-    applyDoWhen: function (view, doWhen, fn) {
-      if (!(view.model && _.isObject(doWhen) && _.size(doWhen) && _.isFunction(fn))) {
-        return;
-      }
-      _doWhen(view, doWhen, function (view, doWhen, options) {
-        var result = _.every(_.map(doWhen, calcDoWhen, view));
-        fn.call(view, result, options);
-      });
-    }
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__components_ReadModeBar__ = __webpack_require__(44);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__components_Toolbar__ = __webpack_require__(25);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_7__helpers_ErrorBanner__ = __webpack_require__(45);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_8__helpers_ErrorParser__ = __webpack_require__(46);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__ = __webpack_require__(9);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_10__helpers_InputContainer__ = __webpack_require__(47);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_11__helpers_InputFactory__ = __webpack_require__(48);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_12__helpers_InputLabel__ = __webpack_require__(49);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_13__helpers_InputWrapper__ = __webpack_require__(50);
+/* eslint max-statements: [2, 11] */
 
 
-/***/ }),
-/* 24 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-len: [2, 150], max-params: [2, 7] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(5),
-  __webpack_require__(25),
-  __webpack_require__(6),
-  __webpack_require__(43),
-  __webpack_require__(44)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, Backbone, SettingsModel, Logger, Notification, ConfirmationDialog) {
-
-  function getRoute(router, route) {
-    var root = _.result(router, 'root') || '';
-    if (root && _.isString(route)) {
-      return [root, route].join('/').replace(/\/{2,}/g, '/');
-    }
-    return route;
-  }
-
-  /**
-   * BaseRouter is a standard [Backbone.Router](http://backbonejs.org/#Router)
-   * with a few additions:
-   * - Explicit mapping between routes and controllers
-   * - Support for rendering notification and confirmation dialogs
-   *
-   * Checkout the [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World)
-   * for a step-by-step guide to using this.
-   *
-   * @class module:Okta.Router
-   * @extends external:Backbone.Router
-   * @param {Object} options options hash
-   * @param {String} options.el a jQuery selector string stating where to attach the controller in the DOM
-   */
-  return Backbone.Router.extend(/** @lends module:Okta.Router.prototype */ {
-
-    /**
-     * The root URL for the router. When setting {@link http://backbonejs.org/#Router-routes|routes},
-     * it will be prepended to each route.
-     * @type {String|Function}
-     */
-    root: '',
-
-    listen: Notification.prototype.listen,
-
-    constructor: function (options) {
-      options || (options = {});
-      this.el = options.el;
-      this.settings = new SettingsModel(_.omit(options, 'el'));
-      if (options.root) {
-        this.root = options.root;
-      }
-
-      Backbone.Router.apply(this, arguments);
-
-      this.listen('notification', this._notify);
-      this.listen('confirmation', this._confirm);
-    },
-
-    /**
-     * Fires up a confirmation dialog
-     *
-     * @param  {Object} options Options Hash
-     * @param  {String} options.title The title
-     * @param  {String} options.subtitle The explain text
-     * @param  {String} options.save The text for the save button
-     * @param  {Function} options.ok The callback function to run when hitting "OK"
-     * @param  {String} options.cancel The text for the cancel button
-     * @param  {Function} options.cancelFn The callback function to run when hitting "Cancel"
-     * @param  {Boolean} options.noCancelButton Don't render the cancel button (useful for alert dialogs)
-     *
-     * @private
-     *
-     * @return {Okta.View} the dialog view
-     */
-    _confirm: function (options) {
-      options || (options = {});
-      var Dialog = ConfirmationDialog.extend(
-        _.pick(options, 'title', 'subtitle', 'save', 'ok', 'cancel', 'cancelFn', 'noCancelButton', 'content', 'danger')
-      );
-      // The model is here because itsa part of the BaseForm paradigm.
-      // It will be ignored in the context of a confirmation dialog.
-      var dialog = new Dialog({model: this.settings});
-      dialog.render();
-      return dialog; // test hook
-    },
-
-    /**
-     * Fires up a notification banner
-     *
-     * @param  {Object} options Options Hash
-     * @return {Okta.View} the notification view
-     * @private
-     */
-    _notify: function (options) {
-      var notification = new Notification(options);
-      $('#content').prepend(notification.render().el);
-      return notification; // test hook
-    },
-
-    /**
-     * Renders a Controller
-     * This will initialize new instance of a controller and call render on it
-     *
-     * @param  {Okta.Controller} Controller The controller Class we which to render
-     * @param  {Object} [options] Extra options to the controller constructor
-     */
-    render: function (Controller, options) {
-      this.unload();
-      options = _.extend(_.pick(this, 'settings', 'el'), options || {});
-      this.controller = new Controller(options);
-      this.controller.render();
-    },
-
-    /**
-    * Starts the backbone history object
-    *
-    * Waits for the dom to be ready before calling `Backbone.history.start()` (IE issue).
-    *
-    * See [Backbone History](http://backbonejs.org/#History) for more information.
-    */
-    start: function () {
-      var args = arguments;
-      $(function () {
-        if (Backbone.History.started) {
-          Logger.error('History has already been started');
-          return;
-        }
-        Backbone.history.start.apply(Backbone.history, args);
-      });
-    },
-
-    /**
-     * Removes active controller and frees up event listeners
-     */
-    unload: function () {
-      if (this.controller) {
-        this.stopListening(this.controller);
-        this.stopListening(this.controller.state);
-        this.controller.remove();
-      }
-    },
-
-    route: function (route, name, callback) {
-      return Backbone.Router.prototype.route.call(this, getRoute(this, route), name, callback);
-    },
-
-    navigate: function (fragment, options) {
-      return Backbone.Router.prototype.navigate.call(this, getRoute(this, fragment), options);
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 
-/***/ }),
-/* 25 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(11)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Model) {
-
-  /**
-   * @class SettingsModel
-   * @extends {Okta.Model}
-   * @private
-   */
-
-  return Model.extend({
-    local: function () {
-      var settings = (window.okta && window.okta.settings) || {};
-      return {
-        orgId: ['string', false, settings.orgId],
-        orgName: ['string', false, settings.orgName],
-        serverStatus: ['string', false, settings.serverStatus],
-        persona: ['string', false, settings.persona],
-        isDeveloperConsole: ['boolean', false, settings.isDeveloperConsole],
-        isPreview: ['boolean', false, settings.isPreview],
-        permissions: ['array', true, settings.permissions || []]
-      };
-    },
-
-    extraProperties: true,
-
-    constructor: function () {
-      this.features = window._features || [];
-      Model.apply(this, arguments);
-    },
-
-    /**
-     * Checks if the user have a feature flag enabled (Based of the org level feature flag)
-     * @param  {String}  feature Feature name
-     * @return {Boolean}
-     */
-    hasFeature: function (feature) {
-      if (this.features.length === 0 && window.okta && window.okta.logHasFeatureError) {
-        window.okta.logHasFeatureError(feature);
-      }
-      return _.contains(this.features, feature);
-    },
-
-    /**
-     * Checks if any of the given feature flags are enabled (Based of the org level feature flags)
-     * @param  {Array}  featureArray Features names
-     * @return {Boolean} true if any of the give features are enabled. False otherwise
-     */
-    hasAnyFeature: function (featureArray) {
-      return _.some(featureArray, this.hasFeature, this);
-    },
-
-    /**
-     * Checks if the user have a specific permission (based on data passed from JSP)
-     * @param  {String}  permission Permission name
-     * @return {Boolean}
-     */
-    hasPermission: function (permission) {
-      return _.contains(this.get('permissions'), permission);
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 
-/***/ }),
-/* 26 */
-/***/ (function(module, exports, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-params: [2, 14], max-statements: [2, 11] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(3),
-  __webpack_require__(4),
-  __webpack_require__(1),
-  __webpack_require__(48),
-  __webpack_require__(49),
-  __webpack_require__(47),
-  __webpack_require__(50),
-  __webpack_require__(51),
-  __webpack_require__(52),
-  __webpack_require__(8),
-  __webpack_require__(53),
-  __webpack_require__(29)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, TemplateUtil, StringUtil, BaseView,
-          InputFactory, InputLabel, InputContainer, InputWrapper,
-          ErrorBanner, ErrorParser, FormUtil, ReadModeBar, Toolbar) {
 
-  var template = '\
+
+
+
+
+
+
+const template =
+  '\
     {{#if hasReadMode}}\
       <h2 class="o-form-title-bar" data-se="o-form-title-bar">\
         {{title}}\
@@ -4259,107 +4207,110 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
       <div class="o-form-fieldset-container" data-se="o-form-fieldset-container"></div>\
     </div>\
   ';
+const pointerEventsSupported = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('<div>').css({ 'pointer-events': 'auto' })[0].style.pointerEvents === 'auto';
 
-  // polyfill for `pointer-events: none;` in IE < 11
-  // Logic borrowed from https://github.com/kmewhort/pointer_events_polyfill (BSD)
-  var pointerEventsSupported = ($('<div>').css({'pointer-events': 'auto'})[0].style.pointerEvents === 'auto');
-  function pointerEventsPolyfill(e) {
-    if (!pointerEventsSupported && this.$el.hasClass('o-form-saving')) {
-      var $el = $(e.currentTarget);
+// polyfill for `pointer-events: none;` in IE < 11
+// Logic borrowed from https://github.com/kmewhort/pointer_events_polyfill (BSD)
 
-      $el.css('display', 'none');
-      var underneathElem = document.elementFromPoint(e.clientX, e.clientY);
-      $el.css('display', 'block');
+function pointerEventsPolyfill(e) {
+  if (!pointerEventsSupported && this.$el.hasClass('o-form-saving')) {
+    const $el = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(e.currentTarget);
 
-      e.target = underneathElem;
-      $(underneathElem).trigger(e);
+    $el.css('display', 'none');
+    const underneathElem = document.elementFromPoint(e.clientX, e.clientY);
 
-      return false;
-    }
+    $el.css('display', 'block');
+
+    e.target = underneathElem;
+    Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(underneathElem).trigger(e);
+
+    return false;
   }
+}
 
+const events = {
+  submit: function (e) {
+    e.preventDefault();
+    this.__save();
+  }
+};
 
-  var events = {
-    submit: function (e) {
-      e.preventDefault();
-      this.__save();
-    }
+__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(['click', 'dblclick', 'mousedown', 'mouseup'], function (event) {
+  events[event + ' .o-form-input'] = pointerEventsPolyfill;
+});
+
+const attributes = function (model) {
+  model || (model = {});
+  const collection = (model && model.collection) || {};
+
+  return {
+    method: 'POST',
+    action: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(model, 'urlRoot') || __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(collection, 'url') || window.location.pathname,
+    'data-se': 'o-form'
   };
+};
 
-  _.each(['click', 'dblclick', 'mousedown', 'mouseup'], function (event) {
-    events[event + ' .o-form-input'] = pointerEventsPolyfill;
-  });
+const convertSavingState = function (rawSavingStateEvent, defaultEvent) {
+  rawSavingStateEvent || (rawSavingStateEvent = '');
+  let savingStateEvent = [];
 
-  var attributes = function (model) {
-    model || (model = {});
-    var collection = model && model.collection || {};
-    return {
-      method: 'POST',
-      action: _.result(model, 'urlRoot') || _.result(collection, 'url') || window.location.pathname,
-      'data-se': 'o-form'
-    };
-  };
+  if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isString(rawSavingStateEvent)) {
+    savingStateEvent = rawSavingStateEvent.split(' ');
+  }
+  savingStateEvent = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].union(savingStateEvent, defaultEvent);
+  return savingStateEvent.join(' ');
+};
 
-  var convertSavingState = function (rawSavingStateEvent, defaultEvent) {
-    rawSavingStateEvent || (rawSavingStateEvent = '');
-    var savingStateEvent = [];
-    if (_.isString(rawSavingStateEvent)) {
-      savingStateEvent = rawSavingStateEvent.split(' ');
-    }
-    savingStateEvent = _.union(savingStateEvent, defaultEvent);
-    return savingStateEvent.join(' ');
-  };
+/**
+ * A Form utility framework
+ *
+ * Okta.Form is a form that operates on one flat model
+ * It exposes one main factory method, {@link module:Okta.Form#addInput|addInput}, which add inputs to the form,
+ * and each input operates on one field in the model, identified by the `name` field.
+ *
+ * See:
+ * [Basic O-Form Tutorial](https://github.com/okta/courage/wiki/Basic-O-Form)
+ *
+ * @class module:Okta.Form
+ * @extends module:Okta.View
+ * @param {Object} options options hash (See {@link module:Okta.View|View})
+ * @param {Object} options.model the model this form operates on
+ * @param {Boolean} [options.label-top=false] position label on top of inputs
+ * @param {Boolean} [options.wide=false] Use a wide input layout for all input
+ */
 
-  /**
-   * A Form utility framework
-   *
-   * Okta.Form is a form that operates on one flat model
-   * It exposes one main factory method, {@link module:Okta.Form#addInput|addInput}, which add inputs to the form,
-   * and each input operates on one field in the model, identified by the `name` field.
-   *
-   * See:
-   * [Basic O-Form Tutorial](https://github.com/okta/courage/wiki/Basic-O-Form)
-   *
-   * @class module:Okta.Form
-   * @extends module:Okta.View
-   * @param {Object} options options hash (See {@link module:Okta.View|View})
-   * @param {Object} options.model the model this form operates on
-   * @param {Boolean} [options.label-top=false] position label on top of inputs
-   * @param {Boolean} [options.wide=false] Use a wide input layout for all input
-   */
+/**
+ * Fired when the "Save" button is clicked
+ * @event module:Okta.Form#save
+ * @param {module:Okta.Model} model Model used in the form
+ */
 
-  /**
-   * Fired when the "Save" button is clicked
-   * @event module:Okta.Form#save
-   * @param {module:Okta.Model} model Model used in the form
-   */
+/**
+ * Fired after the model is successfully saved - applies when {@link module:Okta.Form#autoSave|autoSave}
+ * is set to true
+ * @event module:Okta.Form#saved
+ * @param {module:Okta.Model} model Model used in the form
+ */
 
-  /**
-   * Fired after the model is successfully saved - applies when {@link module:Okta.Form#autoSave|autoSave}
-   * is set to true
-   * @event module:Okta.Form#saved
-   * @param {module:Okta.Model} model Model used in the form
-   */
+/**
+ * Fired when the model fires an invalid event or an error event;
+ * @event module:Okta.Form#error
+ * @param {module:Okta.Model} model Model used in the form
+ */
 
-  /**
-   * Fired when the model fires an invalid event or an error event;
-   * @event module:Okta.Form#error
-   * @param {module:Okta.Model} model Model used in the form
-   */
+/**
+ * Fired when the form layout is likely to be resized
+ * @event module:Okta.Form#resize
+ * @param {module:Okta.Model} model Model used in the form
+ */
 
-  /**
-   * Fired when the form layout is likely to be resized
-   * @event module:Okta.Form#resize
-   * @param {module:Okta.Model} model Model used in the form
-   */
+/**
+ * Fired when the "Cancel" button is clicked
+ * @event module:Okta.Form#cancel
+ */
 
-  /**
-   * Fired when the "Cancel" button is clicked
-   * @event module:Okta.Form#cancel
-   */
-
-  return BaseView.extend(/** @lends module:Okta.Form.prototype */ {
-
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend(
+  /** @lends module:Okta.Form.prototype */ {
     /**
      * Specifies how to validate form:
      * - In case "local" string provided as a value of the property,
@@ -4378,11 +4329,11 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
       options || (options = {});
       this.options = options;
 
-      this.id = _.uniqueId('form');
+      this.id = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].uniqueId('form');
       this.tagName = 'form';
 
-      _.defaults(this.events, events);
-      _.defaults(this.attributes, attributes(options.model));
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults(this.events, events);
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults(this.attributes, attributes(options.model));
 
       this.__buttons = [];
       this.__errorFields = {};
@@ -4391,7 +4342,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
 
       if (this.step) {
         if (!this.save) {
-          this.save = (!this.totalSteps || this.step === this.totalSteps) ? 'Finish' : 'Next';
+          this.save = !this.totalSteps || this.step === this.totalSteps ? 'Finish' : 'Next';
         }
         this.className += ' wizard';
       }
@@ -4399,68 +4350,82 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
 
       this.__toolbar = this.__createToolbar(options);
 
-      BaseView.call(this, options);
+      __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].call(this, options);
 
-      _.each(_.result(this, 'inputs') || [], function (input) {
-        // to ingore extra argumests from `each` iteratee function
-        // http://underscorejs.org/#each
-        this.__addLayoutItem(input);
-      }, this);
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'inputs') || [],
+        function (input) {
+          // to ingore extra argumests from `each` iteratee function
+          // http://underscorejs.org/#each
+          this.__addLayoutItem(input);
+        },
+        this
+      );
 
       this.add(this.__toolbar, '');
 
       this.listenTo(this.model, 'change:__edit__', this.__applyMode);
 
-      this.listenTo(this.model, 'invalid error', _.throttle(function (model, resp, showBanner) {
-        this.__showErrors(model, resp, showBanner !== false);
-      }, 100, {trailing: false}));
+      this.listenTo(
+        this.model,
+        'invalid error',
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].throttle(
+          function (model, resp, showBanner) {
+            this.__showErrors(model, resp, showBanner !== false);
+          },
+          100,
+          { trailing: false }
+        )
+      );
 
       this.listenTo(this.model, 'form:resize', function () {
         this.trigger('resize');
       });
 
-      this.listenTo(this.model, 'form:cancel', _.throttle(this.__cancel, 100, {trailing: false}));
-      this.listenTo(this.model, 'form:previous', _.throttle(this.__previous, 100, {trailing: false}));
+      this.listenTo(this.model, 'form:cancel', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].throttle(this.__cancel, 100, { trailing: false }));
+      this.listenTo(this.model, 'form:previous', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].throttle(this.__previous, 100, { trailing: false }));
 
-      this.__save = _.throttle(this.__save, 200, {trailing: false});
+      this.__save = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].throttle(this.__save, 200, { trailing: false });
       this.listenTo(this.model, 'form:save', function () {
         this.$el.submit();
       });
 
       this.listenTo(this.model, 'sync', function () {
         if (this.model.get('__edit__')) {
-          this.model.set('__edit__', false, {silent: true});
+          this.model.set('__edit__', false, { silent: true });
         }
         this.__saveModelState(this.model);
         this.render();
       });
 
-      var hasSavingState = this.getAttribute('hasSavingState');
+      let hasSavingState = this.getAttribute('hasSavingState');
 
       if (this.getAttribute('autoSave')) {
         this.listenTo(this, 'save', function (model) {
-          var xhr = model.save();
+          const xhr = model.save();
+
           if (xhr && xhr.done) {
-            xhr.done(_.bind(function () {
+            xhr.done(() => {
               this.trigger('saved', model);
-            }, this));
+            });
           }
         });
-        if (_.isUndefined(hasSavingState)) {
+        if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(hasSavingState)) {
           hasSavingState = true;
         }
       }
 
       /*
-       * Attach model event listeners
-       * by default, model's request event starts the form saving state,
-       * error and sync event stops it
-       * you can define customized saving start and stop state, like
-       * customSavingState: {start: 'requestingAdditionalInfo', stop: 'retrievedAdditionalInfo'}
-       * doing this does not override the default events
-       */
+     * Attach model event listeners
+     * by default, model's request event starts the form saving state,
+     * error and sync event stops it
+     * you can define customized saving start and stop state, like
+     * customSavingState: {start: 'requestingAdditionalInfo', stop: 'retrievedAdditionalInfo'}
+     * doing this does not override the default events
+     */
       if (hasSavingState) {
-        var customSavingState = this.getAttribute('customSavingState', {});
+        const customSavingState = this.getAttribute('customSavingState', {});
+
         this.listenTo(
           this.model,
           convertSavingState(customSavingState.start || '', ['request']),
@@ -4481,20 +4446,23 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @private
      */
     __createToolbar: function (options) {
+      const danger = this.getAttribute('danger');
+      const saveBtnClassName = danger === true ? 'button-error' : 'button-primary';
+      const toolbar = new __WEBPACK_IMPORTED_MODULE_6__components_Toolbar__["default"](
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(
+          {
+            save: this.save || __WEBPACK_IMPORTED_MODULE_2__util_StringUtil__["default"].localize('oform.save', 'courage'),
+            saveId: this.saveId,
+            saveClassName: saveBtnClassName,
+            cancel: this.cancel || __WEBPACK_IMPORTED_MODULE_2__util_StringUtil__["default"].localize('oform.cancel', 'courage'),
+            noCancelButton: this.noCancelButton || false,
+            hasPrevStep: this.step && this.step > 1
+          },
+          options || this.options
+        )
+      );
 
-      var danger = this.getAttribute('danger');
-      var saveBtnClassName = danger === true ? 'button-error' : 'button-primary';
-
-      var toolbar = new Toolbar(_.extend({
-        save: this.save || StringUtil.localize('oform.save', 'courage'),
-        saveId: this.saveId,
-        saveClassName: saveBtnClassName,
-        cancel: this.cancel || StringUtil.localize('oform.cancel', 'courage'),
-        noCancelButton: this.noCancelButton || false,
-        hasPrevStep: this.step && this.step > 1
-      }, options || this.options));
-
-      _.each(this.__buttons, function (args) {
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(this.__buttons, function (args) {
         toolbar.addButton.apply(toolbar, args);
       });
 
@@ -4642,11 +4610,12 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @return {Object} The value
      */
     getAttribute: function (name, defaultValue) {
-      var value = _.resultCtx(this.options, name, this);
-      if (_.isUndefined(value)) {
-        value = _.result(this, name);
+      let value = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.options, name, this);
+
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(value)) {
+        value = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, name);
       }
-      return !_.isUndefined(value) ? value : defaultValue;
+      return !__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(value) ? value : defaultValue;
     },
 
     /**
@@ -4674,16 +4643,16 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
     },
 
     render: function () {
-
       this.__readModeBar && this.__readModeBar.remove();
       if (this.hasReadMode() && !this.isReadOnly()) {
-        var readModeBar = ReadModeBar.extend({
+        const readModeBar = __WEBPACK_IMPORTED_MODULE_5__components_ReadModeBar__["a" /* default */].extend({
           formTitle: this.getAttribute('title', '')
         });
+
         this.__readModeBar = this.add(readModeBar, '.o-form-title-bar').last();
       }
 
-      var html = TemplateUtil.tpl(template)({
+      const html = __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl(template)({
         layout: this.getAttribute('layout', ''),
         title: this.getAttribute('title', '', true),
         subtitle: this.getAttribute('subtitle', '', true),
@@ -4693,7 +4662,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
       this.$el.html(html);
       delete this.template;
 
-      BaseView.prototype.render.apply(this, arguments);
+      __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].prototype.render.apply(this, arguments);
 
       this.__applyMode();
 
@@ -4743,21 +4712,22 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @fires cancel
      */
     __cancel: function () {
+      const edit = this.model.get('__edit__');
       /* eslint max-statements: [2, 12] */
-      var edit = this.model.get('__edit__');
-      this.model.clear({silent: true});
-      var data;
+
+      this.model.clear({ silent: true });
+      let data;
+
       if (this.model.sanitizeAttributes) {
         data = this.model.sanitizeAttributes(this.__originalModel);
+      } else {
+        data = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(this.__originalModel);
       }
-      else {
-        data = _.clone(this.__originalModel);
-      }
-      this.model.set(data, {silent: true});
+      this.model.set(data, { silent: true });
       this.trigger('cancel', this.model);
       this.model.trigger('cache:clear');
       if (edit) {
-        this.model.set('__edit__', false, {silent: true});
+        this.model.set('__edit__', false, { silent: true });
         this.model.trigger('change:__edit__', this.model, false);
       }
       this.clearErrors();
@@ -4769,35 +4739,37 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @returns {Boolean}
      */
     isValid: function () {
-      var res;
-      var self = this;
+      let res;
+      const self = this;
 
       function validateArray(arr) {
-        return _.reduce(arr, function (memo, fieldName) {
-          return _.extend(memo, self.model.validateField(fieldName));
-        }, {});
+        return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].reduce(
+          arr,
+          function (memo, fieldName) {
+            return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(memo, self.model.validateField(fieldName));
+          },
+          {}
+        );
       }
 
-      if (_.isUndefined(this.validate)) {
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(this.validate)) {
         return this.model.isValid();
-      }
-      else if (_.isFunction(this.validate)) {
+      } else if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(this.validate)) {
         res = this.validate();
-      }
-      else if (_.isArray(this.validate)) {
+      } else if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isArray(this.validate)) {
         res = validateArray(this.validate);
-      }
-      else if (this.validate === 'local') {
-        res = validateArray(this.getInputs().map(function (input) {
-          return input.options.name;
-        }));
+      } else if (this.validate === 'local') {
+        res = validateArray(
+          this.getInputs().map(function (input) {
+            return input.options.name;
+          })
+        );
       }
 
-      if (!_.isEmpty(res)) {
+      if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(res)) {
         this.model.trigger('invalid', this.model, res);
         return false;
-      }
-      else {
+      } else {
         return true;
       }
     },
@@ -4838,8 +4810,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
         this.$el.removeClass('o-form-read-mode');
         this.$('.o-form-content').removeClass('rounded-btm-4');
         this.focus();
-      }
-      else {
+      } else {
         this.$el.removeClass('o-form-edit-mode');
         this.$el.addClass('o-form-read-mode');
         this.$('.o-form-content').addClass('rounded-btm-4');
@@ -4861,7 +4832,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @method
      * @default _.identity
      */
-    parseErrorMessage: _.identity,
+    parseErrorMessage: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].identity,
 
     /**
      * Show an error message based on an XHR error
@@ -4874,20 +4845,27 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
 
       /* eslint max-statements: 0 */
       if (this.getAttribute('showErrors')) {
-
-        var errorSummary;
-        var responseJSON = ErrorParser.getResponseJSON(resp);
+        let errorSummary;
+        let responseJSON = __WEBPACK_IMPORTED_MODULE_8__helpers_ErrorParser__["a" /* default */].getResponseJSON(resp);
+        const validationErrors = __WEBPACK_IMPORTED_MODULE_8__helpers_ErrorParser__["a" /* default */].parseFieldErrors(resp);
 
         // trigger events for field validation errors
-        var validationErrors = ErrorParser.parseFieldErrors(resp);
-        if (_.size(validationErrors)) {
-          _.each(validationErrors, function (errors, field) {
-            this.model.trigger('form:field-error', this.__errorFields[field] || field, _.map(errors, function (error) {
-              return (/^model\.validation/).test(error) ? StringUtil.localize(error, 'courage') : error;
-            }));
-          }, this);
-        }
-        else if (responseJSON && Array.isArray(responseJSON.errorCauses) && responseJSON.errorCauses.length > 0){
+
+        if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].size(validationErrors)) {
+          __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+            validationErrors,
+            function (errors, field) {
+              this.model.trigger(
+                'form:field-error',
+                this.__errorFields[field] || field,
+                __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(errors, function (error) {
+                  return /^model\.validation/.test(error) ? __WEBPACK_IMPORTED_MODULE_2__util_StringUtil__["default"].localize(error, 'courage') : error;
+                })
+              );
+            },
+            this
+          );
+        } else if (responseJSON && Array.isArray(responseJSON.errorCauses) && responseJSON.errorCauses.length > 0) {
           //set errorSummary from first errorCause which is not field specific error
           errorSummary = responseJSON.errorCauses[0].errorSummary;
         } else {
@@ -4899,17 +4877,17 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
         // show the error message
         if (showBanner) {
           this.$('.o-form-error-container').addClass('o-form-has-errors');
-          this.add(ErrorBanner, '.o-form-error-container', {options: {errorSummary: errorSummary}});
+          this.add(__WEBPACK_IMPORTED_MODULE_7__helpers_ErrorBanner__["a" /* default */], '.o-form-error-container', { options: { errorSummary: errorSummary } });
         }
 
         // slide to and focus on the error message
         if (this.getAttribute('scrollOnError')) {
-          var $el = $('#' + this.id + ' .o-form-error-container');
-          $el.length && $('html, body').animate({scrollTop: $el.offset().top}, 400);
+          const $el = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('#' + this.id + ' .o-form-error-container');
+
+          $el.length && Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('html, body').animate({ scrollTop: $el.offset().top }, 400);
         }
 
         this.model.trigger('form:resize');
-
       }
     },
 
@@ -4923,7 +4901,6 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
       this.model.trigger('form:resize');
     },
 
-
     /**
      * Toggles between edit and read mode
      */
@@ -4933,19 +4910,19 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
     },
 
     __addLayoutItem: function (input) {
-      if (InputFactory.supports(input)) {
+      if (__WEBPACK_IMPORTED_MODULE_11__helpers_InputFactory__["a" /* default */].supports(input)) {
         this.addInput(input);
-      }
-      else {
+      } else {
         this.__addNonInputLayoutItem(input);
       }
     },
 
     __addNonInputLayoutItem: function (item) {
-      var itemOptions = _.omit(item, 'type');
+      const itemOptions = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].omit(item, 'type');
+
       switch (item.type) {
       case 'sectionTitle':
-        this.addSectionTitle(item.title, _.omit(itemOptions, 'title'));
+        this.addSectionTitle(item.title, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].omit(itemOptions, 'title'));
         break;
       case 'divider':
         this.addDivider(itemOptions);
@@ -4970,8 +4947,8 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      */
     addDivider: function (options) {
       this.add('<div class="okta-form-divider form-divider"></div>');
-      FormUtil.applyShowWhen(this.last(), options && options.showWhen);
-      FormUtil.applyToggleWhen(this.last(), options && options.toggleWhen);
+      __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].applyShowWhen(this.last(), options && options.showWhen);
+      __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].applyToggleWhen(this.last(), options && options.toggleWhen);
       return this;
     },
 
@@ -4980,9 +4957,9 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @param {String} title
      */
     addSectionTitle: function (title, options) {
-      this.add(TemplateUtil.tpl('<h2 class="o-form-head">{{title}}</h2>')({title: title}));
-      FormUtil.applyShowWhen(this.last(), options && options.showWhen);
-      FormUtil.applyToggleWhen(this.last(), options && options.toggleWhen);
+      this.add(__WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl('<h2 class="o-form-head">{{title}}</h2>')({ title: title }));
+      __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].applyShowWhen(this.last(), options && options.showWhen);
+      __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].applyToggleWhen(this.last(), options && options.toggleWhen);
       return this;
     },
 
@@ -5010,7 +4987,6 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @param {String} [options.errorField] The API error field here that maps to this input
      * @param {Boolean} [options.inlineValidation=true] Validate input on focusout
      * @param {String} [options.ariaLabel] Used to add aria-label attribute to the input when label is not present.
-
      * @param {Object} [options.options]
      * In the context of `radio` and `select`, a key/value set of options
      *
@@ -5065,41 +5041,48 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * }
      */
     addInput: function (_options) {
+      _options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].clone(_options);
 
-      _options = _.clone(_options);
+      __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].validateInput(_options, this.model);
 
-      FormUtil.validateInput(_options, this.model);
-
-      var inputsOptions = FormUtil.generateInputOptions(_options, this, this.__createInput).reverse();
+      const inputsOptions = __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].generateInputOptions(_options, this, this.__createInput).reverse();
 
       // We need a local variable here to keep track
       // as addInput can be called either directy or through the inputs array.
-      if (_.isEmpty(this.getInputs().toArray())) {
-        _.extend(inputsOptions[0], {validateOnlyIfDirty: true});
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(this.getInputs().toArray())) {
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(inputsOptions[0], { validateOnlyIfDirty: true });
       }
-      var inputs = _.map(inputsOptions, this.__createInput, this);
 
-      _.each(inputsOptions, function (input) {
-        if (input.errorField) {
-          this.__errorFields[input.errorField] = input.name;
-        }
-      }, this);
+      const inputs = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].map(inputsOptions, this.__createInput, this);
 
-      var options = {
-        inputId: _.last(inputs).options.inputId,
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+        inputsOptions,
+        function (input) {
+          if (input.errorField) {
+            this.__errorFields[input.errorField] = input.name;
+          }
+        },
+        this
+      );
+
+      const options = {
+        inputId: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].last(inputs).options.inputId,
         input: inputs,
         multi: inputsOptions.length > 1 ? inputsOptions.length : undefined
       };
-      _.extend(options, _.omit(this.options, 'input'), _.omit(_options, 'input'));
 
-      var inputWrapper = this.__createWrapper(options);
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(options, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].omit(this.options, 'input'), __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].omit(_options, 'input'));
+
+      const inputWrapper = this.__createWrapper(options);
+
       if (options.label !== false) {
         inputWrapper.add(this.__createLabel(options));
       }
       inputWrapper.add(this._createContainer(options));
       inputWrapper.type = options.type || options.input.type || 'custom';
 
-      var args = [inputWrapper].concat(_.drop(arguments, 1));
+      const args = [inputWrapper].concat(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].drop(arguments, 1));
+
       return this.add.apply(this, args);
     },
 
@@ -5107,32 +5090,32 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @private
      */
     __createInput: function (options) {
-      options = _.pick(options, FormUtil.INPUT_OPTIONS);
-      return InputFactory.create(options);
+      options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(options, __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].INPUT_OPTIONS);
+      return __WEBPACK_IMPORTED_MODULE_11__helpers_InputFactory__["a" /* default */].create(options);
     },
 
     /**
      * @private
      */
     __createWrapper: function (options) {
-      options = _.pick(options, FormUtil.WRAPPER_OPTIONS);
-      return new InputWrapper(options);
+      options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(options, __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].WRAPPER_OPTIONS);
+      return new __WEBPACK_IMPORTED_MODULE_13__helpers_InputWrapper__["a" /* default */](options);
     },
 
     /**
      * @private
      */
     __createLabel: function (options) {
-      options = _.pick(options, FormUtil.LABEL_OPTIONS);
-      return new InputLabel(options);
+      options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(options, __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].LABEL_OPTIONS);
+      return new __WEBPACK_IMPORTED_MODULE_12__helpers_InputLabel__["a" /* default */](options);
     },
 
     /**
      * @private
      */
     _createContainer: function (options) {
-      options = _.pick(options, FormUtil.CONTAINER_OPTIONS);
-      return new InputContainer(options);
+      options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(options, __WEBPACK_IMPORTED_MODULE_9__helpers_FormUtil__["default"].CONTAINER_OPTIONS);
+      return new __WEBPACK_IMPORTED_MODULE_10__helpers_InputContainer__["a" /* default */](options);
     },
 
     /**
@@ -5149,16 +5132,18 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @ignore
      */
     add: function () {
-      var args = _.toArray(arguments);
+      const args = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].toArray(arguments);
+
       typeof args[1] === 'undefined' && (args[1] = '> div.o-form-content > .o-form-fieldset-container');
-      return BaseView.prototype.add.apply(this, args);
+      return __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].prototype.add.apply(this, args);
     },
 
     /**
      * Set the focus on the first input in the form
      */
     focus: function () {
-      var first = this.getInputs().first();
+      const first = this.getInputs().first();
+
       if (first && first.focus) {
         first.focus();
       }
@@ -5189,8 +5174,9 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @return {Number}
      */
     contentHeight: function (height) {
-      var content = this.$('.o-form-content');
-      if (_.isNumber(height)) {
+      const content = this.$('.o-form-content');
+
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(height)) {
         content.css('max-height', height);
       } else {
         return content.height();
@@ -5202,402 +5188,527 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
      * @return {InputWrapper[]} An underscore wrapped array of {@link InputWrapper} instances
      */
     getInputs: function () {
-      return _(this.filter(function (view) {
-        return view instanceof InputWrapper;
-      }));
+      return Object(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"])(
+        this.filter(function (view) {
+          return view instanceof __WEBPACK_IMPORTED_MODULE_13__helpers_InputWrapper__["a" /* default */];
+        })
+      );
     }
+  }
+));
 
+
+/***/ }),
+/* 24 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+
+
+function changeEventString(doWhen) {
+  return 'change:' + __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].keys(doWhen).join(' change:');
+}
+
+function calcDoWhen(value, key) {
+  const modelValue = this.model.get(key);
+
+  if (__WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isFunction(value)) {
+    return value.call(this, modelValue);
+  } else {
+    return value === modelValue;
+  }
+}
+
+function _doWhen(view, doWhen, fn) {
+  const toggle = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].bind(fn, view, view, doWhen);
+
+  view.render = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].wrap(view.render, function (render) {
+    const val = render.call(view);
+
+    toggle({ animate: false });
+    return val;
   });
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  view.listenTo(view.model, changeEventString(doWhen), function () {
+    toggle({ animate: true });
+  });
+}
+
+/* harmony default export */ __webpack_exports__["a"] = ({
+  applyDoWhen: function (view, doWhen, fn) {
+    if (!(view.model && __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isObject(doWhen) && __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].size(doWhen) && __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isFunction(fn))) {
+      return;
+    }
+    _doWhen(view, doWhen, function (view, doWhen, options) {
+      const result = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].every(__WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].map(doWhen, calcDoWhen, view));
+
+      fn.call(view, result, options);
+    });
+  }
+});
+
+
+/***/ }),
+/* 25 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__helpers_FormUtil__ = __webpack_require__(9);
+
+
+
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_1__BaseView__["default"].extend({
+  className: 'o-form-button-bar',
+
+  initialize: function (options) {
+    this.addButton({
+      type: 'save',
+      text: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(options, 'save', this),
+      id: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(options, 'saveId', this),
+      className: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(options, 'saveClassName', this)
+    });
+
+    if (!options.noCancelButton) {
+      this.addButton({ type: 'cancel', text: __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(options, 'cancel', this) });
+    }
+
+    if (options.hasPrevStep) {
+      this.addButton({ type: 'previous' }, { prepend: true });
+    }
+  },
+
+  /**
+   * Adds a buttomn to the toolbar
+   * @param {Object} params button parameters
+   * @param {Object} options {@link Okta.View#add} options
+   */
+  addButton: function (params, options) {
+    return this.add(__WEBPACK_IMPORTED_MODULE_2__helpers_FormUtil__["default"].createButton(params), options);
+  }
+}));
+
+
+/***/ }),
+/* 26 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+
+const registry = {};
+
+function isBaseInput(input) {
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(input)) {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(input.prototype.editMode) && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(input.prototype.readMode);
+  } else {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(input) && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(input.editMode) && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(input.readMode);
+  }
+}
+
+/**
+ * @class module:Okta.internal.views.forms.helpers.InputRegistry
+ */
+/* harmony default export */ __webpack_exports__["default"] = ({
+  isBaseInput: isBaseInput,
+
+  /**
+   * Register a form input
+   * @param {String} type string identifier for the input
+   * @param {BaseInput} input the input to register
+   */
+  register: function (type, input) {
+    registry[type] = input;
+  },
+
+  /**
+   * Get a form input by type
+   * @param {Object} options input definition
+   * @param {String} options.type string identifier for the input
+   * @return {BaseInput} a matching input
+   */
+  get: function (options) {
+    const input = registry[options.type];
+
+    return input && (isBaseInput(input) ? input : input(options));
+  },
+
+  /**
+   * Unregister an input type
+   * @param {String} type
+   */
+  unregister: function (type) {
+    delete registry[type];
+  }
+});
 
 
 /***/ }),
 /* 27 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_) {
-  var registry = {};
-
-  function isBaseInput(input) {
-    if (_.isFunction(input)) {
-      return _.isFunction(input.prototype.editMode) && _.isFunction(input.prototype.readMode);
-    } else {
-      return _.isObject(input) && _.isFunction(input.editMode) && _.isFunction(input.readMode);
-    }
-  }
-
-  /**
-   * @class module:Okta.internal.views.forms.helpers.InputRegistry
-   */
-  return /** @lends module:Okta.internal.views.forms.helpers.InputRegistry */ {
-    isBaseInput: isBaseInput,
-
-    /**
-     * Register a form input
-     * @param {String} type string identifier for the input
-     * @param {BaseInput} input the input to register
-     */
-    register: function (type, input) {
-      registry[type] = input;
-    },
-
-    /**
-     * Get a form input by type
-     * @param {Object} options input definition
-     * @param {String} options.type string identifier for the input
-     * @return {BaseInput} a matching input
-     */
-    get: function (options) {
-      var input = registry[options.type];
-      return input && (isBaseInput(input) ? input : input(options));
-    },
-
-    /**
-     * Unregister an input type
-     * @param {String} type
-     */
-    unregister: function (type) {
-      delete registry[type];
-    }
-  };
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 28 */
 /***/ (function(module, exports) {
 
 module.exports = require("qtip");
 
 /***/ }),
+/* 28 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__views_components_BaseButtonLink__ = __webpack_require__(53);
+
+
+
+/**
+ * A factory method wrapper for {@link BaseButtonLink} creation
+ * @class module:Okta.internal.util.ButtonFactory
+ */
+
+function normalizeEvents(options) {
+  const events = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].extend(options.click ? { click: options.click } : {}, options.events || {});
+
+  const target = {};
+
+  __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].each(events, function (fn, eventName) {
+    target[eventName] = function (e) {
+      if (!options.href) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      fn.apply(this, arguments);
+    };
+  });
+  return target;
+}
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  /**
+   * Creates a {@link module:Okta.internal.views.components.BaseButtonLink|BaseButtonLink}.
+   * @param  {Object} options Options hash
+   * @param  {String} [options.title] The button text
+   * @param  {String} [options.icon]
+   * CSS class for the icon to display. See [Style guide](http://rain.okta1.com:1802/su/dev/style-guide#icons)
+   * @param {String} [options.href] The button link
+   * @param {Function} [options.click] On click callback
+   * @param {Object} [options.events] a [Backbone events](http://backbonejs.org/#View-delegateEvents) hash
+   * @returns {module:Okta.internal.views.components.BaseButtonLink} BaseButtonLink prototype ("class")
+   */
+  create: function (options) {
+    options = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].clone(options);
+    options.attrs = options.attributes;
+    delete options.attributes;
+
+    return __WEBPACK_IMPORTED_MODULE_1__views_components_BaseButtonLink__["a" /* default */].extend(
+      __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].extend(options, {
+        events: normalizeEvents(options)
+      })
+    );
+  }
+});
+
+
+/***/ }),
 /* 29 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(8)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView, FormUtil) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_Keys__ = __webpack_require__(8);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_chosen_jquery__ = __webpack_require__(69);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_chosen_jquery___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_4_vendor_plugins_chosen_jquery__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__BaseInput__ = __webpack_require__(10);
 
-  return BaseView.extend({
 
-    className: 'o-form-button-bar',
 
-    initialize: function (options) {
-      this.addButton({
-        type: 'save',
-        text: _.resultCtx(options, 'save', this),
-        id: _.resultCtx(options, 'saveId', this),
-        className: _.resultCtx(options, 'saveClassName', this)
-      });
 
-      if (!options.noCancelButton) {
-        this.addButton({type: 'cancel', text: _.resultCtx(options, 'cancel', this)});
-      }
 
-      if (options.hasPrevStep) {
-        this.addButton({type: 'previous'}, {prepend: true});
-      }
-    },
 
-    /**
-     * Adds a buttomn to the toolbar
-     * @param {Object} params button parameters
-     * @param {Object} options {@link Okta.View#add} options
-     */
-    addButton: function (params, options) {
-      return this.add(FormUtil.createButton(params), options);
-    }
+const template = __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl('<select id="{{inputId}}" name="{{name}}"></select>');
+const option = __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl('<option value="{{key}}">{{value}}</option>');
+const CHOSEN_WINDOW_MARGIN = 20;
 
+// Chosen has known problems when it's at the bottom of a container that has
+// overflow:hidden set. Because it attaches to the parent container, its
+// dropdown will be cut off in the UI. Any modal with a chosen select element
+// at the bottom will manifest this behavior.
+//
+// The fix (aside from replacing Chosen) is to change Chosen's behavior -
+// use the existing styles, but attach it to 'body' and position it correctly
+// so that it is not affected by a parent overflow.
+//
+// More details can be found in OKTA-46489, OKTA-83570
+
+const CHOSEN_MAX_HEIGHT = 240;
+const CHOSEN_Z_INDEX = 50000;
+
+function defer(fn) {
+  if (this.params.autoWidth) {
+    return fn.call(this);
+  } else {
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defer(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(fn, this));
+  }
+}
+
+function findSelectWidth(self) {
+  self.$select.hide();
+  const select = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(self.$select[0]).hide();
+
+  Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('body').append(select);
+  const width = (self.params.width = select.width() * 1.2 + 'px');
+
+  self.$el.append(select.show());
+  return width;
+}
+
+function recalculateChosen($chosen, $results, $clone) {
+  const offset = $clone.offset();
+
+  $chosen.css({
+    left: offset.left,
+    top: offset.top
+  });
+  // Update the max-height to fit within the constraints of the window. This
+  // is especially important for modals because page scrolling is disabled.
+  const $win = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window);
+  const rHeight = $results.outerHeight();
+  const rBottom = rHeight + $results.offset().top - $win.scrollTop();
+  const wHeight = $win.height() - CHOSEN_WINDOW_MARGIN;
+  const maxHeight = Math.min(rHeight + wHeight - rBottom, CHOSEN_MAX_HEIGHT);
+
+  $results.css('max-height', maxHeight);
+}
+
+function fixChosenModal($select) {
+  const $chosen = $select.next('.chzn-container');
+  const $clone = $chosen.clone();
+  const $results = $chosen.find('.chzn-results');
+
+  // Use a hidden clone to maintain layout and calculate offset. This is
+  // necessary for more complex layouts (like adding a group rule) where
+  // the chosen element is floated.
+  $clone.css('visibility', 'hidden');
+  $clone.removeAttr('id');
+  $clone.find('li').removeAttr('id');
+
+  // Save the original styles - we'll revert to them when the select closes
+  const baseStyles = {
+    left: $chosen.css('left'),
+    top: $chosen.css('top'),
+    position: $chosen.css('position'),
+    float: $chosen.css('float'),
+    'z-index': $chosen.css('z-index')
+  };
+
+  $results.hide();
+
+  // Handler for any resize events that happen when the results list is open
+
+  const resizeHandler = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].debounce(function () {
+    recalculateChosen($chosen, $results, $clone);
+  }, 10);
+
+  // When the dropdown opens, attach it to body, with the correct absolute
+  // position coordinates
+  $select.off('.fixChosen'); // Remove events we could have added before
+  $select.on('liszt:showing_dropdown.fixChosen', function () {
+    $chosen.width($chosen.width());
+    $select.after($clone);
+    // .chzn-container can trigger the vertical scrollbar if it causes scrollHeight > window height after append to
+    // the body. Force top -999999 to avoid the scrollbar so $chosen can find the right offset for relocation.
+    $chosen.css({
+      position: 'absolute',
+      float: 'none',
+      'z-index': CHOSEN_Z_INDEX,
+      top: -999999
+    });
+    Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('body').append($chosen);
+    $results.show();
+    recalculateChosen($chosen, $results, $clone);
+    // Capture scroll events:
+    // - for forms that use fixed positioning (like editing attributes in
+    //   Profile Editor) - window scroll
+    // - for forms that are too long for the modal - o-form-content scroll
+    $select.parents().scroll(resizeHandler);
+    Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).on('resize scroll', resizeHandler);
   });
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  // When the dropdown closes or the element is removed, revert to the
+  // original styles and reattach it to its original placement in the dom.
+  $select.on('liszt:hiding_dropdown.fixChosen remove.fixChosen', function () {
+    $select.parents().off('scroll', resizeHandler);
+    Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).off('resize scroll', resizeHandler);
+    $chosen.css(baseStyles);
+    $results.hide();
+    $results.css('max-height', CHOSEN_MAX_HEIGHT);
+    $clone.remove();
+    $select.after($chosen);
+  });
+}
+
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].extend({
+  className: 'o-form-select',
+
+  /**
+   * @Override
+   */
+  events: {
+    'change select': 'update',
+    'keyup .chzn-search > :text': function (e) {
+      if (__WEBPACK_IMPORTED_MODULE_2__util_Keys__["default"].isEsc(e)) {
+        this.$('.chzn-search > :text').val('');
+        e.stopPropagation();
+      }
+    }
+  },
+
+  constructor: function () {
+    this.template = template;
+    this.option = option;
+    __WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].apply(this, arguments);
+    this.params = this.options.params || {};
+  },
+
+  /**
+   * @Override
+   */
+  editMode: function () {
+    /* eslint max-statements: [2, 13] */
+
+    this.$el.html(template(this.options));
+    this.$select = this.$('select');
+
+    const options = this.getOptions();
+
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+      options,
+      function (value, key) {
+        this.$select.append(option({ key: key, value: value }));
+      },
+      this
+    );
+
+    // Fix a regression in jQuery 1.x on Firefox
+    // jQuery.val(value) prepends an empty option to the dropdown
+    // if value doesnt exist in the dropdown.
+    // http://bugs.jquery.com/ticket/13514
+    const value = this.getModelValue();
+
+    if (value) {
+      this.$select.val(value);
+    } else {
+      this.$('option:first-child').prop('selected', true);
+    }
+    this.$el.addClass('o-form-control');
+
+    if (this.params.chosen !== false) {
+      this.__applyChosen();
+    }
+    return this;
+  },
+
+  __applyChosen: function (update) {
+    let width = this.options.wide ? '100%' : this.params.width || '62%';
+
+    if (this.params.autoWidth) {
+      width = findSelectWidth(this);
+    }
+
+    defer.call(this, function () {
+      const searchThreshold = this.getParam('searchThreshold', 10);
+
+      if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this.options, 'autoRender') && update !== false) {
+        this.update();
+      }
+      this.$select.chosen({
+        width: width,
+        disable_search_threshold: searchThreshold, //eslint-disable-line camelcase
+        placeholder_text: this.options['placeholder'] //eslint-disable-line camelcase
+      });
+      fixChosenModal(this.$select);
+
+      if (this.params.autoWidth) {
+        // fix a chosen css bug
+        this.$el.width(0);
+      }
+
+      this.model.trigger('form:resize');
+    });
+  },
+
+  /**
+   * @Override
+   */
+  val: function () {
+    return this.$select && this.$select.val();
+  },
+
+  /**
+   * @Override
+   */
+  focus: function () {
+    if (this.$select) {
+      return this.$select.focus();
+    }
+  },
+
+  /**
+   * @Override
+   */
+  toStringValue: function () {
+    const selectedOption = this.getModelValue();
+    let displayString = selectedOption;
+    const options = this.getOptions();
+
+    if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isEmpty(options)) {
+      displayString = options[selectedOption];
+    }
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isUndefined(displayString)) {
+      displayString = this.defaultValue();
+    }
+    return displayString || '';
+  },
+
+  /**
+   * Convert options to an object
+   * support input options that is a
+   * 1. a static object such as {key1: val1, key2: val2...}
+   * 2. a function to be called to return a static object
+   * will return an object with key-value pairs or with empty content
+   * @return {Object} The value
+   */
+  getOptions: function () {
+    let options = this.options.options;
+
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(options)) {
+      options = options.call(this);
+    }
+
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(options) ? options : {};
+  },
+
+  remove: function () {
+    if (this.$select) {
+      this.$select.trigger('remove');
+    }
+    return __WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].prototype.remove.apply(this, arguments);
+  }
+}));
 
 
 /***/ }),
 /* 30 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(7),
-  __webpack_require__(3),
-  __webpack_require__(9),
-  __webpack_require__(65)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, Keys, TemplateUtil, BaseInput) {
-
-  var template = TemplateUtil.tpl('<select id="{{inputId}}" name="{{name}}"></select>');
-  var option = TemplateUtil.tpl('<option value="{{key}}">{{value}}</option>');
-
-  // Chosen has known problems when it's at the bottom of a container that has
-  // overflow:hidden set. Because it attaches to the parent container, its
-  // dropdown will be cut off in the UI. Any modal with a chosen select element
-  // at the bottom will manifest this behavior.
-  //
-  // The fix (aside from replacing Chosen) is to change Chosen's behavior -
-  // use the existing styles, but attach it to 'body' and position it correctly
-  // so that it is not affected by a parent overflow.
-  //
-  // More details can be found in OKTA-46489, OKTA-83570
-  var CHOSEN_WINDOW_MARGIN = 20;
-  var CHOSEN_MAX_HEIGHT = 240;
-  var CHOSEN_Z_INDEX = 50000;
-
-  function defer(fn) {
-    if (this.params.autoWidth) {
-      return fn.call(this);
-    }
-    else {
-      return _.defer(_.bind(fn, this));
-    }
-  }
-
-  function findSelectWidth(self) {
-    self.$select.hide();
-    var select = $(self.$select[0]).hide();
-    $('body').append(select);
-    var width = self.params.width = (select.width() * 1.2) + 'px';
-    self.$el.append(select.show());
-    return width;
-  }
-
-  function recalculateChosen($chosen, $results, $clone) {
-    var offset = $clone.offset();
-    $chosen.css({
-      left: offset.left,
-      top: offset.top
-    });
-    // Update the max-height to fit within the constraints of the window. This
-    // is especially important for modals because page scrolling is disabled.
-    var $win = $(window),
-        rHeight = $results.outerHeight(),
-        rBottom = rHeight + $results.offset().top - $win.scrollTop(),
-        wHeight = $win.height() - CHOSEN_WINDOW_MARGIN,
-        maxHeight = Math.min(rHeight + wHeight - rBottom, CHOSEN_MAX_HEIGHT);
-    $results.css('max-height', maxHeight);
-  }
-
-  function fixChosenModal($select) {
-    var $chosen = $select.next('.chzn-container'),
-        $clone = $chosen.clone(),
-        $results = $chosen.find('.chzn-results');
-
-    // Use a hidden clone to maintain layout and calculate offset. This is
-    // necessary for more complex layouts (like adding a group rule) where
-    // the chosen element is floated.
-    $clone.css('visibility', 'hidden');
-    $clone.removeAttr('id');
-    $clone.find('li').removeAttr('id');
-
-    // Save the original styles - we'll revert to them when the select closes
-    var baseStyles = {
-      'left': $chosen.css('left'),
-      'top': $chosen.css('top'),
-      'position': $chosen.css('position'),
-      'float': $chosen.css('float'),
-      'z-index': $chosen.css('z-index')
-    };
-    $results.hide();
-
-    // Handler for any resize events that happen when the results list is open
-    var resizeHandler = _.debounce(function () {
-      recalculateChosen($chosen, $results, $clone);
-    }, 10);
-
-    // When the dropdown opens, attach it to body, with the correct absolute
-    // position coordinates
-    $select.off('.fixChosen'); // Remove events we could have added before
-    $select.on('liszt:showing_dropdown.fixChosen', function () {
-      $chosen.width($chosen.width());
-      $select.after($clone);
-      // .chzn-container can trigger the vertical scrollbar if it causes scrollHeight > window height after append to
-      // the body. Force top -999999 to avoid the scrollbar so $chosen can find the right offset for relocation.
-      $chosen.css({
-        'position': 'absolute',
-        'float': 'none',
-        'z-index': CHOSEN_Z_INDEX,
-        'top': -999999
-      });
-      $('body').append($chosen);
-      $results.show();
-      recalculateChosen($chosen, $results, $clone);
-      // Capture scroll events:
-      // - for forms that use fixed positioning (like editing attributes in
-      //   Profile Editor) - window scroll
-      // - for forms that are too long for the modal - o-form-content scroll
-      $select.parents().scroll(resizeHandler);
-      $(window).on('resize scroll', resizeHandler);
-    });
-
-    // When the dropdown closes or the element is removed, revert to the
-    // original styles and reattach it to its original placement in the dom.
-    $select.on('liszt:hiding_dropdown.fixChosen remove.fixChosen', function () {
-      $select.parents().off('scroll', resizeHandler);
-      $(window).off('resize scroll', resizeHandler);
-      $chosen.css(baseStyles);
-      $results.hide();
-      $results.css('max-height', CHOSEN_MAX_HEIGHT);
-      $clone.remove();
-      $select.after($chosen);
-    });
-  }
-
-  return BaseInput.extend({
-
-    className: 'o-form-select',
-
-    /**
-    * @Override
-    */
-    events: {
-      'change select': 'update',
-      'keyup .chzn-search > :text': function (e) {
-        if (Keys.isEsc(e)) {
-          this.$('.chzn-search > :text').val('');
-          e.stopPropagation();
-        }
-      }
-    },
-
-    constructor: function () {
-      this.template = template;
-      this.option = option;
-      BaseInput.apply(this, arguments);
-      this.params = this.options.params || {};
-    },
-
-    /**
-    * @Override
-    */
-    editMode: function () {
-      /* eslint max-statements: [2, 13] */
-
-      this.$el.html(template(this.options));
-      this.$select = this.$('select');
-
-      var options = this.getOptions();
-      _.each(options, function (value, key) {
-        this.$select.append(option({key: key, value: value}));
-      }, this);
-
-      // Fix a regression in jQuery 1.x on Firefox
-      // jQuery.val(value) prepends an empty option to the dropdown
-      // if value doesnt exist in the dropdown.
-      // http://bugs.jquery.com/ticket/13514
-      var value = this.getModelValue();
-      if (value) {
-        this.$select.val(value);
-      }
-      else {
-        this.$('option:first-child').prop('selected', true);
-      }
-      this.$el.addClass('o-form-control');
-
-      if (this.params.chosen !== false) {
-        this.__applyChosen();
-      }
-      return this;
-    },
-
-    __applyChosen: function (update) {
-      var width = this.options.wide ? '100%' : this.params.width || '62%';
-      if (this.params.autoWidth) {
-        width = findSelectWidth(this);
-      }
-
-      defer.call(this, function () {
-        var searchThreshold = this.getParam('searchThreshold', 10);
-        if (!_.result(this.options, 'autoRender') && update !== false) {
-          this.update();
-        }
-        this.$select.chosen({
-          'width': width,
-          'disable_search_threshold': searchThreshold,
-          'placeholder_text': this.options['placeholder']
-        });
-        fixChosenModal(this.$select);
-
-        if (this.params.autoWidth) { // fix a chosen css bug
-          this.$el.width(0);
-        }
-
-        this.model.trigger('form:resize');
-      });
-    },
-
-    /**
-    * @Override
-    */
-    val: function () {
-      return this.$select && this.$select.val();
-    },
-
-    /**
-    * @Override
-    */
-    focus: function () {
-      if (this.$select) {
-        return this.$select.focus();
-      }
-    },
-
-    /**
-     * @Override
-     */
-    toStringValue: function () {
-      var selectedOption = this.getModelValue(),
-          displayString = selectedOption,
-          options = this.getOptions();
-      if (!_.isEmpty(options)) {
-        displayString = options[selectedOption];
-      }
-      if (_.isUndefined(displayString)) {
-        displayString = this.defaultValue();
-      }
-      return displayString || '';
-    },
-
-    /**
-     * Convert options to an object
-     * support input options that is a
-     * 1. a static object such as {key1: val1, key2: val2...}
-     * 2. a function to be called to return a static object
-     * will return an object with key-value pairs or with empty content
-     * @return {Object} The value
-     */
-    getOptions: function () {
-      var options = this.options.options;
-
-      if (_.isFunction(options)) {
-        options = options.call(this);
-      }
-
-      return _.isObject(options) ? options : {};
-    },
-
-    remove: function () {
-      if (this.$select) {
-        this.$select.trigger('remove');
-      }
-      return BaseInput.prototype.remove.apply(this, arguments);
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 31 */
-/***/ (function(module, exports, __webpack_require__) {
-
-!(module.exports = {
+"use strict";
+/* harmony default export */ __webpack_exports__["a"] = ({
   DEBOUNCE_DELAY: 200,
   LOADING_FADE: 400,
   UNLOADING_FADE: 400,
@@ -5605,156 +5716,9 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
   HIDE_ADD_MAPPING_FORM: 300
 });
 
-/***/ }),
-/* 32 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(3),
-  __webpack_require__(9),
-  __webpack_require__(7),
-  __webpack_require__(68),
-  __webpack_require__(28),
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, TemplateUtil, BaseInput, Keys) {
-
-  var className = 'okta-form-input-field input-fix';
-
-  function hasTitleAndText(options) {
-    var title = options.title,
-        text = options.text;
-
-    return title && text && title !== text;
-  }
-
-  // options may be a string or an object.
-  function createQtipContent(options) {
-    if (hasTitleAndText(options)) {
-      return options;
-    }
-    return {text: options.text || options};
-  }
-
-  return BaseInput.extend({
-    template: TemplateUtil.tpl('\
-      {{#if params.innerTooltip}}\
-        <span class="input-tooltip icon form-help-16"></span>\
-      {{/if}}\
-      {{#if params.icon}}\
-        <span class="icon input-icon {{params.icon}}"></span>\
-      {{/if}}\
-      <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" id="{{inputId}}"\
-       value="{{value}}" aria-label="{{placeholder}}" autocomplete="off"/>\
-      {{#if params.iconDivider}}\
-        <span class="input-icon-divider"></span>\
-      {{/if}}\
-      '),
-    /**
-    * @Override
-    */
-    events: {
-      'input input': 'update',
-      'change input': 'update',
-      'keydown input': 'update',
-      'keyup input': function (e) {
-        if (Keys.isEnter(e)) {
-          this.model.trigger('form:save');
-        }
-        else if (Keys.isEsc(e)) {
-          this.model.trigger('form:cancel');
-        }
-      }
-    },
-
-    constructor: function () {
-      BaseInput.apply(this, arguments);
-      this.$el.addClass('o-form-control');
-    },
-
-    /**
-    * @Override
-    */
-    editMode: function () {
-      this.$el.addClass(className);
-      BaseInput.prototype.editMode.apply(this, arguments);
-      this.$('input').placeholder();
-    },
-
-    /**
-    * @Override
-    */
-    readMode: function () {
-      BaseInput.prototype.readMode.apply(this, arguments);
-      if (this.options.type == 'password') {
-        this.$el.text('********');
-      }
-      this.$el.removeClass(className);
-    },
-
-    /**
-    * @Override
-    */
-    val: function () {
-      //IE will only read clear text pw if type="password" is explicitly in selector
-      var inputValue = this.$('input[type="' + this.options.type + '"]').val();
-
-      if (this.options.type !== 'password') {
-        inputValue = $.trim(inputValue);
-      }
-      return inputValue;
-    },
-
-    /**
-    * @Override
-    */
-    focus: function () {
-      return this.$('input').focus();
-    },
-
-    postRender: function () {
-      var params = this.options.params,
-          content;
-
-      if (params && params.innerTooltip) {
-        content = createQtipContent(params.innerTooltip);
-        this.$('.input-tooltip').qtip({
-          content: content,
-          style: {classes: 'okta-tooltip qtip-custom qtip-shadow'},
-          position: {
-            my: 'bottom left',
-            // Note: qTip2 has a known issue calculating the tooltip offset when:
-            // 1. A container element has both:
-            //    a) position: relative/absolute
-            //    b) overlay: value other than 'visible'
-            // 2. The page is scrolled
-            //
-            // We set position:relative and overlay:auto on the body element,
-            // where both are required for:
-            // - Positioning the footer correctly
-            // - Displaying long pages in embedded browsers
-            //
-            // The original design called for a fixed position relative to the
-            // tooltip icon - this has been switched to "relative to mouse, and
-            // update position when mouse moves" because of this constraint.
-            target: 'mouse',
-            adjust: {
-              method: 'flip',
-              mouse: true,
-              y: -5,
-              x: 5
-            },
-            viewport: $('body')
-          }
-        });
-      }
-    }
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
 
 /***/ }),
-/* 33 */
+/* 31 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/**
@@ -5770,7 +5734,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/**
  * licensed under MIT (filamentgroup.com/examples/mit-license.txt)
  * --------------------------------------------------------------------
 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(10)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (jQuery) {
+!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(12)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (jQuery) {
   var $ = jQuery;
   jQuery.fn.customInput = function(){
     return $(this).each(function(){
@@ -5812,185 +5776,704 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/**
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 /***/ }),
+/* 32 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_qtip__ = __webpack_require__(27);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_qtip___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_qtip__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_Keys__ = __webpack_require__(8);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_placeholder__ = __webpack_require__(75);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_placeholder___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_placeholder__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__BaseInput__ = __webpack_require__(10);
+
+
+
+
+
+
+const className = 'okta-form-input-field input-fix';
+
+function hasTitleAndText(options) {
+  const title = options.title;
+  const text = options.text;
+
+  return title && text && title !== text;
+}
+
+// options may be a string or an object.
+function createQtipContent(options) {
+  if (hasTitleAndText(options)) {
+    return options;
+  }
+  return { text: options.text || options };
+}
+
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].extend({
+  template: __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl(
+    '\
+      {{#if params.innerTooltip}}\
+        <span class="input-tooltip icon form-help-16"></span>\
+      {{/if}}\
+      {{#if params.icon}}\
+        <span class="icon input-icon {{params.icon}}"></span>\
+      {{/if}}\
+      <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" id="{{inputId}}"\
+       value="{{value}}" aria-label="{{placeholder}}" autocomplete="off"/>\
+      {{#if params.iconDivider}}\
+        <span class="input-icon-divider"></span>\
+      {{/if}}\
+      '
+  ),
+  /**
+   * @Override
+   */
+  events: {
+    'input input': 'update',
+    'change input': 'update',
+    'keydown input': 'update',
+    'keyup input': function (e) {
+      if (__WEBPACK_IMPORTED_MODULE_2__util_Keys__["default"].isEnter(e)) {
+        this.model.trigger('form:save');
+      } else if (__WEBPACK_IMPORTED_MODULE_2__util_Keys__["default"].isEsc(e)) {
+        this.model.trigger('form:cancel');
+      }
+    }
+  },
+
+  constructor: function () {
+    __WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].apply(this, arguments);
+    this.$el.addClass('o-form-control');
+  },
+
+  /**
+   * @Override
+   */
+  editMode: function () {
+    this.$el.addClass(className);
+    __WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].prototype.editMode.apply(this, arguments);
+    this.$('input').placeholder();
+  },
+
+  /**
+   * @Override
+   */
+  readMode: function () {
+    __WEBPACK_IMPORTED_MODULE_5__BaseInput__["a" /* default */].prototype.readMode.apply(this, arguments);
+    if (this.options.type === 'password') {
+      this.$el.text('********');
+    }
+    this.$el.removeClass(className);
+  },
+
+  /**
+   * @Override
+   */
+  val: function () {
+    let inputValue = this.$('input[type="' + this.options.type + '"]').val();
+    //IE will only read clear text pw if type="password" is explicitly in selector
+
+    if (this.options.type !== 'password') {
+      inputValue = __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(inputValue);
+    }
+    return inputValue;
+  },
+
+  /**
+   * @Override
+   */
+  focus: function () {
+    return this.$('input').focus();
+  },
+
+  postRender: function () {
+    const params = this.options.params;
+    let content;
+
+    if (params && params.innerTooltip) {
+      content = createQtipContent(params.innerTooltip);
+      this.$('.input-tooltip').qtip({
+        content: content,
+        style: { classes: 'okta-tooltip qtip-custom qtip-shadow' },
+        position: {
+          my: 'bottom left',
+          // Note: qTip2 has a known issue calculating the tooltip offset when:
+          // 1. A container element has both:
+          //    a) position: relative/absolute
+          //    b) overlay: value other than 'visible'
+          // 2. The page is scrolled
+          //
+          // We set position:relative and overlay:auto on the body element,
+          // where both are required for:
+          // - Positioning the footer correctly
+          // - Displaying long pages in embedded browsers
+          //
+          // The original design called for a fixed position relative to the
+          // tooltip icon - this has been switched to "relative to mouse, and
+          // update position when mouse moves" because of this constraint.
+          target: 'mouse',
+          adjust: {
+            method: 'flip',
+            mouse: true,
+            y: -5,
+            x: 5
+          },
+          viewport: Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('body')
+        }
+      });
+    }
+  }
+}));
+
+
+/***/ }),
+/* 33 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(34);
+
+
+/***/ }),
 /* 34 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(35);
+"use strict";
 
+
+var _BaseCollection = __webpack_require__(14);
+
+var _BaseCollection2 = _interopRequireDefault(_BaseCollection);
+
+var _BaseModel = __webpack_require__(15);
+
+var _BaseModel2 = _interopRequireDefault(_BaseModel);
+
+var _BaseSchema = __webpack_require__(38);
+
+var _BaseSchema2 = _interopRequireDefault(_BaseSchema);
+
+var _Model = __webpack_require__(11);
+
+var _Model2 = _interopRequireDefault(_Model);
+
+var _SchemaProperty = __webpack_require__(17);
+
+var _SchemaProperty2 = _interopRequireDefault(_SchemaProperty);
+
+var _BaseController = __webpack_require__(40);
+
+var _BaseController2 = _interopRequireDefault(_BaseController);
+
+var _BaseRouter = __webpack_require__(19);
+
+var _BaseRouter2 = _interopRequireDefault(_BaseRouter);
+
+var _ButtonFactory = __webpack_require__(28);
+
+var _ButtonFactory2 = _interopRequireDefault(_ButtonFactory);
+
+var _Class = __webpack_require__(54);
+
+var _Class2 = _interopRequireDefault(_Class);
+
+var _Cookie = __webpack_require__(55);
+
+var _Cookie2 = _interopRequireDefault(_Cookie);
+
+var _Keys = __webpack_require__(8);
+
+var _Keys2 = _interopRequireDefault(_Keys);
+
+var _Logger = __webpack_require__(7);
+
+var _Logger2 = _interopRequireDefault(_Logger);
+
+var _StringUtil = __webpack_require__(4);
+
+var _StringUtil2 = _interopRequireDefault(_StringUtil);
+
+var _TemplateUtil = __webpack_require__(3);
+
+var _TemplateUtil2 = _interopRequireDefault(_TemplateUtil);
+
+var _Util = __webpack_require__(16);
+
+var _Util2 = _interopRequireDefault(_Util);
+
+var _handlebarsWrapper = __webpack_require__(57);
+
+var _handlebarsWrapper2 = _interopRequireDefault(_handlebarsWrapper);
+
+var _jqueryWrapper = __webpack_require__(2);
+
+var _jqueryWrapper2 = _interopRequireDefault(_jqueryWrapper);
+
+var _underscoreWrapper = __webpack_require__(0);
+
+var _underscoreWrapper2 = _interopRequireDefault(_underscoreWrapper);
+
+var _Backbone = __webpack_require__(64);
+
+var _Backbone2 = _interopRequireDefault(_Backbone);
+
+var _BaseView = __webpack_require__(1);
+
+var _BaseView2 = _interopRequireDefault(_BaseView);
+
+var _BaseDropDown = __webpack_require__(66);
+
+var _BaseDropDown2 = _interopRequireDefault(_BaseDropDown);
+
+var _BaseForm = __webpack_require__(23);
+
+var _BaseForm2 = _interopRequireDefault(_BaseForm);
+
+var _Toolbar = __webpack_require__(25);
+
+var _Toolbar2 = _interopRequireDefault(_Toolbar);
+
+var _FormUtil = __webpack_require__(9);
+
+var _FormUtil2 = _interopRequireDefault(_FormUtil);
+
+var _InputRegistry = __webpack_require__(26);
+
+var _InputRegistry2 = _interopRequireDefault(_InputRegistry);
+
+var _SchemaFormFactory = __webpack_require__(67);
+
+var _SchemaFormFactory2 = _interopRequireDefault(_SchemaFormFactory);
+
+var _CheckBox = __webpack_require__(73);
+
+var _CheckBox2 = _interopRequireDefault(_CheckBox);
+
+var _PasswordBox = __webpack_require__(74);
+
+var _PasswordBox2 = _interopRequireDefault(_PasswordBox);
+
+var _Radio = __webpack_require__(76);
+
+var _Radio2 = _interopRequireDefault(_Radio);
+
+var _Select = __webpack_require__(29);
+
+var _Select2 = _interopRequireDefault(_Select);
+
+var _TextBox = __webpack_require__(32);
+
+var _TextBox2 = _interopRequireDefault(_TextBox);
+
+var _backbone = __webpack_require__(6);
+
+var _backbone2 = _interopRequireDefault(_backbone);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Okta = {
+  Backbone: _backbone2.default,
+
+  $: _jqueryWrapper2.default,
+
+  _: _underscoreWrapper2.default,
+
+  Handlebars: _handlebarsWrapper2.default,
+
+  loc: _StringUtil2.default.localize,
+
+  createButton: _ButtonFactory2.default.create,
+
+  registerInput: _InputRegistry2.default.register,
+
+  tpl: _TemplateUtil2.default.tpl,
+
+  Model: _Model2.default,
+
+  BaseModel: _BaseModel2.default,
+
+  Collection: _BaseCollection2.default,
+
+  View: _BaseView2.default,
+
+  ListView: _Backbone2.default,
+
+  Router: _BaseRouter2.default,
+
+  Controller: _BaseController2.default,
+
+  Form: _BaseForm2.default,
+
+  internal: {
+    util: {
+      Util: _Util2.default,
+      Cookie: _Cookie2.default,
+      Logger: _Logger2.default,
+      Class: _Class2.default,
+      Keys: _Keys2.default
+    },
+
+    views: {
+      components: {
+        BaseDropDown: _BaseDropDown2.default
+      },
+
+      forms: {
+        helpers: {
+          FormUtil: _FormUtil2.default,
+          SchemaFormFactory: _SchemaFormFactory2.default
+        },
+
+        components: {
+          Toolbar: _Toolbar2.default
+        },
+
+        inputs: {
+          TextBox: _TextBox2.default,
+          PasswordBox: _PasswordBox2.default,
+          CheckBox: _CheckBox2.default,
+          Radio: _Radio2.default,
+          Select: _Select2.default
+        }
+      }
+    },
+
+    models: {
+      BaseSchema: _BaseSchema2.default,
+      SchemaProperty: _SchemaProperty2.default
+    }
+  }
+};
+
+Okta.registerInput('text', _TextBox2.default);
+Okta.registerInput('password', _PasswordBox2.default);
+Okta.registerInput('checkbox', _CheckBox2.default);
+Okta.registerInput('radio', _Radio2.default);
+Okta.registerInput('select', _Select2.default);
+
+module.exports = Okta;
 
 /***/ }),
 /* 35 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;
-
-/* eslint max-params: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(5), __webpack_require__(2), __webpack_require__(0), __webpack_require__(18), __webpack_require__(11), __webpack_require__(14), __webpack_require__(15), __webpack_require__(19), __webpack_require__(41), __webpack_require__(4), __webpack_require__(3), __webpack_require__(21), __webpack_require__(24), __webpack_require__(54), __webpack_require__(16), __webpack_require__(56), __webpack_require__(6), __webpack_require__(58), __webpack_require__(7), __webpack_require__(1), __webpack_require__(59), __webpack_require__(61), __webpack_require__(26), __webpack_require__(27), __webpack_require__(8), __webpack_require__(62), __webpack_require__(29), __webpack_require__(32), __webpack_require__(69), __webpack_require__(70), __webpack_require__(71), __webpack_require__(30)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (Backbone, $, _, Handlebars, Model, BaseModel, BaseCollection, SchemaProperty, BaseSchema, StringUtil, TemplateUtil, ButtonFactory, BaseRouter, BaseController, Util, Cookie, Logger, Class, Keys, BaseView, ListView, BaseDropDown, BaseForm, InputRegistry, FormUtil, SchemaFormFactory, Toolbar, TextBox, PasswordBox, CheckBox, Radio, Select) {
-
-  var Okta = {
-
-    Backbone: Backbone,
-
-    $: $,
-
-    _: _,
-
-    Handlebars: Handlebars,
-
-    loc: StringUtil.localize,
-
-    createButton: ButtonFactory.create,
-
-    registerInput: InputRegistry.register,
-
-    tpl: TemplateUtil.tpl,
-
-    Model: Model,
-
-    BaseModel: BaseModel,
-
-    Collection: BaseCollection,
-
-    View: BaseView,
-
-    ListView: ListView,
-
-    Router: BaseRouter,
-
-    Controller: BaseController,
-
-    Form: BaseForm,
-
-    internal: {
-
-      util: {
-        Util: Util,
-        Cookie: Cookie,
-        Logger: Logger,
-        Class: Class,
-        Keys: Keys
-      },
-
-      views: {
-        components: {
-          BaseDropDown: BaseDropDown
-        },
-
-        forms: {
-          helpers: {
-            FormUtil: FormUtil,
-            SchemaFormFactory: SchemaFormFactory
-          },
-
-          components: {
-            Toolbar: Toolbar
-          },
-
-          inputs: {
-            TextBox: TextBox,
-            PasswordBox: PasswordBox,
-            CheckBox: CheckBox,
-            Radio: Radio,
-            Select: Select
-          }
-        }
-      },
-
-      models: {
-        BaseSchema: BaseSchema,
-        SchemaProperty: SchemaProperty
-      }
-
-    }
-  };
-
-  Okta.registerInput('text', TextBox);
-  Okta.registerInput('password', PasswordBox);
-  Okta.registerInput('checkbox', CheckBox);
-  Okta.registerInput('radio', Radio);
-  Okta.registerInput('select', Select);
-
-  return Okta;
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-/***/ }),
-/* 36 */
 /***/ (function(module, exports) {
 
 module.exports = require("underscore");
 
 /***/ }),
-/* 37 */
-/***/ (function(module, exports) {
+/* 36 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-module.exports = require("shared/util/Bundles");
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_backbone__);
 
-/***/ }),
-/* 38 */
-/***/ (function(module, exports, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;// Simple "markdown parser" - just handles markdown formatted links. If we
-// find that we need more extensive markdown support, we should include
-// a fully formulated markdown library like:
-// https://github.com/evilstreak/markdown-js
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_) {
 
-  var RE_LINK = /\[[^\]]*\]\([^)]*\)/gi;
-  var RE_LINK_HREF = /\]\(([^)]*)\)/i;
-  var RE_LINK_TEXT = /\[([^\]]*)\]/i;
-  var RE_LINK_JS = /javascript:/gi;
 
-  // Converts links
-  // FROM:
-  // [some link text](http://the/link/url)
-  // TO:
-  // <a href="http://the/link/url">some link text</a>
-  return function mdToHtml(Handlebars, markdownText) {
-    /* eslint  @okta/okta/no-specific-methods: 0*/
-    var linkTemplate = Handlebars.compile('<a href="{{href}}">{{text}}</a>');
-    var res;
-    if (!_.isString(markdownText)) {
-      res = '';
-    } else {
-      res = Handlebars.Utils.escapeExpression(markdownText).replace(RE_LINK_JS, '').replace(RE_LINK, function (mdLink) {
-        return linkTemplate({
-          href: mdLink.match(RE_LINK_HREF)[1],
-          text: mdLink.match(RE_LINK_TEXT)[1]
-        });
-      });
+var STATE = '__STATE__',
+    FETCH_DATA = 'FETCH_DATA',
+    PAGINATION_DATA = 'PAGINATION_DATA',
+    DEFAULT_PARAMS = 'DEFAULT_PARAMS',
+    LINK_BY_HEADER = 'LINK_BY_HEADER',
+    XHR = 'XHR';
+
+/*
+ * Sets the next page URL on the collection from link headers
+ * See: http://www.rfc-editor.org/rfc/rfc5988.txt
+ *
+ * This method is looking for a link header with `rel="next"`
+ * An set's it as the next page's URL.
+ *
+ * If it doesn't find a next page, and current page is set by a link header
+ * it assumes we are at the last page and deletes the current `next`
+ */
+function setLinkHeadersPagination(collection, xhr) {
+  try {
+    var links = parseLinkHeader(xhr.getResponseHeader('link'));
+    collection[STATE].set(LINK_BY_HEADER, true);
+    collection.setPagination(links['next'].href);
+  }
+  catch (e) {
+    if (collection[STATE].get(LINK_BY_HEADER)) {
+      collection.setPagination(null);
     }
-    return new Handlebars.SafeString(res);
-  };
+  }
+}
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+function parseQuery(url) {
+  var params = {},
+      rawQueryStr = url && url.split('?')[1],
+      queryString = rawQueryStr && decodeURIComponent(rawQueryStr.split('#')[0]).replace(/\+/g, ' '),
+      props = queryString ? queryString.split('&') : [];
+  for (var i = 0; i < props.length; i++) {
+    var parts = props[i].split('=');
+    params[parts.shift()] = parts.join('=');
+  }
+  return params;
+}
+
+// ################################################
+// # Source: https://gist.github.com/deiu/9335803
+// ################################################
+
+// unquote string (utility)
+function unquote(value) {
+  if (value.charAt(0) == '"' && value.charAt(value.length - 1) == '"') {
+    return value.substring(1, value.length - 1);
+  }
+  return value;
+}
+/*
+parse a Link header
+Link:<https://example.org/.meta>; rel=meta
+var r = parseLinkHeader(xhr.getResponseHeader('Link');
+r['meta']['href'] outputs https://example.org/.meta
+*/
+function parseLinkHeader(header) {
+  /* eslint max-statements: 0 */
+  var linkexp = /<[^>]*>\s*(\s*;\s*[^()<>@,;:"/[\]?={} \t]+=(([^()<>@,;:"/[\]?={} \t]+)|("[^"]*")))*(,|$)/g,
+      paramexp = /[^()<>@,;:"/[\]?={} \t]+=(([^()<>@,;:"/[\]?={} \t]+)|("[^"]*"))/g;
+
+  var matches = header.match(linkexp);
+  var rels = {};
+  for (var i = 0; i < matches.length; i++) {
+    var split = matches[i].split('>');
+    var href = split[0].substring(1);
+    var link = {};
+    link.href = href;
+    var s = split[1].match(paramexp);
+    for (var j = 0; j < s.length; j++) {
+      var paramsplit = s[j].split('=');
+      var name = paramsplit[0];
+      link[name] = unquote(paramsplit[1]);
+    }
+
+    if (link.rel !== undefined) {
+      rels[link.rel] = link;
+    }
+  }
+
+  return rels;
+}
+
+// ################################################
+// # /Source
+// ################################################
+//
+
+/**
+ *
+ * Archer.Collection is a standard [Backbone.Collection](http://backbonejs.org/#Collection) with pre-set `data`
+ * parameters and built in pagination - works with [http link headers](https://tools.ietf.org/html/rfc5988)
+ * out of the box:
+ *
+ * @class src/framework/Collection
+ * @extends external:Backbone.Collection
+ * @example
+ * var Users = Archer.Collection.extend({
+ *   url: '/api/v1/users'
+ *   params: {expand: true}
+ * });
+ * var users = new Users(null, {params: {type: 'new'}}),
+ *     $button = this.$('a.fetch-more');
+ *
+ * $button.click(function () {
+ *   users.fetchMore();
+ * });
+ *
+ * this.listenTo(users, 'sync', function () {
+ *   $button.toggle(users.hasMore());
+ * });
+ *
+ * collection.fetch(); //=> '/api/v1/users?expand=true&type=new'
+ */
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.extend(/** @lends src/framework/Collection.prototype */ {
+
+  /**
+   * Default fetch parameters
+   * @type {Object}
+   */
+  params: {},
+
+  constructor: function (models, options) {
+    var state = this[STATE] = new __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model();
+    state.set(DEFAULT_PARAMS, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options && options.params || {}, this.params || {}));
+    __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.apply(this, arguments);
+  },
+
+  /**
+   * See [Backbone Collection.sync](http://backbonejs.org/#Collection-sync).
+   */
+  sync: function (method, collection, options) {
+    var self = this,
+        success = options.success;
+    options.success = function (resp, status, xhr) {
+      // its important to set the pagination data *before* we call the success callback
+      // because we want the pagination data to be ready when the collection triggers the `sync` event
+      setLinkHeadersPagination(self, xhr);
+      success.apply(null, arguments);
+    };
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.prototype.sync.call(this, method, collection, options);
+  },
+
+  /**
+   * See [Backbone Collection.fetch](http://backbonejs.org/#Collection-fetch).
+   */
+  fetch: function (options) {
+    options || (options = {});
+    var state = this[STATE],
+        xhr = state.get(XHR);
+
+    options.data = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, state.get(DEFAULT_PARAMS), options.data || {});
+    options.fromFetch = true;
+
+    state.set(FETCH_DATA, options.data);
+    if (xhr && xhr.abort && options.abort !== false) {
+      xhr.abort();
+    }
+    xhr = __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.prototype.fetch.call(this, options);
+    state.set(XHR, xhr);
+    return xhr;
+  },
+
+  /**
+   * Set pagination data to get to the next page
+   * @param {Mixed} params
+   * @param {Object} [options]
+   * @param {Boolean} [options.fromFetch] should we include data from the previous fetch call in this object
+   * @example
+   * collection.setPagination({q: 'foo', page: '2'}); //=> {q: 'foo', page: '2'}
+   *
+   * collection.setPagination('/path/to/resource?q=baz&page=4'); //=> {q: 'baz', page: '4'}
+   *
+   * collection.setPagination('/path/to/resource'); //=> {}
+   *
+   * collection.fetch({data: {q: 'foo'}});
+   * collection.setPagination({page: 2}, {fromFetch: true}); //=> {q: 'foo', page: 2}
+   *
+   * any "falsy" value resets pagination
+   * collection.setPagination(); //=> {}
+   * collection.setPagination(null); //=> {}
+   * collection.setPagination(false); //=> {}
+   * collection.setPagination(''); //=> {}
+   * collection.setPagination(0); //=> {}
+   * @protected
+   */
+  setPagination: function (params, options) {
+    /* eslint complexity: [2, 8] */
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(params) && params) {
+      params = parseQuery(params);
+    }
+    if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(params) || __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(params) || !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(params)) {
+      params = null;
+    }
+    else if (options && options.fromFetch) {
+      params = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, this.getFetchData(), params);
+    }
+    this[STATE].set(PAGINATION_DATA, params);
+  },
+
+  /**
+   * Returns the `data` parameters applied in th most recent `fetch` call
+   * It will include parameters set by {@link #params} and optios.params passed to the constructor
+   * @return {Object}
+   * @protected
+   */
+  getFetchData: function () {
+    return this[STATE].get(FETCH_DATA) || {};
+  },
+
+  /**
+   * Data object for constructing a request to fetch the next page
+   * @return {Object}
+   * @protected
+   */
+  getPaginationData: function () {
+    return this[STATE].get(PAGINATION_DATA) || {};
+  },
+
+  /**
+   * Does this collection have more data on the server (e.g is there a next "page")
+   * @return {Boolean}
+   */
+  hasMore: function () {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(this.getPaginationData()) > 0;
+  },
+
+  /**
+   * Get the next page from the server
+   * @return {Object} xhr returned by {@link #fetch}
+   */
+  fetchMore: function () {
+    if (!this.hasMore()) {
+      throw new Error('Invalid Request');
+    }
+    return this.fetch({ data: this.getPaginationData(), add: true, remove: false, update: true });
+  },
+
+  /**
+   * See [Backbone Collection.reset](http://backbonejs.org/#Collection-reset).
+   */
+  reset: function (models, options) {
+    options || (options = {});
+    // only reset the pagination when reset is being called explicitly.
+    // this is to avoid link headers pagination being overriden and reset when
+    // fetching the collection using `collection.fetch({reset: true})`
+    if (!options.fromFetch) {
+      this.setPagination(null);
+    }
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.prototype.reset.apply(this, arguments);
+  },
+
+  // we want "where" to be able to search through derived properties as well
+  where: function (attrs, first) {
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEmpty(attrs)) {
+      return first ? void 0 : [];
+    }
+    return this[first ? 'find' : 'filter'](function (model) {
+      for (var key in attrs) {
+        if (attrs[key] !== model.get(key)) {
+          return false;
+        }
+      }
+      return true;
+    });
+  },
+
+  /**
+   * See [Backbone Collection.create](http://backbonejs.org/#Collection-create).
+   */
+  create: function (model, options) {
+    options || (options = {});
+    if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(model, 'urlRoot')) {
+      options.url = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'url');
+    }
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Collection.prototype.create.call(this, model, options);
+  }
+
+}));
 
 
 /***/ }),
-/* 39 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 37 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(5), __webpack_require__(6)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
-				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  }
-  /* global module, exports */
-  else if (typeof require === 'function' && typeof exports === 'object') {
-    module.exports = factory(require('okta/underscore'), require('backbone'), require('shared/util/Logger'));
-  }
-  else {
-    root.Archer || (root.Archer = {});
-    root.Archer.Model = factory(root._, root.Backbone, root.Logger);
-  }
-}(this, function (_, Backbone, Logger) {
-  /**
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_backbone__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_Logger__ = __webpack_require__(7);
+
+
+
+
+
+
+/**
    * Archer.Model is a standard [Backbone.Model](http://backbonejs.org/#Model) with a few additions:
    *
    * - {@link src/framework/Model#derived Derived properties}
@@ -6032,196 +6515,196 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * model.get('isLoggedIn'); //=> true
    * model.toJSON(); //=> {fname: 'Joe', lname: 'Doe'}
    */
-  var Model;
+var Model;
 
-  function flatten(value, objectTypeFields, key, target) {
-    var filter = _.contains(objectTypeFields, key);
-    target || (target = {});
-    if (!filter && _.isObject(value) && !_.isArray(value) && !_.isFunction(value)) {
-      _.each(value, function (val, i) {
-        flatten(val, objectTypeFields, key ? (key + '.' + i) : i, target);
-      });
-    }
-    // Case where target is an empty object. Guard against returning {undefined: undefined}.
-    else if (key !== undefined) {
-      target[key] = value;
-    }
-    return target;
-  }
-
-  function unflatten(data) {
-    _.each(data, function (value, key, data) {
-      if (key.indexOf('.') == -1) {
-        return;
-      }
-      var part,
-          ref = data,
-          parts = key.split('.');
-      while ((part = parts.shift()) !== undefined) {
-        if (!ref[part]) {
-          ref[part] = parts.length ? {} : value;
-        }
-        ref = ref[part];
-      }
-      delete data[key];
-    });
-    return data;
-  }
-
-  function createMessage(field, msg) {
-    var obj = {};
-    obj[field.name] = msg;
-    return obj;
-  }
-
-  function normalizeSchemaDef(field, name) {
-    var target;
-    if (_.isString(field)) {
-      target = {
-        type: field
-      };
-    }
-    else if (_.isArray(field)) {
-      target = {
-        type: field[0],
-        required: field[1],
-        value: field[2]
-      };
-    }
-    else {
-      target = _.clone(field);
-    }
-    _.defaults(target, {required: false, name: name});
-    return target;
-  }
-
-  function capitalize(string) {
-    return string.toLowerCase().replace(/\b[a-z]/g, function (letter) {
-      return letter.toUpperCase();
+function flatten(value, objectTypeFields, key, target) {
+  var filter = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(objectTypeFields, key);
+  target || (target = {});
+  if (!filter && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(value) && !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(value) && !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(value)) {
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(value, function (val, i) {
+      flatten(val, objectTypeFields, key ? (key + '.' + i) : i, target);
     });
   }
+  // Case where target is an empty object. Guard against returning {undefined: undefined}.
+  else if (key !== undefined) {
+    target[key] = value;
+  }
+  return target;
+}
 
-  function _validateRegex(value, pattern, error) {
-    if (!pattern.test(value)) {
+function unflatten(data) {
+  __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(data, function (value, key, data) {
+    if (key.indexOf('.') == -1) {
+      return;
+    }
+    var part,
+        ref = data,
+        parts = key.split('.');
+    while ((part = parts.shift()) !== undefined) {
+      if (!ref[part]) {
+        ref[part] = parts.length ? {} : value;
+      }
+      ref = ref[part];
+    }
+    delete data[key];
+  });
+  return data;
+}
+
+function createMessage(field, msg) {
+  var obj = {};
+  obj[field.name] = msg;
+  return obj;
+}
+
+function normalizeSchemaDef(field, name) {
+  var target;
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(field)) {
+    target = {
+      type: field
+    };
+  }
+  else if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(field)) {
+    target = {
+      type: field[0],
+      required: field[1],
+      value: field[2]
+    };
+  }
+  else {
+    target = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(field);
+  }
+  __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(target, {required: false, name: name});
+  return target;
+}
+
+function capitalize(string) {
+  return string.toLowerCase().replace(/\b[a-z]/g, function (letter) {
+    return letter.toUpperCase();
+  });
+}
+
+function _validateRegex(value, pattern, error) {
+  if (!pattern.test(value)) {
+    return error;
+  }
+}
+
+var StringFormatValidators = {
+  /*eslint max-len: 0 */
+  email: function (value) {
+    // Taken from  http://emailregex.com/ on 2017-03-06.
+    var pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_EMAIL);
+  },
+  uri: function (value) {
+    // source: https://mathiasbynens.be/demo/url-regex
+    var pattern = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
+    return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_URI);
+  },
+  ipv4: function (value) {
+    // source: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
+    var pattern = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+    return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_IPV4);
+  },
+  hostname: function (value) {
+    // source: http://www.regextester.com/23
+    var pattern = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
+    return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_HOSTNAME);
+  }
+};
+
+function validateStringFormat(field, value) {
+  var validator = StringFormatValidators[field.format];
+  if (field.format && !validator) {
+    throw new TypeError(field.format + ' is not a supported string format');
+  }
+  return validator && validator(value);
+}
+
+function validateString(field, value) {
+  var createMessageWith = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].partial(createMessage, field),
+      invalidFormat = validateStringFormat(field, value);
+  if (invalidFormat) {
+    return createMessageWith(invalidFormat);
+  }
+  if (value && field.minLength && value.length < field.minLength) {
+    return createMessageWith(Model.ERROR_STRING_STRING_MIN_LENGTH, value.length);
+  }
+  if (value && field.maxLength && value.length > field.maxLength) {
+    return createMessageWith(Model.ERROR_STRING_STRING_MAX_LENGTH, value.length);
+  }
+}
+
+function validateField(field, value) {
+  /* eslint complexity: [2, 23], max-statements: [2, 19] */
+  var createMessageWith = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].partial(createMessage, field),
+      isDefined = !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isUndefined(value) && !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNull(value),
+      checkType,
+      errorMessage;
+
+  // check required fields
+  if (field.required && (!isDefined || __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNull(value) || value === '')) {
+    return createMessageWith(Model.ERROR_BLANK);
+  }
+  // check type
+  checkType = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"]['is' + capitalize(field.type)];
+  if (isDefined && field.type != 'any' && (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(checkType) || !checkType(value))) {
+    return createMessageWith(Model.ERROR_WRONG_TYPE);
+  }
+  // validate string format
+  if (value && field.type == 'string') {
+    var error = validateString(field, value);
+    if (error) {
       return error;
     }
   }
-
-  var StringFormatValidators = {
-    /*eslint max-len: 0 */
-    email: function (value) {
-      // Taken from  http://emailregex.com/ on 2017-03-06.
-      var pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-      return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_EMAIL);
-    },
-    uri: function (value) {
-      // source: https://mathiasbynens.be/demo/url-regex
-      var pattern = /^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))\.?)(?::\d{2,5})?(?:[/?#]\S*)?$/i;
-      return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_URI);
-    },
-    ipv4: function (value) {
-      // source: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html
-      var pattern = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-      return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_IPV4);
-    },
-    hostname: function (value) {
-      // source: http://www.regextester.com/23
-      var pattern = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
-      return _validateRegex(value, pattern, Model.ERROR_INVALID_FORMAT_HOSTNAME);
-    }
-  };
-
-  function validateStringFormat(field, value) {
-    var validator = StringFormatValidators[field.format];
-    if (field.format && !validator) {
-      throw new TypeError(field.format + ' is not a supported string format');
-    }
-    return validator && validator(value);
+  // check pre set values (enum)
+  if (isDefined && field.values && !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(field.values, value)) {
+    return createMessageWith(Model.ERROR_NOT_ALLOWED);
   }
-
-  function validateString(field, value) {
-    var createMessageWith = _.partial(createMessage, field),
-        invalidFormat = validateStringFormat(field, value);
-    if (invalidFormat) {
-      return createMessageWith(invalidFormat);
+  // check validate method
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(field.validate)) {
+    var result = field.validate(value);
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(result) && result) {
+      return createMessageWith(result);
     }
-    if (value && field.minLength && value.length < field.minLength) {
-      return createMessageWith(Model.ERROR_STRING_STRING_MIN_LENGTH, value.length);
-    }
-    if (value && field.maxLength && value.length > field.maxLength) {
-      return createMessageWith(Model.ERROR_STRING_STRING_MAX_LENGTH, value.length);
+    else if (result === false) {
+      return createMessageWith(Model.ERROR_INVALID);
     }
   }
+  // check array items
+  if (isDefined && field.type == 'array' && (errorMessage = validateArrayField(field, value))) {
+    return createMessageWith(errorMessage);
+  }
+}
 
-  function validateField(field, value) {
-    /* eslint complexity: [2, 23], max-statements: [2, 19] */
-    var createMessageWith = _.partial(createMessage, field),
-        isDefined = !_.isUndefined(value) && !_.isNull(value),
-        checkType,
-        errorMessage;
-
-    // check required fields
-    if (field.required && (!isDefined || _.isNull(value) || value === '')) {
-      return createMessageWith(Model.ERROR_BLANK);
-    }
-    // check type
-    checkType = _['is' + capitalize(field.type)];
-    if (isDefined && field.type != 'any' && (!_.isFunction(checkType) || !checkType(value))) {
-      return createMessageWith(Model.ERROR_WRONG_TYPE);
-    }
-    // validate string format
-    if (value && field.type == 'string') {
-      var error = validateString(field, value);
+function validateArrayField(field, arr) {
+  if (field.minItems && arr.length < field.minItems) {
+    return 'model.validation.field.array.minItems';
+  }
+  else if (field.maxItems && arr.length > field.maxItems) {
+    return 'model.validation.field.array.maxItems';
+  }
+  else if (field.uniqueItems && arr.length > __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniq(arr).length) {
+    return Model.ERROR_IARRAY_UNIQUE;
+  }
+  else if (field.items) {
+    /* eslint max-depth: [2, 3] */
+    var arrayField = normalizeSchemaDef(field.items, 'placeholder');
+    for (var i = 0; i < arr.length; i++) {
+      var value = arr[i];
+      var error = validateField(arrayField, value);
       if (error) {
-        return error;
-      }
-    }
-    // check pre set values (enum)
-    if (isDefined && field.values && !_.contains(field.values, value)) {
-      return createMessageWith(Model.ERROR_NOT_ALLOWED);
-    }
-    // check validate method
-    if (_.isFunction(field.validate)) {
-      var result = field.validate(value);
-      if (_.isString(result) && result) {
-        return createMessageWith(result);
-      }
-      else if (result === false) {
-        return createMessageWith(Model.ERROR_INVALID);
-      }
-    }
-    // check array items
-    if (isDefined && field.type == 'array' && (errorMessage = validateArrayField(field, value))) {
-      return createMessageWith(errorMessage);
-    }
-  }
-
-  function validateArrayField(field, arr) {
-    if (field.minItems && arr.length < field.minItems) {
-      return 'model.validation.field.array.minItems';
-    }
-    else if (field.maxItems && arr.length > field.maxItems) {
-      return 'model.validation.field.array.maxItems';
-    }
-    else if (field.uniqueItems && arr.length > _.uniq(arr).length) {
-      return Model.ERROR_IARRAY_UNIQUE;
-    }
-    else if (field.items) {
-      /* eslint max-depth: [2, 3] */
-      var arrayField = normalizeSchemaDef(field.items, 'placeholder');
-      for (var i = 0; i < arr.length; i++) {
-        var value = arr[i];
-        var error = validateField(arrayField, value);
-        if (error) {
-          return error['placeholder'];
-        }
+        return error['placeholder'];
       }
     }
   }
+}
 
-  Model = Backbone.Model.extend(/** @lends src/framework/Model.prototype */ {
+Model = __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model.extend(/** @lends src/framework/Model.prototype */ {
 
-    /**
+  /**
      * Pass props as an object to extend, describing the observable properties of your model. The props
      * properties should not be set on an instance, as this won't define new properties, they should only be passed to
      * extend.
@@ -6263,9 +6746,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *   }
      * });
      */
-    props: {},
+  props: {},
 
-    /**
+  /**
      * Derived properties (also known as computed properties) are properties of the model that depend on the
      * other (props, local or even derived properties to determine their value. Best demonstrated with an example:
      *
@@ -6302,9 +6785,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * person.set('firstName', 'Bob');
      * console.log(person.get('fullName')) //=> "Bob Roberts"
      */
-    derived: {},
+  derived: {},
 
-    /**
+  /**
      * local properties are defined and work in exactly the same way as {@link src/framework/Model#props|props}, but generally only exist for
      * the lifetime of the page.
      * They would not typically be persisted to the server, and are not returned by calls to {@link src/framework/Model#toJSON|toJSON}.
@@ -6320,9 +6803,9 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      *   }
      * );
      */
-    local: {},
+  local: {},
 
-    /**
+  /**
      * Flatten the payload into dot notation string keys:
      *
      * @type {Boolean}
@@ -6347,150 +6830,150 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * person.get('profile.languages.name'); //=> undefined
      * person.toJSON(); //=> {'profile': {'fname': 'John'} }
      */
-    flat: true,
+  flat: true,
 
-    /**
+  /**
      * @deprecated
      * @alias Backbone.Model#defaults
      */
-    defaults: {},
+  defaults: {},
 
-    constructor: function (options) {
-      this.options = options || {};
+  constructor: function (options) {
+    this.options = options || {};
 
-      var schema = this['__schema__'] = {},
-          objectTypeFields = [];
+    var schema = this['__schema__'] = {},
+        objectTypeFields = [];
 
-      schema.computedProperties = {};
+    schema.computedProperties = {};
 
-      schema.props = _.clone(_.result(this, 'props') || {});
-      schema.derived = _.clone(_.result(this, 'derived') || {});
-      schema.local = _.clone(_.result(this, 'local') || {});
+    schema.props = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'props') || {});
+    schema.derived = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'derived') || {});
+    schema.local = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'local') || {});
 
-      var defaults = {};
-      _.each(_.extend({}, schema.props, schema.local), function (options, name) {
-        var schemaDef = normalizeSchemaDef(options, name);
-        if (!_.isUndefined(schemaDef.value)) {
-          defaults[name] = schemaDef.value;
-        }
-        if (schemaDef.type === 'object') {
-          objectTypeFields.push(name);
-        }
-      }, this);
-      if (_.size(defaults)) {
-        var localDefaults = _.result(this, 'defaults');
-        this.defaults = function () {
-          return _.defaults({}, defaults, localDefaults);
-        };
+    var defaults = {};
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, schema.props, schema.local), function (options, name) {
+      var schemaDef = normalizeSchemaDef(options, name);
+      if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isUndefined(schemaDef.value)) {
+        defaults[name] = schemaDef.value;
       }
+      if (schemaDef.type === 'object') {
+        objectTypeFields.push(name);
+      }
+    }, this);
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(defaults)) {
+      var localDefaults = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'defaults');
+      this.defaults = function () {
+        return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults({}, defaults, localDefaults);
+      };
+    }
 
-      // override `validate`
-      this.validate = _.wrap(this.validate, function (validate) {
-        var args = _.rest(arguments),
-            res = _.extend(this._validateSchema.apply(this, args), validate.apply(this, args));
-        return _.size(res) && res || undefined;
-      });
+    // override `validate`
+    this.validate = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].wrap(this.validate, function (validate) {
+      var args = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].rest(arguments),
+          res = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(this._validateSchema.apply(this, args), validate.apply(this, args));
+      return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(res) && res || undefined;
+    });
 
-      // override `parse`
-      this.parse = _.wrap(this.parse, function (parse) {
-        var target = parse.apply(this, _.rest(arguments));
-        if (this.flat) {
-          target = flatten(target, objectTypeFields);
-        }
-        return target;
-      });
+    // override `parse`
+    this.parse = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].wrap(this.parse, function (parse) {
+      var target = parse.apply(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].rest(arguments));
+      if (this.flat) {
+        target = flatten(target, objectTypeFields);
+      }
+      return target;
+    });
 
-      Backbone.Model.apply(this, arguments);
+    __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model.apply(this, arguments);
 
-      _.each(schema.derived, function (options, name) {
-        schema.computedProperties[name] = this.__getDerivedValue(name); // set initial value;
-        var deps = options.deps || [];
-        if (deps.length) {
-          this.on('cache:clear change:' + deps.join(' change:'), function () {
-            var value = this.__getDerivedValue(name);
-            if (value !== schema.computedProperties[name]) {
-              schema.computedProperties[name] = value;
-              this.trigger('change:' + name, this, value);
-            }
-          }, this);
-        }
-      }, this);
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(schema.derived, function (options, name) {
+      schema.computedProperties[name] = this.__getDerivedValue(name); // set initial value;
+      var deps = options.deps || [];
+      if (deps.length) {
+        this.on('cache:clear change:' + deps.join(' change:'), function () {
+          var value = this.__getDerivedValue(name);
+          if (value !== schema.computedProperties[name]) {
+            schema.computedProperties[name] = value;
+            this.trigger('change:' + name, this, value);
+          }
+        }, this);
+      }
+    }, this);
 
-      this.on('sync', function () {
-        this.__syncedData = this.toJSON();
-      }, this);
-    },
+    this.on('sync', function () {
+      this.__syncedData = this.toJSON();
+    }, this);
+  },
 
-    validate: function () {},
+  validate: function () {},
 
-    /**
+  /**
      * Check if the schema settings allow this field to exist in the model
      * @param  {String} key
      * @return {Boolean}
      */
-    allows: function (key) {
-      var schema = this['__schema__'],
-          all = _.extend({}, schema.props, schema.local);
-      if (!_.has(all, key)) {
-        Logger.warn('Field not defined in schema', key);
-      }
-      return true;
-    },
+  allows: function (key) {
+    var schema = this['__schema__'],
+        all = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, schema.props, schema.local);
+    if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].has(all, key)) {
+      __WEBPACK_IMPORTED_MODULE_2__util_Logger__["default"].warn('Field not defined in schema', key);
+    }
+    return true;
+  },
 
-    /**
+  /**
      * Returns the schema for the specific property
      *
      * @param propName - The name of the property
      * @returns {*} | null
      */
-    getPropertySchema: function (propName) {
-      var schema = this['__schema__'];
-      return _.reduce([schema.props, schema.local], function (result, options) {
-        return result || normalizeSchemaDef(options[propName], propName);
-      }, null);
-    },
+  getPropertySchema: function (propName) {
+    var schema = this['__schema__'];
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].reduce([schema.props, schema.local], function (result, options) {
+      return result || normalizeSchemaDef(options[propName], propName);
+    }, null);
+  },
 
-    set: function (key, val) {
-      var attrs;
-      if (typeof key === 'object') {
-        attrs = key;
-      } else {
-        (attrs = {})[key] = val;
+  set: function (key, val) {
+    var attrs;
+    if (typeof key === 'object') {
+      attrs = key;
+    } else {
+      (attrs = {})[key] = val;
+    }
+
+    // Don't override a computed properties
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(attrs, function (value, key) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].has(this['__schema__'].derived, key)) {
+        throw 'overriding derived properties is not supported: ' + key;
       }
+    }, this);
 
-      // Don't override a computed properties
-      _.each(attrs, function (value, key) {
-        if (_.has(this['__schema__'].derived, key)) {
-          throw 'overriding derived properties is not supported: ' + key;
-        }
-      }, this);
+    // Schema validation
+    var errorFields = [];
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(attrs, function (value, key) {
+      this.allows(key) || errorFields.push(key);
+    }, this);
+    if (errorFields.length) {
+      throw 'field not allowed: ' + errorFields.join(', ');
+    }
 
-      // Schema validation
-      var errorFields = [];
-      _.each(attrs, function (value, key) {
-        this.allows(key) || errorFields.push(key);
-      }, this);
-      if (errorFields.length) {
-        throw 'field not allowed: ' + errorFields.join(', ');
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model.prototype.set.apply(this, arguments);
+  },
+
+  get: function (attr) {
+    var schema = this['__schema__'];
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].has(schema.derived, attr)) {
+      if (schema.derived[attr].cache !== false) {
+        return schema.computedProperties[attr];
       }
-
-      return Backbone.Model.prototype.set.apply(this, arguments);
-    },
-
-    get: function (attr) {
-      var schema = this['__schema__'];
-      if (_.has(schema.derived, attr)) {
-        if (schema.derived[attr].cache !== false) {
-          return schema.computedProperties[attr];
-        }
-        else {
-          return this.__getDerivedValue(attr);
-        }
+      else {
+        return this.__getDerivedValue(attr);
       }
-      return Backbone.Model.prototype.get.apply(this, arguments);
-    },
+    }
+    return __WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model.prototype.get.apply(this, arguments);
+  },
 
-    /**
+  /**
      * Return a shallow copy of the model's attributes for JSON stringification.
      * This can be used for persistence, serialization, or for augmentation before being sent to the server.
      * The name of this method is a bit confusing, as it doesn't actually return a JSON string —
@@ -6509,532 +6992,1547 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * artist.set({birthday: 'December 16, 1866'});
      * JSON.stringify(artist); //=> {'firstName':'Wassily','lastName':'Kandinsky','birthday':'December 16, 1866'}
      */
-    toJSON: function (options) {
-      options || (options = {});
-      var res = _.clone(Backbone.Model.prototype.toJSON.apply(this, arguments)),
-          schema = this['__schema__'];
+  toJSON: function (options) {
+    options || (options = {});
+    var res = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(__WEBPACK_IMPORTED_MODULE_1_backbone___default.a.Model.prototype.toJSON.apply(this, arguments)),
+        schema = this['__schema__'];
 
-      // cleanup local properties
-      if (!options.verbose) {
-        res = _.omit(res, _.keys(schema.local));
-      }
-      else { // add derived properties
-        _.each(schema.derived, function (options, name) {
-          res[name] = this.get(name);
-        }, this);
-      }
+    // cleanup local properties
+    if (!options.verbose) {
+      res = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(res, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].keys(schema.local));
+    }
+    else { // add derived properties
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(schema.derived, function (options, name) {
+        res[name] = this.get(name);
+      }, this);
+    }
 
-      if (this.flat) {
-        res = unflatten(res);
-      }
+    if (this.flat) {
+      res = unflatten(res);
+    }
 
-      return res;
-    },
+    return res;
+  },
 
-    /**
+  /**
      * Removes all attributes from the model, including the id attribute.
      * Fires a `"change"` event unless `silent` is passed as an option.
      * Sets the default values to the model
      * @param {Object} [options]
      */
-    reset: function (options) {
-      this.clear(options);
-      this.set(_.result(this, 'defaults'), options);
-    },
+  reset: function (options) {
+    this.clear(options);
+    this.set(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'defaults'), options);
+  },
 
-    /**
+  /**
      * Is the data on the model has local modifications since the last sync event?
      * @return {Boolean} is the model in sync with the server
      */
-    isSynced: function () {
-      return _.isEqual(this.__syncedData, this.toJSON());
-    },
+  isSynced: function () {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEqual(this.__syncedData, this.toJSON());
+  },
 
-    /**
+  /**
      * validate a specific field in the model.
      * @param  {String} key
      * @return {Object} returns `{fieldName: errorMessage}` if invalid, otherwise undefined.
      * @readonly
      */
-    validateField: function (key) {
-      var schema = key && this.getPropertySchema(key);
-      return schema && validateField(schema, this.get(key));
-    },
+  validateField: function (key) {
+    var schema = key && this.getPropertySchema(key);
+    return schema && validateField(schema, this.get(key));
+  },
 
-    /**
+  /**
      * Runs local schema validation. Invoked internally by {@link src/framework/Model#validate|validate}.
      * @return {Object}
      * @protected
      */
-    _validateSchema: function () {
-      var schema = this['__schema__'];
-      return _.reduce(_.extend({}, schema.props, schema.local), function (memo, options, name) {
-        return _.extend(memo, this.validateField(name) || {});
-      }, {}, this);
-    },
-
-    __getDerivedValue: function (name) {
-      var options = this['__schema__'].derived[name];
-      if (_.isString(options)) {
-        var key = options;
-        options = {
-          deps: [key],
-          fn: function () {
-            return this.get(key);
-          }
-        };
-      }
-      var deps = options.deps || [];
-      return options.fn.apply(this, _.map(deps, this.get, this));
-    }
-
+  _validateSchema: function () {
+    var schema = this['__schema__'];
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].reduce(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, schema.props, schema.local), function (memo, options, name) {
+      return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(memo, this.validateField(name) || {});
+    }, {}, this);
   },
-  {
-    ERROR_BLANK: 'model.validation.field.blank',
-    ERROR_WRONG_TYPE: 'model.validation.field.wrong.type',
-    ERROR_NOT_ALLOWED: 'model.validation.field.value.not.allowed',
-    ERROR_INVALID: 'model.validation.field.invalid',
-    ERROR_IARRAY_UNIQUE: 'model.validation.field.array.unique',
-    ERROR_INVALID_FORMAT_EMAIL: 'model.validation.field.invalid.format.email',
-    ERROR_INVALID_FORMAT_URI: 'model.validation.field.invalid.format.uri',
-    ERROR_INVALID_FORMAT_IPV4: 'model.validation.field.invalid.format.ipv4',
-    ERROR_INVALID_FORMAT_HOSTNAME: 'model.validation.field.invalid.format.hostname',
-    ERROR_STRING_STRING_MIN_LENGTH: 'model.validation.field.string.minLength',
-    ERROR_STRING_STRING_MAX_LENGTH: 'model.validation.field.string.maxLength'
+
+  __getDerivedValue: function (name) {
+    var options = this['__schema__'].derived[name];
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(options)) {
+      var key = options;
+      options = {
+        deps: [key],
+        fn: function () {
+          return this.get(key);
+        }
+      };
+    }
+    var deps = options.deps || [];
+    return options.fn.apply(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(deps, this.get, this));
   }
-  );
 
-  return Model;
+},
+{
+  ERROR_BLANK: 'model.validation.field.blank',
+  ERROR_WRONG_TYPE: 'model.validation.field.wrong.type',
+  ERROR_NOT_ALLOWED: 'model.validation.field.value.not.allowed',
+  ERROR_INVALID: 'model.validation.field.invalid',
+  ERROR_IARRAY_UNIQUE: 'model.validation.field.array.unique',
+  ERROR_INVALID_FORMAT_EMAIL: 'model.validation.field.invalid.format.email',
+  ERROR_INVALID_FORMAT_URI: 'model.validation.field.invalid.format.uri',
+  ERROR_INVALID_FORMAT_IPV4: 'model.validation.field.invalid.format.ipv4',
+  ERROR_INVALID_FORMAT_HOSTNAME: 'model.validation.field.invalid.format.hostname',
+  ERROR_STRING_STRING_MIN_LENGTH: 'model.validation.field.string.minLength',
+  ERROR_STRING_STRING_MAX_LENGTH: 'model.validation.field.string.maxLength'
+}
+);
 
-}));
+/* harmony default export */ __webpack_exports__["a"] = (Model);
 
 
 /***/ }),
-/* 40 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 38 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(5)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
-				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-  }
-  /* global module, exports */
-  else if (typeof require == 'function' && typeof exports == 'object') {
-    module.exports = factory(require('okta/underscore'), require('backbone'));
-  }
-  else {
-    root.Archer || (root.Archer = {});
-    root.Archer.Collection = factory(root._, root.Backbone);
-  }
-}(this, function (_, Backbone) {
-  var STATE = '__STATE__',
-      FETCH_DATA = 'FETCH_DATA',
-      PAGINATION_DATA = 'PAGINATION_DATA',
-      DEFAULT_PARAMS = 'DEFAULT_PARAMS',
-      LINK_BY_HEADER = 'LINK_BY_HEADER',
-      XHR = 'XHR';
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__BaseCollection__ = __webpack_require__(14);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseModel__ = __webpack_require__(15);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__SchemaProperty__ = __webpack_require__(17);
 
-  /*
-   * Sets the next page URL on the collection from link headers
-   * See: http://www.rfc-editor.org/rfc/rfc5988.txt
-   *
-   * This method is looking for a link header with `rel="next"`
-   * An set's it as the next page's URL.
-   *
-   * If it doesn't find a next page, and current page is set by a link header
-   * it assumes we are at the last page and deletes the current `next`
-   */
-  function setLinkHeadersPagination(collection, xhr) {
-    try {
-      var links = parseLinkHeader(xhr.getResponseHeader('link'));
-      collection[STATE].set(LINK_BY_HEADER, true);
-      collection.setPagination(links['next'].href);
-    }
-    catch (e) {
-      if (collection[STATE].get(LINK_BY_HEADER)) {
-        collection.setPagination(null);
-      }
-    }
-  }
 
-  function parseQuery(url) {
-    var params = {},
-        rawQueryStr = url && url.split('?')[1],
-        queryString = rawQueryStr && decodeURIComponent(rawQueryStr.split('#')[0]).replace(/\+/g, ' '),
-        props = queryString ? queryString.split('&') : [];
-    for (var i = 0; i < props.length; i++) {
-      var parts = props[i].split('=');
-      params[parts.shift()] = parts.join('=');
-    }
-    return params;
-  }
 
-  // ################################################
-  // # Source: https://gist.github.com/deiu/9335803
-  // ################################################
 
-  // unquote string (utility)
-  function unquote(value) {
-    if (value.charAt(0) == '"' && value.charAt(value.length - 1) == '"') {
-      return value.substring(1, value.length - 1);
-    }
-    return value;
-  }
-  /*
-  parse a Link header
-  Link:<https://example.org/.meta>; rel=meta
-  var r = parseLinkHeader(xhr.getResponseHeader('Link');
-  r['meta']['href'] outputs https://example.org/.meta
-  */
-  function parseLinkHeader(header) {
-    /* eslint max-statements: 0 */
-    var linkexp = /<[^>]*>\s*(\s*;\s*[^()<>@,;:"/[\]?={} \t]+=(([^()<>@,;:"/[\]?={} \t]+)|("[^"]*")))*(,|$)/g,
-        paramexp = /[^()<>@,;:"/[\]?={} \t]+=(([^()<>@,;:"/[\]?={} \t]+)|("[^"]*"))/g;
 
-    var matches = header.match(linkexp);
-    var rels = {};
-    for (var i = 0; i < matches.length; i++) {
-      var split = matches[i].split('>');
-      var href = split[0].substring(1);
-      var link = {};
-      link.href = href;
-      var s = split[1].match(paramexp);
-      for (var j = 0; j < s.length; j++) {
-        var paramsplit = s[j].split('=');
-        var name = paramsplit[0];
-        link[name] = unquote(paramsplit[1]);
-      }
+const parseProperties = function (resp) {
+  const schemaMeta = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].pick(resp, 'id', 'name', 'displayName');
 
-      if (link.rel !== undefined) {
-        rels[link.rel] = link;
-      }
-    }
-
-    return rels;
-  }
-
-  // ################################################
-  // # /Source
-  // ################################################
-  //
-
-  /**
-   *
-   * Archer.Collection is a standard [Backbone.Collection](http://backbonejs.org/#Collection) with pre-set `data`
-   * parameters and built in pagination - works with [http link headers](https://tools.ietf.org/html/rfc5988)
-   * out of the box:
-   *
-   * @class src/framework/Collection
-   * @extends external:Backbone.Collection
-   * @example
-   * var Users = Archer.Collection.extend({
-   *   url: '/api/v1/users'
-   *   params: {expand: true}
-   * });
-   * var users = new Users(null, {params: {type: 'new'}}),
-   *     $button = this.$('a.fetch-more');
-   *
-   * $button.click(function () {
-   *   users.fetchMore();
-   * });
-   *
-   * this.listenTo(users, 'sync', function () {
-   *   $button.toggle(users.hasMore());
-   * });
-   *
-   * collection.fetch(); //=> '/api/v1/users?expand=true&type=new'
-   */
-  return Backbone.Collection.extend(/** @lends src/framework/Collection.prototype */ {
-
-    /**
-     * Default fetch parameters
-     * @type {Object}
-     */
-    params: {},
-
-    constructor: function (models, options) {
-      var state = this[STATE] = new Backbone.Model();
-      state.set(DEFAULT_PARAMS, _.defaults(options && options.params || {}, this.params || {}));
-      Backbone.Collection.apply(this, arguments);
-    },
-
-    /**
-     * See [Backbone Collection.sync](http://backbonejs.org/#Collection-sync).
-     */
-    sync: function (method, collection, options) {
-      var self = this,
-          success = options.success;
-      options.success = function (resp, status, xhr) {
-        // its important to set the pagination data *before* we call the success callback
-        // because we want the pagination data to be ready when the collection triggers the `sync` event
-        setLinkHeadersPagination(self, xhr);
-        success.apply(null, arguments);
-      };
-      return Backbone.Collection.prototype.sync.call(this, method, collection, options);
-    },
-
-    /**
-     * See [Backbone Collection.fetch](http://backbonejs.org/#Collection-fetch).
-     */
-    fetch: function (options) {
-      options || (options = {});
-      var state = this[STATE],
-          xhr = state.get(XHR);
-
-      options.data = _.extend({}, state.get(DEFAULT_PARAMS), options.data || {});
-      options.fromFetch = true;
-
-      state.set(FETCH_DATA, options.data);
-      if (xhr && xhr.abort && options.abort !== false) {
-        xhr.abort();
-      }
-      xhr = Backbone.Collection.prototype.fetch.call(this, options);
-      state.set(XHR, xhr);
-      return xhr;
-    },
-
-    /**
-     * Set pagination data to get to the next page
-     * @param {Mixed} params
-     * @param {Object} [options]
-     * @param {Boolean} [options.fromFetch] should we include data from the previous fetch call in this object
-     * @example
-     * collection.setPagination({q: 'foo', page: '2'}); //=> {q: 'foo', page: '2'}
-     *
-     * collection.setPagination('/path/to/resource?q=baz&page=4'); //=> {q: 'baz', page: '4'}
-     *
-     * collection.setPagination('/path/to/resource'); //=> {}
-     *
-     * collection.fetch({data: {q: 'foo'}});
-     * collection.setPagination({page: 2}, {fromFetch: true}); //=> {q: 'foo', page: 2}
-     *
-     * any "falsy" value resets pagination
-     * collection.setPagination(); //=> {}
-     * collection.setPagination(null); //=> {}
-     * collection.setPagination(false); //=> {}
-     * collection.setPagination(''); //=> {}
-     * collection.setPagination(0); //=> {}
-     * @protected
-     */
-    setPagination: function (params, options) {
-      /* eslint complexity: [2, 8] */
-      if (_.isString(params) && params) {
-        params = parseQuery(params);
-      }
-      if (!_.isObject(params) || _.isArray(params) || !_.size(params)) {
-        params = null;
-      }
-      else if (options && options.fromFetch) {
-        params = _.extend({}, this.getFetchData(), params);
-      }
-      this[STATE].set(PAGINATION_DATA, params);
-    },
-
-    /**
-     * Returns the `data` parameters applied in th most recent `fetch` call
-     * It will include parameters set by {@link #params} and optios.params passed to the constructor
-     * @return {Object}
-     * @protected
-     */
-    getFetchData: function () {
-      return this[STATE].get(FETCH_DATA) || {};
-    },
-
-    /**
-     * Data object for constructing a request to fetch the next page
-     * @return {Object}
-     * @protected
-     */
-    getPaginationData: function () {
-      return this[STATE].get(PAGINATION_DATA) || {};
-    },
-
-    /**
-     * Does this collection have more data on the server (e.g is there a next "page")
-     * @return {Boolean}
-     */
-    hasMore: function () {
-      return _.size(this.getPaginationData()) > 0;
-    },
-
-    /**
-     * Get the next page from the server
-     * @return {Object} xhr returned by {@link #fetch}
-     */
-    fetchMore: function () {
-      if (!this.hasMore()) {
-        throw new Error('Invalid Request');
-      }
-      return this.fetch({data: this.getPaginationData(), add: true, remove: false, update: true});
-    },
-
-    /**
-     * See [Backbone Collection.reset](http://backbonejs.org/#Collection-reset).
-     */
-    reset: function (models, options) {
-      options || (options = {});
-      // only reset the pagination when reset is being called explicitly.
-      // this is to avoid link headers pagination being overriden and reset when
-      // fetching the collection using `collection.fetch({reset: true})`
-      if (!options.fromFetch) {
-        this.setPagination(null);
-      }
-      return Backbone.Collection.prototype.reset.apply(this, arguments);
-    },
-
-    // we want "where" to be able to search through derived properties as well
-    where: function (attrs, first) {
-      if (_.isEmpty(attrs)) {
-        return first ? void 0 : [];
-      }
-      return this[first ? 'find' : 'filter'](function (model) {
-        for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) {
-            return false;
-          }
-        }
-        return true;
-      });
-    },
-
-    /**
-     * See [Backbone Collection.create](http://backbonejs.org/#Collection-create).
-     */
-    create: function (model, options) {
-      options || (options = {});
-      if (!_.result(model, 'urlRoot')) {
-        options.url = _.result(this, 'url');
-      }
-      return Backbone.Collection.prototype.create.call(this, model, options);
-    }
-
+  const properties = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(resp.schema.properties, function (property, name) {
+    return Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])({ name: name })
+      .chain()
+      .extend(property)
+      .omit('__metadata')
+      .value();
   });
 
-}));
+  __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(properties, function (property) {
+    property['__schemaMeta__'] = schemaMeta;
+  });
+  return properties;
+};
+
+const BaseSchemaSchema = __WEBPACK_IMPORTED_MODULE_2__BaseModel__["default"].extend({
+  defaults: {
+    id: undefined,
+    displayName: undefined,
+    name: undefined
+  },
+
+  constructor: function () {
+    this.properties = new __WEBPACK_IMPORTED_MODULE_3__SchemaProperty__["default"].Collection();
+    __WEBPACK_IMPORTED_MODULE_2__BaseModel__["default"].apply(this, arguments);
+  },
+
+  getProperties: function () {
+    return this.properties;
+  },
+
+  clone: function () {
+    const model = __WEBPACK_IMPORTED_MODULE_2__BaseModel__["default"].prototype.clone.apply(this, arguments);
+
+    model.getProperties().set(this.getProperties().toJSON({ verbose: true }));
+    return model;
+  },
+
+  parse: function (resp) {
+    const properties = parseProperties(resp);
+
+    this.properties.set(properties, { parse: true });
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(resp, 'schema');
+  },
+
+  trimProperty: function (property) {
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(property, 'name');
+  },
+
+  toJSON: function () {
+    const json = __WEBPACK_IMPORTED_MODULE_2__BaseModel__["default"].prototype.toJSON.apply(this, arguments);
+
+    json.schema = { properties: {} };
+    this.getProperties().each(function (model) {
+      const property = model.toJSON();
+
+      json.schema.properties[property.name] = this.trimProperty(property);
+    }, this);
+    return json;
+  },
+
+  save: function () {
+    this.getProperties().each(function (model) {
+      model.cleanup();
+    });
+    return __WEBPACK_IMPORTED_MODULE_2__BaseModel__["default"].prototype.save.apply(this, arguments);
+  }
+});
+const BaseSchemaSchemas = __WEBPACK_IMPORTED_MODULE_1__BaseCollection__["default"].extend({
+  model: BaseSchemaSchema
+});
+/* harmony default export */ __webpack_exports__["default"] = ({
+  parseProperties: parseProperties,
+  Model: BaseSchemaSchema,
+  Collection: BaseSchemaSchemas
+});
+
+
+/***/ }),
+/* 39 */
+/***/ (function(module, exports) {
+
+module.exports = require("okta-i18n-bundles");
+
+/***/ }),
+/* 40 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseRouter__ = __webpack_require__(19);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__SettingsModel__ = __webpack_require__(20);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__StateMachine__ = __webpack_require__(52);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__views_BaseView__ = __webpack_require__(1);
+/* eslint max-len: [2, 150] */
+
+
+
+
+
+
+
+function clean(obj) {
+  const res = {};
+
+  __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].each(obj, function (value, key) {
+    if (!__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].isNull(value)) {
+      res[key] = value;
+    }
+  });
+  return res;
+}
+
+/**
+ * A Controller is our application control flow component.
+ *
+ * Typically it will:
+ * - Initialize the models, controller and main views
+ * - Listen to events
+ * - Create, read, update and delete models
+ * - Create modal dialogs, confirmation dialogs and alert dialogs
+ * - Control the application flow
+ *
+ * The constructor is responsible for:
+ * - Create the application state object
+ * - Assign or creates the application settings object
+ * - Create an instance of the main view with the relevant parameters
+ *
+ * See:
+ * [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World),
+ * [Jasmine Spec](https://github.com/okta/okta-core/blob/master/WebContent/js/test/unit/spec/shared/util/BaseController_spec.js)
+ *
+ * @class module:Okta.Controller
+ * @param {Object} options Options Hash
+ * @param {SettingsModel} [options.settings] Application Settings Model
+ * @param {String} options.el a jQuery selector string stating where to attach the controller in the DOM
+ */
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_5__views_BaseView__["default"].extend(
+  /** @lends module:Okta.Controller.prototype */ {
+    constructor: function (options) {
+      /* eslint max-statements: [2, 13], complexity: [2, 7]*/
+      options || (options = {});
+
+      const stateData = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].defaults(clean(options.state), this.state || {});
+
+      this.state = new __WEBPACK_IMPORTED_MODULE_4__StateMachine__["a" /* default */](stateData);
+      delete options.state;
+
+      if (options.settings) {
+        this.settings = options.settings;
+      } else {
+        // allow the controller to live without a router
+        this.settings = options.settings = new __WEBPACK_IMPORTED_MODULE_3__SettingsModel__["a" /* default */](__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].omit(options || {}, 'el'));
+        this.listen('notification', __WEBPACK_IMPORTED_MODULE_2__BaseRouter__["default"].prototype._notify);
+        this.listen('confirmation', __WEBPACK_IMPORTED_MODULE_2__BaseRouter__["default"].prototype._confirm);
+      }
+
+      __WEBPACK_IMPORTED_MODULE_5__views_BaseView__["default"].call(this, options);
+
+      this.listenTo(this.state, '__invoke__', function () {
+        const args = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].toArray(arguments);
+
+        const method = args.shift();
+
+        if (__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].isFunction(this[method])) {
+          this[method].apply(this, args);
+        }
+      });
+
+      if (this.View) {
+        this.add(new this.View(this.toJSON()));
+      }
+    },
+
+    /**
+     * The default values of our application state
+     * @type {Object}
+     * @default {}
+     */
+    state: {},
+
+    /**
+     * The main view this controller operate on
+     * @type {module:Okta.View}
+     * @default null
+     */
+    View: null,
+
+    /**
+     * Renders the {@link module:Okta.Controller#View|main view} after the DOM is ready
+     * in case the controller is the root component of the page (e.g there's no router)
+     */
+    render: function () {
+      const args = arguments;
+      const self = this;
+
+      Object(__WEBPACK_IMPORTED_MODULE_0__jquery_wrapper__["default"])(function () {
+        __WEBPACK_IMPORTED_MODULE_5__views_BaseView__["default"].prototype.render.apply(self, args);
+      });
+      return this;
+    },
+
+    /**
+     * Creates the view constructor options
+     * @param {Object} [options] Extra options
+     * @return {Object} The view constructor options
+     */
+    toJSON: function (options) {
+      return __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].extend(__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].pick(this, 'state', 'settings', 'collection', 'model'), options || {});
+    },
+
+    /**
+     * Removes the child views, empty the DOM element and stop listening to events
+     */
+    remove: function () {
+      this.removeChildren();
+      this.stopListening();
+      this.$el.empty();
+      return this;
+    }
+  }
+));
 
 
 /***/ }),
 /* 41 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(14),
-  __webpack_require__(15),
-  __webpack_require__(19)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseModel, BaseCollection, SchemaProperty) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__BaseFormDialog__ = __webpack_require__(42);
 
-  var parseProperties = function (resp) {
-    var schemaMeta = _.pick(resp, 'id', 'name', 'displayName');
-    var properties = _.map(resp.schema.properties, function (property, name) {
-      return _({name: name}).chain().extend(property).omit('__metadata').value();
-    });
-    _.each(properties, function (property) {
-      property['__schemaMeta__'] = schemaMeta;
-    });
-    return properties;
-  };
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_0__BaseFormDialog__["a" /* default */].extend({
+  save: 'OK',
 
-  var Schema = BaseModel.extend({
+  params: {
+    minWidth: 500,
+    maxWidth: 700,
+    close: true
+  },
 
-    defaults: {
-      id: undefined,
-      displayName: undefined,
-      name: undefined
-    },
+  constructor: function () {
+    __WEBPACK_IMPORTED_MODULE_0__BaseFormDialog__["a" /* default */].apply(this, arguments);
 
-    constructor: function () {
-      this.properties = new SchemaProperty.Collection();
-      BaseModel.apply(this, arguments);
-    },
-
-    getProperties: function () {
-      return this.properties;
-    },
-
-    clone: function () {
-      var model = BaseModel.prototype.clone.apply(this, arguments);
-      model.getProperties().set(this.getProperties().toJSON({verbose: true}));
-      return model;
-    },
-
-    parse: function (resp) {
-      var properties = parseProperties(resp);
-      this.properties.set(properties, {parse: true});
-      return _.omit(resp, 'schema');
-    },
-
-    trimProperty: function (property) { return _.omit(property, 'name'); },
-
-    toJSON: function () {
-      var json = BaseModel.prototype.toJSON.apply(this, arguments);
-      json.schema = {properties: {}};
-      this.getProperties().each(function (model) {
-        var property = model.toJSON();
-        json.schema.properties[property.name] = this.trimProperty(property);
-      }, this);
-      return json;
-    },
-
-    save: function () {
-      this.getProperties().each(function (model) {
-        model.cleanup();
-      });
-      return BaseModel.prototype.save.apply(this, arguments);
+    if (this.content) {
+      this.add(this.content);
     }
-  });
 
-  var Schemas = BaseCollection.extend({
-    model: Schema
-  });
+    this.listenTo(this, 'save', function () {
+      const callback = this.ok || this.options.ok;
 
-  return {
-    parseProperties: parseProperties,
-    Model: Schema,
-    Collection: Schemas
-  };
+      callback && callback();
+      this.remove();
+    });
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+    this.listenTo(this, 'cancel', function () {
+      const callback = this.cancelFn || this.options.cancelFn;
+
+      callback && callback();
+    });
+  }
+}));
 
 
 /***/ }),
 /* 42 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(23)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView, ViewUtil) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__BaseModalDialog__ = __webpack_require__(43);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__forms_BaseForm__ = __webpack_require__(23);
 
-  var disabledEvents = {
-    click: function (e) {
-      e.preventDefault();
-      e.stopPropagation();
+
+
+
+
+const FORM_FIELDS = [
+  'save',
+  'noCancelButton',
+  'inputs',
+  'subtitle',
+  'autoSave',
+  'focus',
+  'cancel',
+  'danger',
+  'hasSavingState',
+  'customSavingState',
+  'parseErrorMessage',
+];
+const FORM_DEFAULTS = {
+  layout: 'o-form-wrap',
+  scrollOnError: false
+};
+const SIMPLE_MODAL_PARAMS = {
+  minWidth: 600,
+  maxWidth: 950,
+  focus: false,
+  close: false,
+  autoResize: false, // (use the resizeModal method, so that the scrolling goes to content, not the whole modal)
+  autoPosition: true
+};
+
+// jquery.simplemodoal options
+
+/**
+ * Okta.FormDialog is a facade layer for a form that lives in a modal dialog.
+ *
+ * The API is proxying the {@link module:Okta.Form|Form} API for the most part.
+ * It also triggers all the form events
+ * It takes care of repositioning, resizing, closing the dialog on cancel, and so on.
+ *
+ * @class module:Okta.FormDialog
+ * @extends module:Okta.View
+ * @borrows module:Okta.Form#event:save as save
+ * @borrows module:Okta.Form#event:saved as saved
+ * @borrows module:Okta.Form#event:resize as resize
+ * @borrows module:Okta.Form#event:cancel as cancel
+ * @borrows module:Okta.Form#title as #title
+ * @borrows module:Okta.Form#subtitle as #subtitle
+ * @borrows module:Okta.Form#save as #save
+ * @borrows module:Okta.Form#inputs as #inputs
+ * @borrows module:Okta.Form#noCancelButton as #noCancelButton
+ * @borrows module:Okta.Form#autoSave as #autoSave
+ * @borrows module:Okta.ModalDialog#params as #params
+ * @borrows module:Okta.Form#addInput as #addInput
+ * @borrows module:Okta.Form#addButton as #addButton
+ * @borrows module:Okta.Form#addDivider as #addDivider
+ * @borrows module:Okta.Form#addSectionTitle as #addSectionTitle
+ * @borrows module:Okta.Form#clearErrors as #clearErrors
+ * @example
+ * var AddUserDialog = Okta.FormDialog({
+ *   autoSave: true,
+ *   title: 'Add a User',
+ *   inputs: [
+ *     {
+ *       type: 'text',
+ *       name: 'fname',
+ *       label: 'First Name'
+ *     },
+ *     {
+ *       type: 'text',
+ *       name: 'lname',
+ *       label: 'Last Name'
+ *     }
+ *   ]
+ * });
+ *
+ * // renders the modal dialog on the page
+ * var dialog = new AddUserDialog({model: new MyModel()}).render();
+ * this.listenTo(dialog, 'saved', function (model) {
+ *   // the model is now saved
+ * });
+ */
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].extend(
+  /** @lends module:Okta.FormDialog.prototype */ {
+    constructor: function (options) {
+      const Form = __WEBPACK_IMPORTED_MODULE_4__forms_BaseForm__["default"].extend(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, FORM_DEFAULTS, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(this, FORM_FIELDS)));
+      /* eslint max-statements: [2, 13] */
+
+      this.form = new Form(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].omit(options, 'title', 'subtitle'));
+
+      this.listenTo(this.form, 'resize', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].debounce(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.resizeModal, this), 100));
+
+      // trigger all form events
+
+      const removeFn = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.remove, this);
+
+      this.listenTo(this.form, 'all', function () {
+        this.trigger.apply(this, arguments);
+        if (arguments[0] === 'cancel') {
+          removeFn();
+        }
+      });
+
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).resize(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].debounce(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.resizeModal, this), 100));
+
+      const BaseFormDialogDialog = __WEBPACK_IMPORTED_MODULE_3__BaseModalDialog__["a" /* default */].extend({
+        title: this.title,
+        className: this.className,
+        params: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, SIMPLE_MODAL_PARAMS, this.params)
+      });
+
+      this.dialog = new BaseFormDialogDialog(options);
+      this.dialog.add(this.form);
+      this.el = this.dialog.el;
+
+      __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].apply(this, arguments);
+
+      if (this.form.getAttribute('autoSave')) {
+        this.listenTo(this, 'saved', this.remove);
+      }
+    },
+
+    /**
+     * The form instance generated by the constructor.
+     * Should **not** be referenced locally, exposed externally for test purposes.
+     * @type {Okta.Form}
+     * @private
+     * @readonly
+     */
+    form: undefined,
+
+    /**
+     * The dialog instance generated by the constructor.
+     * Should **not** be referenced locally, exposed externally for test purposes.
+     * @type {Okta.ModalDialog}
+     * @private
+     * @readonly
+     */
+    dialog: undefined,
+
+    addInput: function () {
+      return this.form.addInput.apply(this.form, arguments);
+    },
+
+    addButton: function () {
+      return this.form.addButton.apply(this.form, arguments);
+    },
+
+    addDivider: function () {
+      return this.form.addDivider.apply(this.form, arguments);
+    },
+
+    addSectionTitle: function () {
+      return this.form.addSectionTitle.apply(this.form, arguments);
+    },
+
+    add: function () {
+      return this.form.add.apply(this.form, arguments);
+    },
+
+    render: function () {
+      this.preRender();
+      this.dialog.render.apply(this.dialog, arguments);
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defer(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.resizeModal, this));
+      this.postRender();
+      return this;
+    },
+
+    remove: function () {
+      this.dialog.remove.apply(this.dialog, arguments);
+      return __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].prototype.remove.apply(this, arguments);
+    },
+
+    /**
+     * Resize modal to fit window height
+     * the whole modal will be within the viewport, only the form content is scrollable
+     * there's no good solution to totally fix the width issue yet for tiny window,
+     * leave it for jquery simplemodal autoResize to do its best
+     */
+    resizeModal: function () {
+      const modal = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('.simplemodal-wrap');
+      const form = this.form;
+      const modalHeight = modal.height();
+      const modalMinHeight = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isNumber(this.dialog.params.minHeight) ? this.dialog.params.minHeight : 0;
+      const windowHeight = Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).height();
+
+      if (modalMinHeight <= modalHeight) {
+        if (modalHeight >= windowHeight) {
+          form.contentHeight(
+            windowHeight -
+              this.dialog.$('h2').outerHeight() -
+              form.$('.o-form-button-bar').outerHeight() -
+              (modal.outerHeight(true) - form.$el.outerHeight(true))
+          );
+        } else {
+          form.contentHeight(form.contentHeight() + (windowHeight - modal.outerHeight()));
+        }
+        this.dialog.resize.apply(this.dialog, arguments);
+      }
+    },
+
+    clearErrors: function () {
+      return this.form.clearErrors.apply(this.form, arguments);
     }
-  };
+  }
+));
+
+
+/***/ }),
+/* 43 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_simplemodal__ = __webpack_require__(22);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_simplemodal___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_4_vendor_plugins_jquery_simplemodal__);
+
+
+
+
+
+const tpl = __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__["default"].tpl;
+
+/**
+ * A view that renders as a modal dialog.
+ * The template of the view will render inside a dialog.
+ *
+ * It uses [SimpleModal](http://www.ericmmartin.com/projects/simplemodal) as the base modal widget.
+ *
+ * In the context of a {@link module:Okta.View|View}, do not `add` this view to the container - simply call render
+ * A modal dialog is a special view in terms of - it has an overlay and takes over the screen, so conceptually
+ * it is not a part of any other view.
+ *
+ * @class module:Okta.ModalDialog
+ * @extends module:Okta.View
+ */
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].extend(
+  /** @lends module:Okta.ModalDialog.prototype */ {
+    /**
+     * Parameters to pass to the simplemodal plugin.
+     * See [Available Options](http://www.ericmmartin.com/projects/simplemodal/#options).
+     * @type {Object}
+     * @property {Object} [params]
+     */
+    params: {},
+
+    constructor: function () {
+      __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].apply(this, arguments);
+      this.$el.addClass('simplemodal-wrap');
+
+      // garbage collection - remove the view when modal is closed
+      this.params = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(
+        {
+          onClose: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].throttle(this.remove, 64), this)
+        },
+        this.params || {}
+      );
+    },
+
+    render: function () {
+      /* eslint max-statements: [2, 16] */
+
+      this.delegateEvents(); // modal may be rendered multiple times
+      __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].prototype.render.apply(this, arguments);
+
+      const options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend({}, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(this, 'title', 'subtitle'), __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(this.options, 'title', 'subtitle'));
+
+      if (options.subtitle) {
+        const subtitle = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(options, 'subtitle', this);
+
+        this.$el.prepend(
+          tpl('<p class="modal-subtitle text-light \
+          padding-20 margin-btm-0">{{subtitle}}</p>')({
+            subtitle: subtitle
+          })
+        );
+      }
+
+      if (options.title) {
+        const title = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(options, 'title', this);
+
+        this.$el.prepend(tpl('<h2 class="block modal-title">{{title}}</h2>')({ title: title }));
+      }
+
+      // running deferred fixes a rendering issue with simplemodal
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defer(() => {
+        this.$el.modal(this.params);
+        this.resize();
+      });
+
+      // make sure scrolling on the body is disabled;
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('body').css('overflow', 'hidden');
+
+      return this;
+    },
+
+    remove: function () {
+      __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].modal.close();
+      // re-enable document scroll; blank property value removes property altogether
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])('body').css('overflow', '');
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defer(function () {
+        __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].modal.close();
+      });
+      return __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].prototype.remove.apply(this, arguments);
+    },
+
+    /**
+     * Adjusts the modal content size based on the current content
+     */
+    resize: function () {
+      __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].modal.update(this.$el.outerHeight());
+    }
+  }
+));
+
+
+/***/ }),
+/* 44 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__helpers_FormUtil__ = __webpack_require__(9);
+
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_0__BaseView__["default"].extend({
+  el: '<span class="o-form-toggle" data-type="header-btn"></span>',
+
+  formTitle: '',
+
+  modelEvents: {
+    'change:__edit__': 'toggle'
+  },
+
+  initialize: function () {
+    this.addButton();
+  },
+
+  addButton: function () {
+    if (this.model.get('__edit__')) {
+      this.add(__WEBPACK_IMPORTED_MODULE_1__helpers_FormUtil__["default"].createReadFormButton({ type: 'cancel' }));
+    } else {
+      this.add(
+        __WEBPACK_IMPORTED_MODULE_1__helpers_FormUtil__["default"].createReadFormButton({
+          type: 'edit',
+          formTitle: this.formTitle
+        })
+      );
+    }
+  },
+
+  toggle: function () {
+    this.removeChildren();
+    this.addButton();
+  }
+}));
+
+
+/***/ }),
+/* 45 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__BaseView__ = __webpack_require__(1);
+
+const template =
+  '\
+    <div class="okta-form-infobox-error infobox infobox-error" role="alert">\
+      <span class="icon error-16"></span>\
+      {{#if errorSummary}}\
+        <p>{{errorSummary}}</p>\
+      {{else}}\
+        <p>{{i18n code="oform.errorbanner.title" bundle="courage"}}</p>\
+      {{/if}}\
+    </div>\
+  ';
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_0__BaseView__["default"].extend({
+  template: template,
+  modelEvents: {
+    'form:clear-errors': 'remove'
+  }
+}));
+
+
+/***/ }),
+/* 46 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_StringUtil__ = __webpack_require__(4);
+
+
+const FIELD_REGEX = /^([\S]+): (.+)$/;
+/* harmony default export */ __webpack_exports__["a"] = ({
+  /**
+   * Helper function that returns the json output of an xhr objext
+   * @param  {jqXhr} xhr
+   * @return {Object}
+   */
+  getResponseJSON: function (xhr) {
+    try {
+      return xhr.responseJSON || JSON.parse(xhr.responseText);
+    } catch (e) {
+      return;
+    }
+  },
 
   /**
-   * A configurable button.
-   * @class module:Okta.internal.views.components.BaseButtonLink
-   * @extends module:Okta.View
-   * @example
-   * var View = BaseButtonLink.extend({
-   *   title: 'Click Me',
-   *   icon: 'help-text'
-   * })
+   * Parses an error summary to extract a field name and an error message
+   * @param  {String} errorSummary The raw error summary
+   * @return {String[]} An array with two members: [field name, error message]
    */
-  return BaseView.extend(/** @lends module:Okta.internal.views.components.BaseButtonLink.prototype */ {
+  parseErrorSummary: function (errorSummary) {
+    const matches = errorSummary.match(FIELD_REGEX);
+    // error format is: `fieldName: The field cannot be left blank`
 
+    if (matches) {
+      return [matches[1], matches[2]];
+    }
+  },
+
+  /**
+   * Parses an error cause object to extract a field name from property attribute
+   * and an error message form errorSummary attribute. It looks to see if there is
+   * a custom override/translation for the erorrCause.reason before using the errorSummary
+   * @param  {Object} errorCause object
+   * @return {String[]} An array with two members: [field name, error message]
+   */
+  parseErrorCauseObject: function (errorCause) {
+    if (errorCause.property && errorCause.errorSummary) {
+      const localizedMsg = __WEBPACK_IMPORTED_MODULE_1__util_StringUtil__["default"].localize(errorCause.reason);
+      const apiMsg = errorCause.errorSummary;
+      const field = errorCause.property;
+      const errorMessage = localizedMsg.indexOf('L10N_ERROR[') === -1 ? localizedMsg : apiMsg;
+
+      return [field, errorMessage];
+    }
+  },
+
+  parseErrors: function (resp) {
+    const responseJSON = this.getResponseJSON(resp);
+
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map((responseJSON && responseJSON.errorCauses) || [], function (errorCause) {
+      return ('' + errorCause.errorSummary).replace(FIELD_REGEX, '$2');
+    });
+  },
+
+  /**
+   * Parses the response for errors
+   * Returns a map of field names > array or error messages
+   * Example:
+   * ```javascript
+   * {
+   *   url: ['The field cannot be left blank', 'The field has to be a valid URI'],
+   *   name: ['The field cannot be left blank']
+   * }
+   * ```
+   * @param  {Object} resp
+   * @return {Object}
+   */
+  parseFieldErrors: function (resp) {
+    const responseJSON = this.getResponseJSON(resp);
+    const errors = {};
+
+    // xhr error object
+    if (responseJSON) {
+      /* eslint complexity: [2, 7] */
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(
+        responseJSON.errorCauses || [],
+        function (cause) {
+          let res = [];
+
+          if (cause.property && cause.errorSummary) {
+            res = this.parseErrorCauseObject(cause);
+          } else {
+            res = this.parseErrorSummary((cause && cause.errorSummary) || '');
+          }
+          if (res) {
+            const fieldName = res[0];
+            const message = res[1];
+
+            errors[fieldName] || (errors[fieldName] = []);
+            errors[fieldName].push(message);
+          }
+        },
+        this
+      );
+    }
+    // validation key/value object
+    else if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isObject(resp) && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(resp)) {
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(resp, function (msg, field) {
+        errors[field] = [msg];
+      });
+    }
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].size(errors) ? errors : undefined;
+  }
+});
+
+
+/***/ }),
+/* 47 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_Logger__ = __webpack_require__(7);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_Util__ = __webpack_require__(16);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__BaseView__ = __webpack_require__(1);
+
+
+
+
+
+const isABaseView = __WEBPACK_IMPORTED_MODULE_3__util_Util__["default"].isABaseView;
+/**
+ * @class InputContainer
+ * @private
+ *
+ * TODO: OKTA-80796
+ * Attention: Please change with caution since this is used in other places
+ */
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend({
+  attributes: function () {
+    return {
+      'data-se': 'o-form-input-container'
+    };
+  },
+
+  className: function () {
+    let className = 'o-form-input';
+
+    if (this.options.wide) {
+      className += ' o-form-wide';
+    }
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains([1, 2, 3, 4], this.options.multi)) {
+      className += ' o-form-multi-input-' + this.options.multi;
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.options.input)) {
+        const inputGroup = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].find(this.options.input, function (input) {
+          return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(['text+select', 'select+text'], input.options.type);
+        });
+
+        inputGroup && (className += ' o-form-multi-input-group-' + this.options.multi);
+      }
+    }
+    return className;
+  },
+
+  _getNames: function () {
+    const names = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.options.name) ? this.options.name : [this.options.name];
+    /*eslint complexity: 0 */
+
+    if (this.options.type === 'group') {
+      names.push.apply(names, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].pluck(this.options.input[0].options.params.inputs, 'name'));
+    } else if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.options.name)) {
+      if (this.options.input && this.options.input.options && this.options.input.options.name) {
+        names.push(this.options.input.options.name);
+      }
+    } else if (this.options.input) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.options.input)) {
+        __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(this.options.input, function (inputItem) {
+          names.push(inputItem.options.name);
+        });
+      } else {
+        names.push(this.options.input.options.name);
+      }
+    }
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniq(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].compact(names));
+  },
+
+  constructor: function () {
+    /* eslint max-statements: [2, 18] */
+    __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].apply(this, arguments);
+
+    // we want to append the input *before* the explain text
+    if (this.options.input) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(this.options.input)) {
+        __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(
+          this.options.input,
+          function (inputItem) {
+            this.add(inputItem, { prepend: true });
+          },
+          this
+        );
+      } else {
+        this.add(this.options.input, { prepend: true });
+      }
+    }
+
+    this.__setExplain(this.options);
+
+    const names = this._getNames();
+
+    this.listenTo(this.model, 'form:field-error', function (name, errors) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(names, name)) {
+        this.__setError(errors);
+      }
+    });
+
+    this.listenTo(this.model, 'form:clear-errors change:' + names.join(' change:'), this.__clearError);
+    this.listenTo(this.model, 'form:clear-error:' + names.join(' form:clear-error:'), this.__clearError);
+
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, 'autoRender', this)) {
+      this.listenTo(this.model, 'change:' + this.options.name, this.render);
+    }
+
+    this.__errorState = false;
+  },
+
+  /**
+   * Populates the explain on the input container (if it exists). There are
+   * two ways to use this:
+   * 1. Raw text - wraps in the correct html template
+   * 2. Custom html
+   *    - pass in a View class (preferred)
+   *    - pass in an instance of a View
+   * Some additional notes:
+   * - You can pass a function that returns any of the above
+   * - This maintains support for the deprecated "customExplain" property
+   *   that was used before. This pattern is superseded by explain, so use
+   *   that instead.
+   * @private
+   */
+  __setExplain: function (options) {
+    let explain;
+
+    // Deprecated - if you need custom html, use explain instead
+    if (options.customExplain) {
+      __WEBPACK_IMPORTED_MODULE_1__util_Logger__["default"].warn('Deprecated - use explain instead of customExplain');
+      this.add(this.options.customExplain);
+      return;
+    }
+
+    explain = options.explain;
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(explain) && !isABaseView(explain)) {
+      explain = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, 'explain', this);
+    }
+    if (!explain) {
+      return;
+    }
+
+    if (isABaseView(explain)) {
+      this.template = '<p class="o-form-explain"></p>';
+      this.add(explain, '.o-form-explain');
+    } else {
+      this.template = '<p class="o-form-explain">{{explain}}</p>';
+    }
+  },
+
+  /**
+   * Highlight the input as invalid (validation failed)
+   * Adds an explaination message of the error
+   * @private
+   */
+  __setError: function (errors) {
+    this.__errorState = true;
+    this.$el.addClass('o-form-has-errors');
+
+    const tmpl = [
+      '<p class="okta-form-input-error o-form-input-error o-form-explain" role="alert">',
+      '<span class="icon icon-16 error-16-small"></span>',
+      '{{text}}',
+      '</p>',
+    ].join('');
+    const html = __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__["default"].tpl(tmpl)({ text: errors.join(', ') });
+    const $elExplain = this.$('.o-form-explain')
+      .not('.o-form-input-error')
+      .first();
+
+    if ($elExplain.length) {
+      $elExplain.before(html);
+    } else {
+      this.$el.append(html);
+    }
+  },
+
+  /**
+   * Un-highlight the input and remove explaination text
+   * @private
+   */
+  __clearError: function () {
+    if (this.__errorState) {
+      this.$('.o-form-input-error').remove();
+      this.$el.removeClass('o-form-has-errors');
+      this.__errorState = false;
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defer(() => {
+        this.model.trigger('form:resize');
+      });
+    }
+  },
+
+  focus: function () {
+    this.each(function (view) {
+      if (view.focus) {
+        return view.focus();
+      }
+    });
+
+    return this;
+  }
+}));
+
+
+/***/ }),
+/* 48 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__InputRegistry__ = __webpack_require__(26);
+/* eslint complexity: 0, max-statements: 0 */
+
+
+
+function createInput(Input, options) {
+  if (__WEBPACK_IMPORTED_MODULE_1__InputRegistry__["default"].isBaseInput(Input)) {
+    return Input.prototype ? new Input(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(options, 'input')) : Input;
+  } else {
+    return Input;
+  }
+}
+
+function create(options) {
+  options = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].clone(options);
+  if (options.input) {
+    return createInput(options.input, options);
+  }
+  const Input = __WEBPACK_IMPORTED_MODULE_1__InputRegistry__["default"].get(options);
+
+  if (!Input) {
+    throw new Error('unknown input: ' + options.type);
+  }
+  return createInput(Input, options);
+}
+
+function supports(options) {
+  return !!options.input || !!__WEBPACK_IMPORTED_MODULE_1__InputRegistry__["default"].get(options);
+}
+
+/* harmony default export */ __webpack_exports__["a"] = ({
+  create: create,
+  supports: supports
+});
+
+
+/***/ }),
+/* 49 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_qtip__ = __webpack_require__(27);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_qtip___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_qtip__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__BaseView__ = __webpack_require__(1);
+
+
+
+
+
+/**
+ * @class InputLabel
+ * @extends {Okta.View}
+ * @private
+ * The input's label.
+ */
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].extend({
+  className: 'okta-form-label o-form-label',
+
+  attributes: {
+    'data-se': 'o-form-label'
+  },
+
+  /**
+   * @constructor
+   * @param  {Object} options options hash
+   * @param  {String} [options.type] Input type
+   * @param  {String|Function} [options.label] Label text
+   * @param  {String|Function} [options.sublabel] Sub label text
+   * @param  {String|Function} [options.tooltip] Tooltip text
+   * @param  {String|Function} [options.inputId] Id of the inputs
+   * @param  {String|Function} [options.id] Id of the inputs
+   */
+  constructor: function (options) {
+    /* eslint max-statements: [2, 16] complexity: [2, 7]*/
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options, { inputId: options.id });
+    delete options.id;
+
+    __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].apply(this, arguments);
+
+    let template;
+
+    if (this._isLabelView(options.label)) {
+      template = '<label for="{{inputId}}"></label>';
+    } else if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains(['radio', 'checkbox'], options.type) || !options.label) {
+      template = '{{label}}';
+    } else {
+      //space added in the end of the label to avoid selecting label text with double click in read mode
+      template = '<label for="{{inputId}}">{{label}}&nbsp;</label>';
+    }
+    if (options.sublabel) {
+      template += '<span class="o-form-explain">{{sublabel}}</span>';
+    }
+    if (options.tooltip) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isString(options.tooltip)) {
+        options.tooltip = {
+          text: options.tooltip
+        };
+      }
+      template += '<span class="o-form-tooltip icon-16 icon-only form-help-16" title="{{tooltip.text}}"></span>';
+    }
+    this.template = __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__["default"].tpl(template);
+  },
+
+  getTemplateData: function () {
+    const options = { label: '' };
+
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(
+      ['inputId', 'label', 'sublabel', 'tooltip'],
+      function (option) {
+        options[option] = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, option, this);
+      },
+      this
+    );
+
+    return options;
+  },
+
+  _isLabelView: function (label) {
+    return !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isUndefined(label) && label instanceof __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"];
+  },
+
+  postRender: function () {
+    const options = this.getTemplateData();
+
+    if (this._isLabelView(options.label)) {
+      this.removeChildren();
+      this.add(options.label, 'label');
+    }
+
+    if (options.tooltip) {
+      this.$('.o-form-tooltip').qtip(
+        __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(
+          {
+            style: { classes: 'qtip-custom qtip-shadow' },
+            position: {
+              my: 'bottom left',
+              at: 'top center'
+            },
+            hide: { fixed: true },
+            show: { delay: 0 }
+          },
+          options.tooltip.options
+        )
+      );
+    }
+  }
+}));
+
+
+/***/ }),
+/* 50 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__FormUtil__ = __webpack_require__(9);
+
+
+
+
+function runCallback(callback, field) {
+  callback.apply(
+    this,
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].map(
+      field.split(/\s+/),
+      function (field) {
+        return this.model.get(field);
+      },
+      this
+    )
+  );
+}
+
+function runIf(fn, ctx) {
+  if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isFunction(fn)) {
+    fn.call(ctx);
+  }
+}
+
+/**
+ * @class InputWrapper
+ * @extends Okta.View
+ * @private
+ * The outer wrapper that warps the label and the input container
+ */
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_1__BaseView__["default"].extend({
+  className: function () {
+    let className = 'o-form-fieldset';
+
+    if (this.options['label-top']) {
+      className += ' o-form-label-top';
+    }
+
+    if (this.options.readOnly) {
+      className += ' o-form-read-mode';
+    }
+
+    return className;
+  },
+
+  attributes: function () {
+    return {
+      'data-se': this.options['data-se'] || 'o-form-fieldset'
+    };
+  },
+
+  /**
+   * @constructor
+   * @param  {Object} options options hash
+   * @param  {Object} [options.events]
+   * @param  {Object} [options.bindings]
+   * @param  {Object} [options.showWhen]
+   * @param  {Function} [options.initialize] post initialize callback
+   * @param  {Function} [options.render] post render callback
+   */
+  constructor: function (options) {
+    if (options.className) {
+      this.inputWrapperClassName = this.className;
+      this.optionsClassName = options.className;
+      options.className = function () {
+        return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'inputWrapperClassName', '') + ' ' + __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'optionsClassName');
+      };
+    }
+    __WEBPACK_IMPORTED_MODULE_1__BaseView__["default"].apply(this, arguments);
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(
+      options.events || {},
+      function (callback, event) {
+        this.listenTo(this.model, event, callback);
+      },
+      this
+    );
+
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(
+      options.bindings || {},
+      function (callback, field) {
+        this.listenTo(
+          this.model,
+          __WEBPACK_IMPORTED_MODULE_2__FormUtil__["default"].changeEventString(field.split(/\s+/)),
+          __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].bind(runCallback, this, callback, field)
+        );
+      },
+      this
+    );
+
+    __WEBPACK_IMPORTED_MODULE_2__FormUtil__["default"].applyShowWhen(this, options.showWhen);
+    __WEBPACK_IMPORTED_MODULE_2__FormUtil__["default"].applyToggleWhen(this, options.toggleWhen);
+
+    runIf(options.initialize, this);
+  },
+
+  postRender: function () {
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(this.options.bindings || {}, runCallback, this);
+    runIf(this.options.render, this);
+  },
+
+  /**
+   * @return {InputLabel}
+   */
+  getLabel: function () {
+    return this.size() > 1 ? this.at(0) : null;
+  },
+  /**
+   * @deprecated ambiguous naming, use {@link #getInputContainer}
+   */
+  getInput: function () {
+    return this.getInputContainer();
+  },
+
+  /**
+   * @return {InputContainer}
+   */
+  getInputContainer: function () {
+    return this.at(this.size() > 1 ? 1 : 0);
+  },
+
+  /**
+   * @return {BaseInput[]}
+   */
+  getInputs: function () {
+    return this.getInputContainer().toArray();
+  },
+
+  focus: function () {
+    return this.getInput().focus();
+  }
+}));
+
+
+/***/ }),
+/* 51 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseView__ = __webpack_require__(1);
+
+
+
+const defaults = {
+  level: 'success',
+  message: 'Great Success!',
+  hide: true,
+  fade: 400,
+  delay: 3000,
+  width: 0,
+  dismissable: false
+};
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].extend({
+  className: 'infobox infobox-confirm infobox-confirm-fixed',
+
+  events: {
+    'click .infobox-dismiss-link': function (e) {
+      e.preventDefault();
+      this.fadeOut();
+    }
+  },
+
+  template:
+    '\
+      {{#if dismissable}}\
+      <a class="infobox-dismiss-link" title="Dismiss" href="#">\
+        <span class="dismiss-icon"></span>\
+      </a>\
+      {{/if}}\
+      <span class="icon {{level}}-16"></span>\
+      {{#if title}}<h3>{{title}}</h3>{{/if}}\
+      <p>{{message}}</p>\
+    ',
+
+  initialize: function () {
+    this.options = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].defaults({}, this.options, defaults);
+    this.$el.addClass('infobox-' + this.options.level);
+    if (this.options.width) {
+      this.$el.width(this.options.width).css({
+        'margin-left': '0px',
+        left: Math.round((Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(window).width() - this.options.width) / 2)
+      });
+    }
+  },
+
+  getTemplateData: function () {
+    return __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].pick(this.options, 'level', 'message', 'title'), {
+      dismissable: this.options.hide === false || this.options.dismissable === true
+    });
+  },
+
+  postRender: function () {
+    if (this.options.hide) {
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].delay(__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.fadeOut, this), this.options.delay);
+    }
+  },
+
+  fadeOut: function () {
+    this.$el.fadeOut(this.options.fade, __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].bind(this.remove, this));
+  }
+}));
+
+
+/***/ }),
+/* 52 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__models_Model__ = __webpack_require__(11);
+
+
+
+/**
+ * @class StateMachine
+ * @extends Okta.Model
+ * @private
+ *
+ * A state object that holds the applciation state
+ */
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_1__models_Model__["default"].extend({
+  extraProperties: true,
+  /**
+   * Invokes a method on the applicable {@link Okta.Controller}
+   *
+   * ```javascript
+   * state.invoke('methodName', 'param1', 'param2')
+   * // Will call
+   * contoller.methodName('param1', 'param2')
+   * ```
+   * @param {String} methodName the name of the controller method to invoke on the controller
+   */
+  invoke: function () {
+    const args = __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].toArray(arguments);
+
+    args.unshift('__invoke__');
+    this.trigger.apply(this, args);
+  }
+}));
+
+
+/***/ }),
+/* 53 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_ViewUtil__ = __webpack_require__(24);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseView__ = __webpack_require__(1);
+
+
+
+const disabledEvents = {
+  click: function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+};
+
+/**
+ * A configurable button.
+ * @class module:Okta.internal.views.components.BaseButtonLink
+ * @extends module:Okta.View
+ * @example
+ * var View = BaseButtonLink.extend({
+ *   title: 'Click Me',
+ *   icon: 'help-text'
+ * })
+ */
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].extend(
+  /** @lends module:Okta.internal.views.components.BaseButtonLink.prototype */ {
     attributes() {
       const defaultAttrs = {
         'data-se': 'button'
       };
       const additionalAttr = this.__getAttribute('attrs');
-      return _.extend(defaultAttrs, additionalAttr);
+      return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(defaultAttrs, additionalAttr);
     },
     /**
      * The main text for the button
@@ -7104,11 +8602,11 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
 
     constructor: function (options) {
       this.options = options || {};
-      var data = this.getTemplateData();
+      const data = this.getTemplateData();
 
       this.disabled = false;
 
-      BaseView.apply(this, arguments);
+      __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].apply(this, arguments);
 
       this.$el.addClass('link-button');
       if (data.icon) {
@@ -7128,34 +8626,35 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     },
 
     initialize: function () {
-      ViewUtil.applyDoWhen(this, _.resultCtx(this, 'enableWhen', this), this.toggle);
-      ViewUtil.applyDoWhen(this, _.resultCtx(this, 'showWhen', this), this.toggleVisible);
+      __WEBPACK_IMPORTED_MODULE_1__util_ViewUtil__["a" /* default */].applyDoWhen(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this, 'enableWhen', this), this.toggle);
+      __WEBPACK_IMPORTED_MODULE_1__util_ViewUtil__["a" /* default */].applyDoWhen(this, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this, 'showWhen', this), this.toggleVisible);
     },
 
     render: function () {
+      __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].prototype.render.apply(this, arguments);
 
-      BaseView.prototype.render.apply(this, arguments);
-
-      if (!_.result(this, 'enabled')) {
+      if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'enabled')) {
         this.toggle(false);
       }
 
-      if (!_.result(this, 'visible')) {
+      if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'visible')) {
         this.toggleVisible(false);
       }
 
-      var data = this.getTemplateData();
+      const data = this.getTemplateData();
+
       this.$el.attr('href', data.href || '#');
 
       return this;
     },
 
     __getAttribute: function (name, defaultValue) {
-      var value = _.resultCtx(this.options, name, this);
-      if (_.isUndefined(value)) {
-        value = _.result(this, name);
+      let value = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, name, this);
+
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isUndefined(value)) {
+        value = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, name);
       }
-      return !_.isUndefined(value) ? value : defaultValue;
+      return !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isUndefined(value) ? value : defaultValue;
     },
 
     enable: function () {
@@ -7175,1327 +8674,91 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
     },
 
     toggle: function (enable) {
+      const bool = !!enable && __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'enabled');
       //this is to toggle the enability
-      var bool = !!enable && _.result(this, 'enabled');
+
       this.disabled = !bool;
       this.$el.toggleClass('link-button-disabled btn-disabled disabled', this.disabled);
 
       // delegateEvents asynchronously in case the button is not yet added to the DOM
       // in these cases the alternate events won't work
-      _.defer(_.bind(function () {
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defer(() => {
         this.delegateEvents(this.disabled ? disabledEvents : null);
-      }, this));
+      });
     },
 
     toggleVisible: function (visible) {
-      var hidden = !visible || !_.result(this, 'visible');
+      const hidden = !visible || !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(this, 'visible');
+
       this.$el.toggleClass('hide', hidden);
     }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 43 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(1)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, BaseView) {
-
-  var defaults = {
-    level: 'success',
-    message: 'Great Success!',
-    hide: true,
-    fade: 400,
-    delay: 3000,
-    width: 0,
-    dismissable: false
-  };
-
-  return BaseView.extend({
-
-    className: 'infobox infobox-confirm infobox-confirm-fixed',
-
-    events: {
-      'click .infobox-dismiss-link': function (e) {
-        e.preventDefault();
-        this.fadeOut();
-      }
-    },
-
-    template: '\
-      {{#if dismissable}}\
-      <a class="infobox-dismiss-link" title="Dismiss" href="#">\
-        <span class="dismiss-icon"></span>\
-      </a>\
-      {{/if}}\
-      <span class="icon {{level}}-16"></span>\
-      {{#if title}}<h3>{{title}}</h3>{{/if}}\
-      <p>{{message}}</p>\
-    ',
-
-    initialize: function () {
-      this.options = _.defaults({}, this.options, defaults);
-      this.$el.addClass('infobox-' + this.options.level);
-      if (this.options.width) {
-        this.$el.width(this.options.width).css({
-          'margin-left': '0px',
-          'left': Math.round(($(window).width() - this.options.width) / 2)
-        });
-      }
-    },
-
-    getTemplateData: function () {
-      return _.extend(_.pick(this.options, 'level', 'message', 'title'), {
-        dismissable: this.options.hide === false || this.options.dismissable === true
-      });
-    },
-
-    postRender: function () {
-      if (this.options.hide) {
-        _.delay(_.bind(this.fadeOut, this), this.options.delay);
-      }
-    },
-
-    fadeOut: function () {
-      this.$el.fadeOut(this.options.fade, _.bind(this.remove, this));
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 44 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(45)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (BaseFormDialog) {
-
-  return BaseFormDialog.extend({
-
-    'save': 'OK',
-
-    params: {
-      minWidth: 500,
-      maxWidth: 700,
-      close: true
-    },
-
-    constructor: function () {
-      BaseFormDialog.apply(this, arguments);
-
-      if (this.content) {
-        this.add(this.content);
-      }
-
-      this.listenTo(this, 'save', function () {
-        var callback = this.ok || this.options.ok;
-        callback && callback();
-        this.remove();
-      });
-
-      this.listenTo(this, 'cancel', function () {
-        var callback = this.cancelFn || this.options.cancelFn;
-        callback && callback();
-      });
-
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 45 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(46),
-  __webpack_require__(26)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, BaseView, BaseModalDialog, BaseForm) {
-
-  var FORM_FIELDS = [
-    'save',
-    'noCancelButton',
-    'inputs',
-    'subtitle',
-    'autoSave',
-    'focus',
-    'cancel',
-    'danger',
-    'hasSavingState',
-    'customSavingState',
-    'parseErrorMessage'
-  ];
-  var FORM_DEFAULTS = {
-    layout: 'o-form-wrap',
-    scrollOnError: false
-  };
-
-  // jquery.simplemodoal options
-  var SIMPLE_MODAL_PARAMS = {
-    minWidth: 600,
-    maxWidth: 950,
-    focus: false,
-    close: false,
-    autoResize: false, // (use the resizeModal method, so that the scrolling goes to content, not the whole modal)
-    autoPosition: true
-  };
-
-  /**
-   * Okta.FormDialog is a facade layer for a form that lives in a modal dialog.
-   *
-   * The API is proxying the {@link module:Okta.Form|Form} API for the most part.
-   * It also triggers all the form events
-   * It takes care of repositioning, resizing, closing the dialog on cancel, and so on.
-   *
-   * @class module:Okta.FormDialog
-   * @extends module:Okta.View
-   * @borrows module:Okta.Form#event:save as save
-   * @borrows module:Okta.Form#event:saved as saved
-   * @borrows module:Okta.Form#event:resize as resize
-   * @borrows module:Okta.Form#event:cancel as cancel
-   * @borrows module:Okta.Form#title as #title
-   * @borrows module:Okta.Form#subtitle as #subtitle
-   * @borrows module:Okta.Form#save as #save
-   * @borrows module:Okta.Form#inputs as #inputs
-   * @borrows module:Okta.Form#noCancelButton as #noCancelButton
-   * @borrows module:Okta.Form#autoSave as #autoSave
-   * @borrows module:Okta.ModalDialog#params as #params
-   * @borrows module:Okta.Form#addInput as #addInput
-   * @borrows module:Okta.Form#addButton as #addButton
-   * @borrows module:Okta.Form#addDivider as #addDivider
-   * @borrows module:Okta.Form#addSectionTitle as #addSectionTitle
-   * @borrows module:Okta.Form#clearErrors as #clearErrors
-   * @example
-   * var AddUserDialog = Okta.FormDialog({
-   *   autoSave: true,
-   *   title: 'Add a User',
-   *   inputs: [
-   *     {
-   *       type: 'text',
-   *       name: 'fname',
-   *       label: 'First Name'
-   *     },
-   *     {
-   *       type: 'text',
-   *       name: 'lname',
-   *       label: 'Last Name'
-   *     }
-   *   ]
-   * });
-   *
-   * // renders the modal dialog on the page
-   * var dialog = new AddUserDialog({model: new MyModel()}).render();
-   * this.listenTo(dialog, 'saved', function (model) {
-   *   // the model is now saved
-   * });
-   */
-  return BaseView.extend(/** @lends module:Okta.FormDialog.prototype */ {
-
-    constructor: function (options) {
-      /* eslint max-statements: [2, 13] */
-
-      var Form = BaseForm.extend(_.extend({}, FORM_DEFAULTS, _.pick(this, FORM_FIELDS)));
-      this.form = new Form(_.omit(options, 'title', 'subtitle'));
-
-      this.listenTo(this.form, 'resize', _.debounce(_.bind(this.resizeModal, this), 100));
-
-      // trigger all form events
-      var removeFn = _.bind(this.remove, this);
-      this.listenTo(this.form, 'all', function () {
-        this.trigger.apply(this, arguments);
-        if (arguments[0] === 'cancel') {
-          removeFn();
-        }
-      });
-
-      $(window).resize(_.debounce(_.bind(this.resizeModal, this), 100));
-
-      var Dialog = BaseModalDialog.extend({
-        title: this.title,
-        className: this.className,
-        params: _.extend({}, SIMPLE_MODAL_PARAMS, this.params)
-      });
-
-      this.dialog = new Dialog(options);
-      this.dialog.add(this.form);
-      this.el = this.dialog.el;
-
-
-      BaseView.apply(this, arguments);
-
-      if (this.form.getAttribute('autoSave')) {
-        this.listenTo(this, 'saved', this.remove);
-      }
-
-    },
-
-    /**
-     * The form instance generated by the constructor.
-     * Should **not** be referenced locally, exposed externally for test purposes.
-     * @type {Okta.Form}
-     * @private
-     * @readonly
-     */
-    form: undefined,
-
-    /**
-     * The dialog instance generated by the constructor.
-     * Should **not** be referenced locally, exposed externally for test purposes.
-     * @type {Okta.ModalDialog}
-     * @private
-     * @readonly
-     */
-    dialog: undefined,
-
-    addInput: function () {
-      return this.form.addInput.apply(this.form, arguments);
-    },
-
-    addButton: function () {
-      return this.form.addButton.apply(this.form, arguments);
-    },
-
-    addDivider: function () {
-      return this.form.addDivider.apply(this.form, arguments);
-    },
-
-    addSectionTitle: function () {
-      return this.form.addSectionTitle.apply(this.form, arguments);
-    },
-
-    add: function () {
-      return this.form.add.apply(this.form, arguments);
-    },
-
-    render: function () {
-      this.preRender();
-      this.dialog.render.apply(this.dialog, arguments);
-      _.defer(_.bind(this.resizeModal, this));
-      this.postRender();
-      return this;
-    },
-
-    remove: function () {
-      this.dialog.remove.apply(this.dialog, arguments);
-      return BaseView.prototype.remove.apply(this, arguments);
-    },
-
-    /**
-     * Resize modal to fit window height
-     * the whole modal will be within the viewport, only the form content is scrollable
-     * there's no good solution to totally fix the width issue yet for tiny window,
-     * leave it for jquery simplemodal autoResize to do its best
-     */
-    resizeModal: function () {
-      var modal = $('.simplemodal-wrap'),
-          form = this.form,
-          modalHeight = modal.height(),
-          modalMinHeight = _.isNumber(this.dialog.params.minHeight) ? this.dialog.params.minHeight : 0,
-          windowHeight = $(window).height();
-      if (modalMinHeight <= modalHeight) {
-        if (modalHeight >= windowHeight) {
-          form.contentHeight(
-            windowHeight - this.dialog.$('h2').outerHeight() - form.$('.o-form-button-bar').outerHeight() -
-            (modal.outerHeight(true) - form.$el.outerHeight(true)));
-        }
-        else {
-          form.contentHeight(
-            form.contentHeight() + (windowHeight - modal.outerHeight())
-          );
-        }
-        this.dialog.resize.apply(this.dialog, arguments);
-      }
-    },
-
-    clearErrors: function () {
-      return this.form.clearErrors.apply(this.form, arguments);
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 46 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(3),
-  __webpack_require__(1),
-  __webpack_require__(13)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, TemplateUtil, BaseView) {
-
-  var tpl = TemplateUtil.tpl;
-
-  /**
-  * A view that renders as a modal dialog.
-  * The template of the view will render inside a dialog.
-  *
-  * It uses [SimpleModal](http://www.ericmmartin.com/projects/simplemodal) as the base modal widget.
-  *
-  * In the context of a {@link module:Okta.View|View}, do not `add` this view to the container - simply call render
-  * A modal dialog is a special view in terms of - it has an overlay and takes over the screen, so conceptually
-  * it is not a part of any other view.
-  *
-  * @class module:Okta.ModalDialog
-  * @extends module:Okta.View
-  */
-  return BaseView.extend(/** @lends module:Okta.ModalDialog.prototype */ {
-
-    /**
-     * Parameters to pass to the simplemodal plugin.
-     * See [Available Options](http://www.ericmmartin.com/projects/simplemodal/#options).
-     * @type {Object}
-     * @property {Object} [params]
-     */
-    params: {},
-
-    constructor: function () {
-      BaseView.apply(this, arguments);
-      this.$el.addClass('simplemodal-wrap');
-
-      // garbage collection - remove the view when modal is closed
-      this.params = _.extend({
-        onClose: _.bind(_.throttle(this.remove, 64), this)
-      }, this.params || {});
-    },
-
-    render: function () {
-      /* eslint max-statements: [2, 16] */
-
-      this.delegateEvents(); // modal may be rendered multiple times
-      BaseView.prototype.render.apply(this, arguments);
-
-      var options = _.extend({}, _.pick(this, 'title', 'subtitle'), _.pick(this.options, 'title', 'subtitle'));
-
-      if (options.subtitle) {
-        var subtitle = _.resultCtx(options, 'subtitle', this);
-        this.$el.prepend(tpl('<p class="modal-subtitle text-light \
-          padding-20 margin-btm-0">{{subtitle}}</p>')({subtitle: subtitle}));
-      }
-
-      if (options.title) {
-        var title = _.resultCtx(options, 'title', this);
-        this.$el.prepend(tpl('<h2 class="block modal-title">{{title}}</h2>')({title: title}));
-      }
-
-      // running deferred fixes a rendering issue with simplemodal
-      _.defer(_.bind(function () {
-        this.$el.modal(this.params);
-        this.resize();
-      }, this));
-
-      // make sure scrolling on the body is disabled;
-      $('body').css('overflow', 'hidden');
-
-      return this;
-    },
-
-    remove: function () {
-      $.modal.close();
-      // re-enable document scroll; blank property value removes property altogether
-      $('body').css('overflow', '');
-      _.defer(function () {
-        $.modal.close();
-      });
-      return BaseView.prototype.remove.apply(this, arguments);
-    },
-
-    /**
-     * Adjusts the modal content size based on the current content
-     */
-    resize: function () {
-      $.modal.update(this.$el.outerHeight());
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 47 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(3),
-  __webpack_require__(6),
-  __webpack_require__(1),
-  __webpack_require__(16)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, TemplateUtil, Logger, BaseView, Util) {
-  /**
-   * @class InputContainer
-   * @private
-   *
-   * TODO: OKTA-80796
-   * Attention: Please change with caution since this is used in other places
-   */
-
-  var isABaseView = Util.isABaseView;
-
-  return BaseView.extend({
-
-    attributes: function () {
-      return {
-        'data-se': 'o-form-input-container'
-      };
-    },
-
-    className: function () {
-      var className = 'o-form-input';
-      if (this.options.wide) {
-        className += ' o-form-wide';
-      }
-      if (_.contains([1, 2, 3, 4], this.options.multi)) {
-        className += ' o-form-multi-input-' + this.options.multi;
-        if (_.isArray(this.options.input)) {
-          var inputGroup = _.find(this.options.input, function (input) {
-            return _.contains(['text+select', 'select+text'], input.options.type);
-          });
-          inputGroup && (className += ' o-form-multi-input-group-' + this.options.multi);
-        }
-      }
-      return className;
-    },
-
-    _getNames: function () {
-      /*eslint complexity: 0 */
-      var names = _.isArray(this.options.name) ? this.options.name : [this.options.name];
-      if (this.options.type == 'group') {
-        names.push.apply(names, _.pluck(this.options.input[0].options.params.inputs, 'name'));
-      }
-      else if (_.isArray(this.options.name)) {
-        if (this.options.input && this.options.input.options && this.options.input.options.name) {
-          names.push(this.options.input.options.name);
-        }
-      }
-      else if (this.options.input) {
-        if (_.isArray(this.options.input)) {
-          _.each(this.options.input, function (inputItem) {
-            names.push(inputItem.options.name);
-          });
-        }
-        else {
-          names.push(this.options.input.options.name);
-        }
-      }
-      return _.uniq(_.compact(names));
-    },
-
-    constructor: function () {
-      /* eslint max-statements: [2, 18] */
-      BaseView.apply(this, arguments);
-
-      // we want to append the input *before* the explain text
-      if (this.options.input) {
-        if (_.isArray(this.options.input)) {
-          _.each(this.options.input, function (inputItem) {
-            this.add(inputItem, {prepend: true});
-          }, this);
-        } else {
-          this.add(this.options.input, {prepend: true});
-        }
-      }
-
-      this.__setExplain(this.options);
-
-      var names = this._getNames();
-
-      this.listenTo(this.model, 'form:field-error', function (name, errors) {
-        if (_.contains(names, name)) {
-          this.__setError(errors);
-        }
-      });
-
-      this.listenTo(this.model, 'form:clear-errors change:' + names.join(' change:'), this.__clearError);
-      this.listenTo(this.model, 'form:clear-error:' + names.join(' form:clear-error:'), this.__clearError);
-
-      if (_.resultCtx(this.options, 'autoRender', this)) {
-        this.listenTo(this.model, 'change:' + this.options.name, this.render);
-      }
-
-      this.__errorState = false;
-
-    },
-
-    /**
-     * Populates the explain on the input container (if it exists). There are
-     * two ways to use this:
-     * 1. Raw text - wraps in the correct html template
-     * 2. Custom html
-     *    - pass in a View class (preferred)
-     *    - pass in an instance of a View
-     * Some additional notes:
-     * - You can pass a function that returns any of the above
-     * - This maintains support for the deprecated "customExplain" property
-     *   that was used before. This pattern is superseded by explain, so use
-     *   that instead.
-     * @private
-     */
-    __setExplain: function (options) {
-      var explain;
-
-      // Deprecated - if you need custom html, use explain instead
-      if (options.customExplain) {
-        Logger.warn('Deprecated - use explain instead of customExplain');
-        this.add(this.options.customExplain);
-        return;
-      }
-
-      explain = options.explain;
-      if (_.isFunction(explain) && !isABaseView(explain)) {
-        explain = _.resultCtx(this.options, 'explain', this);
-      }
-      if (!explain) {
-        return;
-      }
-
-      if (isABaseView(explain)) {
-        this.template = '<p class="o-form-explain"></p>';
-        this.add(explain, '.o-form-explain');
-      }
-      else {
-        this.template = '<p class="o-form-explain">{{explain}}</p>';
-      }
-    },
-
-    /**
-     * Highlight the input as invalid (validation failed)
-     * Adds an explaination message of the error
-     * @private
-     */
-    __setError: function (errors) {
-
-      this.__errorState = true;
-      this.$el.addClass('o-form-has-errors');
-
-      var tmpl = [
-        '<p class="okta-form-input-error o-form-input-error o-form-explain" role="alert">',
-        '<span class="icon icon-16 error-16-small"></span>',
-        '{{text}}',
-        '</p>'
-      ].join('');
-
-      var html = TemplateUtil.tpl(tmpl)({text: errors.join(', ')});
-      var $elExplain = this.$('.o-form-explain').not('.o-form-input-error').first();
-
-      if ($elExplain.length) {
-        $elExplain.before(html);
-      }
-      else {
-        this.$el.append(html);
-      }
-
-
-    },
-
-    /**
-     * Un-highlight the input and remove explaination text
-     * @private
-     */
-    __clearError: function () {
-      if (this.__errorState) {
-        this.$('.o-form-input-error').remove();
-        this.$el.removeClass('o-form-has-errors');
-        this.__errorState = false;
-        _.defer(_.bind(function () {
-          this.model.trigger('form:resize');
-        }, this));
-      }
-    },
-
-
-    focus: function () {
-      this.each(function (view) {
-        if (view.focus) {
-          return view.focus();
-        }
-      });
-
-      return this;
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 48 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-params: 0, complexity: 0, max-statements: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(27)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, InputRegistry) {
-
-  function createInput(Input, options) {
-    if (InputRegistry.isBaseInput(Input)) {
-      return Input.prototype ? new Input(_.omit(options, 'input')) : Input;
-    }
-    else {
-      return Input;
-    }
   }
-
-  function create(options) {
-    options = _.clone(options);
-    if (options.input) {
-      return createInput(options.input, options);
-    }
-    var Input = InputRegistry.get(options);
-    if (!Input) {
-      throw new Error('unknown input: ' + options.type);
-    }
-    return createInput(Input, options);
-  }
-
-  function supports(options) {
-    return !!options.input || !!InputRegistry.get(options);
-  }
-
-  return {
-    create: create,
-    supports: supports
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 49 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(3),
-  __webpack_require__(1),
-  __webpack_require__(28)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, TemplateUtil, BaseView) {
-
-  /**
-   * @class InputLabel
-   * @extends {Okta.View}
-   * @private
-   * The input's label.
-   */
-  return BaseView.extend({
-
-    className: 'okta-form-label o-form-label',
-
-    attributes: {
-      'data-se': 'o-form-label'
-    },
-
-    /**
-     * @constructor
-     * @param  {Object} options options hash
-     * @param  {String} [options.type] Input type
-     * @param  {String|Function} [options.label] Label text
-     * @param  {String|Function} [options.sublabel] Sub label text
-     * @param  {String|Function} [options.tooltip] Tooltip text
-     * @param  {String|Function} [options.inputId] Id of the inputs
-     * @param  {String|Function} [options.id] Id of the inputs
-     */
-    constructor: function (options) {
-      /* eslint max-statements: [2, 16] complexity: [2, 7]*/
-      _.defaults(options, {inputId: options.id});
-      delete options.id;
-
-      BaseView.apply(this, arguments);
-
-      var template;
-      if (this._isLabelView(options.label)) {
-        template = '<label for="{{inputId}}"></label>';
-      } else if (_.contains(['radio', 'checkbox'], options.type) || !options.label) {
-        template = '{{label}}';
-      } else {
-        //space added in the end of the label to avoid selecting label text with double click in read mode
-        template = '<label for="{{inputId}}">{{label}}&nbsp;</label>';
-      }
-      if (options.sublabel) {
-        template += '<span class="o-form-explain">{{sublabel}}</span>';
-      }
-      if (options.tooltip) {
-        if (_.isString(options.tooltip)) {
-          options.tooltip = {
-            text: options.tooltip
-          };
-        }
-        template += '<span class="o-form-tooltip icon-16 icon-only form-help-16" title="{{tooltip.text}}"></span>';
-      }
-      this.template = TemplateUtil.tpl(template);
-
-    },
-
-    getTemplateData: function () {
-      var options = {label: ''};
-      _.each(['inputId', 'label', 'sublabel', 'tooltip'], function (option) {
-        options[option] = _.resultCtx(this.options, option, this);
-      }, this);
-
-      return options;
-    },
-
-    _isLabelView: function (label) {
-      return !_.isUndefined(label) && label instanceof BaseView;
-    },
-
-    postRender: function () {
-      var options = this.getTemplateData();
-      if (this._isLabelView(options.label)) {
-        this.removeChildren();
-        this.add(options.label, 'label');
-      }
-
-      if (options.tooltip) {
-        this.$('.o-form-tooltip').qtip(_.extend({
-          style: {classes: 'qtip-custom qtip-shadow'},
-          position: {
-            my: 'bottom left',
-            at: 'top center'
-          },
-          hide: {fixed: true},
-          show: {delay: 0}
-        }, options.tooltip.options));
-      }
-    }
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 50 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(1), __webpack_require__(8)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView, FormUtil) {
-
-  function runCallback(callback, field) {
-    callback.apply(this, _.map(field.split(/\s+/), function (field) {
-      return this.model.get(field);
-    }, this));
-  }
-
-  function runIf(fn, ctx) {
-    if (_.isFunction(fn)) {
-      fn.call(ctx);
-    }
-  }
-
-  /**
-   * @class InputWrapper
-   * @extends Okta.View
-   * @private
-   * The outer wrapper that warps the label and the input container
-   */
-  return BaseView.extend({
-
-    className: function () {
-      var className = 'o-form-fieldset';
-
-      if (this.options['label-top']) {
-        className += ' o-form-label-top';
-      }
-
-      if (this.options.readOnly) {
-        className += ' o-form-read-mode';
-      }
-
-      return className;
-    },
-
-    attributes: function () {
-      return {
-        'data-se': this.options['data-se'] || 'o-form-fieldset'
-      };
-    },
-
-    /**
-     * @constructor
-     * @param  {Object} options options hash
-     * @param  {Object} [options.events]
-     * @param  {Object} [options.bindings]
-     * @param  {Object} [options.showWhen]
-     * @param  {Function} [options.initialize] post initialize callback
-     * @param  {Function} [options.render] post render callback
-     */
-    constructor: function (options) {
-      if (options.className) {
-        this.inputWrapperClassName = this.className;
-        this.optionsClassName = options.className;
-        options.className = function () {
-          return _.result(this, 'inputWrapperClassName', '') + ' ' + _.result(this, 'optionsClassName');
-        };
-      }
-      BaseView.apply(this, arguments);
-      _.each(options.events || {}, function (callback, event) {
-        this.listenTo(this.model, event, callback);
-      }, this);
-
-      _.each(options.bindings || {}, function (callback, field) {
-        this.listenTo(this.model, FormUtil.changeEventString(field.split(/\s+/)),
-          _.bind(runCallback, this, callback, field));
-      }, this);
-
-      FormUtil.applyShowWhen(this, options.showWhen);
-      FormUtil.applyToggleWhen(this, options.toggleWhen);
-
-      runIf(options.initialize, this);
-    },
-
-    postRender: function () {
-      _.each(this.options.bindings || {}, runCallback, this);
-      runIf(this.options.render, this);
-    },
-
-    /**
-     * @return {InputLabel}
-     */
-    getLabel: function () {
-      return this.size() > 1 ? this.at(0) : null;
-    },
-    /**
-     * @deprecated ambiguous naming, use {@link #getInputContainer}
-     */
-    getInput: function () {
-      return this.getInputContainer();
-    },
-
-    /**
-     * @return {InputContainer}
-     */
-    getInputContainer: function () {
-      return this.at(this.size() > 1 ? 1 : 0);
-    },
-
-    /**
-     * @return {BaseInput[]}
-     */
-    getInputs: function () {
-      return this.getInputContainer().toArray();
-    },
-
-    focus: function () {
-      return this.getInput().focus();
-    }
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 51 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(1)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (BaseView) {
-
-  var template = '\
-    <div class="okta-form-infobox-error infobox infobox-error" role="alert">\
-      <span class="icon error-16"></span>\
-      {{#if errorSummary}}\
-        <p>{{errorSummary}}</p>\
-      {{else}}\
-        <p>{{i18n code="oform.errorbanner.title" bundle="courage"}}</p>\
-      {{/if}}\
-    </div>\
-  ';
-
-  return BaseView.extend({
-    template: template,
-    modelEvents: {
-      'form:clear-errors': 'remove'
-    }
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 52 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(4)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, StringUtil) {
-
-  var FIELD_REGEX = /^([\S]+): (.+)$/;
-
-  return {
-
-    /**
-     * Helper function that returns the json output of an xhr objext
-     * @param  {jqXhr} xhr
-     * @return {Object}
-     */
-    getResponseJSON: function (xhr) {
-      try {
-        return xhr.responseJSON || JSON.parse(xhr.responseText);
-      }
-      catch (e) {
-        return;
-      }
-    },
-
-    /**
-     * Parses an error summary to extract a field name and an error message
-     * @param  {String} errorSummary The raw error summary
-     * @return {String[]} An array with two members: [field name, error message]
-     */
-    parseErrorSummary: function (errorSummary) {
-      // error format is: `fieldName: The field cannot be left blank`
-      var matches = errorSummary.match(FIELD_REGEX);
-      if (matches) {
-        return [matches[1], matches[2]];
-      }
-    },
-
-    /**
-     * Parses an error cause object to extract a field name from property attribute
-     * and an error message form errorSummary attribute. It looks to see if there is
-     * a custom override/translation for the erorrCause.reason before using the errorSummary
-     * @param  {Object} errorCause object
-     * @return {String[]} An array with two members: [field name, error message]
-     */
-    parseErrorCauseObject: function (errorCause) {
-      if (errorCause.property && errorCause.errorSummary) {
-        var localizedMsg = StringUtil.localize(errorCause.reason),
-            apiMsg = errorCause.errorSummary,
-            field = errorCause.property,
-            errorMessage = localizedMsg.indexOf('L10N_ERROR[') === -1 ? localizedMsg : apiMsg;
-        return [field, errorMessage];
-      }
-    },
-
-    parseErrors: function (resp) {
-      var responseJSON = this.getResponseJSON(resp);
-      return _.map(responseJSON && responseJSON.errorCauses || [], function (errorCause) {
-        return ('' + errorCause.errorSummary).replace(FIELD_REGEX, '$2');
-      });
-    },
-
-    /**
-     * Parses the response for errors
-     * Returns a map of field names > array or error messages
-     * Example:
-     * ```javascript
-     * {
-     *   url: ['The field cannot be left blank', 'The field has to be a valid URI'],
-     *   name: ['The field cannot be left blank']
-     * }
-     * ```
-     * @param  {Object} resp
-     * @return {Object}
-     */
-    parseFieldErrors: function (resp) {
-      var responseJSON = this.getResponseJSON(resp),
-          errors = {};
-
-      // xhr error object
-      if (responseJSON) {
-        /* eslint complexity: [2, 7] */
-        _.each(responseJSON.errorCauses || [], function (cause) {
-          var res = [];
-          if (cause.property && cause.errorSummary) {
-            res = this.parseErrorCauseObject(cause);
-          } else {
-            res = this.parseErrorSummary(cause && cause.errorSummary || '');
-          }
-          if (res) {
-            var fieldName = res[0], message = res[1];
-            errors[fieldName] || (errors[fieldName] = []);
-            errors[fieldName].push(message);
-          }
-        }, this);
-      }
-      // validation key/value object
-      else if (_.isObject(resp) && _.size(resp)) {
-        _.each(resp, function (msg, field) {
-          errors[field] = [msg];
-        });
-      }
-      return _.size(errors) ? errors : undefined;
-    }
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 53 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(1),
-  __webpack_require__(8)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (BaseView, FormUtil) {
-
-  return BaseView.extend({
-
-    el: '<span class="o-form-toggle" data-type="header-btn"></span>',
-    
-    formTitle: '',
-
-    modelEvents: {
-      'change:__edit__': 'toggle'
-    },
-
-    initialize: function () {
-      this.addButton();
-    },
-
-    addButton: function () {
-      if (this.model.get('__edit__')) {
-        this.add(FormUtil.createReadFormButton({type: 'cancel'}));
-      }
-      else {
-        this.add(FormUtil.createReadFormButton({
-          type: 'edit',
-          formTitle: this.formTitle
-        }));
-      }
-    },
-
-    toggle: function () {
-      this.removeChildren();
-      this.addButton();
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+));
 
 
 /***/ }),
 /* 54 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-params: [2, 6], max-len: [2, 150] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(2),
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(55),
-  __webpack_require__(25),
-  __webpack_require__(24)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function ($, _, BaseView, StateMachine, SettingsModel, BaseRouter) {
-
-  function clean(obj) {
-    var res = {};
-    _.each(obj, function (value, key) {
-      if (!_.isNull(value)) {
-        res[key] = value;
-      }
-    });
-    return res;
-  }
-
-  /**
-   * A Controller is our application control flow component.
-   *
-   * Typically it will:
-   * - Initialize the models, controller and main views
-   * - Listen to events
-   * - Create, read, update and delete models
-   * - Create modal dialogs, confirmation dialogs and alert dialogs
-   * - Control the application flow
-   *
-   * The constructor is responsible for:
-   * - Create the application state object
-   * - Assign or creates the application settings object
-   * - Create an instance of the main view with the relevant parameters
-   *
-   * See:
-   * [Hello World Tutorial](https://github.com/okta/courage/wiki/Hello-World),
-   * [Jasmine Spec](https://github.com/okta/okta-core/blob/master/WebContent/js/test/unit/spec/shared/util/BaseController_spec.js)
-   *
-   * @class module:Okta.Controller
-   * @param {Object} options Options Hash
-   * @param {SettingsModel} [options.settings] Application Settings Model
-   * @param {String} options.el a jQuery selector string stating where to attach the controller in the DOM
-   */
-  return BaseView.extend(/** @lends module:Okta.Controller.prototype */{
-
-    constructor: function (options) {
-      /* eslint max-statements: [2, 13], complexity: [2, 7]*/
-      options || (options = {});
-
-      var stateData = _.defaults(clean(options.state), this.state || {});
-      this.state = new StateMachine(stateData);
-      delete options.state;
-
-      if (options.settings) {
-        this.settings = options.settings;
-      }
-      else { // allow the controller to live without a router
-        this.settings = options.settings = new SettingsModel(_.omit(options || {}, 'el'));
-        this.listen('notification', BaseRouter.prototype._notify);
-        this.listen('confirmation', BaseRouter.prototype._confirm);
-      }
-
-      BaseView.call(this, options);
-
-      this.listenTo(this.state, '__invoke__', function () {
-        var args = _.toArray(arguments),
-            method = args.shift();
-        if (_.isFunction(this[method])) {
-          this[method].apply(this, args);
-        }
-      });
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone__ = __webpack_require__(6);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_backbone___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_backbone__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
 
 
-      if (this.View) {
-        this.add(new this.View(this.toJSON()));
-      }
-    },
 
-    /**
-     * The default values of our application state
-     * @type {Object}
-     * @default {}
-     */
-    state: {},
+function Class(options) {
+  this.options = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].clone(options || {});
+  this.cid = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].uniqueId('class');
+  this.initialize.apply(this, arguments);
+}
 
+__WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].extend(Class.prototype, __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Events, {
+  initialize: function () {}
+});
 
-    /**
-     * The main view this controller operate on
-     * @type {module:Okta.View}
-     * @default null
-     */
-    View: null,
+Class.extend = __WEBPACK_IMPORTED_MODULE_0_backbone___default.a.Model.extend;
 
-    /**
-     * Renders the {@link module:Okta.Controller#View|main view} after the DOM is ready
-     * in case the controller is the root component of the page (e.g there's no router)
-     */
-    render: function () {
-      var args = arguments,
-          self = this;
-      $(function () {
-        BaseView.prototype.render.apply(self, args);
-      });
-      return this;
-    },
-
-    /**
-     * Creates the view constructor options
-     * @param {Object} [options] Extra options
-     * @return {Object} The view constructor options
-     */
-    toJSON: function (options) {
-      return _.extend(_.pick(this, 'state', 'settings', 'collection', 'model'), options || {});
-    },
-
-    /**
-     * Removes the child views, empty the DOM element and stop listening to events
-     */
-    remove: function () {
-      this.removeChildren();
-      this.stopListening();
-      this.$el.empty();
-      return this;
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+/* harmony default export */ __webpack_exports__["default"] = (Class);
 
 
 /***/ }),
 /* 55 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(11)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Model) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie__ = __webpack_require__(56);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie__);
 
-  /**
-   * @class StateMachine
-   * @extends Okta.Model
-   * @private
-   *
-   * A state object that holds the applciation state
-   */
 
-  return Model.extend({
-    extraProperties: true,
-    /**
-     * Invokes a method on the applicable {@link Okta.Controller}
-     *
-     * ```javascript
-     * state.invoke('methodName', 'param1', 'param2')
-     * // Will call
-     * contoller.methodName('param1', 'param2')
-     * ```
-     * @param {String} methodName the name of the controller method to invoke on the controller
-     */
-    invoke: function () {
-      var args = _.toArray(arguments);
-      args.unshift('__invoke__');
-      this.trigger.apply(this, args);
-    }
-  });
+const SECURED_COOKIE = /^https/.test(window.location.href);
+/* harmony default export */ __webpack_exports__["default"] = ({
+  setCookie: function (name, value, options) {
+    __WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default.a.set(
+      name,
+      value,
+      __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].defaults(options || {}, {
+        secure: SECURED_COOKIE,
+        path: '/'
+      })
+    );
+  },
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  getCookie: function () {
+    return __WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default.a.get.apply(__WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default.a, arguments);
+  },
+
+  removeCookie: function () {
+    return __WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default.a.remove.apply(__WEBPACK_IMPORTED_MODULE_1_vendor_lib_js_cookie___default.a, arguments);
+  }
+});
 
 
 /***/ }),
 /* 56 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(57)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Cookie) {
-
-  var SECURED_COOKIE = /^https/.test(window.location.href);
-
-  return {
-    setCookie: function (name, value, options) {
-      Cookie.set(name, value, _.defaults(options || {}, {
-        secure: SECURED_COOKIE,
-        path: '/'
-      }));
-    },
-
-    getCookie: function () {
-      return Cookie.get.apply(Cookie, arguments);
-    },
-
-    removeCookie: function () {
-      return Cookie.remove.apply(Cookie, arguments);
-    }
-  };
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
@@ -8650,69 +8913,262 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 
 
 /***/ }),
+/* 57 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__handlebars_helper_date__ = __webpack_require__(58);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__handlebars_helper_i18n__ = __webpack_require__(59);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__handlebars_helper_img__ = __webpack_require__(60);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__handlebars_helper_markdown__ = __webpack_require__(61);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__handlebars_helper_xsrfTokenInput__ = __webpack_require__(63);
+/* eslint @okta/okta/no-specific-modules: 0 */
+
+
+
+
+
+
+
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
+
+
+/***/ }),
 /* 58 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(5)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Backbone) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_moment__ = __webpack_require__(22);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_moment___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_moment__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__ = __webpack_require__(0);
+/* eslint @okta/okta/enforce-requirejs-names: 0, @okta/okta/no-specific-modules: 0, max-params: 0, max-statements: 0 */
 
-  function Class(options) {
-    this.options = _.clone(options || {});
-    this.cid = _.uniqueId('class');
-    this.initialize.apply(this, arguments);
-  }
 
-  _.extend(Class.prototype, Backbone.Events, {
-    initialize: function () {}
-  });
 
-  Class.extend = Backbone.Model.extend;
 
-  return Class;
+function formatDate(format, dateInISOString) {
+  return __WEBPACK_IMPORTED_MODULE_1_moment___default.a
+    .utc(dateInISOString)
+    .utcOffset('-07:00')
+    .format(format);
+}
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('shortDate', __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].partial(formatDate, 'MMM Do'));
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('mediumDate', __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].partial(formatDate, 'MMMM DD, YYYY'));
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('longDate', __WEBPACK_IMPORTED_MODULE_2__underscore_wrapper__["default"].partial(formatDate, 'MMMM DD, YYYY, h:mma'));
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('formatDate', formatDate);
+
+/* unused harmony default export */ var _unused_webpack_default_export = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
 
 
 /***/ }),
 /* 59 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(1),
-  __webpack_require__(60)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (BaseView, ListView) {
-  /**
-  * See {@link src/framework/ListView} for more detail and examples from the base class.
-  * @class module:Okta.ListView
-  * @extends src/framework/ListView
-  * @mixes module:Okta.View
-  */
-  return BaseView.decorate(ListView);
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__StringUtil__ = __webpack_require__(4);
+/* eslint @okta/okta/no-specific-modules: 0 */
+
+
+
+
+function trim(str) {
+  return str && str.replace(/^\s+|\s+$/g, '');
+}
+
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('i18n', function (options) {
+  let params;
+  const key = trim(options.hash.code);
+  const bundle = trim(options.hash.bundle);
+  const args = trim(options.hash['arguments']);
+
+  if (args) {
+    params = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].map(
+      trim(args).split(';'),
+      function (param) {
+        param = trim(param);
+        let val;
+        const data = this;
+
+        /*
+       * the context(data) may be a deep object, ex {user: {name: 'John', gender: 'M'}}
+       * arguments may be 'user.name'
+       * return data['user']['name']
+       */
+        __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].each(param.split('.'), function (p) {
+          val = val ? val[p] : data[p];
+        });
+        return val;
+      },
+      this
+    );
+  }
+
+  return __WEBPACK_IMPORTED_MODULE_2__StringUtil__["default"].localize(key, bundle, params);
+});
+
+/* unused harmony default export */ var _unused_webpack_default_export = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
 
 
 /***/ }),
 /* 60 */
-/***/ (function(module, exports, __webpack_require__) {
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (root, factory) {
-  if (true) {
-    !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(0), __webpack_require__(22)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
-				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__ = __webpack_require__(0);
+/* eslint @okta/okta/no-specific-modules: 0 */
+
+
+const CACHE_BUST_URL_PREFIX = '/assets';
+
+function prependCachebustPrefix(path) {
+  if (path.indexOf(CACHE_BUST_URL_PREFIX) === 0) {
+    return path;
   }
-  /* global module, exports */
-  else if (typeof require == 'function' && typeof exports == 'object') {
-    module.exports = factory(require('okta/underscore'), require('./View'));
+  return CACHE_BUST_URL_PREFIX + path;
+}
+
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('img', function (options) {
+  const cdn = (typeof okta !== 'undefined' && okta.cdnUrlHostname) || '';
+  /*global okta */
+
+  const hash = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].pick(options.hash, ['src', 'alt', 'width', 'height', 'class', 'title']);
+
+  hash.src = '' + cdn + prependCachebustPrefix(hash.src);
+
+  const attrs = __WEBPACK_IMPORTED_MODULE_1__underscore_wrapper__["default"].map(hash, function (value, attr) {
+    return attr + '="' + __WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.Utils.escapeExpression(value) + '"';
+  });
+
+  return new __WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.SafeString('<img ' + attrs.join(' ') + '/>');
+});
+
+/* unused harmony default export */ var _unused_webpack_default_export = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
+
+
+/***/ }),
+/* 61 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__markdownToHtml__ = __webpack_require__(62);
+/* eslint @okta/okta/no-specific-modules: 0 */
+
+
+
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('markdown', function (mdText) {
+  return Object(__WEBPACK_IMPORTED_MODULE_1__markdownToHtml__["a" /* default */])(__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a, mdText);
+});
+
+/* unused harmony default export */ var _unused_webpack_default_export = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
+
+
+/***/ }),
+/* 62 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony export (immutable) */ __webpack_exports__["a"] = mdToHtml;
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__ = __webpack_require__(0);
+// Simple "markdown parser" - just handles markdown formatted links. If we
+// find that we need more extensive markdown support, we should include
+// a fully formulated markdown library like:
+// https://github.com/evilstreak/markdown-js
+
+const RE_LINK = /\[[^\]]*\]\([^)]*\)/gi;
+const RE_LINK_HREF = /\]\(([^)]*)\)/i;
+const RE_LINK_TEXT = /\[([^\]]*)\]/i;
+const RE_LINK_JS = /javascript:/gi;
+
+// Converts links
+// FROM:
+// [some link text](http://the/link/url)
+// TO:
+// <a href="http://the/link/url">some link text</a>
+function mdToHtml(Handlebars, markdownText) {
+  const linkTemplate = Handlebars.compile('<a href="{{href}}">{{text}}</a>');
+  /* eslint  @okta/okta/no-specific-methods: 0*/
+
+  let res;
+
+  if (!__WEBPACK_IMPORTED_MODULE_0__underscore_wrapper__["default"].isString(markdownText)) {
+    res = '';
+  } else {
+    res = Handlebars.Utils.escapeExpression(markdownText)
+      .replace(RE_LINK_JS, '')
+      .replace(RE_LINK, function (mdLink) {
+        return linkTemplate({
+          href: mdLink.match(RE_LINK_HREF)[1],
+          text: mdLink.match(RE_LINK_TEXT)[1]
+        });
+      });
   }
-  else {
-    root.Archer || (root.Archer = {});
-    root.Archer.ListView = factory(root._, root.Archer.View);
-  }
-}(this, function (_, View) {
-  /**
+  return new Handlebars.SafeString(res);
+}
+
+
+/***/ }),
+/* 63 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars__ = __webpack_require__(5);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_handlebars___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_handlebars__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__jquery_wrapper__ = __webpack_require__(2);
+/* eslint @okta/okta/no-specific-modules: 0 */
+
+
+
+__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.registerHelper('xsrfTokenInput', function () {
+  return new __WEBPACK_IMPORTED_MODULE_0_handlebars___default.a.SafeString(
+    '<input type="hidden" class="hide" name="_xsrfToken" ' + 'value="' + Object(__WEBPACK_IMPORTED_MODULE_1__jquery_wrapper__["default"])('#_xsrfToken').text() + '">'
+  );
+});
+
+/* unused harmony default export */ var _unused_webpack_default_export = (__WEBPACK_IMPORTED_MODULE_0_handlebars___default.a);
+
+
+/***/ }),
+/* 64 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__framework_ListView__ = __webpack_require__(65);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__BaseView__ = __webpack_require__(1);
+
+
+
+/**
+ * See {@link src/framework/ListView} for more detail and examples from the base class.
+ * @class module:Okta.ListView
+ * @extends src/framework/ListView
+ * @mixes module:Okta.View
+ */
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_1__BaseView__["default"].decorate(__WEBPACK_IMPORTED_MODULE_0__framework_ListView__["a" /* default */]));
+
+
+/***/ }),
+/* 65 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__View__ = __webpack_require__(21);
+
+
+/**
    * Archer.ListView is a {@link src/framework/View} that operates on a
    * collection and builds a list of "things" of the same type.
    *
@@ -8745,43 +9201,43 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
    * users.first().destroy();
    * userList.el; //=> "<ul><li>Jane Doe</li><li>Jim Doe</li></ul>"
    */
-  return View.extend(/** @lends src/framework/ListView.prototype */ {
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_0__View__["a" /* default */].extend(/** @lends src/framework/ListView.prototype */ {
 
-    constructor: function () {
-      View.apply(this, arguments);
-      if (!this.collection) {
-        throw new Error('Missing collection');
-      }
-      this.listenTo(this.collection, 'reset sort', this.reset);
-      this.listenTo(this.collection, 'add', this.addItem);
-      this.collection.each(this.addItem, this);
-    },
+  constructor: function () {
+    __WEBPACK_IMPORTED_MODULE_0__View__["a" /* default */].apply(this, arguments);
+    if (!this.collection) {
+      throw new Error('Missing collection');
+    }
+    this.listenTo(this.collection, 'reset sort', this.reset);
+    this.listenTo(this.collection, 'add', this.addItem);
+    this.collection.each(this.addItem, this);
+  },
 
-    /**
+  /**
      * The view/template we will use to render each model in the collection.
      * @type {String|module:Okta.View}
      */
-    item: null,
+  item: null,
 
-    /**
+  /**
      * A selector in the local template where to append each item
      * @type {String}
      */
-    itemSelector: null,
+  itemSelector: null,
 
 
-    /**
+  /**
      * Empty the list and re-add everything from the collection.
      * Usefull for handling `collection.reset()` or for handling the initial load
      * @protected
      */
-    reset: function () {
-      this.removeChildren();
-      this.collection.each(this.addItem, this);
-      return this;
-    },
+  reset: function () {
+    this.removeChildren();
+    this.collection.each(this.addItem, this);
+    return this;
+  },
 
-    /**
+  /**
      * Add an item view to the list that will represent one model from the collection
      *
      * Listen to the model so when it is destoyed or removed from the collection
@@ -8790,29 +9246,31 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
      * @param {Backbone.Model} model The model this row operates on
      * @protected
      */
-    addItem: function (model) {
-      var view = this.add(this.item, this.itemSelector, {options: {model: model}}).last();
-      view.listenTo(model, 'destroy remove', view.remove);
-      return this;
-    }
-
-  });
+  addItem: function (model) {
+    var view = this.add(this.item, this.itemSelector, {options: {model: model}}).last();
+    view.listenTo(model, 'destroy remove', view.remove);
+    return this;
+  }
 
 }));
 
 
 /***/ }),
-/* 61 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 66 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(3),
-  __webpack_require__(1)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, TemplateUtil, BaseView) {
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__BaseView__ = __webpack_require__(1);
 
-  var optionsTemplate = TemplateUtil.tpl('\
+
+
+
+const optionsTemplate = __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__["default"].tpl(
+  '\
     <a class="icon-16 {{className}}" data-se="{{seleniumId}}">\
       {{#if icon}}\
       <span class="icon {{icon}}"></span>\
@@ -8824,73 +9282,78 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
         <p class="option-subtitle">{{subtitle}}</p>\
       {{/if}}\
    </a>\
-   ');
+   '
+);
+const BaseDropDownDropDownOption = __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].extend({
+  tagName: 'li',
 
-  var DropDownOption = BaseView.extend({
-    tagName: 'li',
-
-    events: {
-      click: function (e) {
-        e.preventDefault();
-        this.action && this.action.call(this);
-      }
-    },
-
-    constructor: function () {
-      BaseView.apply(this, arguments);
-      this.$el.addClass('okta-dropdown-option option');
-    },
-
-    render: function () {
-      this.$el.html(optionsTemplate({
-        icon: _.result(this, 'icon'),
-        className: _.result(this, 'className') || '',
-        title: _.result(this, 'title'),
-        subtitle: _.result(this, 'subtitle'),
-        seleniumId: _.result(this, 'seleniumId')
-      }));
-      return this;
+  events: {
+    click: function (e) {
+      e.preventDefault();
+      this.action && this.action.call(this);
     }
-  });
+  },
 
-  return BaseView.extend({
+  constructor: function () {
+    __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].apply(this, arguments);
+    this.$el.addClass('okta-dropdown-option option');
+  },
 
-    events: {
-      'click a.option-selected': function (e) {
-        e.preventDefault();
-        if (_.result(this, 'disabled')) {
-          e.stopPropagation();
-        }
-      },
-      'click .dropdown-disabled': function (e) {
-        e.preventDefault();
+  render: function () {
+    this.$el.html(
+      optionsTemplate({
+        icon: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'icon'),
+        className: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'className') || '',
+        title: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'title'),
+        subtitle: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'subtitle'),
+        seleniumId: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'seleniumId')
+      })
+    );
+    return this;
+  }
+});
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].extend({
+  events: {
+    'click a.option-selected': function (e) {
+      e.preventDefault();
+      if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'disabled')) {
         e.stopPropagation();
       }
     },
+    'click .dropdown-disabled': function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  },
 
-    items: [],
+  items: [],
 
-    constructor: function () {
+  constructor: function () {
+    const className = this.className;
 
-      // In this very specific case we want to NOT append className to $el
-      // but to the <a> tag in the template
-      // so we want to disable backbone default functionality.
-      var className = this.className;
-      this.className = null;
+    // In this very specific case we want to NOT append className to $el
+    // but to the <a> tag in the template
+    // so we want to disable backbone default functionality.
 
-      BaseView.apply(this, arguments);
+    this.className = null;
 
-      this.className = className;
+    __WEBPACK_IMPORTED_MODULE_3__BaseView__["default"].apply(this, arguments);
 
-      this.$el.addClass('dropdown more-actions float-l');
+    this.className = className;
 
-      _.each(_.result(this, 'items'), function (option) {
+    this.$el.addClass('dropdown more-actions float-l');
+
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+      __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'items'),
+      function (option) {
         this.addOption(option, this.options);
-      }, this);
+      },
+      this
+    );
+  },
 
-    },
-
-    template: '\
+  template:
+    '\
       <a href="#" class="link-button {{className}} link-button-icon option-selected center">\
         {{#if icon}}\
         <span class="icon {{icon}}"></span>\
@@ -8903,562 +9366,371 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
       </div>\
     ',
 
-    getTemplateData: function () {
-      var className = [_.result(this, 'className') || '',
-        _.result(this, 'disabled') ? 'dropdown-disabled' : ''
-      ];
-      return {
-        icon: _.result(this, 'icon'),
-        className: $.trim(className.join(' ')),
-        title: _.result(this, 'title')
-      };
-    },
+  getTemplateData: function () {
+    const className = [__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'className') || '', __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'disabled') ? 'dropdown-disabled' : ''];
 
-    addOption: function (proto, options) {
-      this.add(DropDownOption.extend(proto), 'ul.options-wrap', {options: options || {}});
-    }
+    return {
+      icon: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'icon'),
+      className: __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"].trim(className.join(' ')),
+      title: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].result(this, 'title')
+    };
+  },
 
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  addOption: function (proto, options) {
+    this.add(BaseDropDownDropDownOption.extend(proto), 'ul.options-wrap', { options: options || {} });
+  }
+}));
 
 
 /***/ }),
-/* 62 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 67 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-statements: 0, max-params: 0 */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(4),
-  __webpack_require__(63),
-  __webpack_require__(66),
-  __webpack_require__(20),
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, StringUtil, BooleanSelect, TextBoxSet, EnumTypeHelper) {
-  // Maps each __displayType__ to a basic set of inputOptions.
-  function defaultOptions(property) {
-    /* eslint complexity: [2, 22] */
-    var type = property.get('__displayType__'),
-        values = property.get('__possibleValues__'),
-        name = property.get('name'),
-        title = property.get('title');
-    var inputOptions = {
-      type: 'text',
-      name: name,
-      label: title || name
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__inputs_BooleanSelect__ = __webpack_require__(68);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__ = __webpack_require__(71);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__EnumTypeHelper__ = __webpack_require__(18);
+/* eslint max-statements: 0, max-params: 0 */
+
+
+
+
+
+
+// Maps each __displayType__ to a basic set of inputOptions.
+function defaultOptions(property) {
+  const type = property.get('__displayType__');
+  const values = property.get('__possibleValues__');
+  const name = property.get('name');
+  const title = property.get('title');
+  /* eslint complexity: [2, 24] */
+
+  const inputOptions = {
+    type: 'text',
+    name: name,
+    label: title || name
+  };
+
+  // @see customOptions for enum complex "object" type,
+  // a.k.a "object" or "arrayofobject" type has enum values defined.
+  // Other cases (e.g., nested object type) are not support yet.
+
+  switch (type) {
+  case 'arrayofstring':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__["a" /* default */];
+    inputOptions.params = { itemType: 'string' };
+    break;
+  case 'arrayofnumber':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__["a" /* default */];
+    inputOptions.params = { itemType: 'number' };
+    break;
+  case 'arrayofinteger':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__["a" /* default */];
+    inputOptions.params = { itemType: 'integer' };
+    break;
+  case 'arrayofobject':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__["a" /* default */];
+    inputOptions.params = { itemType: property.get('items').type };
+    break;
+  case 'arrayofref-id':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_3__inputs_TextBoxSet__["a" /* default */];
+    inputOptions.params = { itemType: property.get('items').format };
+    break;
+  case 'boolean':
+    inputOptions.input = __WEBPACK_IMPORTED_MODULE_2__inputs_BooleanSelect__["a" /* default */];
+    break;
+  case 'integer':
+  case 'number':
+    inputOptions.to = convertStringToNumber;
+    break;
+  case 'reference':
+    inputOptions.type = 'select';
+    inputOptions.options = getChoices(values);
+    break;
+  case 'image':
+    inputOptions.readOnly = true;
+    inputOptions.from = function (value) {
+      return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEmpty(value) ? '' : __WEBPACK_IMPORTED_MODULE_1__util_StringUtil__["default"].localize('user.profile.image.image_set', 'courage'); //TODO
+    };
+    break;
+  case 'password':
+    inputOptions.type = 'password';
+    break;
+  case 'date':
+    inputOptions.type = 'date';
+    break;
+  case 'uri':
+  case 'country-code':
+  case 'country_code':
+  case 'language-code':
+  case 'language_code':
+  case 'email':
+  case 'locale':
+  case 'timezone':
+  case 'string':
+  case 'object':
+    //default input options
+    break;
+  default:
+    throw new Error('unknown type: ' + type);
+  }
+  return inputOptions;
+}
+
+// Sets nonbasic inputOptions, such as an array with possible values
+function customOptions(property) {
+  let inputOptions = {};
+  const name = property.get('name');
+  const type = property.get('__displayType__');
+  const values = property.get('__possibleValues__');
+  const prefix = property.get('__fieldNamePrefix__');
+
+  if (prefix) {
+    inputOptions.name = prefix + name;
+    inputOptions.errorField = name;
+  }
+
+  if (property.isEnumType()) {
+    const configs = {
+      displayType: type,
+      title: property.get('title'),
+      enumValues: property.getEnumValues()
     };
 
-    // @see customOptions for enum complex "object" type,
-    // a.k.a "object" or "arrayofobject" type has enum values defined.
-    // Other cases (e.g., nested object type) are not support yet.
+    inputOptions = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend({}, __WEBPACK_IMPORTED_MODULE_4__EnumTypeHelper__["a" /* default */].getEnumInputOptions(configs), inputOptions);
+  } else if (isArray(type) && values) {
+    inputOptions.type = 'checkboxset';
+    inputOptions.input = null;
+    inputOptions.options = getChoices(values);
+  }
 
-    switch (type) {
-    case 'arrayofstring':
-      inputOptions.input = TextBoxSet;
-      inputOptions.params = {itemType: 'string'};
-      break;
-    case 'arrayofnumber':
-      inputOptions.input = TextBoxSet;
-      inputOptions.params = {itemType: 'number'};
-      break;
-    case 'arrayofinteger':
-      inputOptions.input = TextBoxSet;
-      inputOptions.params = {itemType: 'integer'};
-      break;
-    case 'arrayofobject':
-      inputOptions.input = TextBoxSet;
-      inputOptions.params = {itemType: property.get('items').type};
-      break;
-    case 'arrayofref-id':
-      inputOptions.input = TextBoxSet;
-      inputOptions.params = {itemType: property.get('items').format};
-      break;
-    case 'boolean':
-      inputOptions.input = BooleanSelect;
-      break;
-    case 'integer':
-    case 'number':
-      inputOptions.to = convertStringToNumber;
-      break;
-    case 'reference':
-      inputOptions.type = 'select';
-      inputOptions.options = getChoices(values);
-      break;
-    case 'image':
-      inputOptions.readOnly = true;
-      inputOptions.from = function (value) {
-        return _.isEmpty(value) ? '' : StringUtil.localize('user.profile.image.image_set', 'courage'); //TODO
-      };
-      break;
-    case 'password':
-      inputOptions.type = 'password';
-      break;
-    case 'date':
-      inputOptions.type = 'date';
-      break;
-    case 'uri':
-    case 'country-code':
-    case 'language-code':
-    case 'email':
-    case 'locale':
-    case 'timezone':
-    case 'string':
-    case 'object':
-      //default input options
-      break;
-    default:
-      throw new Error('unknown type: ' + type);
+  return inputOptions;
+}
+
+function convertStringToNumber(string) {
+  const number = __WEBPACK_IMPORTED_MODULE_1__util_StringUtil__["default"].parseFloat(string);
+
+  return string === '' ? null : number;
+}
+
+function isArray(type) {
+  return type && type.indexOf('array') >= 0;
+}
+
+// converts possibleValues to choices
+// [a, b, c] => {a: a, b: b, c: c}
+function getChoices(values) {
+  return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].object(values, values);
+}
+
+// A schema property may have an objectName either
+// at the root level or nested in the items object
+function getObjectName(schemaProp) {
+  const items = schemaProp.get('items');
+
+  if (items) {
+    return items.objectName;
+  } else {
+    return schemaProp.get('objectName');
+  }
+}
+
+function augmentSchemaProp(schemaProp, possibleValues, profile) {
+  const name = schemaProp.get('name');
+  const prefix = profile['__nestedProperty__'];
+  let defaultValues = possibleValues[name];
+  const userValues = profile.get(name);
+  let //TODO: Not implemented
+      fixedValues;
+  let values;
+
+  // If API responds with a field name that differs from the form-field name
+  // example: Model's 'profile.username' vs. server's 'username'
+  if (prefix) {
+    schemaProp.set('__fieldNamePrefix__', prefix);
+  }
+
+  // case 1: objectName - fixed list of values are set for the input
+  fixedValues = possibleValues[getObjectName(schemaProp)];
+
+  // case 2: name only - default list of values are provided, user can add more
+  // TODO: this case does not yet exist, so it is not tested
+  if (defaultValues && userValues) {
+    defaultValues = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].union(defaultValues, userValues);
+  }
+
+  // If both fixed and default values exist,
+  // take the fixed values unless they are empty
+  if (fixedValues && fixedValues.length) {
+    values = fixedValues;
+  } else if (defaultValues && defaultValues.length) {
+    values = defaultValues;
+  }
+
+  schemaProp.set('__possibleValues__', values);
+}
+
+function augmentSchemaProps(schemaProps, possibleValues, profile) {
+  schemaProps.each(function (schemaProp) {
+    augmentSchemaProp(schemaProp, possibleValues, profile);
+  });
+
+  return schemaProps;
+}
+
+/**
+ * Remove invalid schema properties from a collection
+ *
+ * @param {SchemaProperties Collection} [properties] A collection of schema properties
+ * @param {Object} [values] An object of the form { key: [value1, value2]}
+ * @return {Array} An array of valid schema models, this can be used to reset
+ * a schema properties collection for example.
+ * @private
+ */
+function cleanSchema(properties, values) {
+  return properties.filter(function (schema) {
+    return isValidSchemaProp(schema, values);
+  });
+}
+
+/**
+ * Checks the validity of a schema property.
+ *
+ * @param {SchemaProperty} [schemaProp] A schema property backbone model
+ * @param {Object} [values] An object of the form { key: [value1, value2]}
+ * @return {Boolean} true/false
+ * @private
+ */
+function isValidSchemaProp(schemaProp, values) {
+  const objectName = getObjectName(schemaProp);
+  const results = values[objectName];
+
+  // a schema property that references an empty list of values
+  // Im looking at you, google apps.
+  if (objectName && Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])(results).isEmpty()) {
+    return false;
+  }
+  return true;
+}
+
+/* harmony default export */ __webpack_exports__["default"] = ({
+  /**
+   * Creates the options hash for BaseForm.addInput from a prepared schema
+   * property.
+   *
+   * @param {Okta.Model} [preparedSchemaProp] A schema property backbone model
+   * that has been standardized by the prepareSchema method.
+   * @return {Object} An object containing all of the options needed by
+   * BaseForm's addInput()
+   */
+  createInputOptions: function (preparedSchemaProp) {
+    const custom = customOptions(preparedSchemaProp);
+    const standard = defaultOptions(preparedSchemaProp);
+
+    // underscore did not support nested extend
+    // https://github.com/jashkenas/underscore/issues/162
+    if (custom.params && standard.params) {
+      custom.params = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(custom.params, standard.params);
     }
-    return inputOptions;
-  }
+    return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(custom, standard);
+  },
 
-  // Sets nonbasic inputOptions, such as an array with possible values
-  function customOptions(property) {
-    var inputOptions = {},
-        name = property.get('name'),
-        type = property.get('__displayType__'),
-        values = property.get('__possibleValues__'),
-        prefix = property.get('__fieldNamePrefix__');
-
-    if (prefix) {
-      inputOptions.name = prefix + name;
-      inputOptions.errorField = name;
-    }
-
-    if (property.isEnumType()) {
-      var configs = {
-        displayType: type,
-        title: property.get('title'),
-        enumValues: property.getEnumValues()
-      };
-      inputOptions = _.extend({}, EnumTypeHelper.getEnumInputOptions(configs), inputOptions);
-    } else if (isArray(type) && values) {
-      inputOptions.type = 'checkboxset';
-      inputOptions.input = null;
-      inputOptions.options = getChoices(values);
-    }
-
-    return inputOptions;
-  }
-
-  function convertStringToNumber(string) {
-    var number = StringUtil.parseFloat(string);
-    return (string === '' ? null : number);
-  }
-
-  function isArray(type) {
-    return (type && type.indexOf('array') >= 0);
-  }
-
-  // converts possibleValues to choices
-  // [a, b, c] => {a: a, b: b, c: c}
-  function getChoices(values) {
-    return _.object(values, values);
-  }
-
-  // A schema property may have an objectName either
-  // at the root level or nested in the items object
-  function getObjectName(schemaProp) {
-    var items = schemaProp.get('items');
-    if (items) {
-      return items.objectName;
+  hasValidSchemaProps: function (schemaProps, possibleValues) {
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEmpty(schemaProps)) {
+      return false;
     } else {
-      return schemaProp.get('objectName');
+      const validSchema = cleanSchema(schemaProps, possibleValues);
+
+      return !!validSchema.length;
     }
-  }
-
-  function augmentSchemaProp(schemaProp, possibleValues, profile) {
-    var name = schemaProp.get('name'),
-        prefix = profile['__nestedProperty__'],
-        defaultValues = possibleValues[name],
-        userValues = profile.get(name), //TODO: Not implemented
-        fixedValues, values;
-
-    // If API responds with a field name that differs from the form-field name
-    // example: Model's 'profile.username' vs. server's 'username'
-    if (prefix) {
-      schemaProp.set('__fieldNamePrefix__', prefix);
-    }
-
-    // case 1: objectName - fixed list of values are set for the input
-    fixedValues = possibleValues[getObjectName(schemaProp)];
-
-    // case 2: name only - default list of values are provided, user can add more
-    // TODO: this case does not yet exist, so it is not tested
-    if (defaultValues && userValues) {
-      defaultValues = _.union(defaultValues, userValues);
-    }
-
-    // If both fixed and default values exist,
-    // take the fixed values unless they are empty
-    if (fixedValues && fixedValues.length) {
-      values = fixedValues;
-    } else if (defaultValues && defaultValues.length) {
-      values = defaultValues;
-    }
-
-    schemaProp.set('__possibleValues__', values);
-  }
-
-  function augmentSchemaProps(schemaProps, possibleValues, profile) {
-    schemaProps.each(function (schemaProp) {
-      augmentSchemaProp(schemaProp, possibleValues, profile);
-    });
-
-    return schemaProps;
-  }
+  },
 
   /**
-   * Remove invalid schema properties from a collection
+   * This method is responsible for preparing a collection for the form
+   * factory to use by putting all of the information to create an input
+   * into the schema property and removing invalid properties.
+   * The typical UD form takes 3 models:
+   * The data model has the input values.
+   * The schema model describes which input to use, such as a textbox or a checkbox.
+   * The possible values model provide a list of default options to display, for example in a drop down menu.
    *
-   * @param {SchemaProperties Collection} [properties] A collection of schema properties
-   * @param {Object} [values] An object of the form { key: [value1, value2]}
-   * @return {Array} An array of valid schema models, this can be used to reset
-   * a schema properties collection for example.
-   * @private
+   * @param {SchemaProperty Collection} [schemaProps] A schema property backbone model.
+   * @param {Object} [possibleValues] An object of the form { key: [value1, value2]}
+   * @param {Okta.Model} [profile] A backbone model containing the property described by the schema property.
+   * @return {SchemaProperty Collection} A schema property collection with standardized models.
+   * The standard schema model adds a couple of additional private properties to
+   * allow the form factory to reference lookup values or name prefixes without going to a second model.
    */
-  function cleanSchema(properties, values) {
-    return properties.filter(function (schema) {
-      return isValidSchemaProp(schema, values);
-    });
-  }
+  prepareSchema: function (schemaProps, possibleValues, profile) {
+    schemaProps.reset(cleanSchema(schemaProps, possibleValues));
+    return augmentSchemaProps(schemaProps, possibleValues, profile);
+  },
 
   /**
-   * Checks the validity of a schema property.
+   * `prepareSchema` will reset the property list which may not be necessary at some case.
+   * like when setting default value for schema properties.
+   * (more detail about such case @see wiki UX, App+Entitlements+for+Provisioning)
    *
-   * @param {SchemaProperty} [schemaProp] A schema property backbone model
-   * @param {Object} [values] An object of the form { key: [value1, value2]}
-   * @return {Boolean} true/false
-   * @private
+   * @param { }
+   * @return {String}
    */
-  function isValidSchemaProp(schemaProp, values) {
-    var objectName = getObjectName(schemaProp),
-        results = values[objectName];
 
-    // a schema property that references an empty list of values
-    // Im looking at you, google apps.
-    if (objectName && _(results).isEmpty()) {
-      return false;
-    }
+  augmentSchemaProps: augmentSchemaProps,
+
+  augmentSchemaProp: augmentSchemaProp
+});
+
+
+/***/ }),
+/* 68 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__Select__ = __webpack_require__(29);
+
+const options = {
+  undefined: 'undefined',
+  true: 'true',
+  false: 'false'
+};
+
+const from = function (val) {
+  if (val) {
+    return 'true';
+  }
+  if (val === false) {
+    return 'false';
+  }
+  return 'undefined';
+};
+
+const to = function (val) {
+  switch (val) {
+  case 'undefined':
+    return null;
+  case 'true':
     return true;
+  case 'false':
+    return false;
+  default:
+    return null;
   }
+};
 
-
-  return {
-
-    /**
-     * Creates the options hash for BaseForm.addInput from a prepared schema
-     * property.
-     *
-     * @param {Okta.Model} [preparedSchemaProp] A schema property backbone model
-     * that has been standardized by the prepareSchema method.
-     * @return {Object} An object containing all of the options needed by
-     * BaseForm's addInput()
-     */
-    createInputOptions: function (preparedSchemaProp) {
-      var custom = customOptions(preparedSchemaProp),
-          standard = defaultOptions(preparedSchemaProp);
-
-      // underscore did not support nested extend
-      // https://github.com/jashkenas/underscore/issues/162
-      if (custom.params && standard.params) {
-        custom.params = _.defaults(custom.params, standard.params);
-      }
-      return _.defaults(custom, standard);
-    },
-
-    hasValidSchemaProps: function (schemaProps, possibleValues) {
-      if (_.isEmpty(schemaProps)) {
-        return false;
-      } else {
-        var validSchema = cleanSchema(schemaProps, possibleValues);
-        return !!validSchema.length;
-      }
-    },
-
-    /**
-     * This method is responsible for preparing a collection for the form
-     * factory to use by putting all of the information to create an input
-     * into the schema property and removing invalid properties.
-     * The typical UD form takes 3 models:
-     * The data model has the input values.
-     * The schema model describes which input to use, such as a textbox or a checkbox.
-     * The possible values model provide a list of default options to display, for example in a drop down menu.
-     *
-     * @param {SchemaProperty Collection} [schemaProps] A schema property backbone model.
-     * @param {Object} [possibleValues] An object of the form { key: [value1, value2]}
-     * @param {Okta.Model} [profile] A backbone model containing the property described by the schema property.
-     * @return {SchemaProperty Collection} A schema property collection with standardized models.
-     * The standard schema model adds a couple of additional private properties to
-     * allow the form factory to reference lookup values or name prefixes without going to a second model.
-     */
-    prepareSchema: function (schemaProps, possibleValues, profile) {
-      schemaProps.reset(cleanSchema(schemaProps, possibleValues));
-      return augmentSchemaProps(schemaProps, possibleValues, profile);
-    },
-
-    /**
-     * `prepareSchema` will reset the property list which may not be necessary at some case.
-     * like when setting default value for schema properties.
-     * (more detail about such case @see wiki UX, App+Entitlements+for+Provisioning)
-     *
-     * @param { }
-     * @return {String}
-     */
-
-    augmentSchemaProps: augmentSchemaProps,
-
-    augmentSchemaProp: augmentSchemaProp
-  };
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_0__Select__["default"].extend({
+  initialize: function () {
+    this.options.options = options;
+    this.options.from = from;
+    this.options.to = to;
+  }
+}));
 
 
 /***/ }),
-/* 63 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(30)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (Select) {
-
-  var options = {
-    'undefined': 'undefined',
-    'true': 'true',
-    'false': 'false'
-  };
-
-  var from = function (val) {
-    if (val) {
-      return 'true';
-    }
-    if (val === false) {
-      return 'false';
-    }
-    return 'undefined';
-  };
-
-  var to = function (val) {
-    switch (val) {
-    case 'undefined':
-      return null;
-    case 'true':
-      return true;
-    case 'false':
-      return false;
-    default:
-      return null;
-    }
-  };
-
-  return Select.extend({
-
-    initialize: function () {
-      this.options.options = options;
-      this.options.from = from;
-      this.options.to = to;
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 64 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(31)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView, Time) {
-
-  function getOption(callout, option) {
-    return _.resultCtx(callout.options, option, callout) || _.result(callout, option);
-  }
-
-  function getTopClass(callout) {
-    var klass = 'infobox clearfix infobox-' + getOption(callout, 'type');
-    switch (getOption(callout, 'size')) {
-    case 'standard':
-      klass += '';
-      break;
-    case 'slim':
-      klass += ' infobox-slim';
-      break;
-    case 'compact':
-      klass += ' infobox-compact';
-      break;
-    case 'large':
-      klass += ' infobox-md';
-      break;
-
-    }
-    if (getOption(callout, 'dismissible')) {
-      klass += ' infobox-dismiss';
-    }
-    return klass;
-  }
-
-  var events = {
-    'click .infobox-dismiss-link': function (e) {
-      e.preventDefault();
-      this.$el.fadeOut(Time.UNLOADING_FADE, _.bind(function () {
-        this.trigger('dismissed');
-        this.remove();
-      }, this));
-    }
-  };
-
-  var template = '\
-    {{#if dismissible}}\
-      <a data-se="dismiss-link" class="infobox-dismiss-link" title="Dismiss" href="#">\
-        <span data-se="icon" class="dismiss-icon"></span>\
-      </a>\
-    {{/if}}\
-    <span data-se="icon" class="icon {{icon}}"></span>\
-    {{#if title}}<h3 data-se="header">{{title}}</h3>{{/if}}\
-    {{#if subtitle}}<p data-se="sub-header">{{subtitle}}</p>{{/if}}\
-    {{#if bullets}}\
-      <ul data-se="list" class="bullets">\
-      {{#each bullets}}<li data-se="list-item">{{this}}</li>{{/each}}\
-      </ul>\
-    {{/if}}\
-  ';
-
-  /**
-   * @class src/views/components/Callout
-   * @extends module:Okta.View
-   */
-
-  var Callout = BaseView.extend(/** @lends src/views/components/Callout.prototype */ {
-
-    attributes: {
-      'data-se': 'callout'
-    },
-
-    /**
-     * Custom HTML or view to inject to the callout
-     * @type {String|Okta.View}
-     */
-    content: null,
-
-    /**
-     * Size of icon. options are standard, large, compact
-     * @type {String}
-     */
-    size: 'standard',
-
-    /**
-     * Type of the callout. Valid values are: info, success, warning, error, tip
-     * @type {String}
-     */
-    type: 'info',
-
-    /**
-     * Can the callout be dismissed
-     * @type {Boolean}
-     */
-    dismissible: false,
-
-    /**
-     * Callout title
-     * @type {String}
-     */
-    title: null,
-
-    /**
-     * Callout subtitle
-     * @type {String}
-     */
-    subtitle: null,
-
-    /**
-     * Array of strings to render as bullet points
-     * @type {Array}
-     */
-    bullets: null,
-
-    /**
-     * Fired after the callout is dismised - applies when 
-     * {@link module:Okta.internal.views.components.Callout|dismissible} is set to true
-     * @event src/views/components/Callout#dismissed
-     */
-
-    constructor: function () {
-      this.events = _.defaults(this.events || {}, events);
-
-      BaseView.apply(this, arguments);
-
-      this.$el.addClass(getTopClass(this));
-
-      this.template = template;
-
-      var content = getOption(this, 'content');
-      if (content) {
-        this.add(content);
-      }
-    },
-
-    getTemplateData: function () {
-      var icon = getOption(this, 'type');
-      const size = getOption(this, 'size');
-      if (icon === 'tip') { // css is inconsistent
-        icon = 'light-bulb';
-      }
-      switch (size) {
-      case 'slim':
-        icon = '';
-        break;
-      case 'large':
-        icon = [icon, '-', '24'].join('');
-        break;
-      default:
-        icon = [icon, '-', '16'].join('');
-      }
-      return {
-        icon,
-        title: getOption(this, 'title'),
-        subtitle: getOption(this, 'subtitle'),
-        bullets: getOption(this, 'bullets'),
-        dismissible: getOption(this, 'dismissible')
-      };
-    }
-  });
-
-  /**
-   * @class module:Okta.internal.views.components.Callout
-   */
-  return /** @lends module:Okta.internal.views.components.Callout */ {
-    /**
-     * Creates a {@link src/views/components/Callout|Callout}.
-     * @static
-     * @param {Object} options
-     * @param {String|Function} [options.size] Size of icon. options are standard, large, compact, slim
-     * @param {String|Okta.View} [options.content] Custom HTML or view to inject to the callout
-     * @param {String|Function} [options.title] Callout title
-     * @param {String|Function} [options.subtitle] Callout subtitle
-     * @param {Array|Function} [options.bullets] Array of strings to render as bullet points
-     * @param {Boolean|Function} [options.dismissible] Can the callout be dismissed
-     * @param {String|Function} [options.type] Callout type. Valid values are: info, success, warning, error, tip
-     *
-     * @return {src/views/components/Callout}
-     */
-    create: function (options) {
-      return new Callout(options);
-    }
-  };
-
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-
-
-/***/ }),
-/* 65 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;// Chosen, a Select Box Enhancer for jQuery and Prototype
@@ -9471,7 +9743,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;// Chosen, a Sel
 // MIT License, https://github.com/harvesthq/chosen/blob/master/LICENSE.md
 // This file is generated by `grunt build`, do not edit it by hand.
 
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(10)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (jQuery) {
+!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(12)], __WEBPACK_AMD_DEFINE_RESULT__ = (function (jQuery) {
   (function() {
     var SelectParser;
 
@@ -10599,150 +10871,355 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;// Chosen, a Sel
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 /***/ }),
-/* 66 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 70 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(9),
-  __webpack_require__(12),
-  __webpack_require__(67)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseInput, SchemaUtil, DeletableBox) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_Time__ = __webpack_require__(30);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseView__ = __webpack_require__(1);
 
-  return BaseInput.extend({
-    className: 'array-input',
 
-    template: '<a href="#" class="array-inputs-button link-button">Add Another</a>',
 
-    params: {
-      itemType: 'string'
+
+function getOption(callout, option) {
+  return __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(callout.options, option, callout) || __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].result(callout, option);
+}
+
+function getTopClass(callout) {
+  let klass = 'infobox clearfix infobox-' + getOption(callout, 'type');
+
+  switch (getOption(callout, 'size')) {
+  case 'standard':
+    klass += '';
+    break;
+  case 'slim':
+    klass += ' infobox-slim';
+    break;
+  case 'compact':
+    klass += ' infobox-compact';
+    break;
+  case 'large':
+    klass += ' infobox-md';
+    break;
+  }
+  if (getOption(callout, 'dismissible')) {
+    klass += ' infobox-dismiss';
+  }
+  return klass;
+}
+
+const events = {
+  'click .infobox-dismiss-link': function (e) {
+    e.preventDefault();
+    this.$el.fadeOut(__WEBPACK_IMPORTED_MODULE_1__util_Time__["a" /* default */].UNLOADING_FADE, () => {
+      this.trigger('dismissed');
+      this.remove();
+    });
+  }
+};
+const template =
+  '\
+    {{#if dismissible}}\
+      <a data-se="dismiss-link" class="infobox-dismiss-link" title="Dismiss" href="#">\
+        <span data-se="icon" class="dismiss-icon"></span>\
+      </a>\
+    {{/if}}\
+    <span data-se="icon" class="icon {{icon}}"></span>\
+    {{#if title}}<h3 data-se="header">{{title}}</h3>{{/if}}\
+    {{#if subtitle}}<p data-se="sub-header">{{subtitle}}</p>{{/if}}\
+    {{#if bullets}}\
+      <ul data-se="list" class="bullets">\
+      {{#each bullets}}<li data-se="list-item">{{this}}</li>{{/each}}\
+      </ul>\
+    {{/if}}\
+  ';
+const CalloutCallout = __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].extend(
+  /** @lends src/views/components/Callout.prototype */ {
+    attributes: {
+      'data-se': 'callout'
     },
 
-    events: {
-      'click .array-inputs-button': function (e) {
-        e.preventDefault();
-        if (this.isEditMode()) {
-          this.addNewElement();
-        }
+    /**
+     * Custom HTML or view to inject to the callout
+     * @type {String|Okta.View}
+     */
+    content: null,
+
+    /**
+     * Size of icon. options are standard, large, compact
+     * @type {String}
+     */
+    size: 'standard',
+
+    /**
+     * Type of the callout. Valid values are: info, success, warning, error, tip
+     * @type {String}
+     */
+    type: 'info',
+
+    /**
+     * Can the callout be dismissed
+     * @type {Boolean}
+     */
+    dismissible: false,
+
+    /**
+     * Callout title
+     * @type {String}
+     */
+    title: null,
+
+    /**
+     * Callout subtitle
+     * @type {String}
+     */
+    subtitle: null,
+
+    /**
+     * Array of strings to render as bullet points
+     * @type {Array}
+     */
+    bullets: null,
+
+    /**
+     * Fired after the callout is dismised - applies when
+     * {@link module:Okta.internal.views.components.Callout|dismissible} is set to true
+     * @event src/views/components/Callout#dismissed
+     */
+
+    constructor: function () {
+      this.events = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(this.events || {}, events);
+
+      __WEBPACK_IMPORTED_MODULE_2__BaseView__["default"].apply(this, arguments);
+
+      this.$el.addClass(getTopClass(this));
+
+      this.template = template;
+
+      const content = getOption(this, 'content');
+
+      if (content) {
+        this.add(content);
       }
     },
 
-    initialize: function (options) {
-      options || (options = {});
-      this.params = _.defaults(options.params || {}, this.params);
-      this.uniqueIdPrefix = 'array';
-    },
+    getTemplateData: function () {
+      let icon = getOption(this, 'type');
 
-    // api returns null for an array that does not have value
-    // convert it to an empty array
-    from: function (val) {
-      if (!_.isArray(val)) {
-        return [];
+      const size = getOption(this, 'size');
+      if (icon === 'tip') {
+        // css is inconsistent
+        icon = 'light-bulb';
       }
-      return val;
-    },
-
-    // @Override
-    editMode: function () {
-      this._setArrayObject();
-      this.$el.html(this.template);
-      _.each(this.arrayObject, _.bind(this._addDeletableBox, this));
-
-      return this;
-    },
-
-    // @Override
-    readMode: function () {
-      this.editMode();
-      this.$('.array-inputs-button').addClass('link-button-disabled');
-    },
-
-    // @Override
-    // converts arrayObject to a plain array
-    // for string type array, returns all values
-    // for number/integer type array, returns values in number type
-    val: function () {
-      var values = _.values(this.arrayObject);
-      if (_.contains([SchemaUtil.DATATYPE.number, SchemaUtil.DATATYPE.integer], this.params.itemType)) {
-        values = _.filter(values, _.isNumber);
+      switch (size) {
+      case 'slim':
+        icon = '';
+        break;
+      case 'large':
+        icon = [icon, '-', '24'].join('');
+        break;
+      default:
+        icon = [icon, '-', '16'].join('');
       }
-      return values;
-    },
-
-    focus: function () {},
-
-    addNewElement: function () {
-      var value = '',
-          key = _.uniqueId(this.uniqueIdPrefix);
-      this.arrayObject[key] = value;
-      this._addDeletableBox(value, key);
-      // update is called to make sure an empty string value is added for string type array
-      this.update();
-    },
-
-    _addDeletableBox: function (value, key) {
-      var deletableBox = new DeletableBox(
-        _.extend(
-          _.pick(this.options, 'read', 'readOnly', 'model'), {key: key, value: value, itemType: this.params.itemType}
-        )
-      );
-      this.listenTo(deletableBox, 'updateArray', function (updatedValue) {
-        if (_.isNull(updatedValue)) {
-          delete this.arrayObject[key];
-          this.stopListening(deletableBox);
-        } else {
-          this.arrayObject[key] = updatedValue;
-        }
-        this.update();
-      });
-
-      deletableBox.render().$el.hide();
-      this.$('.array-inputs-button').before(deletableBox.el);
-      deletableBox.$el.slideDown();
-
-      return deletableBox;
-    },
-
-    _setArrayObject: function () {
-      var array = this.model.get(this.options.name);
-      this.arrayObject = {};
-      if (_.isArray(array) && !_.isEmpty(array)) {
-        var keys = [],
-            self = this;
-        _(array.length).times(function () {
-          keys.push(_.uniqueId(self.uniqueIdPrefix));
-        });
-        this.arrayObject = _.object(keys, array);
-      }
+      return {
+        icon,
+        title: getOption(this, 'title'),
+        subtitle: getOption(this, 'subtitle'),
+        bullets: getOption(this, 'bullets'),
+        dismissible: getOption(this, 'dismissible')
+      };
     }
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+);
+
+/**
+ * @class src/views/components/Callout
+ * @extends module:Okta.View
+ */
+
+/**
+ * @class module:Okta.internal.views.components.Callout
+ */
+/* harmony default export */ __webpack_exports__["a"] = ({
+  /**
+   * Creates a {@link src/views/components/Callout|Callout}.
+   * @static
+   * @param {Object} options
+   * @param {String|Function} [options.size] Size of icon. options are standard, large, compact, slim
+   * @param {String|Okta.View} [options.content] Custom HTML or view to inject to the callout
+   * @param {String|Function} [options.title] Callout title
+   * @param {String|Function} [options.subtitle] Callout subtitle
+   * @param {Array|Function} [options.bullets] Array of strings to render as bullet points
+   * @param {Boolean|Function} [options.dismissible] Can the callout be dismissed
+   * @param {String|Function} [options.type] Callout type. Valid values are: info, success, warning, error, tip
+   *
+   * @return {src/views/components/Callout}
+   */
+  create: function (options) {
+    return new CalloutCallout(options);
+  }
+});
 
 
 /***/ }),
-/* 67 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 71 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-params: [2, 6] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(1),
-  __webpack_require__(12),
-  __webpack_require__(4),
-  __webpack_require__(3),
-  __webpack_require__(31)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, BaseView, SchemaUtil, StringUtil, TemplateUtil, Time) {
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__BaseInput__ = __webpack_require__(10);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__DeletableBox__ = __webpack_require__(72);
 
-  var isVowel = function (string) {
-    return (/^[aeiou]/).test(string);
-  };
 
-  var getArticle = function (string) {
-    return isVowel(string) ? 'an' : 'a';
-  };
 
-  var template = TemplateUtil.tpl('\
+
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_2__BaseInput__["a" /* default */].extend({
+  className: 'array-input',
+
+  template: '<a href="#" class="array-inputs-button link-button">Add Another</a>',
+
+  params: {
+    itemType: 'string'
+  },
+
+  events: {
+    'click .array-inputs-button': function (e) {
+      e.preventDefault();
+      if (this.isEditMode()) {
+        this.addNewElement();
+      }
+    }
+  },
+
+  initialize: function (options) {
+    options || (options = {});
+    this.params = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].defaults(options.params || {}, this.params);
+    this.uniqueIdPrefix = 'array';
+  },
+
+  // api returns null for an array that does not have value
+  // convert it to an empty array
+  from: function (val) {
+    if (!__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(val)) {
+      return [];
+    }
+    return val;
+  },
+
+  // @Override
+  editMode: function () {
+    this._setArrayObject();
+    this.$el.html(this.template);
+    __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].each(this.arrayObject, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].bind(this._addDeletableBox, this));
+
+    return this;
+  },
+
+  // @Override
+  readMode: function () {
+    this.editMode();
+    this.$('.array-inputs-button').addClass('link-button-disabled');
+  },
+
+  // @Override
+  // converts arrayObject to a plain array
+  // for string type array, returns all values
+  // for number/integer type array, returns values in number type
+  val: function () {
+    let values = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].values(this.arrayObject);
+
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].contains([__WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__["a" /* default */].DATATYPE.number, __WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__["a" /* default */].DATATYPE.integer], this.params.itemType)) {
+      values = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].filter(values, __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNumber);
+    }
+    return values;
+  },
+
+  focus: function () {},
+
+  addNewElement: function () {
+    const value = '';
+
+    const key = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniqueId(this.uniqueIdPrefix);
+
+    this.arrayObject[key] = value;
+    this._addDeletableBox(value, key);
+    // update is called to make sure an empty string value is added for string type array
+    this.update();
+  },
+
+  _addDeletableBox: function (value, key) {
+    const deletableBox = new __WEBPACK_IMPORTED_MODULE_3__DeletableBox__["a" /* default */](
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].pick(this.options, 'read', 'readOnly', 'model'), {
+        key: key,
+        value: value,
+        itemType: this.params.itemType
+      })
+    );
+
+    this.listenTo(deletableBox, 'updateArray', function (updatedValue) {
+      if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNull(updatedValue)) {
+        delete this.arrayObject[key];
+        this.stopListening(deletableBox);
+      } else {
+        this.arrayObject[key] = updatedValue;
+      }
+      this.update();
+    });
+
+    deletableBox.render().$el.hide();
+    this.$('.array-inputs-button').before(deletableBox.el);
+    deletableBox.$el.slideDown();
+
+    return deletableBox;
+  },
+
+  _setArrayObject: function () {
+    const array = this.model.get(this.options.name);
+
+    this.arrayObject = {};
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isArray(array) && !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isEmpty(array)) {
+      const keys = [];
+      const self = this;
+
+      Object(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"])(array.length).times(function () {
+        keys.push(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].uniqueId(self.uniqueIdPrefix));
+      });
+      this.arrayObject = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].object(keys, array);
+    }
+  }
+}));
+
+
+/***/ }),
+/* 72 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__ = __webpack_require__(13);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_StringUtil__ = __webpack_require__(4);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__util_Time__ = __webpack_require__(30);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5__BaseView__ = __webpack_require__(1);
+
+
+
+
+
+
+
+const isVowel = function (string) {
+  return /^[aeiou]/.test(string);
+};
+
+const getArticle = function (string) {
+  return isVowel(string) ? 'an' : 'a';
+};
+
+const template = __WEBPACK_IMPORTED_MODULE_3__util_TemplateUtil__["default"].tpl(
+  '\
     <div class="o-form-input-group-controls">\
       <span class="input-fix o-form-control">\
         <input type="text" class="o-form-text" name="{{key}}" id="{{key}}" value="{{value}}" \
@@ -10755,115 +11232,278 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-pa
     <p class="o-form-input-error o-form-explain">\
       <span class="icon icon-16 error-16-small"></span> {{errorExplain}}\
     </p>\
-  '),
-      errorClass = 'o-form-has-errors',
-      updateArrayEvent = 'updateArray';
+  '
+);
+const errorClass = 'o-form-has-errors';
+const updateArrayEvent = 'updateArray';
+/* harmony default export */ __webpack_exports__["a"] = (__WEBPACK_IMPORTED_MODULE_5__BaseView__["default"].extend({
+  tagName: 'div',
 
-  return BaseView.extend({
+  className: 'o-form-input-group',
 
-    tagName: 'div',
-
-    className: 'o-form-input-group',
-
-    events: {
-      'click a': function (e) {
-        e.preventDefault();
-        this.remove();
-      },
-      'keyup input': function () {
-        this.update();
-      }
+  events: {
+    'click a': function (e) {
+      e.preventDefault();
+      this.remove();
     },
-
-    isEditMode: function () {
-      return !this.options.readOnly && (this.options.read !== true || this.model.get('__edit__') === true);
-    },
-
-    initialize: function () {
-      this.template = template(
-        _.extend(this.options, {
-          placeholder: this.getPlaceholderText(),
-          errorExplain: this.getErrorExplainText()
-        })
-      );
-      this.update = _.debounce(this.update, this.options.debounceDelay || Time.DEBOUNCE_DELAY);
-    },
-
-    render: function () {
-      if (this.isEditMode()) {
-        this.$el.html(this.template);
-      }
-      else {
-        this.$el.text(this.options.value);
-        this.$('a').hide();
-      }
-      return this;
-    },
-
-    remove: function () {
-      this.trigger(updateArrayEvent, null);
-      this.$el.slideUp(_.bind(function () {
-        BaseView.prototype.remove.call(this, arguments);
-      }, this));
-    },
-
-    update: function () {
-      var updatedValue = this.$('input').val(),
-          parseFunc = _.object(
-            [SchemaUtil.DATATYPE.number, SchemaUtil.DATATYPE.integer],
-            [StringUtil.parseFloat, this.parseInt]
-          );
-      if (_.has(parseFunc, this.options.itemType)) {
-        updatedValue = parseFunc[this.options.itemType](updatedValue);
-        !_.isNumber(updatedValue) ? this.markInvalid() : this.clearInvalid();
-      }
-      this.trigger(updateArrayEvent, updatedValue);
-    },
-
-    markInvalid: function () {
-      this.$el.addClass(errorClass);
-    },
-
-    clearInvalid: function () {
-      this.$el.removeClass(errorClass);
-    },
-
-    getPlaceholderText: function () {
-      var text = ['Enter'];
-      text.push(getArticle(this.options.itemType));
-      text.push(this.options.itemType.toLowerCase());
-      return text.join(' ');
-    },
-
-    getErrorExplainText: function () {
-      var text = ['Value must be'];
-      text.push(getArticle(this.options.itemType));
-      text.push(this.options.itemType.toLowerCase());
-      return text.join(' ');
-    },
-
-    parseInt: function (string) {
-      // native javascript parseInt is aggressive
-      // there're cases we don't want a string to be parsed even though it is convertable
-      // so that we don't convert a string silently before warning a user the potential error
-      // this is to make sure the string is in an integer format before we parse it
-      if (/^-?\d+$/.test(string)) {
-        var num = parseInt(string, 10);
-        return !_.isNaN(num) ? num : string;
-      }
-      return string;
+    'keyup input': function () {
+      this.update();
     }
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  },
+
+  isEditMode: function () {
+    return !this.options.readOnly && (this.options.read !== true || this.model.get('__edit__') === true);
+  },
+
+  initialize: function () {
+    this.template = template(
+      __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(this.options, {
+        placeholder: this.getPlaceholderText(),
+        errorExplain: this.getErrorExplainText()
+      })
+    );
+    this.update = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].debounce(this.update, this.options.debounceDelay || __WEBPACK_IMPORTED_MODULE_4__util_Time__["a" /* default */].DEBOUNCE_DELAY);
+  },
+
+  render: function () {
+    if (this.isEditMode()) {
+      this.$el.html(this.template);
+    } else {
+      this.$el.text(this.options.value);
+      this.$('a').hide();
+    }
+    return this;
+  },
+
+  remove: function () {
+    this.trigger(updateArrayEvent, null);
+    this.$el.slideUp(() => {
+      __WEBPACK_IMPORTED_MODULE_5__BaseView__["default"].prototype.remove.call(this, arguments);
+    });
+  },
+
+  update: function () {
+    let updatedValue = this.$('input').val();
+
+    const parseFunc = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].object(
+      [__WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__["a" /* default */].DATATYPE.number, __WEBPACK_IMPORTED_MODULE_1__util_SchemaUtil__["a" /* default */].DATATYPE.integer],
+      [__WEBPACK_IMPORTED_MODULE_2__util_StringUtil__["default"].parseFloat, this.parseInt]
+    );
+
+    if (__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].has(parseFunc, this.options.itemType)) {
+      updatedValue = parseFunc[this.options.itemType](updatedValue);
+      !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNumber(updatedValue) ? this.markInvalid() : this.clearInvalid();
+    }
+    this.trigger(updateArrayEvent, updatedValue);
+  },
+
+  markInvalid: function () {
+    this.$el.addClass(errorClass);
+  },
+
+  clearInvalid: function () {
+    this.$el.removeClass(errorClass);
+  },
+
+  getPlaceholderText: function () {
+    const text = ['Enter'];
+
+    text.push(getArticle(this.options.itemType));
+    text.push(this.options.itemType.toLowerCase());
+    return text.join(' ');
+  },
+
+  getErrorExplainText: function () {
+    const text = ['Value must be'];
+
+    text.push(getArticle(this.options.itemType));
+    text.push(this.options.itemType.toLowerCase());
+    return text.join(' ');
+  },
+
+  parseInt: function (string) {
+    // native javascript parseInt is aggressive
+    // there're cases we don't want a string to be parsed even though it is convertable
+    // so that we don't convert a string silently before warning a user the potential error
+    // this is to make sure the string is in an integer format before we parse it
+    if (/^-?\d+$/.test(string)) {
+      const num = parseInt(string, 10);
+
+      return !__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].isNaN(num) ? num : string;
+    }
+    return string;
+  }
+}));
 
 
 /***/ }),
-/* 68 */
+/* 73 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_Keys__ = __webpack_require__(8);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_vendor_plugins_jquery_custominput__ = __webpack_require__(31);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3_vendor_plugins_jquery_custominput___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_3_vendor_plugins_jquery_custominput__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__BaseInput__ = __webpack_require__(10);
+
+
+
+
+
+const template = __WEBPACK_IMPORTED_MODULE_2__util_TemplateUtil__["default"].tpl(
+  '\
+    <input type="checkbox" name="{{name}}" id="{{inputId}}"/>\
+    <label for="{{inputId}}" data-se-for-name="{{name}}">{{placeholder}}</label>\
+  '
+);
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_4__BaseInput__["a" /* default */].extend({
+  template: template,
+  /**
+   * @Override
+   */
+  events: {
+    'change :checkbox': 'update',
+    keyup: function (e) {
+      if (__WEBPACK_IMPORTED_MODULE_1__util_Keys__["default"].isSpaceBar(e)) {
+        this.$(':checkbox').click();
+      } else if (__WEBPACK_IMPORTED_MODULE_1__util_Keys__["default"].isEnter(e)) {
+        this.model.trigger('form:save');
+      }
+    }
+  },
+
+  /**
+   * @Override
+   */
+  editMode: function () {
+    let placeholder = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, 'placeholder', this);
+
+    if (placeholder === '') {
+      placeholder = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].resultCtx(this.options, 'label', this);
+    } else if (placeholder === false) {
+      placeholder = '';
+    }
+
+    this.$el.html(this.template(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].extend(__WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].omit(this.options, 'placeholder'), { placeholder: placeholder })));
+    const $input = this.$(':checkbox');
+
+    $input.prop('checked', this.getModelValue() || false);
+
+    this.$('input').customInput();
+    this.model.trigger('form:resize');
+
+    return this;
+  },
+
+  /**
+   * @Override
+   */
+  readMode: function () {
+    this.editMode();
+    this.$(':checkbox').prop('disabled', true);
+    return this;
+  },
+
+  /**
+   * @Override
+   */
+  val: function () {
+    return this.$(':checkbox').prop('checked');
+  },
+
+  /**
+   * @Override
+   */
+  focus: function () {
+    return this.$(':checkbox').focus();
+  }
+}));
+
+
+/***/ }),
+/* 74 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_TemplateUtil__ = __webpack_require__(3);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__TextBox__ = __webpack_require__(32);
+/*!
+ * Copyright (c) 2015-2018, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+
+
+
+const toggleTemplate = __WEBPACK_IMPORTED_MODULE_1__util_TemplateUtil__["default"].tpl(
+  '\
+      <span class="password-toggle">\
+        <span class="eyeicon visibility-16 button-show"></span>\
+        <span class="eyeicon visibility-off-16 button-hide"></span>\
+      </span>\
+  '
+);
+const toggleTimeout = 30000;
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_2__TextBox__["default"].extend({
+  initialize: function () {
+    if (this.__showPasswordToggle()) {
+      this.events['click .password-toggle .button-show'] = '__showPassword';
+      this.events['click .password-toggle .button-hide'] = '__hidePassword';
+    }
+    this.delegateEvents();
+  },
+
+  postRender: function () {
+    if (this.isEditMode() && this.__showPasswordToggle()) {
+      this.$el.append(toggleTemplate);
+      this.$el.find('input[type="password"]').addClass('password-with-toggle');
+    }
+    __WEBPACK_IMPORTED_MODULE_2__TextBox__["default"].prototype.postRender.apply(this, arguments);
+  },
+
+  __showPasswordToggle: function () {
+    return this.options.params && this.options.params.showPasswordToggle;
+  },
+
+  __showPassword: function () {
+    __WEBPACK_IMPORTED_MODULE_2__TextBox__["default"].prototype.changeType.apply(this, ['text']);
+    this.$('.password-toggle .button-show').hide();
+    this.$('.password-toggle .button-hide').show();
+    this.passwordToggleTimer = __WEBPACK_IMPORTED_MODULE_0__util_underscore_wrapper__["default"].delay(() => {
+      this.__hidePassword();
+    }, toggleTimeout);
+  },
+
+  __hidePassword: function () {
+    __WEBPACK_IMPORTED_MODULE_2__TextBox__["default"].prototype.changeType.apply(this, ['password']);
+    this.$('.password-toggle .button-show').show();
+    this.$('.password-toggle .button-hide').hide();
+    // clear timeout
+    if (this.passwordToggleTimer) {
+      clearTimeout(this.passwordToggleTimer);
+    }
+  }
+}));
+
+
+/***/ }),
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*! http://mths.be/placeholder v2.0.7 by @mathias */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(10)], __WEBPACK_AMD_DEFINE_RESULT__ = (function($){
+!(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(12)], __WEBPACK_AMD_DEFINE_RESULT__ = (function($){
 
 	var isInputSupported = 'placeholder' in document.createElement('input'),
 	    isTextareaSupported = 'placeholder' in document.createElement('textarea'),
@@ -11021,291 +11661,137 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*! http://mths.
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 /***/ }),
-/* 69 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 76 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
- * Copyright (c) 2015-2018, Okta, Inc. and/or its affiliates. All rights reserved.
- * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
- *
- * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- * See the License for the specific language governing permissions and limitations under the License.
- */
-
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(3),
-  __webpack_require__(32)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, TemplateUtil, TextBox) {
-
-  var toggleTemplate = TemplateUtil.tpl('\
-      <span class="password-toggle">\
-        <span class="eyeicon visibility-16 button-show"></span>\
-        <span class="eyeicon visibility-off-16 button-hide"></span>\
-      </span>\
-  ');
-
-  var toggleTimeout = 30000;
-
-  return TextBox.extend({
-    initialize: function () {
-      if (this.__showPasswordToggle()) {
-        this.events['click .password-toggle .button-show'] = '__showPassword';
-        this.events['click .password-toggle .button-hide'] = '__hidePassword';
-      }
-      this.delegateEvents();
-    },
-
-    postRender: function () {
-      if (this.isEditMode() && this.__showPasswordToggle()) {
-        this.$el.append(toggleTemplate);
-        this.$el.find('input[type="password"]').addClass('password-with-toggle');
-      }
-      TextBox.prototype.postRender.apply(this, arguments);
-    },
-
-    __showPasswordToggle: function () {
-      return (this.options.params && this.options.params.showPasswordToggle);
-    },
-
-    __showPassword: function () {
-      TextBox.prototype.changeType.apply(this, ['text']);
-      this.$('.password-toggle .button-show').hide();
-      this.$('.password-toggle .button-hide').show();
-      this.passwordToggleTimer = _.delay(() => {
-        this.__hidePassword();
-      }, toggleTimeout);
-    },
-
-    __hidePassword: function () {
-      TextBox.prototype.changeType.apply(this, ['password']);
-      this.$('.password-toggle .button-show').show();
-      this.$('.password-toggle .button-hide').hide();
-      // clear timeout
-      if (this.passwordToggleTimer) {
-        clearTimeout(this.passwordToggleTimer);
-      }
-    }
-  });
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__ = __webpack_require__(2);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2__util_Keys__ = __webpack_require__(8);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_3__util_Util__ = __webpack_require__(16);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_4__BaseView__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5_vendor_plugins_jquery_custominput__ = __webpack_require__(31);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_5_vendor_plugins_jquery_custominput___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_5_vendor_plugins_jquery_custominput__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_6__BaseInput__ = __webpack_require__(10);
+/* eslint max-statements: [2, 12], max-params: [2, 6] */
 
 
-/***/ }),
-/* 70 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(7),
-  __webpack_require__(3),
-  __webpack_require__(9),
-  __webpack_require__(33)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, Keys, TemplateUtil, BaseInput) {
-
-  var template = TemplateUtil.tpl('\
-    <input type="checkbox" name="{{name}}" id="{{inputId}}"/>\
-    <label for="{{inputId}}" data-se-for-name="{{name}}">{{placeholder}}</label>\
-  ');
-
-  return BaseInput.extend({
-    template: template,
-    /**
-    * @Override
-    */
-    events: {
-      'change :checkbox': 'update',
-      'keyup': function (e) {
-        if (Keys.isSpaceBar(e)) {
-          this.$(':checkbox').click();
-        }
-        else if (Keys.isEnter(e)) {
-          this.model.trigger('form:save');
-        }
-      }
-    },
-
-    /**
-    * @Override
-    */
-    editMode: function () {
-      var placeholder = _.resultCtx(this.options, 'placeholder', this);
-      if (placeholder === '') {
-        placeholder = _.resultCtx(this.options, 'label', this);
-      } else if (placeholder === false) {
-        placeholder = '';
-      }
-
-      this.$el.html(this.template(_.extend(_.omit(this.options, 'placeholder'), { placeholder: placeholder })));
-      var $input = this.$(':checkbox');
-      $input.prop('checked', this.getModelValue() || false);
-
-      this.$('input').customInput();
-      this.model.trigger('form:resize');
-
-      return this;
-    },
-
-    /**
-     * @Override
-    */
-    readMode: function () {
-      this.editMode();
-      this.$(':checkbox').prop('disabled', true);
-      return this;
-    },
-
-    /**
-    * @Override
-    */
-    val: function () {
-      return this.$(':checkbox').prop('checked');
-    },
-
-    /**
-    * @Override
-    */
-    focus: function () {
-      return this.$(':checkbox').focus();
-    }
-
-  });
-
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 
 
-/***/ }),
-/* 71 */
-/***/ (function(module, exports, __webpack_require__) {
 
-var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/* eslint max-statements: [2, 12], max-params: [2, 6] */
-!(__WEBPACK_AMD_DEFINE_ARRAY__ = [
-  __webpack_require__(0),
-  __webpack_require__(2),
-  __webpack_require__(7),
-  __webpack_require__(16),
-  __webpack_require__(9),
-  __webpack_require__(1),
-  __webpack_require__(33)
-], __WEBPACK_AMD_DEFINE_RESULT__ = (function (_, $, Keys, Util, BaseInput, BaseView) {
 
-  var isABaseView = Util.isABaseView;
 
-  var RadioOption = BaseView.extend({
-    template: '\
+const isABaseView = __WEBPACK_IMPORTED_MODULE_3__util_Util__["default"].isABaseView;
+const RadioRadioOption = __WEBPACK_IMPORTED_MODULE_4__BaseView__["default"].extend({
+  template:
+    '\
       <input type="radio" name="{{name}}" data-se-name="{{realName}}" value="{{value}}" id="{{optionId}}">\
       <label for="{{optionId}}" data-se-for-name="{{realName}}" class="radio-label">\
         {{label}}\
       </label>\
     ',
-    initialize: function (options) {
-      var explain;
+  initialize: function (options) {
+    let explain;
 
-      explain = options.explain;
-      if (_.isFunction(explain) && !isABaseView(explain)) {
-        explain = _.resultCtx(this.options, 'explain', this);
-      }
-      if (!explain) {
-        return;
-      }
+    explain = options.explain;
+    if (__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isFunction(explain) && !isABaseView(explain)) {
+      explain = __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].resultCtx(this.options, 'explain', this);
+    }
+    if (!explain) {
+      return;
+    }
 
-      if (isABaseView(explain)) {
-        this.add('<p class="o-form-explain"></p>', '.radio-label');
-        this.add(explain, '.o-form-explain');
-      }
-      else {
-        this.add('<p class="o-form-explain">{{explain}}</p>', '.radio-label');
+    if (isABaseView(explain)) {
+      this.add('<p class="o-form-explain"></p>', '.radio-label');
+      this.add(explain, '.o-form-explain');
+    } else {
+      this.add('<p class="o-form-explain">{{explain}}</p>', '.radio-label');
+    }
+  }
+});
+/* harmony default export */ __webpack_exports__["default"] = (__WEBPACK_IMPORTED_MODULE_6__BaseInput__["a" /* default */].extend({
+  /**
+   * @Override
+   */
+  events: {
+    'change :radio': 'update',
+    keyup: function (e) {
+      if (__WEBPACK_IMPORTED_MODULE_2__util_Keys__["default"].isSpaceBar(e)) {
+        Object(__WEBPACK_IMPORTED_MODULE_0__util_jquery_wrapper__["default"])(e.target).click();
+      } else if (__WEBPACK_IMPORTED_MODULE_2__util_Keys__["default"].isEnter(e)) {
+        this.model.trigger('form:save');
       }
     }
-  });
+  },
 
-  return BaseInput.extend({
+  /**
+   * @Override
+   */
+  editMode: function () {
+    const templates = [];
 
-    /**
-    * @Override
-    */
-    events: {
-      'change :radio': 'update',
-      'keyup': function (e) {
-        if (Keys.isSpaceBar(e)) {
-          $(e.target).click();
-        }
-        else if (Keys.isEnter(e)) {
-          this.model.trigger('form:save');
-        }
-      }
-    },
+    this.$el.empty();
 
-    /**
-    * @Override
-    */
-    editMode: function () {
-      var templates = [];
-      this.$el.empty();
-
-      _.each(this.options.options, function (value, key) {
-        var options = {
-          optionId: _.uniqueId('option'),
+    __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].each(
+      this.options.options,
+      function (value, key) {
+        const options = {
+          optionId: __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].uniqueId('option'),
           name: this.options.inputId,
           realName: this.options.name,
           value: key
         };
 
-        if (!_.isObject(value)) {
+        if (!__WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].isObject(value)) {
           value = { label: value };
         }
-        _.extend(options, value);
+        __WEBPACK_IMPORTED_MODULE_1__util_underscore_wrapper__["default"].extend(options, value);
 
-        templates.push(new RadioOption(options).render().el);
-      }, this);
-      this.$el.append(templates);
-      var value = this.getModelValue();
-      if (value) {
-        this.$(':radio[value=' + value + ']').prop('checked', true);
-      }
+        templates.push(new RadioRadioOption(options).render().el);
+      },
+      this
+    );
+    this.$el.append(templates);
+    let value = this.getModelValue();
 
-      this.$('input').customInput();
-      this.model.trigger('form:resize');
-
-      if (this.getParam('inline') === true) {
-        this.$('div.custom-radio').addClass('inline');
-      }
-
-      return this;
-    },
-
-    /**
-    * @Override
-    */
-    readMode: function () {
-      this.editMode();
-      this.$(':radio').prop('disabled', true);
-      return this;
-    },
-
-    /**
-    * @Override
-    */
-    val: function () {
-      return this.$(':radio:checked').val();
-    },
-
-    /**
-    * @Override
-    */
-    focus: function () {
-      return this.$('label:eq(0)').focus();
+    if (value) {
+      this.$(':radio[value=' + value + ']').prop('checked', true);
     }
 
-  });
+    this.$('input').customInput();
+    this.model.trigger('form:resize');
 
-}).apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+    if (this.getParam('inline') === true) {
+      this.$('div.custom-radio').addClass('inline');
+    }
+
+    return this;
+  },
+
+  /**
+   * @Override
+   */
+  readMode: function () {
+    this.editMode();
+    this.$(':radio').prop('disabled', true);
+    return this;
+  },
+
+  /**
+   * @Override
+   */
+  val: function () {
+    return this.$(':radio:checked').val();
+  },
+
+  /**
+   * @Override
+   */
+  focus: function () {
+    return this.$('label:eq(0)').focus();
+  }
+}));
 
 
 /***/ })

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -7,7 +7,7 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@okta/courage": "4.4.0",
+    "@okta/courage": "4.6.0-beta.2098.gc581fa3",
     "webpack": "^3.5.4",
     "webpack-bundle-analyzer": "^3.0.2"
   }

--- a/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.js
+++ b/packages/@okta/courage-for-signin-widget/src/CourageForSigninWidget.js
@@ -1,128 +1,114 @@
-/* eslint max-params: 0 */
-define([
-  'backbone',
-  '@okta/courage/src/util/jquery-wrapper',
-  '@okta/courage/src/util/underscore-wrapper',
-  '@okta/courage/src/util/handlebars-wrapper',
-  '@okta/courage/src/models/Model',
-  '@okta/courage/src/models/BaseModel',
-  '@okta/courage/src/models/BaseCollection',
-  '@okta/courage/src/models/SchemaProperty',
-  '@okta/courage/src/models/BaseSchema',
-  '@okta/courage/src/util/StringUtil',
-  '@okta/courage/src/util/TemplateUtil',
-  '@okta/courage/src/util/ButtonFactory',
-  '@okta/courage/src/util/BaseRouter',
-  '@okta/courage/src/util/BaseController',
-  '@okta/courage/src/util/Util',
-  '@okta/courage/src/util/Cookie',
-  '@okta/courage/src/util/Logger',
-  '@okta/courage/src/util/Class',
-  '@okta/courage/src/util/Keys',
-  '@okta/courage/src/views/BaseView',
-  '@okta/courage/src/views/Backbone.ListView',
-  '@okta/courage/src/views/components/BaseDropDown',
-  '@okta/courage/src/views/forms/BaseForm',
-  '@okta/courage/src/views/forms/helpers/InputRegistry',
-  '@okta/courage/src/views/forms/helpers/FormUtil',
-  '@okta/courage/src/views/forms/helpers/SchemaFormFactory',
-  '@okta/courage/src/views/forms/components/Toolbar',
-  '@okta/courage/src/views/forms/inputs/TextBox',
-  '@okta/courage/src/views/forms/inputs/PasswordBox',
-  '@okta/courage/src/views/forms/inputs/CheckBox',
-  '@okta/courage/src/views/forms/inputs/Radio',
-  '@okta/courage/src/views/forms/inputs/Select',
-],
-  function (Backbone, $, _, Handlebars,
-    Model, BaseModel, BaseCollection, SchemaProperty, BaseSchema,
-    StringUtil, TemplateUtil, ButtonFactory, BaseRouter, BaseController,
-    Util, Cookie, Logger, Class, Keys,
-    BaseView, ListView, BaseDropDown,
-    BaseForm, InputRegistry, FormUtil, SchemaFormFactory, Toolbar,
-    TextBox, PasswordBox, CheckBox, Radio, Select) {
+import BaseCollection from '@okta/courage/src/models/BaseCollection';
+import BaseModel from '@okta/courage/src/models/BaseModel';
+import BaseSchema from '@okta/courage/src/models/BaseSchema';
+import Model from '@okta/courage/src/models/Model';
+import SchemaProperty from '@okta/courage/src/models/SchemaProperty';
+import BaseController from '@okta/courage/src/util/BaseController';
+import BaseRouter from '@okta/courage/src/util/BaseRouter';
+import ButtonFactory from '@okta/courage/src/util/ButtonFactory';
+import Class from '@okta/courage/src/util/Class';
+import Cookie from '@okta/courage/src/util/Cookie';
+import Keys from '@okta/courage/src/util/Keys';
+import Logger from '@okta/courage/src/util/Logger';
+import StringUtil from '@okta/courage/src/util/StringUtil';
+import TemplateUtil from '@okta/courage/src/util/TemplateUtil';
+import Util from '@okta/courage/src/util/Util';
+import Handlebars from '@okta/courage/src/util/handlebars-wrapper';
+import $ from '@okta/courage/src/util/jquery-wrapper';
+import _ from '@okta/courage/src/util/underscore-wrapper';
+import ListView from '@okta/courage/src/views/Backbone.ListView';
+import BaseView from '@okta/courage/src/views/BaseView';
+import BaseDropDown from '@okta/courage/src/views/components/BaseDropDown';
+import BaseForm from '@okta/courage/src/views/forms/BaseForm';
+import Toolbar from '@okta/courage/src/views/forms/components/Toolbar';
+import FormUtil from '@okta/courage/src/views/forms/helpers/FormUtil';
+import InputRegistry from '@okta/courage/src/views/forms/helpers/InputRegistry';
+import SchemaFormFactory from '@okta/courage/src/views/forms/helpers/SchemaFormFactory';
+import CheckBox from '@okta/courage/src/views/forms/inputs/CheckBox';
+import PasswordBox from '@okta/courage/src/views/forms/inputs/PasswordBox';
+import Radio from '@okta/courage/src/views/forms/inputs/Radio';
+import Select from '@okta/courage/src/views/forms/inputs/Select';
+import TextBox from '@okta/courage/src/views/forms/inputs/TextBox';
+import Backbone from 'backbone';
 
-    var Okta = {
+const Okta = {
+  Backbone: Backbone,
 
-      Backbone: Backbone,
+  $: $,
 
-      $: $,
+  _: _,
 
-      _: _,
+  Handlebars: Handlebars,
 
-      Handlebars: Handlebars,
+  loc: StringUtil.localize,
 
-      loc: StringUtil.localize,
+  createButton: ButtonFactory.create,
 
-      createButton: ButtonFactory.create,
+  registerInput: InputRegistry.register,
 
-      registerInput: InputRegistry.register,
+  tpl: TemplateUtil.tpl,
 
-      tpl: TemplateUtil.tpl,
+  Model: Model,
 
-      Model: Model,
+  BaseModel: BaseModel,
 
-      BaseModel: BaseModel,
+  Collection: BaseCollection,
 
-      Collection: BaseCollection,
+  View: BaseView,
 
-      View: BaseView,
+  ListView: ListView,
 
-      ListView: ListView,
+  Router: BaseRouter,
 
-      Router: BaseRouter,
+  Controller: BaseController,
 
-      Controller: BaseController,
+  Form: BaseForm,
 
-      Form: BaseForm,
+  internal: {
+    util: {
+      Util,
+      Cookie,
+      Logger,
+      Class,
+      Keys,
+    },
 
-      internal: {
+    views: {
+      components: {
+        BaseDropDown,
+      },
 
-        util: {
-          Util,
-          Cookie,
-          Logger,
-          Class,
-          Keys,
+      forms: {
+        helpers: {
+          FormUtil,
+          SchemaFormFactory,
         },
 
-        views: {
-          components: {
-            BaseDropDown,
-          },
-
-          forms: {
-            helpers: {
-              FormUtil,
-              SchemaFormFactory
-            },
-
-            components: {
-              Toolbar,
-            },
-
-            inputs: {
-              TextBox,
-              PasswordBox,
-              CheckBox,
-              Radio,
-              Select
-            }
-          }
+        components: {
+          Toolbar,
         },
 
-        models: {
-          BaseSchema,
-          SchemaProperty
+        inputs: {
+          TextBox,
+          PasswordBox,
+          CheckBox,
+          Radio,
+          Select,
         },
+      },
+    },
 
-      }
-    };
+    models: {
+      BaseSchema,
+      SchemaProperty,
+    },
+  },
+};
 
-    Okta.registerInput('text', TextBox);
-    Okta.registerInput('password', PasswordBox);
-    Okta.registerInput('checkbox', CheckBox);
-    Okta.registerInput('radio', Radio);
-    Okta.registerInput('select', Select);
+Okta.registerInput('text', TextBox);
+Okta.registerInput('password', PasswordBox);
+Okta.registerInput('checkbox', CheckBox);
+Okta.registerInput('radio', Radio);
+Okta.registerInput('select', Select);
 
-    return Okta;
-  });
+module.exports = Okta;

--- a/packages/@okta/courage-for-signin-widget/webpack.config.js
+++ b/packages/@okta/courage-for-signin-widget/webpack.config.js
@@ -15,7 +15,7 @@ const EXTERNAL_PATHS = [
   'backbone',
   'underscore',
   'handlebars',
-  'shared/util/Bundles'
+  'okta-i18n-bundles'
 ];
 
 const webpackConfig = {
@@ -33,11 +33,6 @@ const webpackConfig = {
   resolve: {
     alias: {
 
-      'okta/jquery': SHARED_JS + '/util/jquery-wrapper',
-      'okta/underscore': SHARED_JS + '/util/underscore-wrapper',
-      'okta/handlebars': SHARED_JS + '/util/handlebars-wrapper',
-      'okta/moment': SHARED_JS + '/util/moment-wrapper',
-
       // jsons is from StringUtil
       'vendor/lib/json2': EMPTY,
 
@@ -52,7 +47,6 @@ const webpackConfig = {
       //   BaseRouter -> ConfirmationDialog -> BaseFormDialog -> BaseModalDialog -> simplemodal
       'vendor/plugins/jquery.simplemodal': EMPTY,
 
-      'shared': SHARED_JS,
       'vendor': SHARED_JS + '/vendor',
     }
   },

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -2,22 +2,12 @@
 # yarn lockfile v1
 
 
-"@okta/core.components@0.1.0-beta.0c7b0449":
-  version "0.1.0-beta.0c7b0449"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/core.components/-/@okta/core.components-0.1.0-beta.0c7b0449.tgz#674e5233d3b6f721fa611ea15637153fdb37d0f4"
-
-"@okta/core.vendor@0.1.0-beta.c02666d5":
-  version "0.1.0-beta.c02666d5"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/core.vendor/-/@okta/core.vendor-0.1.0-beta.c02666d5.tgz#09535c70fcdf1b1d062e7149e57a91d81e01857e"
-
-"@okta/courage@4.4.0":
-  version "4.4.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/courage/-/@okta/courage-4.4.0.tgz#29a1c358499fd0a7677b7fc460d887e8cedc578f"
+"@okta/courage@4.6.0-beta.2098.gc581fa3":
+  version "4.6.0-beta.2098.gc581fa3"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/courage/-/@okta/courage-4.6.0-beta.2098+c581fa3.tgz#ad210af8cc385e8e00d44d32a53fb5f938974f84"
   dependencies:
-    "@okta/core.components" "0.1.0-beta.0c7b0449"
-    "@okta/core.vendor" "0.1.0-beta.c02666d5"
-    "@okta/jquery.simplemodal" "1.4.9"
-    "@okta/moment" "1.0.4"
+    "@okta/jquery.simplemodal" "1.4.17"
+    "@okta/moment" "1.0.5"
     backbone "^1.3.3"
     clipboard "^1.5.16"
     handlebars "2.0.0"
@@ -25,13 +15,13 @@
     selectize "0.12.4"
     underscore "1.8.3"
 
-"@okta/jquery.simplemodal@1.4.9":
-  version "1.4.9"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/jquery.simplemodal/-/@okta/jquery.simplemodal-1.4.9.tgz#1a6f84f42cbbdcc83f246f05f30e144521695a69"
+"@okta/jquery.simplemodal@1.4.17":
+  version "1.4.17"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/jquery.simplemodal/-/@okta/jquery.simplemodal-1.4.17.tgz#db8a33d91d93940a8d2332c5b66fac5cf23c132f"
 
-"@okta/moment@1.0.4":
-  version "1.0.4"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/moment/-/@okta/moment-1.0.4.tgz#2d004fe8cb07f83c8fdab4e96ee0e65b7a7b16f5"
+"@okta/moment@1.0.5":
+  version "1.0.5"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/moment/-/@okta/moment-1.0.5.tgz#c463c886eddb9940b4b43dd8abbc3aa7cf39d2a0"
   dependencies:
     moment "^2.19.1"
 

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -69,6 +69,13 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
           'description': 'How did you hear about us?',
           'maxLength': 1024
         },
+        'countryCode': {
+          'type': 'country-code',
+          'format': 'country-code'
+        },
+        'preferredLanguage': {
+          'type': 'language_code',
+        },
         'password' : {
           'type' : 'string',
           'description' : 'Password',
@@ -97,7 +104,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         }
       },
       'required': ['firstName', 'lastName', 'userName', 'password', 'referrer'],
-      'fieldOrder': ['userName', 'password', 'firstName', 'lastName', 'accountLevel', 'referrer']
+      'fieldOrder': ['userName', 'password', 'firstName', 'lastName', 'accountLevel', 'referrer', 'preferredLanguage', 'countryCode']
     }
   };
 
@@ -244,6 +251,20 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
           var userName = test.form.userNameField();
           expect(userName.length).toBe(1);
           expect(userName.attr('type')).toEqual('text');
+        });
+      });
+      itp('has a preferredLanguage field', function () {
+        return setup().then(function (test) {
+          var preferredLanguage = test.form.input('preferredLanguage');
+          expect(preferredLanguage.length).toBe(1);
+          expect(preferredLanguage.attr('type')).toEqual('text');
+        });
+      });
+      itp('has a countryCode field', function () {
+        return setup().then(function (test) {
+          var countryCode = test.form.input('countryCode');
+          expect(countryCode.length).toBe(1);
+          expect(countryCode.attr('type')).toEqual('text');
         });
       });
       itp('has a password field', function () {
@@ -658,6 +679,14 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
                 'default': 'Enter your zip code',
                 'maxLength': 255
               };
+              schema.profileSchema.properties.preferredLanguage = {
+                'type': 'language_code',
+                'title': 'Preferred language',
+              };
+              schema.profileSchema.properties.countryCode = {
+                'type': 'country_code',
+                'title': 'Country code',
+              };
               onSuccess(schema);
             },
             'preSubmit': function (postData, onSuccess, onFailure) {
@@ -673,15 +702,25 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
             $.ajax.calls.reset();
             expect(test.form.getFieldByName('zip').length).toBe(1);
             expect(test.form.fieldPlaceholder('zip')).toBe('Zip');
+            expect(test.form.getFieldByName('countryCode').length).toBe(1);
+            expect(test.form.fieldPlaceholder('countryCode')).toBe('Country code');
+            expect(test.form.getFieldByName('preferredLanguage').length).toBe(1);
+            expect(test.form.fieldPlaceholder('preferredLanguage')).toBe('Preferred language');
             test.form.setUserName('test');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
+            test.form.input('preferredLanguage').val('en');
+            test.form.input('preferredLanguage').trigger('change');
+            test.form.input('countryCode').val('us');
+            test.form.input('countryCode').trigger('change');
             test.form.submit();
             expect(test.router.controller.model.get('userName')).toBe('test');
             var model = test.router.controller.model;
             spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
             model.save();
             expect(test.router.controller.model.get('userName')).toBe('test@example.com');
+            expect(test.router.controller.model.get('preferredLanguage')).toBe('en');
+            expect(test.router.controller.model.get('countryCode')).toBe('us');
             expect(setting.registration.postSubmit).toHaveBeenCalled();
           });
       });

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -22,7 +22,7 @@ module.exports = function (outputFilename) {
         // General remapping
         'nls': '@okta/i18n/dist/json',
         'okta': `${LOCAL_PACKAGES}/@okta/courage-dist/okta.js`,
-        'shared/util/Bundles': 'util/Bundles',
+        'okta-i18n-bundles': 'util/Bundles',
 
         // Vendor files from courage that are remapped in OSW to point to an npm
         // module in our package.json dependencies


### PR DESCRIPTION
## Description
These version upgrades were prompted by a [customer urgent](https://oktainc.atlassian.net/browse/OKTA-199716) in which users were unable to register when `countryCode` or `preferredLanguage` were added as fields to the registration form. However, given that it has been close to three months since the last Courage version upgrade, other changes have been brought in as well. I have included video showing successful registration using the new widget below.

Bacon: https://bacon.aue1e.internal/#!/commits/okta-signin-widget/sha/d419a8b72bbd8c9559e4215eca077bc9f368cc43

## Video
**Registration with the new widget**
![registrationwithnewwidget](https://user-images.githubusercontent.com/30125633/50847693-12b4c580-1327-11e9-9ef8-cad03b007436.gif)
