### PR TITLE
fix: allow okta verify push to work without otp as backup

### DIFF
--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -288,20 +288,21 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
     model: Factor,
     comparator: 'sortOrder',
 
-    // One override necessary here - Okta Verify with Push is treated like
-    // one factor. In the beacon menu, there's only one option - only in the
-    // view can you choose to enable the other factor (which will be exposed
-    // by the backupFactor property)
+    // One override necessary here - When Okta Verify OTP and Push are in the list,
+    // they are presented in the view as one factor - in the beacon menu,
+    // there's only one option (Okta Verify), and we show a form with Push
+    // with an inline totp option. What we need to do is to add totp
+    // as a "backupFactor" for push
     parse: function (factors) {
       // Keep a track of the last used factor, since
       // we need it to determine the default factor.
       this.lastUsedFactor = factors[0];
 
       var oktaPushFactor = _.findWhere(factors, { provider: 'OKTA', factorType: 'push' });
-      if (!oktaPushFactor) {
+      var totpFactor = _.findWhere(factors, { provider: 'OKTA', factorType: 'token:software:totp' });
+      if (!oktaPushFactor || !totpFactor) {
         return factors;
       }
-      var totpFactor = _.findWhere(factors, { provider: 'OKTA', factorType: 'token:software:totp' });
 
       var isTotpFirst = (totpFactor === factors[0]);
 

--- a/test/unit/helpers/xhr/MFA_REQUIRED_oktaVerifyPushOnly.js
+++ b/test/unit/helpers/xhr/MFA_REQUIRED_oktaVerifyPushOnly.js
@@ -1,0 +1,72 @@
+define({
+  "status": 200,
+  "responseType": "json",
+  "response": {
+    "stateToken": "testStateToken",
+    "expiresAt": "2015-06-11T21:33:24.778Z",
+    "status": "MFA_REQUIRED",
+    "_embedded": {
+      "user": {
+        "id": "00uhn6dAGR4nUB4iY0g3",
+        "profile": {
+          "login": "administrator1@clouditude.net",
+          "firstName": "Add-Min",
+          "lastName": "O'Cloudy Tud",
+          "locale": "en_US",
+          "timeZone": "America\/Los_Angeles"
+        }
+      },
+      "policy": {
+        "allowRememberDevice": true,
+        "rememberDeviceLifetimeInMinutes": 0,
+        "rememberDeviceByDefault": false,
+        "factorsPolicyInfo":{
+            "opfhw7v2OnxKpftO40g3":{
+               "autoPushEnabled": false
+            }
+         }
+      },
+      "factors": [{
+        "id": "opfhw7v2OnxKpftO40g3",
+        "factorType": "push",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
+        "profile": {
+          "credentialId": "administrator1@clouditude.net",
+          "deviceType": "SmartPhone_IPhone",
+          "keys": [{
+            "kty": "PKIX",
+            "use": "sig",
+            "kid": "default",
+            "x5c": [
+              "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs4LfXaaQW6uIpkjoiKn2g9B6nNQDraLyC3XgHP5cvX\/qaqry43SwyqjbQtwRkScosDHl59r0DX1V\/3xBtBYwdo8rAdX3I5h6z8lW12xGjOkmb20TuAiy8wSmzchdm52kWodUb7OkMk6CgRJRSDVbC97eNcfKk0wmpxnCJWhC+AiSzRVmgkpgp8NanuMcpI\/X+W5qeqWO0w3DGzv43FkrYtfSkvpDdO4EvDL8bWX1Ad7mBoNVLWErcNf\/uI+r\/jFpKHgjvx3iqs2Q7vcfY706Py1m91vT0vs4SWXwzVV6pAVjD\/kumL+nXfzfzAHw+A2vb6J2w06Rj71bqUkC2b8TpQIDAQAB"
+            ]
+          }],
+          "name": "Test iPhone",
+          "platform": "IOS",
+          "version": "8.1.3"
+        },
+        "_links": {
+          "verify": {
+            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors\/opfhw7v2OnxKpftO40g3\/verify",
+            "hints": {
+              "allow": [
+                "POST"
+              ]
+            }
+          }
+        }
+      }]
+    },
+    "_links": {
+      "cancel": {
+        "href": "https:\/\/foo.com\/api\/v1\/authn\/cancel",
+        "hints": {
+          "allow": [
+            "POST"
+          ]
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
- Previously Okta Verify Push worked only if Okta Verify OTP was on the list. After this change that restriciton is removed

Resolves: OKTA-207556

Only Okta Push:
![ovpushonly](https://user-images.githubusercontent.com/6979296/53209876-c41a6c80-35f0-11e9-94a6-ef3f9afa52dd.gif)
