### PR TITLE
Replace Okta.Handlebars.compile by Okta.tpl.

### DIFF
--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -26,7 +26,6 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
 
   var _ = Okta._;
   var $ = Okta.$;
-  var compile = Okta.Handlebars.compile;
 
   var DEFAULT_APP_LOGO = '/img/logos/default.png';
   var USER_NOT_SEEN_ON_DEVICE = '/img/security/unknown.png';
@@ -36,7 +35,7 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
   var UNDEFINED_USER_IMAGE_DESCRIPTION = '';
   var UNKNOWN_IMAGE_DESCRIPTION = '';
 
-  var securityImageUrlTpl = compile('{{baseUrl}}/login/getimage?username={{username}}');
+  var securityImageUrlTpl = Okta.tpl('{{baseUrl}}/login/getimage?username={{username}}');
 
   function getSecurityImage (baseUrl, username, deviceFingerprint) {
     // When the username is empty, we want to show the default image.

--- a/src/views/enroll-factors/PhoneTextBox.js
+++ b/src/views/enroll-factors/PhoneTextBox.js
@@ -20,7 +20,7 @@ function (Okta, ) {
 
   return TextBox.extend({
 
-    template: Okta.Handlebars.compile('\
+    template: Okta.tpl('\
       <span class="okta-form-label-inline o-form-label-inline">{{countryCallingCode}}</span>\
       <span class="okta-form-input-field input-fix o-form-control">\
         <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" \

--- a/src/views/mfa-verify/PassCodeForm.js
+++ b/src/views/mfa-verify/PassCodeForm.js
@@ -17,7 +17,7 @@ define([
   'util/Enums'
 ], function (Okta, Q, TextBox, Enums) {
 
-  var subtitleTpl = Okta.Handlebars.compile('({{subtitle}})');
+  var subtitleTpl = Okta.tpl('({{subtitle}})');
   var _ = Okta._;
   var warningTemplate = '<div class="okta-form-infobox-warning infobox infobox-warning login-timeout-warning">\
                            <span class="icon warning-16"></span>\

--- a/src/views/mfa-verify/PushForm.js
+++ b/src/views/mfa-verify/PushForm.js
@@ -20,7 +20,7 @@ function (Okta, CookieUtil, Util, NumberChallengeView) {
 
   var _ = Okta._;
   // deviceName is escaped on BaseForm (see BaseForm's template)
-  var titleTpl = Okta.Handlebars.compile('{{factorName}} ({{{deviceName}}})');
+  var titleTpl = Okta.tpl('{{factorName}} ({{{deviceName}}})');
   var WARNING_TIMEOUT = 30000; //milliseconds
   var warningTemplate = '<div class="okta-form-infobox-warning infobox infobox-warning">\
                            <span class="icon warning-16"></span>\

--- a/src/views/mfa-verify/dropdown/FactorsDropDownOptions.js
+++ b/src/views/mfa-verify/dropdown/FactorsDropDownOptions.js
@@ -16,7 +16,7 @@ define(['okta', 'util/RouterUtil'], function (Okta, RouterUtil) {
   var _ = Okta._;
 
   // deviceName is escaped on BaseForm (see BaseForm's template)
-  var pushTitleTpl = Okta.Handlebars.compile('{{factorName}} ({{{deviceName}}})');
+  var pushTitleTpl = Okta.tpl('{{factorName}} ({{{deviceName}}})');
   var action = function (model) {
 
     var factorIndex;

--- a/src/views/shared/Footer.js
+++ b/src/views/shared/Footer.js
@@ -16,7 +16,6 @@ define([
 function (Okta) {
 
   var { Util } = Okta.internal.util;
-  var compile = Okta.Handlebars.compile;
   var _ = Okta._;
 
   return Okta.View.extend({
@@ -66,7 +65,7 @@ function (Okta) {
       if (customHelpPage) {
         helpLinkUrl = customHelpPage;
       } else {
-        helpLinkUrl = compile('{{baseUrl}}/help/login')({baseUrl: this.settings.get('baseUrl')});
+        helpLinkUrl = Okta.tpl('{{baseUrl}}/help/login')({baseUrl: this.settings.get('baseUrl')});
       }
       return _.extend(this.settings.toJSON({verbose: true}), {helpLinkUrl: helpLinkUrl});
     },


### PR DESCRIPTION
- `Okta.tpl` is sort of able to 'cache' compiled template. ([more details](https://github.com/okta/okta-ui/blob/master/packages/courage/src/util/TemplateUtil.js#L15))
- also better encapsulation.