### PR TITLE
feat: Increase contrast on primary button

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -33,7 +33,7 @@ $error-text-color: #e34843;
 $icon-button-bg-color: #fff;
 $button-bg-color: #fbfbfb;
 $dark-button-bg-color: #929292;
-$primary-button-bg-color: #007dc1;
+$primary-button-bg-color: #1662dd; // Action base
 $success-button-bg-color: #4cbf9c;
 $negative-button-bg-color: #c35151;
 $disabled-button-text-color: #aaa;


### PR DESCRIPTION
### Description


The primary button color is now a brighter blue color. This increases contrast and follows latest design standards.

JIRA: https://oktainc.atlassian.net/browse/OKTA-210957

### Screenshots
<img width="481" alt="Screen Shot 2019-05-28 at 3 41 56 PM" src="https://user-images.githubusercontent.com/47947204/58517176-63567f00-815f-11e9-93bb-7debb4a51fa3.png">

### Reviewers
@manueltanzi-okta @maggielaw-okta 