### PR TITLE
fix:  Handle input[type="tel"] the same way as other text input types.

### DIFF
--- a/assets/sass/common/shared/o-forms/_o-form.scss
+++ b/assets/sass/common/shared/o-forms/_o-form.scss
@@ -87,6 +87,7 @@
 
     input[type="text"],
     input[type="textbox"], /* Some custom type created by ghost dev */
+    input[type="tel"],
     input[type="number"],
     input[type="password"] {
       height: 100%;


### PR DESCRIPTION
## Description

This is a CSS fix to complete PR#367.  That PR introduced the use of type="tel" input fields.  This PR updates the CSS to treat those fields in the same way as e.g. "text", "number" and "password" input fields -- in particular, the entire input field (including the right-hand part) should be clickable, not just the left-hand part.

Part of:  OKTA-201572