### PR TITLE
Send device fingerprint only if cookie is not present in getImage call.

### DIFF
--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -18,7 +18,7 @@ define([
   'models/PrimaryAuth',
   'views/shared/Footer',
   'util/BaseLoginController',
-  'util/DeviceFingerprint'
+  'util/DeviceFingerprint',
 ],
 function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthModel,
   Footer, BaseLoginController, DeviceFingerprint) {
@@ -76,8 +76,8 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
 
     events: {
       'focusout input[name=username]': function () {
-        // Get DeviceFingerprint so we can use it for security image and for primary auth
-        if (this.settings.get('features.deviceFingerprinting')) {
+        if (this.settings.get('features.deviceFingerprinting') &&
+            this.settings.get('features.useDeviceFingerprintForSecurityImage')) {
           var self = this;
           DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
             .then(function (fingerprint) {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -89,6 +89,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, OAuth2Util, config) {
       'features.showPasswordToggleOnSignInPage': ['boolean', false, false],
       'features.trackTypingPattern': ['boolean', false, false],
       'features.redirectByFormSubmit': ['boolean', false, false],
+      'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -554,7 +554,8 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     });
 
     Expect.describe('Device Fingerprint', function () {
-      itp('contains fingerprint header in get security image request if feature is enabled', function () {
+      itp(`contains fingerprint header in get security image request if deviceFingerprinting
+        is true (useDeviceFingerprintForSecurityImage defaults to true)`, function () {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
           var deferred = Q.defer();
           deferred.resolve('thisIsTheDeviceFingerprint');
@@ -571,6 +572,60 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             var ajaxArgs = $.ajax.calls.argsFor(0);
             expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
+          });
+      });
+      itp(`contains fingerprint header in get security image request if both features(
+        deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`, function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+          var deferred = Q.defer();
+          deferred.resolve('thisIsTheDeviceFingerprint');
+          return deferred.promise;
+        });
+        return setup({ features: { securityImage: true, deviceFingerprinting: true,
+          useDeviceFingerprintForSecurityImage: true}})
+          .then(function (test) {
+            test.setNextResponse(resSecurityImage);
+            test.form.setUsername('testuser@clouditude.net');
+            return waitForBeaconChange(test);
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(1);
+            expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
+            var ajaxArgs = $.ajax.calls.argsFor(0);
+            expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
+          });
+      });
+      itp(`does not contain fingerprint header in get security image request if deviceFingerprinting
+          is enabled but useDeviceFingerprintForSecurityImage is disabled`, function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
+        return setup({ features: { securityImage: true, deviceFingerprinting: true,
+          useDeviceFingerprintForSecurityImage: false}})
+          .then(function (test) {
+            test.setNextResponse(resSecurityImage);
+            test.form.setUsername('testuser@clouditude.net');
+            return waitForBeaconChange(test);
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(1);
+            expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
+            var ajaxArgs = $.ajax.calls.argsFor(0);
+            expect(ajaxArgs[0].headers).toBeUndefined();
+          });
+      });
+      itp(`does not contain fingerprint header in get security image request if deviceFingerprinting
+        is disabled and useDeviceFingerprintForSecurityImage is enabled`, function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
+        return setup({ features: { securityImage: true, useDeviceFingerprintForSecurityImage: true }})
+          .then(function (test) {
+            test.setNextResponse(resSecurityImage);
+            test.form.setUsername('testuser@clouditude.net');
+            return waitForBeaconChange(test);
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(1);
+            expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
+            var ajaxArgs = $.ajax.calls.argsFor(0);
+            expect(ajaxArgs[0].headers).toBeUndefined();
           });
       });
       itp('does not contain fingerprint header in get security image request if feature is disabled', function () {


### PR DESCRIPTION
* Currently to retrieve the Beacon image in SIW, we send the device fingerprint and
cookie. If cookie is present we can avoid computing and sending the device fingerprint.(saves 2 api calls).

* Verified if getimage has fingerprint in (first login and expired cookie case) and not when proximity cookie is present.

* authn call still sends device fingerprint and remains unaffected.

* Introduced a feature flag in SIW to tell if we need to compute device fingerprint for getImage call.

**Auth n call has device fingerprint**
<img width="1417" alt="screen shot 2019-02-14 at 1 21 05 pm" src="https://user-images.githubusercontent.com/17267130/52810507-b862ff00-3060-11e9-9f82-951c6c1ed0ee.png">

**First Get image call - device fingerprint is set when there is no proximity cookie** 
<img width="1271" alt="screen shot 2019-02-14 at 1 21 30 pm" src="https://user-images.githubusercontent.com/17267130/52810508-b862ff00-3060-11e9-8e3e-2778697796b1.png">

**Get image call when proximity cookie is present**
<img width="1275" alt="screen shot 2019-02-14 at 1 21 46 pm" src="https://user-images.githubusercontent.com/17267130/52810509-b862ff00-3060-11e9-9454-939bb525a1a7.png">


e2e flow - first login and next login 
![siw](https://user-images.githubusercontent.com/17267130/52810463-a1bca800-3060-11e9-8679-5bf3ca8f6660.gif)
