### PR TITLE
 fix: prevent redirect when app is in background

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -89,7 +89,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.trackTypingPattern': ['boolean', false, false],
       'features.redirectByFormSubmit': ['boolean', false, false],
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
-      'features.restrictRedirectToForeground': ['boolean', false, true],
+      'features.restrictRedirectToForeground': ['boolean', true, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -89,6 +89,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.trackTypingPattern': ['boolean', false, false],
       'features.redirectByFormSubmit': ['boolean', false, false],
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
+      'features.restrictRedirectToForeground': ['boolean', false, true],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 40], max-statements: [2, 30] */
+/* eslint complexity: [2, 42], max-statements: [2, 30] */
 define([
   'okta',
   './OAuth2Util',
@@ -197,12 +197,7 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
       // Check if we need to wait for redirect based on host.
       if (router.settings.get('features.restrictRedirectToForeground') &&
           fn.isHostBackgroundChromeTab()) {
-        var checkVisibilityAndCallSuccess = function () {
-          if (document.visibilityState === 'visible') {
-            router.settings.callGlobalSuccess(Enums.SUCCESS, successData);
-          }
-        }
-        document.addEventListener('visibilitychange', function checkVisibilityAndCallSuccess() {
+        document.addEventListener('visibilitychange', function checkVisibilityAndCallSuccess () {
           if (fn.isDocumentVisible()) {
             document.removeEventListener('visibilitychange', checkVisibilityAndCallSuccess);
             router.settings.callGlobalSuccess(Enums.SUCCESS, successData);

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 18] */
+/* eslint max-params: [2, 19] */
 define([
   'q',
   'okta',
@@ -182,10 +182,13 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Bro
         test.form.selectQuestion('favorite_security_question');
         test.form.setAnswer('No question! Hah!');
         test.setNextResponse(resSuccess);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callThrough();
         test.form.submit();
         return tick();
       })
         .then(function () {
+          // restrictRedirectToForeground Flag is not enabled
+          expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
           expect($.ajax.calls.count()).toBe(1);
           Expect.isJsonPost($.ajax.calls.argsFor(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -208,15 +211,17 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Bro
         test.form.selectQuestion('favorite_security_question');
         test.form.setAnswer('No question! Hah!');
         test.setNextResponse(resSuccess);
-        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function() {
+        // Set flag
+        test.router.settings.set('features.restrictRedirectToForeground', true);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
           return true;
         });
-        spyOn(document, 'addEventListener').and.callFake(function(type, fn){
+        spyOn(document, 'addEventListener').and.callFake(function (type, fn){
           fn();
         });
         spyOn(document, 'removeEventListener').and.callThrough();
         test.form.submit();
-        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function() {
+        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function () {
           return true;
         });
         return tick();


### PR DESCRIPTION
 * Introduces a flag to check if SIW host is in background before redirecting.

    This is to overcome the issue where Chrome on android prevents app url redirects when not in foreground. This is currently happening in chrome but not on firefox on android. IOS is not an issue as safari takes care of it.

    * Ideally the check could  go in redirectUtilFn in settings model and callGlobalError/Success,
    so all paths involving redirects are handled. In order to reduce the surface area we are adding the check in success state handler for now.



    **TODO:**

    * Test on ios chrome if we support it.
    * Add more tests to cover other scenarios.