### PR TITLE
Adds css for accessibility to set visual focus indication

### DIFF
--- a/assets/sass/modules/_accessibility.scss
+++ b/assets/sass/modules/_accessibility.scss
@@ -8,3 +8,13 @@
   height: 0;
   overflow: hidden;
 }
+
+.focused-input,
+.link.help:focus {
+  box-shadow: 0 0 8px rgba(81, 203, 238, 1);
+}
+
+.o-form-button-bar.focused-input {
+  margin-bottom: 25px;
+  padding-bottom: 0px;
+}

--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -50,7 +50,6 @@
   @import 'modules/factors-dropdown';
   @import 'modules/footer';
   @import 'modules/enroll';
-  @import 'modules/accessibility';
   @import 'modules/registration';
 
   &.can-remove-beacon {
@@ -73,12 +72,15 @@
     }
   }
 
+
+  @import 'modules/accessibility';
 }
 /* stylelint-enable selector-max-id */
 
 @import 'modules/qtip';
 @import 'widgets/chosen';
 @import 'modules/forms';
+
 
 .chzn-container-active {
   margin: 0;


### PR DESCRIPTION
**Description**
Changes the UX to have a visual indicator when focus is given to a field or button.

**Changes**
 - Adds a box-shadow to the `focused-input` and `link help` classes
 - moves accessibility scss module to the end of the scss list to allow for overrides that deal with accessibility

**Resolves**
 - [OKTA-210992](https://oktainc.atlassian.net/browse/OKTA-210992)

**Photos**

![Widget Focus](https://user-images.githubusercontent.com/1906920/58496703-698d3100-8148-11e9-88a1-b265e38436d5.gif)



