### PR TITLE
chore: Upgrades okta-auth-js to v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "prepublish": "yarn build:release"
   },
   "devDependencies": {
+    "@okta/okta-auth-js": "~2.4.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "6.7.7",
     "axe-core": "2.0.7",
@@ -65,6 +66,7 @@
     "babel-plugin-istanbul": "^5.0.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
+    "backbone": "1.2.1",
     "cssnano": "^4.1.7",
     "eslint": "^5.9.0",
     "fs-extra": "^7.0.1",
@@ -107,8 +109,6 @@
     "webdriver-manager": "12.0.6",
     "webpack": "^3.5.4",
     "webpack-bundle-analyzer": "^3.0.2",
-    "@okta/okta-auth-js": "~2.3.1",
-    "backbone": "1.2.1",
     "webpack-dev-server": "2.11.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,9 +198,9 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@okta/okta-auth-js@~2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.3.1.tgz#17c6190ab6cb30d0c1f02715538c7e0b5a70fec1"
+"@okta/okta-auth-js@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.4.0.tgz#f2dcee4c7638c2400d180b74bb994ecf78547334"
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"


### PR DESCRIPTION
### Description

Need to upgrade again okta-auth-js to 2.4 in order to include https://github.com/okta/okta-auth-js/commit/dde3dfb5e69cd0f58fa57416f7d2dddec660066f (“backported” from 17.1), since widget is already using that change injected in 17.1 and relative new tests have been added.

### Reviewers

@haishengwu-okta

### Additional Reviewers

@antonshyltsev-okta 
