### PR TITLE
fix: disables submit button when submitting change password form

### DIFF
--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -36,6 +36,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
         return ValidationUtil.validatePasswordMatch(this);
       },
       save: function () {
+        this.trigger('save');
         return this.doTransaction(function (transaction) {
           return transaction.changePassword({
             oldPassword: this.get('oldPassword'),

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -286,6 +286,35 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
             });
           });
       });
+      itp('makes submit button disable when form is submitted', function () {
+        return setup()
+          .then(function (test) {
+            $.ajax.calls.reset();
+            test.setNextResponse(resSuccess);
+            submitNewPass(test, 'oldpass', 'newpass', 'newpass');
+            return Expect.waitForSpyCall(test.successSpy, test);
+          })
+          .then(function (test) {
+            var button = test.form.submitButton();
+            var buttonClass = button.attr('class');
+            expect(buttonClass).toContain('link-button-disabled');
+          });
+      });
+      itp('makes submit button enabled after error response', function () {
+        return setup()
+          .then(function (test) {
+            $.ajax.calls.reset();
+            test.setNextResponse(resErrorOldPass);
+            submitNewPass(test, 'wrongoldpass', 'boo', 'boo');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            var button = test.form.submitButton();
+            var buttonClass = button.attr('class');
+            expect(buttonClass).not.toContain('link-button-disabled');
+          });
+      });
       itp('shows an error if the server returns a wrong old pass error', function () {
         return setup()
           .then(function (test) {


### PR DESCRIPTION
- Similar to [reset password](https://github.com/okta/okta-signin-widget/blob/master/src/PasswordResetController.js#L36-L45), we now disable "Change password" when the user clicks on the button
- Taking over from https://github.com/okta/okta-signin-widget/pull/663, which was intended to fix the same thing

Resolves: OKTA-207909

![changepassword-disableAfterSubmit](https://user-images.githubusercontent.com/6979296/56004039-1b969980-5c7e-11e9-910c-f319b8dbb4dc.gif)
