### PR TITLE
feat: Updates inputs to use labels instead of placeholders

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -14,6 +14,7 @@ $font-size-default: 14px;
 
 // Font Weight
 $font-weight-body: normal;
+$font-weight-labels: 600;
 $font-weight-header: bold;
 
 // Theme Color

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -74,10 +74,15 @@
     color: $header-text-color;
   }
 
-  .okta-form-subtitle,
-  .okta-form-label {
+  .okta-form-subtitle {
     /* -- Fonts and Text Colors -- */
     color: $medium-text-color;
+  }
+
+  .okta-form-label {
+    /* -- Fonts and Text Colors -- */
+    font-weight: $font-weight-labels;
+    color: $dark-text-color;
   }
 
   .link {

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -171,6 +171,10 @@
     .margin-btm-30 {
       margin-bottom: 30px;
     }
+
+    .margin-top-30 {
+      margin-top: 30px;
+    }
   }
 
   .okta-sign-in-header {

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -158,6 +158,14 @@
         }
       }
     }
+
+    .margin-btm-5 {
+      margin-bottom: 5px;
+    }
+
+    .margin-btm-30 {
+      margin-bottom: 30px;
+    }
   }
 
   .okta-sign-in-header {

--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -197,7 +197,8 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
           options: CountryUtil.getCountries()
         }),
         FormType.Input({
-          placeholder: Okta.loc('mfa.phoneNumber.placeholder', 'login'),
+          label: Okta.loc('mfa.phoneNumber.placeholder', 'login'),
+          'label-top': true,
           className: numberFieldClassName,
           name: 'phoneNumber',
           input: PhoneTextBox,
@@ -212,7 +213,8 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
       ];
       if (isCall) {
         formChildren.push(FormType.Input({
-          placeholder: Okta.loc('mfa.phoneNumber.ext.placeholder', 'login'),
+          label: Okta.loc('mfa.phoneNumber.ext.placeholder', 'login'),
+          'label-top': true,
           className: 'enroll-call-extension',
           name: 'phoneExtension',
           input: TextBox,
@@ -253,7 +255,8 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
           showWhen: factorIdIsDefined
         }),
         FormType.Input({
-          placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
+          label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
+          'label-top': true,
           name: 'passCode',
           input: TextBox,
           type: 'tel',

--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -225,7 +225,7 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
         FormType.Button({
           title: formSubmit,
           attributes: { 'data-se': buttonClassName },
-          className: 'button button-primary js-enroll-phone ' + buttonClassName,
+          className: 'button button-primary js-enroll-phone margin-top-30 ' + buttonClassName,
           click: function () {
             this.model.sendCode();
           }
@@ -233,7 +233,7 @@ function (Okta, FormController, Footer, PhoneTextBox, TextBox, CountryUtil, Form
         FormType.Button({
           title: formRetry,
           attributes: { 'data-se': buttonClassName },
-          className: 'button js-enroll-phone ' + buttonClassName,
+          className: 'button js-enroll-phone margin-top-30 ' + buttonClassName,
           click: function () {
             this.model.resendCode();
           },

--- a/src/EnrollOnPremController.js
+++ b/src/EnrollOnPremController.js
@@ -84,19 +84,21 @@ function (Okta, FormType, FormController, Footer, TextBox) {
         },
         formChildren: [
           FormType.Input({
+            label: Okta.loc('enroll.onprem.username.placeholder', 'login', [vendorName]),
+            'label-top': true,
             name: 'credentialId',
             input: TextBox,
             type: 'text',
-            placeholder: Okta.loc('enroll.onprem.username.placeholder', 'login', [vendorName]),
             params: {
               innerTooltip: Okta.loc('enroll.onprem.username.tooltip', 'login', [_.escape(vendorName)])
             }
           }),
           FormType.Input({
+            label: Okta.loc('enroll.onprem.passcode.placeholder', 'login', [vendorName]),
+            'label-top': true,
             name: 'passCode',
             input: TextBox,
             type: 'password',
-            placeholder: Okta.loc('enroll.onprem.passcode.placeholder', 'login', [vendorName]),
             params: {
               innerTooltip: Okta.loc('enroll.onprem.passcode.tooltip', 'login', [_.escape(vendorName)])
             }

--- a/src/EnrollPasswordController.js
+++ b/src/EnrollPasswordController.js
@@ -53,18 +53,16 @@ function (Okta, FormController, ValidationUtil, Footer, TextBox) {
       inputs: function () {
         return [
           {
-            label: false,
+            label: Okta.loc('mfa.challenge.password.placeholder', 'login'),
             'label-top': true,
-            placeholder: Okta.loc('mfa.challenge.password.placeholder', 'login'),
             className: 'o-form-fieldset o-form-label-top auth-passcode',
             name: 'password',
             input: TextBox,
             type: 'password'
           },
           {
-            label: false,
+            label: Okta.loc('password.confirmPassword.placeholder', 'login'),
             'label-top': true,
-            placeholder: Okta.loc('password.confirmPassword.placeholder', 'login'),
             className: 'o-form-fieldset o-form-label-top auth-passcode',
             name: 'confirmPassword',
             input: TextBox,

--- a/src/EnrollQuestionController.js
+++ b/src/EnrollQuestionController.js
@@ -66,9 +66,8 @@ function (Okta, FormController, FactorUtil, Footer, TextBox) {
             }
           },
           {
-            label: false,
+            label: Okta.loc('mfa.challenge.answer.placeholder', 'login'),
             'label-top': true,
-            placeholder: Okta.loc('mfa.challenge.answer.placeholder', 'login'),
             className: 'o-form-fieldset o-form-label-top auth-passcode',
             name: 'answer',
             input: TextBox,

--- a/src/EnrollSymantecVipController.js
+++ b/src/EnrollSymantecVipController.js
@@ -54,28 +54,31 @@ function (Okta, FormType, FormController, Footer, TextBox) {
       formChildren: function () {
         return [
           FormType.Input({
+            label: Okta.loc('enroll.symantecVip.credentialId.placeholder', 'login'),
+            'label-top': true,
             name: 'credentialId',
             input: TextBox,
             type: 'text',
-            placeholder: Okta.loc('enroll.symantecVip.credentialId.placeholder', 'login'),
             params: {
               innerTooltip: Okta.loc('enroll.symantecVip.credentialId.tooltip', 'login')
             }
           }),
           FormType.Input({
+            label: Okta.loc('enroll.symantecVip.passcode1.placeholder', 'login'),
+            'label-top': true,
             name: 'passCode',
             input: TextBox,
             type: 'text',
-            placeholder: Okta.loc('enroll.symantecVip.passcode1.placeholder', 'login'),
             params: {
               innerTooltip: Okta.loc('enroll.symantecVip.passcode1.tooltip', 'login')
             }
           }),
           FormType.Input({
+            label: Okta.loc('enroll.symantecVip.passcode2.placeholder', 'login'),
+            'label-top': true,
             name: 'nextPassCode',
             input: TextBox,
             type: 'text',
-            placeholder: Okta.loc('enroll.symantecVip.passcode2.placeholder', 'login'),
             params: {
               innerTooltip: Okta.loc('enroll.symantecVip.passcode2.tooltip', 'login')
             }

--- a/src/ForgotPasswordController.js
+++ b/src/ForgotPasswordController.js
@@ -106,14 +106,15 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, Util, ContactSu
         }
         else {
           formChildren.push(FormType.Input({
-            placeholder: Okta.loc('password.forgot.email.or.username.placeholder', 'login'),
+            label: Okta.loc('password.forgot.email.or.username.placeholder', 'login'),
+            'label-top': true,
             name: 'username',
             input: TextBox,
+            inputId: 'account-recovery-username',
             type: 'text',
             inlineValidation: false,
             params: {
-              innerTooltip: Okta.loc('password.forgot.email.or.username.tooltip', 'login'),
-              icon: 'person-16-gray'
+              innerTooltip: Okta.loc('password.forgot.email.or.username.tooltip', 'login')
             }
           }));
           if (smsEnabled || callEnabled) {

--- a/src/ManualSetupPushController.js
+++ b/src/ManualSetupPushController.js
@@ -163,7 +163,8 @@ function (Okta, CountryUtil, FactorUtil, FormController, FormType, RouterUtil,
           }),
 
           FormType.Input({
-            placeholder: Okta.loc('mfa.phoneNumber.placeholder', 'login'),
+            label: Okta.loc('mfa.phoneNumber.placeholder', 'login'),
+            'label-top': true,
             className: 'enroll-sms-phone',
             name: 'phoneNumber',
             input: PhoneTextBox,

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -88,20 +88,19 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
             input: TextBox,
             type: 'password',
             params: {
-              innerTooltip: Okta.loc('password.oldPassword.tooltip', 'login'),
-              icon: 'credentials-16'
+              innerTooltip: Okta.loc('password.oldPassword.tooltip', 'login')
             }
           }),
           FormType.Divider(),
           FormType.Input({
+            className: 'margin-btm-5',
             'label-top': true,
             label: Okta.loc('password.newPassword.placeholder', 'login'),
             name: 'newPassword',
             input: TextBox,
             type: 'password',
             params: {
-              innerTooltip: Okta.loc('password.newPassword.tooltip', 'login'),
-              icon: 'credentials-16'
+              innerTooltip: Okta.loc('password.newPassword.tooltip', 'login')
             }
           }),
           FormType.Input({
@@ -111,8 +110,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
             input: TextBox,
             type: 'password',
             params: {
-              innerTooltip: Okta.loc('password.confirmPassword.tooltip', 'login'),
-              icon: 'credentials-16'
+              innerTooltip: Okta.loc('password.confirmPassword.tooltip', 'login')
             }
           })
         ];

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -83,8 +83,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
         return [
           FormType.Input({
             'label-top': true,
-            label: false,
-            placeholder: Okta.loc('password.oldPassword.placeholder', 'login'),
+            label: Okta.loc('password.oldPassword.placeholder', 'login'),
             name: 'oldPassword',
             input: TextBox,
             type: 'password',
@@ -96,8 +95,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
           FormType.Divider(),
           FormType.Input({
             'label-top': true,
-            label: false,
-            placeholder: Okta.loc('password.newPassword.placeholder', 'login'),
+            label: Okta.loc('password.newPassword.placeholder', 'login'),
             name: 'newPassword',
             input: TextBox,
             type: 'password',
@@ -108,8 +106,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Foo
           }),
           FormType.Input({
             'label-top': true,
-            label: false,
-            placeholder: Okta.loc('password.confirmPassword.placeholder', 'login'),
+            label: Okta.loc('password.confirmPassword.placeholder', 'login'),
             name: 'confirmPassword',
             input: TextBox,
             type: 'password',

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -62,14 +62,14 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, FooterSign
       formChildren: function () {
         return [
           FormType.Input({
+            className: 'margin-btm-5',
             label: Okta.loc('password.newPassword.placeholder', 'login'),
             'label-top': true,
             name: 'newPassword',
             input: TextBox,
             type: 'password',
             params: {
-              innerTooltip: Okta.loc('password.newPassword.tooltip', 'login'),
-              icon: 'credentials-16'
+              innerTooltip: Okta.loc('password.newPassword.tooltip', 'login')
             }
           }),
           FormType.Input({
@@ -79,8 +79,7 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, FooterSign
             input: TextBox,
             type: 'password',
             params: {
-              innerTooltip: Okta.loc('password.confirmPassword.tooltip', 'login'),
-              icon: 'credentials-16'
+              innerTooltip: Okta.loc('password.confirmPassword.tooltip', 'login')
             }
           })
         ];

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -62,7 +62,8 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, FooterSign
       formChildren: function () {
         return [
           FormType.Input({
-            placeholder: Okta.loc('password.newPassword.placeholder', 'login'),
+            label: Okta.loc('password.newPassword.placeholder', 'login'),
+            'label-top': true,
             name: 'newPassword',
             input: TextBox,
             type: 'password',
@@ -72,7 +73,8 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, FooterSign
             }
           }),
           FormType.Input({
-            placeholder: Okta.loc('password.confirmPassword.placeholder', 'login'),
+            label: Okta.loc('password.confirmPassword.placeholder', 'login'),
+            'label-top': true,
             name: 'confirmPassword',
             input: TextBox,
             type: 'password',

--- a/src/RecoveryChallengeController.js
+++ b/src/RecoveryChallengeController.js
@@ -92,7 +92,8 @@ function (Okta, FormController, FormType, Enums, FooterSignout, TextBox) {
             }
           }),
           FormType.Input({
-            placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
+            label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
+            'label-top': true,
             className: 'enroll-sms-phone',
             name: 'passCode',
             input: TextBox,

--- a/src/UnlockAccountController.js
+++ b/src/UnlockAccountController.js
@@ -99,14 +99,15 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, ContactSupport,
         }
         else {
           formChildren.push(FormType.Input({
-            placeholder: Okta.loc('account.unlock.email.or.username.placeholder', 'login'),
+            label: Okta.loc('account.unlock.email.or.username.placeholder', 'login'),
+            'label-top': true,
             name: 'username',
             input: TextBox,
+            inputId: 'account-recovery-username',
             type: 'text',
             inlineValidation: false,
             params: {
-              innerTooltip: Okta.loc('account.unlock.email.or.username.tooltip', 'login'),
-              icon: 'person-16-gray'
+              innerTooltip: Okta.loc('account.unlock.email.or.username.tooltip', 'login')
             }
           }));
 

--- a/src/views/enroll-factors/EnterPasscodeForm.js
+++ b/src/views/enroll-factors/EnterPasscodeForm.js
@@ -32,10 +32,11 @@ define([
     formChildren: function () {
       return [
         FormType.Input({
+          label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
+          'label-top': true,
           name: 'passCode',
           input: TextBox,
           type: 'tel',
-          placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
           params: {
             innerTooltip: Okta.loc('mfa.challenge.enterCode.tooltip', 'login')
           }

--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -32,15 +32,15 @@ define([
     inputs: function () {
       var inputs = [];
       var usernameProps = {
+        label: Okta.loc('primaryauth.username.placeholder', 'login'),
+        'label-top': true,
         inputId: 'idp-discovery-username',
-        placeholder: Okta.loc('primaryauth.username.placeholder', 'login'),
         disabled: false,
         params: {
           innerTooltip: {
             title: Okta.loc('primaryauth.username.placeholder', 'login'),
             text: Okta.loc('primaryauth.username.tooltip', 'login')
-          },
-          icon: 'person-16-gray'
+          }
         }
       };
       inputs.push(_.extend(this.getUsernameField(), usernameProps));

--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -32,6 +32,7 @@ define([
     inputs: function () {
       var inputs = [];
       var usernameProps = {
+        className: 'margin-btm-30',
         label: Okta.loc('primaryauth.username.placeholder', 'login'),
         'label-top': true,
         inputId: 'idp-discovery-username',

--- a/src/views/mfa-verify/InlineTOTPForm.js
+++ b/src/views/mfa-verify/InlineTOTPForm.js
@@ -24,7 +24,7 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
     });
     form.add(Okta.createButton({
       attributes: { 'data-se': 'inline-totp-verify' },
-      className: 'button inline-totp-verify',
+      className: 'button inline-totp-verify margin-top-30',
       title: Okta.loc('mfa.challenge.verify', 'login'),
       click: function () {
         if (!form.isValid()) {

--- a/src/views/mfa-verify/InlineTOTPForm.js
+++ b/src/views/mfa-verify/InlineTOTPForm.js
@@ -15,9 +15,8 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
   function addInlineTotp (form) {
     form.addDivider();
     form.addInput({
-      label: false,
+      label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
       'label-top': true,
-      placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
       className: 'o-form-fieldset o-form-label-top inline-input auth-passcode',
       name: 'answer',
       input: TextBox,

--- a/src/views/mfa-verify/PassCodeForm.js
+++ b/src/views/mfa-verify/PassCodeForm.js
@@ -106,9 +106,8 @@ define(['okta', 'q', 'views/shared/TextBox'], function (Okta, Q, TextBox) {
         }
       }));
       this.addInput({
-        label: false,
+        label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
         'label-top': true,
-        placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
         className: 'o-form-fieldset o-form-label-top auth-passcode',
         name: 'answer',
         input: TextBox,

--- a/src/views/mfa-verify/PasswordForm.js
+++ b/src/views/mfa-verify/PasswordForm.js
@@ -27,9 +27,8 @@ define(['okta'], function (Okta) {
       this.title = this.model.get('factorLabel');
 
       this.addInput({
-        label: false,
+        label: Okta.loc('mfa.challenge.password.placeholder', 'login'),
         'label-top': true,
-        placeholder: Okta.loc('mfa.challenge.password.placeholder', 'login'),
         className: 'auth-passcode',
         name: 'password',
         type: 'password',

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -35,9 +35,8 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
       }
 
       this.addInput({
-        label: false,
+        label: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
         'label-top': true,
-        placeholder: Okta.loc('mfa.challenge.enterCode.placeholder', 'login'),
         className: 'o-form-fieldset o-form-label-top auth-passcode',
         name: 'answer',
         input: TextBox,

--- a/src/views/mfa-verify/YubikeyForm.js
+++ b/src/views/mfa-verify/YubikeyForm.js
@@ -30,13 +30,13 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
       this.subtitle = Okta.loc('factor.totpHard.yubikey.description', 'login');
 
       this.addInput({
-        label: false,
+        label: Okta.loc('factor.totpHard.yubikey.placeholder', 'login'),
         'label-top': true,
         className: 'o-form-fieldset o-form-label-top auth-passcode',
         name: 'answer',
         input: TextBox,
-        type: 'password',
-        placeholder: Okta.loc('factor.totpHard.yubikey.placeholder', 'login')
+        inputId: 'mfa-answer',
+        type: 'password'
       });
 
       if (this.options.appState.get('allowRememberDevice')) {

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -99,9 +99,9 @@ define([
 
     getUsernameField: function () {
       var userNameFieldObject = {
-        label: false,
+        className: 'margin-btm-5',
+        label: Okta.loc('primaryauth.username.placeholder', 'login'),
         'label-top': true,
-        placeholder: Okta.loc('primaryauth.username.placeholder', 'login'),
         name: 'username',
         input: TextBox,
         inputId: 'okta-signin-username',
@@ -111,8 +111,7 @@ define([
           innerTooltip: {
             title: Okta.loc('primaryauth.username.placeholder', 'login'),
             text: Okta.loc('primaryauth.username.tooltip', 'login')
-          },
-          icon: 'person-16-gray'
+          }
         }
       };
 
@@ -124,9 +123,9 @@ define([
 
     getPasswordField: function () {
       var passwordFieldObject = {
-        label: false,
+        className: 'margin-btm-30',
+        label: Okta.loc('primaryauth.password.placeholder', 'login'),
         'label-top': true,
-        placeholder: Okta.loc('primaryauth.password.placeholder', 'login'),
         name: 'password',
         inputId: 'okta-signin-password',
         validateOnlyIfDirty: true,
@@ -135,8 +134,7 @@ define([
           innerTooltip: {
             title: Okta.loc('primaryauth.password.placeholder', 'login'),
             text: Okta.loc('primaryauth.password.tooltip', 'login')
-          },
-          icon: 'remote-lock-16'
+          }
         }
       };
       if (this.settings.get('features.showPasswordToggleOnSignInPage')) {

--- a/test/unit/helpers/dom/AccountRecoveryForm.js
+++ b/test/unit/helpers/dom/AccountRecoveryForm.js
@@ -1,6 +1,7 @@
 define(['./Form'], function (Form) {
 
   var USERNAME_FIELD = 'username';
+  var USERNAME_LABEL = 'label[for="account-recovery-username"]';
   var SMS_BUTTON_SELECTOR = '.sms-button';
   var SMS_HINT_SELECTOR = '.sms-hint';
   var CALL_BUTTON_SELECTOR = '.call-button';
@@ -14,6 +15,10 @@ define(['./Form'], function (Form) {
 
     usernameField: function () {
       return this.input(USERNAME_FIELD);
+    },
+
+    usernameLabel: function () {
+      return this.$(USERNAME_LABEL);
     },
 
     getUsernameAutocomplete: function () {

--- a/test/unit/helpers/dom/IDPDiscoveryForm.js
+++ b/test/unit/helpers/dom/IDPDiscoveryForm.js
@@ -1,5 +1,6 @@
 define(['./PrimaryAuthForm'], function (PrimaryAuthForm) {
 
+  var IDP_DISCOVERY_USERNAME_LABEL = 'label[for="idp-discovery-username"]';
   var CLASS_SELECTOR = '.idp-discovery';
   var NEXT_BUTTON = '.button.button-primary';
 
@@ -11,6 +12,10 @@ define(['./PrimaryAuthForm'], function (PrimaryAuthForm) {
 
     idpDiscoveryForm: function () {
       return this.$(CLASS_SELECTOR + ' form');
+    },
+
+    idpDiscoveryUsernameLabel: function () {
+      return this.$(IDP_DISCOVERY_USERNAME_LABEL);
     },
 
     nextButton: function () {

--- a/test/unit/helpers/dom/MfaVerifyForm.js
+++ b/test/unit/helpers/dom/MfaVerifyForm.js
@@ -1,6 +1,7 @@
 define(['./Form'], function (Form) {
 
   var ANSWER_FIELD = 'answer';
+  var ANSWER_LABEL = 'label[for="mfa-answer"]';
   var PASSWORD_FIELD = 'password';
   var SHOW_ANSWER_FIELD = 'showAnswer';
   var REMEMBER_DEVICE = 'rememberDevice';
@@ -50,6 +51,10 @@ define(['./Form'], function (Form) {
 
     answerField: function () {
       return this.input(ANSWER_FIELD);
+    },
+
+    answerLabel: function () {
+      return this.$(ANSWER_LABEL);
     },
 
     setAnswer: function (val) {

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -2,7 +2,9 @@ define(['okta', './Form'], function (Okta, Form) {
 
   var { _, $ } = Okta;
   var USERNAME_FIELD = 'username';
+  var USERNAME_LABEL = 'label[for="okta-signin-username"]';
   var PASSWORD_FIELD = 'password';
+  var PASSWORD_LABEL = 'label[for="okta-signin-password"]';
   var REMEMBER_ME_FIELD = 'remember';
   var REMEMBER_ME_LABEL = 'label[data-se-for-name="remember"]';
   var SECURITY_BEACON = 'security-beacon';
@@ -23,6 +25,10 @@ define(['okta', './Form'], function (Okta, Form) {
       return this.input(USERNAME_FIELD);
     },
 
+    usernameLabel: function () {
+      return this.$(USERNAME_LABEL);
+    },
+
     usernameErrorField: function () {
       return this.error(USERNAME_FIELD);
     },
@@ -33,6 +39,10 @@ define(['okta', './Form'], function (Okta, Form) {
 
     passwordField: function () {
       return this.input(PASSWORD_FIELD);
+    },
+
+    passwordLabel: function () {
+      return this.$(PASSWORD_LABEL);
     },
 
     passwordErrorField: function () {

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -83,10 +83,10 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           expect(test.form.titleText()).toEqual('Reset Password');
         });
       });
-      itp('uses default for username placeholder', function () {
+      itp('uses default for username label', function () {
         return setup().then(function (test) {
-          var $username = test.form.usernameField();
-          expect($username.attr('placeholder')).toEqual('Email or Username');
+          var $usernameLabel = test.form.usernameLabel();
+          expect($usernameLabel.text().trim()).toEqual('Email or Username');
         });
       });
       itp('does not allow autocomplete', function () {

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -280,10 +280,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           expect(test.form.titleText()).toEqual('Sign In');
         });
       });
-      itp('uses default for username placeholder', function () {
+      itp('uses default for username label', function () {
         return setup().then(function (test) {
-          var $username = test.form.usernameField();
-          expect($username.attr('placeholder')).toEqual('Username');
+          var $usernameLabel = test.form.idpDiscoveryUsernameLabel();
+          expect($usernameLabel.text().trim()).toEqual('Username');
         });
       });
       itp('prevents autocomplete on username', function () {

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -619,11 +619,6 @@ function (Okta,
       expect(password.attr('type')).toEqual(fieldType);
     }
 
-    function expectHasRightPlaceholderText (test, placeholderText){
-      var answer = test.form.answerField();
-      expect(answer.attr('placeholder')).toEqual(placeholderText);
-    }
-
     function expectError (test, code, message, controller, resError) {
       expect(test.form.hasErrors()).toBe(true);
       expect(test.form.errorMessage()).toBe(message);
@@ -2210,9 +2205,10 @@ function (Okta,
             expectHasAnswerField(test, 'password');
           });
         });
-        itp('has right placeholder text in answer field', function () {
+        itp('has right label for answer field', function () {
           return setupYubikey().then(function (test) {
-            expectHasRightPlaceholderText(test, 'Click here, then tap your YubiKey');
+            var $answerLabel = test.form.answerLabel();
+            expect($answerLabel.text().trim()).toEqual('Click here, then tap your YubiKey');
           });
         });
         itp('does not autocomplete', function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -266,10 +266,10 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           expect(test.form.titleText()).toEqual('Sign In');
         });
       });
-      itp('uses default for username placeholder', function () {
+      itp('uses default for username label', function () {
         return setup().then(function (test) {
-          var $username = test.form.usernameField();
-          expect($username.attr('placeholder')).toEqual('Username');
+          var $usernameLabel = test.form.usernameLabel();
+          expect($usernameLabel.text().trim()).toEqual('Username');
         });
       });
       itp('prevents autocomplete on username', function () {
@@ -282,10 +282,10 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           expect(test.form.getPasswordFieldAutocomplete()).toBe('off');
         });
       });
-      itp('uses default for password placeholder', function () {
+      itp('uses default for password label', function () {
         return setup().then(function (test) {
-          var $password = test.form.passwordField();
-          expect($password.attr('placeholder')).toEqual('Password');
+          var $passwordLabel = test.form.passwordLabel();
+          expect($passwordLabel.text().trim()).toEqual('Password');
         });
       });
       itp('uses default for rememberMe', function () {

--- a/test/unit/spec/UnlockAccount_spec.js
+++ b/test/unit/spec/UnlockAccount_spec.js
@@ -99,10 +99,10 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, Beacon, Expect, Router,
           expect(test.form.titleText()).toEqual('Unlock account');
         });
       });
-      itp('has correct username placeholder', function () {
+      itp('has correct username label', function () {
         return setup().then(function (test) {
-          var $username = test.form.usernameField();
-          expect($username.attr('placeholder')).toEqual('Email or username');
+          var $usernameLabel = test.form.usernameLabel();
+          expect($usernameLabel.text().trim()).toEqual('Email or username');
         });
       });
       itp('does not allow autocomplete', function () {


### PR DESCRIPTION
### Description

- Placeholders for inputs resulted to be not good in term of accessibility. Converting to use top labels.
- Also removing icons inside inputs.

JIRA: https://oktainc.atlassian.net/browse/OKTA-210951

**Note**: Will go in okta-signin-widget v3.0.0.

### Screenshots

<img width="643" alt="Screen Shot 2019-05-10 at 10 56 35 AM" src="https://user-images.githubusercontent.com/19613940/57546808-538f0c00-7312-11e9-9531-b267a9902ca1.png">

<img width="642" alt="Screen Shot 2019-05-10 at 10 56 01 AM" src="https://user-images.githubusercontent.com/19613940/57546824-5a1d8380-7312-11e9-9f87-72b2016b7981.png">

<img width="621" alt="Screen Shot 2019-05-10 at 10 56 21 AM" src="https://user-images.githubusercontent.com/19613940/57546856-5e49a100-7312-11e9-8840-9c98f4fd4153.png">

<img width="490" alt="InlineTOTPForm" src="https://user-images.githubusercontent.com/19613940/57955529-0fb87b80-78ab-11e9-8925-df8281ce9943.png">
<img width="486" alt="TOTPForm" src="https://user-images.githubusercontent.com/19613940/57955530-0fb87b80-78ab-11e9-84aa-ef3b3c23f92f.png">
<img width="512" alt="EnterPasscodeForm" src="https://user-images.githubusercontent.com/19613940/57955531-0fb87b80-78ab-11e9-87f7-6cbf6365e250.png">
<img width="527" alt="IDPDiscoveryForm" src="https://user-images.githubusercontent.com/19613940/57955532-10511200-78ab-11e9-9d54-21d330d67e32.png">
<img width="510" alt="UnlockAccountController" src="https://user-images.githubusercontent.com/19613940/57955533-10511200-78ab-11e9-96ff-74a4fa0e837f.png">
<img width="498" alt="EnrollCallAndSmsController (Voice)" src="https://user-images.githubusercontent.com/19613940/57955534-10511200-78ab-11e9-895a-6a9e55b21cd9.png">
<img width="499" alt="EnrollOnPremController2" src="https://user-images.githubusercontent.com/19613940/57955535-10511200-78ab-11e9-8baa-f05326995e0c.png">
<img width="507" alt="EnrollOnPremController" src="https://user-images.githubusercontent.com/19613940/57955536-10511200-78ab-11e9-8222-c9e1832b4278.png">
<img width="502" alt="EnrollSymantecVipController" src="https://user-images.githubusercontent.com/19613940/57955537-10e9a880-78ab-11e9-8c63-b6b5ac33207f.png">
<img width="546" alt="EnrollCallAndSmsController2" src="https://user-images.githubusercontent.com/19613940/57955538-10e9a880-78ab-11e9-9be5-a02d90a773e9.png">
<img width="531" alt="EnrollCallAndSmsController1" src="https://user-images.githubusercontent.com/19613940/57955539-10e9a880-78ab-11e9-8445-93191d2b0eb6.png">
<img width="505" alt="EnrollCallAndSmsController" src="https://user-images.githubusercontent.com/19613940/57955541-10e9a880-78ab-11e9-8a7a-387a72341d91.png">
<img width="506" alt="PasswordExpiredController" src="https://user-images.githubusercontent.com/19613940/57955542-10e9a880-78ab-11e9-9d0d-693ae5c270d8.png">
<img width="492" alt="PasswordResetController" src="https://user-images.githubusercontent.com/19613940/57955543-11823f00-78ab-11e9-9b9c-d18530a41a6e.png">


### Reviewers

@hor-kanchan-okta @haishengwu-okta @alexdahl-okta @nbarbettini 
