### PR TITLE
Adding tooltip to identifier first widget

### DIFF
--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -36,6 +36,10 @@ define([
         placeholder: Okta.loc('primaryauth.username.placeholder', 'login'),
         disabled: false,
         params: {
+          innerTooltip: {
+            title: Okta.loc('primaryauth.username.placeholder', 'login'),
+            text: Okta.loc('primaryauth.username.tooltip', 'login')
+          },
           icon: 'person-16-gray'
         }
       };

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -330,6 +330,12 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           expect(cb.length).toBe(0);
         });
       });
+      itp('uses default for username tooltip', function () {
+        return setup().then(function (test) {
+          var tip = test.form.usernameTooltipText();
+          expect(tip).toEqual('Username');
+        });
+      });
       itp('has "Need help?" link', function () {
         return setup().then(function (test) {
           expect(test.form.helpFooterLabel().trim()).toBe('Need help signing in?');


### PR DESCRIPTION
Resolves: OKTA-205616

Adding tooltip to username field. Password field tooltip already exists

<img width="459" alt="username" src="https://user-images.githubusercontent.com/26014510/53265703-c41f7880-3693-11e9-9015-056ba1ec30ca.png">
<img width="453" alt="password" src="https://user-images.githubusercontent.com/26014510/53265709-c5e93c00-3693-11e9-8a71-84c7ef1c387a.png">

@okta/idx 