### PR TITLE
:seedling: Support next link in any SUCCESS state

### DIFF
--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -124,7 +124,7 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
 
       var successData = {
         user: res._embedded.user,
-        type: res.type
+        type: res.type || Enums.SESSION_SSO
       };
 
       if (res.relayState) {
@@ -133,17 +133,12 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
 
       var redirectFn = router.settings.get('redirectUtilFn');
 
-      if (res.type === Enums.SESSION_STEP_UP) {
-        var targetUrl = res._links && res._links.next && res._links.next.href;
-        successData.stepUp = {
-          url: targetUrl,
-          finish: function () {
-            redirectFn(targetUrl);
-          }
+      var nextUrl = res._links && res._links.next && res._links.next.href;
+      if (nextUrl) {
+        successData.next = function () {
+          redirectFn(nextUrl);
         };
       } else {
-        // Add the type for now until the API returns it.
-        successData.type = Enums.SESSION_SSO;
         successData.session = {
           token: res.sessionToken,
           setCookieAndRedirect: function (redirectUrl) {

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 30],max-statements: [2, 30] */
+/* eslint complexity: [2, 35], max-statements: [2, 30] */
 define([
   'okta',
   './OAuth2Util',
@@ -133,12 +133,23 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
 
       var redirectFn = router.settings.get('redirectUtilFn');
 
-      var nextUrl = res._links && res._links.next && res._links.next.href;
-      if (nextUrl) {
+      var nextUrl = res._links &&
+                    ((res._links.original && res._links.original.href) || (res._links.next && res._links.next.href));
+      if (res.type === Enums.SESSION_STEP_UP) {
+        var targetUrl = res._links && res._links.next && res._links.next.href;
+        successData.stepUp = {
+          url: targetUrl,
+          finish: function () {
+            redirectFn(targetUrl);
+          }
+        };
+      } else if (nextUrl) {
         successData.next = function () {
           redirectFn(nextUrl);
         };
       } else {
+        // Add the type for now until the API returns it.
+        successData.type = Enums.SESSION_SSO;
         successData.session = {
           token: res.sessionToken,
           setCookieAndRedirect: function (redirectUrl) {

--- a/test/unit/helpers/xhr/SUCCESS_next.js
+++ b/test/unit/helpers/xhr/SUCCESS_next.js
@@ -4,6 +4,7 @@ define({
   "response": {
     "expiresAt": "2015-08-05T14:10:54.000Z",
     "status": "SUCCESS",
+    "type": "NEW_TYPE",
     "sessionToken": "THE_SESSION_TOKEN",
     "_embedded": {
       "user": {

--- a/test/unit/helpers/xhr/SUCCESS_next.js
+++ b/test/unit/helpers/xhr/SUCCESS_next.js
@@ -1,0 +1,31 @@
+define({
+  "status": 200,
+  "responseType": "json",
+  "response": {
+    "expiresAt": "2015-08-05T14:10:54.000Z",
+    "status": "SUCCESS",
+    "sessionToken": "THE_SESSION_TOKEN",
+    "_embedded": {
+      "user": {
+        "id": "00ui0jgywTAHxYGMM0g3",
+        "profile": {
+          "login": "administrator1@clouditude.net",
+          "firstName": "Add-Min",
+          "lastName": "O'Cloudy Tud",
+          "locale": "en_US",
+          "timeZone": "America\/Los_Angeles"
+        }
+      }
+    },
+    "_links": {
+      "next": {
+        "href": "http://foo.okta.com/next/redirect?stateToken=aStateToken",
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      }
+    }
+  }
+});

--- a/test/unit/helpers/xhr/SUCCESS_original.js
+++ b/test/unit/helpers/xhr/SUCCESS_original.js
@@ -4,6 +4,7 @@ define({
   "response": {
     "expiresAt": "2015-08-05T14:10:54.000Z",
     "status": "SUCCESS",
+    "type": "NEW_TYPE",
     "sessionToken": "THE_SESSION_TOKEN",
     "_embedded": {
       "user": {

--- a/test/unit/helpers/xhr/SUCCESS_original.js
+++ b/test/unit/helpers/xhr/SUCCESS_original.js
@@ -1,0 +1,31 @@
+define({
+  "status": 200,
+  "responseType": "json",
+  "response": {
+    "expiresAt": "2015-08-05T14:10:54.000Z",
+    "status": "SUCCESS",
+    "sessionToken": "THE_SESSION_TOKEN",
+    "_embedded": {
+      "user": {
+        "id": "00ui0jgywTAHxYGMM0g3",
+        "profile": {
+          "login": "administrator1@clouditude.net",
+          "firstName": "Add-Min",
+          "lastName": "O'Cloudy Tud",
+          "locale": "en_US",
+          "timeZone": "America\/Los_Angeles"
+        }
+      }
+    },
+    "_links": {
+      "original": {
+        "href": "http://foo.okta.com/original/redirect?stateToken=aStateToken",
+        "hints": {
+          "allow": [
+            "GET"
+          ]
+        }
+      }
+    }
+  }
+});

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -278,17 +278,21 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
         });
     });
     itp('has a success callback which correctly implements the setCookieAndRedirect function', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          resp.session.setCookieAndRedirect('http://baz.com/foo');
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
-      var successSpy = jasmine.createSpy('successSpy');
-      return setup({ globalSuccessFn: successSpy })
+      return setup({ globalSuccessFn: spied.successFn })
         .then(function (test) {
           test.setNextResponse(resSuccess);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var setCookieAndRedirect = successSpy.calls.mostRecent().args[0].session.setCookieAndRedirect;
-          setCookieAndRedirect('http://baz.com/foo');
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
           '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
@@ -296,17 +300,21 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
         });
     });
     itp('has a success callback which correctly implements the setCookieAndRedirect function when features.redirectByFormSubmit is on', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          resp.session.setCookieAndRedirect('http://baz.com/foo');
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(WidgetUtil, 'redirectWithFormGet');
-      var successSpy = jasmine.createSpy('successSpy');
-      return setup({ globalSuccessFn: successSpy, 'features.redirectByFormSubmit': true })
+      return setup({ globalSuccessFn: spied.successFn, 'features.redirectByFormSubmit': true })
         .then(function (test) {
           test.setNextResponse(resSuccess);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var setCookieAndRedirect = successSpy.calls.mostRecent().args[0].session.setCookieAndRedirect;
-          setCookieAndRedirect('http://baz.com/foo');
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
           '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
@@ -314,127 +322,159 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
         });
     });
     itp('for SESSION_STEP_UP type, success callback data contains the target resource url and a finish function', function () {
+      var targetUrl;
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'SESSION_STEP_UP') {
+            targetUrl = resp.stepUp.url;
+            resp.stepUp.finish();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
-      var successSpy = jasmine.createSpy('successSpy');
-      return setup({ stateToken: 'aStateToken', globalSuccessFn: successSpy })
+      return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn })
         .then(function (test) {
           test.setNextResponse(resSuccessStepUp);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var targetUrl = successSpy.calls.mostRecent().args[0].stepUp.url;
           expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
-          var finish = successSpy.calls.mostRecent().args[0].stepUp.finish;
-          expect(finish).toEqual(jasmine.any(Function));
-          finish();
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken'
           );
         });
     });
     itp('for SESSION_STEP_UP type, success callback data contains the target resource url and a finish function when features.redirectByFormSubmit is on', function () {
+      var targetUrl;
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'SESSION_STEP_UP') {
+            targetUrl = resp.stepUp.url;
+            resp.stepUp.finish();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(WidgetUtil, 'redirectWithFormGet');
-      var successSpy = jasmine.createSpy('successSpy');
       var opt = {
         'features.redirectByFormSubmit': true,
         stateToken: 'aStateToken',
-        globalSuccessFn: successSpy
+        globalSuccessFn: spied.successFn
       };
       return setup(opt)
         .then(function (test) {
           test.setNextResponse(resSuccessStepUp);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var targetUrl = successSpy.calls.mostRecent().args[0].stepUp.url;
           expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
-          var finish = successSpy.calls.mostRecent().args[0].stepUp.finish;
-          expect(finish).toEqual(jasmine.any(Function));
-          finish();
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken'
           );
         });
     });
     itp('for success with an original link, success callback data contains a next function that redirects to original.href', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'NEW_TYPE' && resp.next) {
+            resp.next();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
-      var successSpy = jasmine.createSpy('successSpy');
-      return setup({ stateToken: 'aStateToken', globalSuccessFn: successSpy })
+      return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn })
         .then(function (test) {
           test.setNextResponse(resSuccessOriginal);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var next = successSpy.calls.mostRecent().args[0].next;
-          expect(next).toEqual(jasmine.any(Function));
-          next();
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://foo.okta.com/original/redirect?stateToken=aStateToken'
           );
         });
     });
     itp('for success with an original link, success callback data contains a next function that redirects to original.href when features.redirectByFormSubmit is on', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'NEW_TYPE' && resp.next) {
+            resp.next();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(WidgetUtil, 'redirectWithFormGet');
-      var successSpy = jasmine.createSpy('successSpy');
       var opt = {
         'features.redirectByFormSubmit': true,
         stateToken: 'aStateToken',
-        globalSuccessFn: successSpy
+        globalSuccessFn: spied.successFn
       };
       return setup(opt)
         .then(function (test) {
           test.setNextResponse(resSuccessOriginal);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var next = successSpy.calls.mostRecent().args[0].next;
-          expect(next).toEqual(jasmine.any(Function));
-          next();
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/original/redirect?stateToken=aStateToken'
           );
         });
     });
     itp('for success with a next link, success callback data contains a next function that redirects to next.href', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'NEW_TYPE' && resp.next) {
+            resp.next();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
-      var successSpy = jasmine.createSpy('successSpy');
-      return setup({ stateToken: 'aStateToken', globalSuccessFn: successSpy })
+      return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn })
         .then(function (test) {
           test.setNextResponse(resSuccessNext);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var next = successSpy.calls.mostRecent().args[0].next;
-          expect(next).toEqual(jasmine.any(Function));
-          next();
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://foo.okta.com/next/redirect?stateToken=aStateToken'
           );
         });
     });
     itp('for success with a next link, success callback data contains a next function that redirects to next.href when features.redirectByFormSubmit is on', function () {
+      var spied = { };
+      spied.successFn = function (resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.type === 'NEW_TYPE' && resp.next) {
+            resp.next();
+          }
+        }
+      };
+      spyOn(spied, 'successFn').and.callThrough();
       spyOn(WidgetUtil, 'redirectWithFormGet');
-      var successSpy = jasmine.createSpy('successSpy');
       var opt = {
         'features.redirectByFormSubmit': true,
         stateToken: 'aStateToken',
-        globalSuccessFn: successSpy
+        globalSuccessFn: spied.successFn
       };
       return setup(opt)
         .then(function (test) {
           test.setNextResponse(resSuccessNext);
           test.router.refreshAuthState('dummy-token');
-          return Expect.waitForSpyCall(successSpy);
+          return Expect.waitForSpyCall(spied.successFn);
         })
         .then(function () {
-          var next = successSpy.calls.mostRecent().args[0].next;
-          expect(next).toEqual(jasmine.any(Function));
-          next();
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/next/redirect?stateToken=aStateToken'
           );

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -321,9 +321,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
           return Expect.waitForSpyCall(successSpy);
         })
         .then(function () {
-          var targetUrl = successSpy.calls.mostRecent().args[0].stepUp.url;
-          expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
-          var finish = successSpy.calls.mostRecent().args[0].stepUp.finish;
+          var finish = successSpy.calls.mostRecent().args[0].next;
           expect(finish).toEqual(jasmine.any(Function));
           finish();
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
@@ -346,9 +344,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
           return Expect.waitForSpyCall(successSpy);
         })
         .then(function () {
-          var targetUrl = successSpy.calls.mostRecent().args[0].stepUp.url;
-          expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
-          var finish = successSpy.calls.mostRecent().args[0].stepUp.finish;
+          var finish = successSpy.calls.mostRecent().args[0].next;
           expect(finish).toEqual(jasmine.any(Function));
           finish();
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(


### PR DESCRIPTION
### Description
- In any SUCCESS state add a `next` function to `successData` which redirect to `next.href`, if available, instead of  the`setCookieAndRedirect` function.

Part of: [OKTA-197158](https://oktainc.atlassian.net/browse/OKTA-197158)

### Reviewers
@haishengwu-okta @royalchan-okta @tthompson-okta 