### PR TITLE
fix: change polling to 4 seconds

### DIFF
--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -23,7 +23,7 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
 
   // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
   // in network connection lost errors in Safari and IE.
-  var PUSH_INTERVAL = 6000;
+  var PUSH_INTERVAL = 4000;
 
   var Factor = BaseLoginModel.extend({
     extraProperties: true,

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -21,8 +21,8 @@ define([
 function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
   var _ = Okta._;
 
-  // Note: Keep-alive is set to 5 seconds - using 5 seconds here will result
-  // in network connection lost errors in Safari and IE.
+  // Avoid setting interval to same value as keep-alive time (5 seconds) because it
+  // caused an occasional issue with network connection lost errors in Safari and IE
   var PUSH_INTERVAL = 4000;
 
   var Factor = BaseLoginModel.extend({

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -2496,7 +2496,7 @@ function (Okta,
                 });
               });
             });
-            itp('starts poll after a delay of 6000ms', function () {
+            itp('starts poll after a delay of 4000ms', function () {
               var callAfterTimeoutStub;
               return setupOktaPush()
                 .then(function (test) {
@@ -2517,7 +2517,7 @@ function (Okta,
                   return Expect.waitForSpyCall(LoginUtil.callAfterTimeout, test);
                 })
                 .then(function (test) {
-                  expect(LoginUtil.callAfterTimeout.calls.argsFor(0)[1]).toBe(6000);
+                  expect(LoginUtil.callAfterTimeout.calls.argsFor(0)[1]).toBe(4000);
                   expect(test.router.controller.model.appState.get('transaction').status).toBe('MFA_CHALLENGE');
                   var transaction = test.router.controller.model.appState.get('transaction');
                   spyOn(transaction, 'poll');
@@ -2527,10 +2527,10 @@ function (Okta,
                 })
                 .then(function (transaction) {
                   expect(transaction.poll.calls.count()).toBe(1);
-                  expect(transaction.poll).toHaveBeenCalledWith({delay: 6000});
+                  expect(transaction.poll).toHaveBeenCalledWith({delay: 4000});
                 });
             });
-            itp('does not start poll if factor was switched before 6000ms', function () {
+            itp('does not start polling if factor was switched before the initial poll delay', function () {
               return setupOktaPushWithTOTP().then(function (test) {
                 spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
                   // reducing the timeout to 100 so that test is fast.


### PR DESCRIPTION
It has been reported that Okta Verify Push takes too long to update it's status, so changing the poll interval to 4 sec (2 seconds less than current interval)