### PR TITLE
feat: Adds afterError events for OAUTH_ERROR and REGISTRATION_FAILED

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ signIn.renderEl(
 
   function error(err) {
     // This function is invoked with errors the widget cannot recover from:
-    // Known errors: CONFIG_ERROR, UNSUPPORTED_BROWSER_ERROR, OAUTH_ERROR, REGISTRATION_FAILED
+    // Known errors: CONFIG_ERROR, UNSUPPORTED_BROWSER_ERROR
   }
 );
 ```
@@ -1346,7 +1346,7 @@ signIn.on('ready', function (context) {
 
 ### afterError
 
-The widget will handle most types of errors - for example, if the user enters an invalid password or there are issues authenticating. To capture an authentication state change error after it is handled and rendered by the Widget, listen to the `afterError` event. For other error types, it is encouraged to handle them using the [`renderEl` error handler](#renderel).
+The widget will handle most types of errors - for example, if the user enters an invalid password or there are issues authenticating. To capture an authentication state change error after it is handled and rendered by the Widget, listen to the `afterError` event. You can also capture OAuth and registration errors. For other error types, it is encouraged to handle them using the [`renderEl` error handler](#renderel).
 
 Returns `context` and `error` objects containing the following properties:
 

--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -44,10 +44,12 @@ function (Okta, PrimaryAuthController, PrimaryAuthModel, IDPDiscoveryForm, IDPDi
       // If social auth is configured, 'socialAuthPositionTop' will determine
       // the order in which the social auth and primary auth are shown on the screen.
       if (options.settings.get('hasConfiguredButtons')) {
-        // CustomButtons needs current controller as parameter
         this.add(CustomButtons, {
           prepend: options.settings.get('socialAuthPositionTop'),
-          options: { currentController: this }
+          options: {
+            // To trigger an afterError event, we require the current controller
+            currentController: this
+          }
         });
       }
 

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -51,7 +51,10 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
         // CustomButtons needs current controller as parameter
         this.add(CustomButtons, {
           prepend: options.settings.get('socialAuthPositionTop'),
-          options: { currentController: this }
+          options: {
+            // To trigger an afterError event, we require the current controller
+            currentController: this
+          }
         });
       }
 

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -48,7 +48,6 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
       // If social auth is configured, 'socialAuthPositionTop' will determine
       // the order in which the social auth and primary auth are shown on the screen.
       if (options.settings.get('hasConfiguredButtons')) {
-        // CustomButtons needs current controller as parameter
         this.add(CustomButtons, {
           prepend: options.settings.get('socialAuthPositionTop'),
           options: {

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -160,7 +160,7 @@ function (
       });
 
       //throw registration error
-      var errMsg = error.callback? error.callback+':'+ error.errorSummary: error.errorSummary;
+      var errMsg = error.callback ? error.callback + ':' + error.errorSummary : error.errorSummary;
       Util.triggerAfterError(this, new Errors.RegistrationError(errMsg));
 
       if (hideRegisterButton) {

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -17,7 +17,8 @@ define([
   'util/Enums',
   'util/RegistrationFormFactory',
   'views/registration/SubSchema',
-  'util/Errors'
+  'util/Errors',
+  'util/Util'
 ],
 function (
   Okta,
@@ -27,7 +28,8 @@ function (
   Enums,
   RegistrationFormFactory,
   SubSchema,
-  Errors
+  Errors,
+  Util
 ) {
 
   var { _, Backbone } = Okta;
@@ -110,7 +112,7 @@ function (
         var responseJSON = err.responseJSON;
         if (responseJSON && responseJSON.errorCauses.length) {
           var errMsg = responseJSON.errorCauses[0].errorSummary;
-          self.settings.callGlobalError(new Errors.RegistrationError(errMsg));
+          Util.triggerAfterError(self, new Errors.RegistrationError(errMsg));
         }
       });
     },
@@ -157,9 +159,9 @@ function (
         responseJSON: error
       });
 
-      //throw global error
+      //throw registration error
       var errMsg = error.callback? error.callback+':'+ error.errorSummary: error.errorSummary;
-      this.settings.callGlobalError(new Errors.RegistrationError(errMsg));
+      Util.triggerAfterError(this, new Errors.RegistrationError(errMsg));
 
       if (hideRegisterButton) {
         this.$el.find('.button-primary').hide();

--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', './Enums', './Errors'], function (Okta, Enums, Errors) {
+define(['okta', './Enums', './Errors', './Util'], function (Okta, Enums, Errors, Util) {
 
   var util = {};
   var _ = Okta._;
@@ -42,9 +42,8 @@ define(['okta', './Enums', './Errors'], function (Okta, Enums, Errors) {
       if (error.errorCode === 'access_denied') {
         controller.model.trigger('error', controller.model, {'responseJSON': error});
         controller.model.appState.trigger('removeLoading');
-      } else {
-        settings.callGlobalError(new Errors.OAuthError(error.message));
       }
+      Util.triggerAfterError(controller, new Errors.OAuthError(error.message), settings);
     }
 
     var authClient = settings.getAuthClient(),

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -146,7 +146,7 @@ define(['okta', './Logger', './Enums'], function (Okta, Logger, Enums) {
     var error = _.pick(err, 'name', 'message', 'statusCode', 'xhr');
     controller.trigger('afterError', { controller: className }, error);
     // Logs to console only in dev mode
-    Logger.info('controller: ' + className + ', error: ' + error);
+    Logger.warn('controller: ' + className + ', error: ' + error);
   };
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -145,6 +145,8 @@ define(['okta', './Logger', './Enums'], function (Okta, Logger, Enums) {
     var className = _.isFunction(controller.className) ? controller.className() : controller.className;
     var error = _.pick(err, 'name', 'message', 'statusCode', 'xhr');
     controller.trigger('afterError', { controller: className }, error);
+    // Logs to console only in dev mode
+    Logger.info('controller: ' + className + ', error: ' + error);
   };
 
   /**

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -35,6 +35,8 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
 
   var BEACON_LOADING_CLS = 'beacon-loading';
 
+  var OIDC_STATE = 'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg';
+
   function setup (settings, requests) {
     settings || (settings = {});
     settings['features.idpDiscovery'] = true;
@@ -50,6 +52,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     var baseUrl = 'https://foo.com';
     var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: WidgetUtil.transformErrorXHR, headers: {}});
     var successSpy = jasmine.createSpy('success');
+    var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
 
     var setNextWebfingerResponse = function (res, reject) {
       spyOn(authClient, 'webfinger').and.callFake(function () {
@@ -74,6 +77,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     var authContainer = new AuthContainer($sandbox);
     var form = new IDPDiscoveryForm($sandbox);
     var beacon = new Beacon($sandbox);
+    router.on('afterError', afterErrorHandler);
     router.idpDiscovery();
     Util.mockJqueryCss();
     return Expect.waitForIDPDiscovery({
@@ -84,13 +88,45 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
       ac: authClient,
       setNextResponse: setNextResponse,
       setNextWebfingerResponse: setNextWebfingerResponse,
-      successSpy: successSpy
+      successSpy: successSpy,
+      afterErrorHandler: afterErrorHandler
     });
+  }
+
+  function setupSocial (settings) {
+    Util.mockOIDCStateGenerator();
+    return setup(_.extend({
+      clientId: 'someClientId',
+      redirectUri: 'https://0.0.0.0:9999',
+      authScheme: 'OAUTH2',
+      authParams: {
+        responseType: 'id_token',
+        display: 'popup',
+        scopes: [
+          'openid',
+          'email',
+          'profile'
+        ]
+      },
+      idps: [
+        {
+          type: 'FACEBOOK',
+          id: '0oaidiw9udOSceD1234'
+        }
+      ]
+    }, settings))
+      .then(function (test) {
+        spyOn(window, 'open').and.callFake(function () {
+          test.oidcWindow = {closed: false, close: jasmine.createSpy()};
+          return test.oidcWindow;
+        });
+        return tick(test);
+      });
   }
 
   function setupPasswordlessAuth (requests) {
     return setup({ 'features.passwordlessAuth': true }, requests)
-      .then(function (test){
+      .then(function (test) {
         Util.mockRouterNavigate(test.router);
         test.setNextWebfingerResponse(resSuccessOktaIDP);
         test.setNextResponse(resPasswordlessUnauthenticated);
@@ -1324,21 +1360,21 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     });
     Expect.describe('Additional Auth Button', function () {
       itp('does not display custom buttons when it is undefined', function () {
-        return setupWithoutCustomButtonsAndWithIdp().then(function (test){
+        return setupWithoutCustomButtonsAndWithIdp().then(function (test) {
           expect(test.form.authDivider().length).toBe(1);
           expect(test.form.additionalAuthButton().length).toBe(0);
           expect(test.form.facebookButton().length).toBe(1);
         });
       });
       itp('does not display social auth/generic idp when idps is undefined', function () {
-        return setupWithCustomButtons().then(function (test){
+        return setupWithCustomButtons().then(function (test) {
           expect(test.form.authDivider().length).toBe(1);
           expect(test.form.additionalAuthButton().length).toBe(1);
           expect(test.form.facebookButton().length).toBe(0);
         });
       });
       itp('does not display any additional buttons when idps and customButtons are undefined', function () {
-        return setupWithoutCustomButtonsWithoutIdp().then(function (test){
+        return setupWithoutCustomButtonsWithoutIdp().then(function (test) {
           expect(test.form.authDivider().length).toBe(0);
           expect(test.form.additionalAuthButton().length).toBe(0);
           expect(test.form.facebookButton().length).toBe(0);
@@ -1357,24 +1393,24 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
         });
       });
       itp('sets text with property passed', function () {
-        return setupWithCustomButtons().then(function (test){
+        return setupWithCustomButtons().then(function (test) {
           expect(test.form.additionalAuthButton().text()).toEqual('test text');
         });
       });
       itp('sets class with property passed', function () {
-        return setupWithCustomButtons().then(function (test){
+        return setupWithCustomButtons().then(function (test) {
           expect(test.form.additionalAuthButton().hasClass('test-class')).toBe(true);
         });
       });
       itp('clickHandler is called when button is clicked', function () {
-        return setupWithCustomButtons().then(function (test){
+        return setupWithCustomButtons().then(function (test) {
           expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(false);
           test.form.additionalAuthButton().click();
           expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(true);
         });
       });
       itp('displays generic idp buttons', function () {
-        return setupWith({ genericIdp: true }).then(function (test){
+        return setupWith({ genericIdp: true }).then(function (test) {
           expect(test.form.authDivider()).toHaveLength(1);
           expect(test.form.additionalAuthButton()).toHaveLength(0);
           expect(test.form.facebookButton()).toHaveLength(0);
@@ -1383,7 +1419,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
         });
       });
       itp('displays generic idp and custom buttons', function () {
-        return setupWith({ genericIdp: true, customButtons: true }).then(function (test){
+        return setupWith({ genericIdp: true, customButtons: true }).then(function (test) {
           expect(test.form.authDivider()).toHaveLength(1);
           expect(test.form.additionalAuthButton()).toHaveLength(1);
           expect(test.form.facebookButton()).toHaveLength(0);
@@ -1392,7 +1428,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
         });
       });
       itp('displays generic idp and social auth buttons', function () {
-        return setupWith({ genericIdp: true, socialAuth: true }).then(function (test){
+        return setupWith({ genericIdp: true, socialAuth: true }).then(function (test) {
           expect(test.form.authDivider()).toHaveLength(1);
           expect(test.form.additionalAuthButton()).toHaveLength(0);
           expect(test.form.facebookButton()).toHaveLength(1);
@@ -1401,7 +1437,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
         });
       });
       itp('displays generic idp, custom buttons, and social auth buttons', function () {
-        return setupWith({ genericIdp: true, customButtons: true, socialAuth: true }).then(function (test){
+        return setupWith({ genericIdp: true, customButtons: true, socialAuth: true }).then(function (test) {
           expect(test.form.authDivider()).toHaveLength(1);
           expect(test.form.additionalAuthButton()).toHaveLength(1);
           expect(test.form.facebookButton()).toHaveLength(1);
@@ -1410,13 +1446,43 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
         });
       });
       itp('displays social auth and custom buttons', function () {
-        return setupWithCustomButtonsWithIdp().then(function (test){
+        return setupWithCustomButtonsWithIdp().then(function (test) {
           expect(test.form.authDivider()).toHaveLength(1);
           expect(test.form.additionalAuthButton()).toHaveLength(1);
           expect(test.form.facebookButton()).toHaveLength(1);
           expect(test.form.socialAuthButton('general-idp')).toHaveLength(0);
           expect(test.form.forgotPasswordLinkVisible()).toBe(false);
         });
+      });
+      itp('triggers the afterError event if there is no valid id token returned', function () {
+        spyOn(window, 'addEventListener');
+        return setupSocial()
+          .then(function (test) {
+            test.form.facebookButton().click();
+            var args = window.addEventListener.calls.argsFor(0);
+            var callback = args[1];
+            callback.call(null, {
+              origin: 'https://foo.com',
+              data: {
+                state: OIDC_STATE,
+                error: 'OAuth Error',
+                error_description: 'Message from server'
+              }
+            });
+            return tick(test);
+          })
+          .then(function (test) {
+            expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+              {
+                controller: 'idp-discovery'
+              },
+              {
+                name: 'OAUTH_ERROR',
+                message: 'Message from server'
+              }
+            ]);
+          });
       });
     });
   });

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -120,7 +120,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           test.oidcWindow = {closed: false, close: jasmine.createSpy()};
           return test.oidcWindow;
         });
-        return tick(test);
+        return test;
       });
   }
 
@@ -1469,7 +1469,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
                 error_description: 'Message from server'
               }
             });
-            return tick(test);
+            return Expect.waitForSpyCall(test.afterErrorHandler, test);
           })
           .then(function (test) {
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1128,9 +1128,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
           });
       });
       itp('calls the global error function if an idToken is not returned', function () {
-        var errorSpy = jasmine.createSpy('errorSpy');
-        return setupOAuth2({ globalErrorFn: errorSpy })
-          .then(function () {
+        return setupOAuth2()
+          .then(function (test) {
             var args = window.addEventListener.calls.argsFor(0);
             var callback = args[1];
             callback.call(null, {
@@ -1141,14 +1140,19 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
                 error_description: 'Invalid value for client_id parameter.'
               }
             });
-            return tick();
+            return tick(test);
           })
-          .then(function () {
-            expect(errorSpy.calls.count()).toBe(1);
-            var err = errorSpy.calls.argsFor(0)[0];
-            expect(err instanceof Errors.OAuthError).toBe(true);
-            expect(err.name).toBe('OAUTH_ERROR');
-            expect(err.message).toBe('Invalid value for client_id parameter.');
+          .then(function (test) {
+            expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+              {
+                controller: 'mfa-verify'
+              },
+              {
+                name: 'OAUTH_ERROR',
+                message: 'Invalid value for client_id parameter.'
+              }
+            ]);
           });
       });
     });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1127,7 +1127,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
             });
           });
       });
-      itp('calls the global error function if an idToken is not returned', function () {
+      itp('triggers the afterError event if an idToken is not returned', function () {
         return setupOAuth2()
           .then(function (test) {
             var args = window.addEventListener.calls.argsFor(0);

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1140,7 +1140,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil,
                 error_description: 'Invalid value for client_id parameter.'
               }
             });
-            return tick(test);
+            return Expect.waitForSpyCall(test.afterErrorHandler, test);
           })
           .then(function (test) {
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -2453,7 +2453,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
             expect(data[1].tokenType).toBe('Bearer');
           });
       });
-      itp('calls the global error function if there is no valid id token returned', function () {
+      itp('triggers the afterError event if there is no valid id token returned', function () {
         spyOn(window, 'addEventListener');
         return setupSocial()
           .then(function (test) {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -2454,9 +2454,8 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           });
       });
       itp('calls the global error function if there is no valid id token returned', function () {
-        var errorSpy = jasmine.createSpy('errorSpy');
         spyOn(window, 'addEventListener');
-        return setupSocial({ globalErrorFn: errorSpy })
+        return setupSocial()
           .then(function (test) {
             test.form.facebookButton().click();
             var args = window.addEventListener.calls.argsFor(0);
@@ -2469,14 +2468,19 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
                 error_description: 'Message from server'
               }
             });
-            return tick();
+            return tick(test);
           })
-          .then(function () {
-            expect(errorSpy.calls.count()).toBe(1);
-            var err = errorSpy.calls.argsFor(0)[0];
-            expect(err instanceof Errors.OAuthError).toBe(true);
-            expect(err.name).toBe('OAUTH_ERROR');
-            expect(err.message).toEqual('Message from server');
+          .then(function (test) {
+            expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+              {
+                controller: 'primary-auth'
+              },
+              {
+                name: 'OAUTH_ERROR',
+                message: 'Message from server'
+              }
+            ]);
           });
       });
       itp('ignores messages with the wrong origin', function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -165,7 +165,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           test.oidcWindow = {closed: false, close: jasmine.createSpy()};
           return test.oidcWindow;
         });
-        return tick(test);
+        return test;
       });
   }
 
@@ -2468,7 +2468,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
                 error_description: 'Message from server'
               }
             });
-            return tick(test);
+            return Expect.waitForSpyCall(test.afterErrorHandler, test);
           })
           .then(function (test) {
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -114,6 +114,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
     var baseUrl = 'https://foo.com';
     var authClient = new OktaAuth({url: baseUrl});
     var successSpy = jasmine.createSpy('success');
+    var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
@@ -124,6 +125,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
     var form = new RegForm($sandbox);
     var beacon = new Beacon($sandbox);
     Util.registerRouter(router);
+    router.on('afterError', afterErrorHandler);
     spyOn(RegSchema.prototype, 'fetch').and.callFake(function () {
       this.set(this.parse(testData));
       return $.Deferred().resolve();
@@ -135,7 +137,8 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
       form: form,
       beacon: beacon,
       ac: authClient,
-      setNextResponse: setNextResponse
+      setNextResponse: setNextResponse,
+      afterErrorHandler: afterErrorHandler
     });
   }
 
@@ -542,18 +545,30 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
     });
 
     var expectRegCallbackError = function (test, callback, message) {
-      var err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
-      expect(err instanceof Errors.RegistrationError).toBe(true);
-      expect(err.name).toBe('REGISTRATION_FAILED');
       var errMsg = callback+':'+ message;
-      expect(err.message).toEqual(errMsg);
+      expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+      expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+        {
+          controller: 'registration'
+        },
+        {
+          name: 'REGISTRATION_FAILED',
+          message: errMsg
+        }
+      ]);
     };
 
     var expectRegApiError = function (test, message) {
-      var err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
-      expect(err instanceof Errors.RegistrationError).toBe(true);
-      expect(err.name).toBe('REGISTRATION_FAILED');
-      expect(err.message).toEqual(message);
+      expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+      expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+        {
+          controller: 'registration'
+        },
+        {
+          name: 'REGISTRATION_FAILED',
+          message: message
+        }
+      ]);
     };
     Expect.describe('Registration callback hooks', function () {
       var DEFAULT_CALLBACK_ERROR = 'We could not process your registration at this time. Please try again later.';

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -831,7 +831,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
             expectRegCallbackError(test, 'preSubmit', DEFAULT_CALLBACK_ERROR);
           });
       });
-      itp('calls globalError when registration API throws an error ', function () {
+      itp('triggers the afterError event when registration API throws an error', function () {
         var parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
         var preSubmitSpy = jasmine.createSpy('preSubmitSpy');
         var postSubmitSpy = jasmine.createSpy('postSubmitSpy');


### PR DESCRIPTION
### Description

- Remove global error handler for OAUTH_ERROR and REGISTRATION_FAILED in favor of afterError events

**Note:** This PR contains mostly breaking changes, this is why it’s a draft PR. Will be merged on the release of okta-signing-widget 3.0.

### Reviewers

@haishengwu-okta @jmelberg-okta @robertjd @nbarbettini 