### PR TITLE
Fix security image loading issue for logins with "+" symbols in them

### DIFF
--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -39,6 +39,8 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
   var securityImageUrlTpl = compile('{{baseUrl}}/login/getimage?username={{username}}');
 
   function getSecurityImage (baseUrl, username, deviceFingerprint) {
+    // Reserved characters in the username must be escaped before the query can be safely executed
+    username = encodeURIComponent(username);
     var url = securityImageUrlTpl({ baseUrl: baseUrl, username: username });
 
     // When the username is empty, we want to show the default image.

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -559,7 +559,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             expect(test.router.settings.transformUsername.calls.count()).toBe(0);
             expect($.ajax.calls.count()).toBe(1);
             expect($.ajax.calls.argsFor(0)[0]).toEqual({
-              url: 'https://foo.com/login/getimage?username=testuser@clouditude.net',
+              url: 'https://foo.com/login/getimage?username=testuser%40clouditude.net',
               dataType: 'json'
             });
           });
@@ -799,7 +799,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
             expect($.ajax.calls.argsFor(0)[0]).toEqual({
-              url: 'https://foo.com/login/getimage?username=testuser@clouditude.net',
+              url: 'https://foo.com/login/getimage?username=testuser%40clouditude.net',
               dataType: 'json'
             });
             expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1347,13 +1347,14 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
         return setup({ features: { securityImage: true }})
           .then(function (test) {
             test.setNextResponse(resSecurityImage);
-            test.form.setUsername('testuser');
+            test.form.setUsername('test+user');
             return waitForBeaconChange(test);
           })
           .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
             expect($.ajax.calls.argsFor(0)[0]).toEqual({
-              url: 'https://foo.com/login/getimage?username=testuser',
+              // reserved characters in the username (like "+") should be escaped, since it's in the query
+              url: 'https://foo.com/login/getimage?username=test%2Buser',
               dataType: 'json'
             });
             expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');


### PR DESCRIPTION
### Description

- Since username is in the query string when we hit the endpoint to fetch the security image upon login (`/login/getImage?username=`), we were not properly retrieving images for users with a "+" in their username because the symbol was being interpreted as a space. This PR properly escapes "+" symbols in the username.
- Resolves [OKTA-210776](https://oktainc.atlassian.net/browse/OKTA-210776)

### Reviewers

@haishengwu-okta @okta/idx 