### PR TITLE
Print warnings for missing E2E variables before running tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -292,6 +292,9 @@ module.exports = function (grunt) {
     'Runs end to end webdriver tests. Pass in `--browserName {{browser}}` to ' +
     'override default phantomjs browser',
     function () {
+      // Print warnings for missing environment variables
+      ENV.checkValues();
+
       // We will only run webdriver tests in these two environments:
       // 1. Travis, non pull request builds
       // 2. Local, developer has set up an org to test against and has their

--- a/test/e2e/env.js
+++ b/test/e2e/env.js
@@ -15,11 +15,14 @@ function config () {
       process.env[key] = DEFAULTS[key];
     }
     VALUES[key] = process.env[key];
+  });
+}
 
+function checkValues () {
+  Object.keys(DEFAULTS).forEach(function (key) {
     if (!VALUES[key]) {
       console.error('ERROR: no value set for environment variable: ' + key);
     }
-
   });
 }
 
@@ -35,6 +38,7 @@ function getValues () {
 
 module.exports = {
   config: config,
+  checkValues: checkValues,
   printValues: printValues,
   getValues: getValues
 };


### PR DESCRIPTION
- Currently warnings are shown whenever running grunt, including for a build
- With this change, warnings are only shown when running E2E tests