### PR TITLE
upload artifact version number to eng prod s3 for downstream artifact

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -31,4 +31,13 @@ if ! artifactory_curl -X PUT -u ${ARTIFACTORY_CREDS} ${DATALOAD} -v -f; then
   exit $PUBLISH_ARTIFACTORY_FAILURE
 fi
 
+# upload artifact version to eng prod s3 to be used by downstream jobs
+artifact_version="$(ci-pkginfo -t pkgname)@$(ci-pkginfo -t pkgsemver)"
+if upload_job_data global artifact_version ${artifact_version}; then
+  echo "Upload okta-signin-widget job data artifact_version=${artifact_version} to s3!"
+else
+  # only echo the info since the upload is not crucial
+  echo "Fail to upload okta-signin-widget job data artifact_version=${artifact_version} to s3!" >&2
+fi
+
 exit $SUCCESS


### PR DESCRIPTION
Upload the artifact version to s3 at the end of publishing so downstream artifact can utilize it.
Relevant PR made in monolith for creating monolith commit that use a certain okta-signin-widget version: https://github.com/okta/okta-core/pull/35707
 
Example:
The version generated and uploaded is of the form: `@okta/okta-signin-widget@3.1.0-alpha.ga006098`

Monolith commit made via automatically pulling the version from s3 that is generated and uploaded by publish script here:
https://github.com/okta/okta-core/commit/269ef8cf201af2306b26c643acba9a90953a1926
