### PR TITLE
:fix Do not compute device fingerprint when security image is off

### DIFF
--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -80,8 +80,7 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
 
     events: {
       'focusout input[name=username]': function () {
-        if (this.settings.get('features.deviceFingerprinting') &&
-            this.settings.get('features.useDeviceFingerprintForSecurityImage')) {
+        if (this.shouldComputeDeviceFingerprint()) {
           var self = this;
           DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
             .then(function (fingerprint) {
@@ -124,6 +123,12 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
       this.listenTo(this.model, 'error', function () {
         this.state.set('enabled', true);
       });
+    },
+
+    shouldComputeDeviceFingerprint: function () {
+      return this.settings.get('features.securityImage') &&
+          this.settings.get('features.deviceFingerprinting') &&
+          this.settings.get('features.useDeviceFingerprintForSecurityImage');
     }
   });
 

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -594,6 +594,21 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     });
 
     Expect.describe('Device Fingerprint', function () {
+      itp(`is not computed if securityImage is off, deviceFingerprinting is
+        true and useDeviceFingerprintForSecurityImage is true`, function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
+        return setup({ features: { securityImage: false, deviceFingerprinting: true,
+          useDeviceFingerprintForSecurityImage: true}})
+          .then(function (test) {
+            test.setNextResponse(resSecurityImage);
+            test.form.setUsername('testuser@clouditude.net');
+            return waitForBeaconChange(test);
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(0);
+            expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
+          });
+      });
       itp(`contains fingerprint header in get security image request if deviceFingerprinting
         is true (useDeviceFingerprintForSecurityImage defaults to true)`, function () {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -985,6 +985,21 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
     });
 
     Expect.describe('Device Fingerprint', function () {
+      itp(`is not computed if securityImage is off, deviceFingerprinting is true
+        and useDeviceFingerprintForSecurityImage is true`, function () {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
+        return setup({ features: { securityImage: false, deviceFingerprinting: true,
+          useDeviceFingerprintForSecurityImage: true }})
+          .then(function (test) {
+            test.setNextResponse(resSecurityImage);
+            test.form.setUsername('testuser');
+            return waitForBeaconChange(test);
+          })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(0);
+            expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
+          });
+      });
       itp(`contains fingerprint header in get security image request if deviceFingerprinting
         is true (useDeviceFingerprintForSecurityImage defaults to true)`, function () {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
@@ -992,8 +1007,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
-        return setup({ features: { securityImage: true, deviceFingerprinting: true,
-          useDeviceFingerprintForSecurityImage: true }})
+        return setup({ features: { securityImage: true, deviceFingerprinting: true }})
           .then(function (test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
@@ -1006,7 +1020,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
             expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
           });
       });
-      itp(`contains fingerprint header in get security image request if both features(
+      itp(`contains fingerprint header in get security image request if both features
         deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`, function () {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
           var deferred = Q.defer();


### PR DESCRIPTION
* When user tabs out after typing username, we should not compute device fingerprint
if sec image feature is off.

OKTA-218737

**BEfore** 
<img width="1514" alt="Screen Shot 2019-04-02 at 7 47 06 AM" src="https://user-images.githubusercontent.com/17267130/55419322-4fa8e680-5529-11e9-9658-335e1ec51b9e.png">

**After** 
<img width="1158" alt="Screen Shot 2019-04-02 at 7 49 58 AM" src="https://user-images.githubusercontent.com/17267130/55419294-461f7e80-5529-11e9-96eb-6c8852b4b5ec.png">

![secdev](https://user-images.githubusercontent.com/17267130/55419265-3b64e980-5529-11e9-9b2d-ff340a97093e.gif)
