### PR TITLE
refactor: Unifies two css files into single one

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,11 +229,6 @@ module.exports = function (grunt) {
         files: {
           'target/css/okta-sign-in.css': SASS + '/okta-sign-in.scss'
         }
-      },
-      buildtheme: {
-        files: {
-          'target/css/okta-theme.css': SASS + '/okta-theme.scss'
-        }
       }
     },
     postcss: {
@@ -247,9 +242,6 @@ module.exports = function (grunt) {
       },
       build: {
         src: 'target/css/okta-sign-in.css'
-      },
-      buildtheme: {
-        src: 'target/css/okta-theme.css'
       },
       minify: {
         options: {
@@ -325,8 +317,6 @@ module.exports = function (grunt) {
       'exec:generate-config',
       'copy:app-to-target',
       'exec:generate-jsonp',
-      'sass:buildtheme',
-      'postcss:buildtheme',
       'sass:build',
       ...buildTasks,
       ...postBuildTasks,

--- a/README.md
+++ b/README.md
@@ -90,12 +90,6 @@ To use the CDN, include links to the JS and CSS files in your HTML:
   href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.14.0/css/okta-sign-in.min.css"
   type="text/css"
   rel="stylesheet"/>
-
-<!-- Theme file: Customize or replace this file if you want to override our default styles -->
-<link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.14.0/css/okta-theme.css"
-  type="text/css"
-  rel="stylesheet"/>
 ```
 
 ### Using the npm module
@@ -125,10 +119,7 @@ node_modules/@okta/okta-signin-widget/dist/
 │   │   # Main CSS file for widget styles. Try not to override the classes in this
 │   │   # file when creating a custom theme - the classes/elements are subject to
 │   │   # change between releases
-│   ├── okta-sign-in.min.css
-│   │
-│   │   # Example theme that you can use as a template to create your own custom theme
-│   └── okta-theme.css
+│   └── okta-sign-in.min.css
 │
 │   # Base font and image files that are used in rendering the widget
 ├── font/

--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -9,6 +9,7 @@
 @import 'container';
 @import 'modules/okta-footer';
 @import 'ie';
+@import 'okta-theme';
 
 /* Layout */
 .login-bg-image {

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -1,6 +1,4 @@
 /* stylelint-disable selector-max-id */
-@import 'variables';
-@import 'helpers';
 
 @mixin light-button-template($bg-color) {
   @include button-template($bg-color, 1%, $dark-text-color, 22%, 25%);

--- a/playground/index.html
+++ b/playground/index.html
@@ -6,7 +6,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="css/okta-sign-in.css" type="text/css" rel="stylesheet"/>
-  <link href="css/okta-theme.css" type="text/css" rel="stylesheet"/>
 </head>
 
 <body>

--- a/test/e2e/angular-app/.angular-cli.json
+++ b/test/e2e/angular-app/.angular-cli.json
@@ -20,8 +20,7 @@
       "prefix": "app",
       "styles": [
         "styles.css",
-        "../node_modules/@okta/okta-signin-widget/dist/css/okta-sign-in.min.css",
-        "../node_modules/@okta/okta-signin-widget/dist/css/okta-theme.css"
+        "../node_modules/@okta/okta-signin-widget/dist/css/okta-sign-in.min.css"
       ],
       "scripts": [],
       "environmentSource": "environments/environment.ts",

--- a/test/e2e/layouts/cdn-dev.tpl
+++ b/test/e2e/layouts/cdn-dev.tpl
@@ -6,7 +6,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="css/okta-sign-in.css" type="text/css" rel="stylesheet"/>
-  <link href="css/okta-theme.css" type="text/css" rel="stylesheet"/>
   <script src="js/okta-sign-in.js"></script>
 </head>
 

--- a/test/e2e/layouts/cdn.tpl
+++ b/test/e2e/layouts/cdn.tpl
@@ -6,7 +6,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="css/okta-sign-in.css" type="text/css" rel="stylesheet"/>
-  <link href="css/okta-theme.css" type="text/css" rel="stylesheet"/>
   <script src="js/okta-sign-in.min.js"></script>
 </head>
 

--- a/test/e2e/layouts/npm.tpl
+++ b/test/e2e/layouts/npm.tpl
@@ -6,7 +6,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link href="css/okta-sign-in.css" type="text/css" rel="stylesheet"/>
-  <link href="css/okta-theme.css" type="text/css" rel="stylesheet"/>
 </head>
 
 <body>

--- a/test/e2e/react-app/src/OktaSignInWidget.js
+++ b/test/e2e/react-app/src/OktaSignInWidget.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import OktaSignIn from '@okta/okta-signin-widget';
 import '@okta/okta-signin-widget/dist/css/okta-sign-in.min.css';
-import '@okta/okta-signin-widget/dist/css/okta-theme.css';
 
 export default class OktaSignInWidget extends Component {
   componentDidMount() {


### PR DESCRIPTION
### Description

- Unifies _okta-sign-in.css_ and _okta-theme.css_ into only _okta-sign-in.css_

**Note:** this will go in _okta-signin-widget v3.0.0_ so it should be ok to make this breaking change

**Question:** Should we add a migration strategy in the README or it should go in the CHANGELOG/Release Notes? @nbarbettini 

### Screenshots

**BEFORE:**
<img width="1355" alt="Screen Shot 2019-03-11 at 2 49 59 PM" src="https://user-images.githubusercontent.com/19613940/54161488-80589d00-440f-11e9-800c-ab7ddea6cb88.png">

**AFTER:**
<img width="1349" alt="Screen Shot 2019-03-11 at 2 48 24 PM" src="https://user-images.githubusercontent.com/19613940/54161492-864e7e00-440f-11e9-8fe3-d3cde07a2b00.png">

### Reviewers
@haishengwu-okta @robertjd @nbarbettini 

### Additional Reviewers
@eugenebakaiev-okta 
