### PR TITLE
chore: Upgrade okta-auth-js in okta-signin-widget 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prepublish": "yarn build:release"
   },
   "devDependencies": {
-    "@okta/okta-auth-js": "~2.4.0",
+    "@okta/okta-auth-js": "~2.5.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "6.7.7",
     "axe-core": "2.0.7",

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -61,12 +61,11 @@ define(['okta', './Logger', './Enums'], function (Okta, Logger, Enums) {
       return xhr;
     }
     if (!xhr.responseJSON) {
-      try {
-        xhr.responseJSON = JSON.parse(xhr.responseText);
-      } catch (parseException) {
+      if (!xhr.responseText) {
         xhr.responseJSON = { errorSummary: Okta.loc('oform.error.unexpected', 'login') };
         return xhr;
       }
+      xhr.responseJSON = xhr.responseText;
     }
     // Temporary solution to display field errors
     // Assuming there is only one field error in a response

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -95,7 +95,7 @@ var OktaSignIn = (function () {
   function OktaSignIn (options) {
     require('okta');
 
-    var OktaAuth = require('@okta/okta-auth-js/jquery');
+    var OktaAuth = require('@okta/okta-auth-js');
     var Util = require('util/Util');
     var LoginRouter = require('LoginRouter');
 

--- a/test/unit/helpers/xhr/ERROR_VALID_RESPONSE.js
+++ b/test/unit/helpers/xhr/ERROR_VALID_RESPONSE.js
@@ -1,0 +1,5 @@
+define({
+  status: 401,
+  responseType: 'text',
+  response: { errorCode :"E0000004", errorSummary :"Authentication failed", errorLink :"E0000004", errorId :"oaeDtg9knyJR7agwMN-70SYgw", errorCauses:[]}
+});

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1920,36 +1920,6 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
             expectErrorEvent(test, 429, 'API call exceeded rate limit due to too many requests.');
           });
       });
-      itp('shows an error if authClient returns with an error that is plain text', function () {
-        return setup()
-          .then(function (test) {
-            test.setNextResponse(resNonJson, true);
-            test.form.setUsername('testuser');
-            test.form.setPassword('invalidpass');
-            test.form.submit();
-            return Expect.waitForFormError(test.form, test);
-          })
-          .then(function (test) {
-            expect(test.form.hasErrors()).toBe(true);
-            expect(test.form.errorMessage()).toBe('Sign in failed!');
-            expectErrorEvent(test, 401, 'Authentication failed');
-          });
-      });
-      itp('shows an error if authClient returns with an error that is plain text and not a valid json', function () {
-        return setup()
-          .then(function (test) {
-            test.form.setUsername('testuser');
-            test.form.setPassword('invalidpass');
-            test.setNextResponse(resInvalidText, true);
-            test.form.submit();
-            return Expect.waitForFormError(test.form, test);
-          })
-          .then(function (test) {
-            expect(test.form.hasErrors()).toBe(true);
-            expect(test.form.errorMessage()).toBe('There was an unexpected internal error. Please try again.');
-            expectErrorEvent(test, 401, 'Unknown error');
-          });
-      });
       itp('shows an error if authClient returns with LOCKED_OUT response and selfServiceUnlock is off', function () {
         return setup()
           .then(function (test) {

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -26,7 +26,7 @@ define([
         expect(xhr.responseJSON.errorSummary).toEqual('There was an unexpected internal error. Please try again.');
       });
       it('errorSummary is set from responseText when there is no responseJSON', function () {
-        var responseText = '{"errorSummary": "errorSummary from responseText"}';
+        var responseText = { errorSummary: 'errorSummary from responseText' };
         var xhr = {
           'status': 400,
           'responseText': responseText

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,9 +198,9 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@okta/okta-auth-js@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.4.0.tgz#f2dcee4c7638c2400d180b74bb994ecf78547334"
+"@okta/okta-auth-js@~2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.5.0.tgz#04ca8e5bb5c6ccbf97b3b2ad36264aca4aa220cc"
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"


### PR DESCRIPTION
### Description

- Upgrade okta-auth-js in okta-signin-widget 3.0
- Use cross-fetch auth-js version instead of jquery one

**Note:** Will go in okta-signin-widget v3.0.0.

### Reviewers

@gowthamidommety-okta @robertdamphousse-okta 
