### PR TITLE
Updating CDN links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,19 +72,9 @@ To use the CDN, include links to the JS and CSS files in your HTML:
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script
-  src="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/js/okta-sign-in.min.js"
-  type="text/javascript"></script>
-<link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/css/okta-sign-in.min.css"
-  type="text/css"
-  rel="stylesheet"/>
+<script src="https://global.oktacdn.com/okta-signin-widget/3.1.0/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<!-- Theme file: Customize or replace this file if you want to override our default styles -->
-<link
-  href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.16.0/css/okta-theme.css"
-  type="text/css"
-  rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/3.1.0/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 ### Using the npm module


### PR DESCRIPTION
- Use new global CDN urls
- Remove the theme file link, as it is no longer used in 3.x