### PR TITLE
fix: Upgraded u2f lib to remove jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "handlebars": "4.0.14",
     "jquery": "1.12.1",
     "q": "1.4.1",
-    "u2f-api-polyfill": "0.4.1",
+    "u2f-api-polyfill": "0.4.3",
     "underscore": "1.8.3"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8611,9 +8611,9 @@ type-is@~1.6.16, type-is@~1.6.17:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-u2f-api-polyfill@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/u2f-api-polyfill/-/u2f-api-polyfill-0.4.1.tgz#6e415c473eefc40a8973f37271952b52d443d9ad"
+u2f-api-polyfill@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/u2f-api-polyfill/-/u2f-api-polyfill-0.4.3.tgz#b7ad165a6f962558517a867c5c4bf9399fcf7e98"
 
 uglify-js@^2.8.29:
   version "2.8.29"


### PR DESCRIPTION
* the version that was used in SIW had a dependency on jquery. (Relied on $ being
present on window.)
* Upgraded u2f lib to newer version with one other fixe and mainly removed dependency on $.
* Original fix pr - https://github.com/mastahyeti/u2f-api/commit/d5f63522907f3c0e63ae426dea7ed2f9d76bb11b
* This issues happens only in certain browsers. Only when certain checks fail the 'isIosChrome_' is called and this is where jquery was used.

**u2f ff mac** 
![u2f-ff](https://user-images.githubusercontent.com/17267130/60534523-e5821800-9cb6-11e9-8c14-73c2ae572bb9.gif)
**u2f chrome mac** 
![u2f](https://user-images.githubusercontent.com/17267130/60534524-e5821800-9cb6-11e9-8677-61a461acb345.gif)

**safari shows right error message**

![Screen Shot 2019-07-02 at 10 26 29 AM](https://user-images.githubusercontent.com/17267130/60534592-064a6d80-9cb7-11e9-8933-11dcd6348757.png)

**FIX wind edge shows right message**
![Screen Shot 2019-07-02 at 10 30 21 AM](https://user-images.githubusercontent.com/17267130/60534624-1c582e00-9cb7-11e9-879b-ce57ae263d9e.png)

**prompted for u2f on chrome n ff on windows**
![Screen Shot 2019-07-02 at 10 34 05 AM](https://user-images.githubusercontent.com/17267130/60534660-2f6afe00-9cb7-11e9-9f8c-80c6aad5dba8.png)

![Screen Shot 2019-07-02 at 10 40 55 AM](https://user-images.githubusercontent.com/17267130/60534649-2aa64a00-9cb7-11e9-9a7b-38a5b970f806.png)


RESOLVES: OKTA-236038