### PR TITLE
Adds bypass for jquery CVE-2019-11358

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -1,0 +1,7 @@
+[
+  {
+    "component": "jquery",
+    "version": "1.12.1",
+    "justification": "This CVE (CVE-2019-11358) deals with pollution of prototype. The CVE is a blocker and should be solved with the release of SIW 3.0"
+  }
+]


### PR DESCRIPTION
During development of the Okta Signin Widget, we were alerted to [CVE-2019-11358](https://nvd.nist.gov/vuln/detail/CVE-2019-11358) where jQuery before 3.4.0 would allow unsanitized source objects to extend the native `Object.prototype`.  We have looked at our codebase and confirmed that we do not allow for unsanitized inputs to be passed into `$.extend(true, {}, ...)` methods. We are currently in the process of updating our Signin Widet which will fully resolve this issue. For current development, we are still using jQuery 1.12.1 which does not have the backported version of the fix. In order for us to develop the Signin Widget further, we have suppressed our tooling to alert us on this low priority CVE since we have manually confirmed we are not affected by this issue.