### PR TITLE
Runs e2e tests on chrome headless instead of saucelabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "start:angular": "yarn --cwd test/e2e/angular-app start & wait-on http-get://localhost:4200",
     "pretest:e2e": "yarn install:react && yarn install:angular && node pretest.js",
     "test:e2e": "yarn build:release && yarn start:react && yarn start:angular && grunt test-e2e",
-    "protractor": "webdriver-manager update && protractor target/e2e/conf.js",
+    "protractor": "webdriver-manager update --versions.standalone=3.141.59 --gecko false && protractor target/e2e/conf.js",
     "build:dev": "grunt build:dev",
     "build:release": "grunt build:release",
     "build:webpack-dev": "webpack --config webpack.dev.config.js",
@@ -104,7 +104,7 @@
     "stylelint-scss": "^3.4.0",
     "time-grunt": "^2.0.0",
     "wait-on": "2.0.2",
-    "webdriver-manager": "12.0.6",
+    "webdriver-manager": "^12.0.6",
     "webpack": "^3.5.4",
     "webpack-bundle-analyzer": "^3.0.2",
     "webpack-dev-server": "2.11.3"

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -17,24 +17,23 @@ var config = {
 
 // Travis sauceLabs tests
 if (process.env.TRAVIS) {
-  config.sauceUser = process.env.SAUCE_USERNAME;
-  config.sauceKey = process.env.SAUCE_ACCESS_KEY;
-
   // Mobile devices
   if (process.env.SAUCE_PLATFORM_NAME === 'iOS') {
     var appium = require('./appium/ios-conf.js');
+    config.sauceUser = process.env.SAUCE_USERNAME;
+    config.sauceKey = process.env.SAUCE_ACCESS_KEY;
     config.port = appium.port;
     config.multiCapabilities = appium.iosCapabilities;
   }
 
   // Desktop browsers
   else {
+    console.log('-- Using Chrome Headless --');
     config.capabilities = {
-      'browserName': process.env.SAUCE_BROWSER_NAME,
-      'version': process.env.SAUCE_BROWSER_VERSION,
-      'platform': process.env.SAUCE_PLATFORM,
-      'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
-      'build': process.env.TRAVIS_BUILD_NUMBER
+      'browserName': 'chrome',
+      'chromeOptions': {
+        'args': ['--headless','--disable-gpu','--window-size=1600x1200','--no-sandbox']
+      }
     };
   }
 }
@@ -44,10 +43,10 @@ if (process.env.TRAVIS) {
 // WIDGET_BASIC_USER
 // WIDGET_BASIC_PASSWORD
 else {
-  const webdriverManegerConfig = require('webdriver-manager/selenium/update-config.json');
+  const webdriverManagerConfig = require('webdriver-manager/selenium/update-config.json');
 
   config.directConnect = true;
-  config.chromeDriver = webdriverManegerConfig.chrome.last;
+  config.chromeDriver = webdriverManagerConfig.chrome.last;
   config.capabilities = {
     browserName: 'chrome',
   };


### PR DESCRIPTION
* We are constantly hitting the saucelabs VM limits for our license (https://oktainc.atlassian.net/browse/OKTA-224058)
* I noticed that we are running chrome browser e2e tests on saucelabs which can be done on travis headless chrome instead
* This change removes the saucelabs dependency for travis builds