### PR TITLE
webauthn cardinality fix

### DIFF
--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -82,7 +82,8 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
       },
       profile: ['object'],
       vendorName: 'string',
-      policy: ['object']
+      policy: ['object'],
+      profiles: ['object']
     },
 
     local: {
@@ -168,14 +169,39 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
           return status === 'ACTIVE';
         }
       },
-      additionalEnrollment : {
-        deps: ['policy'],
-        fn: function (policy) {
-          if (!policy || !policy.enrollment) {
+      cardinality : {
+        deps: ['policy', 'profiles'],
+        fn: function (policy, profiles) {
+          if (profiles && profiles.length > 0) {
+            //assume for now we only get one profile (multiple profiles are not supported yet)
+            var profile = profiles[0];
+            var enrolled = profile._embedded.enrolledFactors.length;
+            var adoption = _.findWhere(profile._embedded.features, {type: 'adoption'});
+            if (adoption && adoption.cardinality) {
+              return {
+                enrolled: enrolled,
+                minimum: adoption.cardinality.min,
+                maximum: adoption.cardinality.max
+              }; 
+            }
             return false;
           }
+          else if (policy && policy.enrollment) {
+            return policy.enrollment;
+          }
           else {
-            return policy.enrollment.enrolled !== 0 && policy.enrollment.enrolled < policy.enrollment.maximum;
+            return false;
+          }
+        }
+      },
+      additionalEnrollment : {
+        deps: ['cardinality'],
+        fn: function (cardinality) {
+          if (cardinality) {
+            return cardinality.enrolled !== 0 && cardinality.enrolled < cardinality.maximum;
+          }
+          else {
+            return false;
           }
         }
       },

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -347,7 +347,7 @@ function (Okta, TimeUtil) {
         return (cardinality.enrolled === 1) ? '' :
           Okta.loc('enroll.choices.cardinality.setup', 'login', [cardinality.enrolled]);
       }
-      else if (required) {
+      else if (required && cardinality.maximum > 1) {
         return Okta.loc('enroll.choices.cardinality.setup.remaining', 'login',
           [cardinality.enrolled, cardinality.minimum]);
       }

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -341,16 +341,15 @@ function (Okta, TimeUtil) {
     return result.join(' ');
   };
 
-  fn.getCardinalityText = function (enrolled, required, policy) {
-    if (policy && policy.enrollment) {
-      var enrollmentInfo = policy.enrollment;
+  fn.getCardinalityText = function (enrolled, required, cardinality) {
+    if (cardinality) {
       if (enrolled) {
-        return (enrollmentInfo.enrolled === 1) ? '' :
-          Okta.loc('enroll.choices.cardinality.setup', 'login', [enrollmentInfo.enrolled]);
+        return (cardinality.enrolled === 1) ? '' :
+          Okta.loc('enroll.choices.cardinality.setup', 'login', [cardinality.enrolled]);
       }
       else if (required) {
         return Okta.loc('enroll.choices.cardinality.setup.remaining', 'login',
-          [enrollmentInfo.enrolled, enrollmentInfo.minimum]);
+          [cardinality.enrolled, cardinality.minimum]);
       }
     }
     return '';

--- a/src/views/enroll-choices/FactorList.js
+++ b/src/views/enroll-choices/FactorList.js
@@ -44,7 +44,7 @@ define([
       var children = [],
           enrolled = this.model.get('enrolled'),
           required = this.model.get('required'),
-          policy = this.model.get('policy');
+          cardinality = this.model.get('cardinality');
 
       if (this.options.showInlineSetupButton) {
         return [[Okta.createButton({
@@ -65,7 +65,7 @@ define([
         children.push(['<span class="icon success-16-gray"></span>', '.enroll-factor-label']);
       }
 
-      var cardinalityText = FactorUtil.getCardinalityText(enrolled, required, policy);
+      var cardinalityText = FactorUtil.getCardinalityText(enrolled, required, cardinality);
       if (cardinalityText) {
         children.push([cardinalityTextTpl({cardinalityText: cardinalityText}), '.enroll-factor-description']);
       }

--- a/test/unit/helpers/xhr/MFA_ENROLL_allFactorsProfile.js
+++ b/test/unit/helpers/xhr/MFA_ENROLL_allFactorsProfile.js
@@ -182,13 +182,23 @@ define({
         "factorType": "webauthn",
         "provider": "FIDO",
         "vendorName": "FIDO",
-        "policy": {
-          "enrollment": {
-            "enrolled": 0,
-            "minimum": 0,
-            "maximum": 2
+        "profiles": [{
+          "id": "fp12345",
+          "name": "Security key or built-in authenticator",
+          "default": true,
+          "_embedded": {
+            "features": [
+              {
+                "type": "adoption",
+                "cardinality": {
+                    "min": 0,
+                    "max": 3
+                }
+              }
+            ],
+            "enrolledFactors": []
           }
-        },
+        }],
         "_links": {
           "enroll": {
             "href": "https:\/\/foo.com\/api\/v1\/authn\/factors",
@@ -260,51 +270,7 @@ define({
        "profile":{
           "user":"inca@clouditude.net"
        }
-    }, {
-        "enrollment": "OPTIONAL",
-        "status": "NOT_SETUP",
-        "factorType":"claims_provider",
-        "provider":"CUSTOM",
-        "vendorName":"IDP factor",
-        "_links":{
-          "enroll":{
-            "href":"http://rain.okta1.com:1802/api/v1/authn/factors",
-            "hints":{
-              "allow":[
-                "POST"
-              ]
-            }
-          }
-        }
-     }, {
-        "enrollment": "OPTIONAL",
-        "status": "NOT_SETUP",
-        "factorType": "token:hotp",
-        "provider": "CUSTOM",
-        "profiles": [{
-          "id": '123',
-          "name": 'Entrust',
-          "_embedded": {
-            "enrolledFactors": []
-          }
-        }, {
-          "id": '124',
-          "name": 'Entrust2',
-          "_embedded": {
-            "enrolledFactors": []
-          }
-        }],
-        "_links": {
-          "enroll": {
-            "href": "https:\/\/foo.com\/api\/v1\/authn\/factors",
-            "hints": {
-              "allow": [
-                "POST"
-              ]
-            }
-          }
-        }
-      }]
+    }]
     },
     "_links": {
       "skip": {

--- a/test/unit/helpers/xhr/MFA_ENROLL_multipleWebauthn.js
+++ b/test/unit/helpers/xhr/MFA_ENROLL_multipleWebauthn.js
@@ -1,0 +1,63 @@
+define({
+    "status": 200,
+    "responseType": "json",
+    "response": {
+      "stateToken": "testStateToken",
+      "expiresAt": "2015-06-15T21:06:04.794Z",
+      "status": "MFA_ENROLL",
+      "_embedded": {
+        "user": {
+          "id": "00uhncCcppZD2158x0g3",
+          "profile": {
+            "login": "administrator1@clouditude.net",
+            "firstName": "Add-Min",
+            "lastName": "O'Cloudy Tud",
+            "locale": "en_US",
+            "timeZone": "America\/Los_Angeles"
+          }
+        },
+        "factors": [{
+          "enrollment": "OPTIONAL",
+          "status": "NOT_SETUP",
+          "factorType": "webauthn",
+          "provider": "FIDO",
+          "vendorName": "FIDO",
+          "policy": {
+            "enrollment": {
+              "enrolled": 0,
+              "minimum": 0,
+              "maximum": 2
+            }
+          },
+          "_links": {
+            "enroll": {
+              "href": "https:\/\/foo.com\/api\/v1\/authn\/factors",
+              "hints": {
+                "allow": [
+                  "POST"
+                ]
+              }
+            }
+          }
+        }]
+      },
+      "_links": {
+        "skip": {
+          "href": "https:\/\/foo.com\/api\/v1\/authn\/skip",
+          "hints": {
+            "allow": [
+              "POST"
+            ]
+          }
+        },
+        "cancel": {
+          "href": "https:\/\/foo.com\/api\/v1\/authn\/cancel",
+          "hints": {
+            "allow": [
+              "POST"
+            ]
+          }
+        }
+      }
+    }
+  });

--- a/test/unit/helpers/xhr/MFA_ENROLL_multipleWebauthnProfile.js
+++ b/test/unit/helpers/xhr/MFA_ENROLL_multipleWebauthnProfile.js
@@ -1,0 +1,73 @@
+define({
+    "status": 200,
+    "responseType": "json",
+    "response": {
+      "stateToken": "testStateToken",
+      "expiresAt": "2015-06-15T21:06:04.794Z",
+      "status": "MFA_ENROLL",
+      "_embedded": {
+        "user": {
+          "id": "00uhncCcppZD2158x0g3",
+          "profile": {
+            "login": "administrator1@clouditude.net",
+            "firstName": "Add-Min",
+            "lastName": "O'Cloudy Tud",
+            "locale": "en_US",
+            "timeZone": "America\/Los_Angeles"
+          }
+        },
+        "factors": [{
+          "enrollment": "OPTIONAL",
+          "status": "NOT_SETUP",
+          "factorType": "webauthn",
+          "provider": "FIDO",
+          "vendorName": "FIDO",
+          "profiles": [{
+            "id": "fp12345",
+            "name": "Security key or built-in authenticator",
+            "default": true,
+            "_embedded": {
+              "features": [
+                {
+                  "type": "adoption",
+                  "cardinality": {
+                      "min": 0,
+                      "max": 3
+                  }
+                }
+              ],
+              "enrolledFactors": []
+            }
+          }],
+          "_links": {
+            "enroll": {
+              "href": "https:\/\/foo.com\/api\/v1\/authn\/factors",
+              "hints": {
+                "allow": [
+                  "POST"
+                ]
+              }
+            }
+          }
+        }]
+      },
+      "_links": {
+        "skip": {
+          "href": "https:\/\/foo.com\/api\/v1\/authn\/skip",
+          "hints": {
+            "allow": [
+              "POST"
+            ]
+          }
+        },
+        "cancel": {
+          "href": "https:\/\/foo.com\/api\/v1\/authn\/cancel",
+          "hints": {
+            "allow": [
+              "POST"
+            ]
+          }
+        }
+      }
+    }
+  });

--- a/test/unit/spec/EnrollChoices_spec.js
+++ b/test/unit/spec/EnrollChoices_spec.js
@@ -924,6 +924,20 @@ function (Okta, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, FactorUtil, R
             expect(test.form.factorCardinalityText(factorName)).toBe('');
           });
         });
+        itp('does not display cardinality text when factor is REQUIRED and maximum=1', function () {
+          return setupMultipleFactorEnrollments({
+            factorName,
+            status: 'NOT_SETUP',
+            enrollment: 'REQUIRED',
+            cardinality: {'enrolled': 0, 'minimum': 0, 'maximum': 1},
+            webauthnEnabled,
+            useProfiles,
+          }).then(function (test) {
+            expect(test.form.factorButtonText(factorName)).toBe('');
+            expect(test.form.factorCardinalityText(factorName)).toBe('');
+            expect(test.form.submitButtonText()).toBe('Configure factor');
+          });
+        });
         itp('displays correct button and cardinality text when enrolled=1 optional=2', function () {
           return setupMultipleFactorEnrollments({
             factorName,


### PR DESCRIPTION
Commit 1 -  Fixes to accomodate updates to api due to factor profiles.
Already reviewed 
https://github.com/okta/okta-signin-widget/pull/729

commit 2 -  Fix cardinality text when max is 1. With factor profiles cardinality is always present. Max 1 means the factor actually doenst support cardinality. 
**Before** 
<img width="594" alt="Screen Shot 2019-08-06 at 5 12 58 PM" src="https://user-images.githubusercontent.com/17267130/62639997-77ec8b80-b8f5-11e9-9859-62d187fb857f.png">
**After**
<img width="478" alt="Screen Shot 2019-08-06 at 5 14 50 PM" src="https://user-images.githubusercontent.com/17267130/62639998-77ec8b80-b8f5-11e9-9e74-96c8ae54f9d2.png">

More testing videos 
**Multiple webauthn optional** 
![mul-web](https://user-images.githubusercontent.com/17267130/62658859-a763be00-b91e-11e9-9982-ec3b4bb4ae0a.gif)
**multiple webauthn from enduser**
![mul-web2-enduser-settingw](https://user-images.githubusercontent.com/17267130/62658861-a763be00-b91e-11e9-91bc-7bf297529509.gif)
**multiple webauthn required** 
![mul-web3-req](https://user-images.githubusercontent.com/17267130/62658862-a763be00-b91e-11e9-96ed-e3f40d4deb71.gif)
**claims provider  required** 
![mul-web4-idp-required-real](https://user-images.githubusercontent.com/17267130/62658863-a7fc5480-b91e-11e9-88ec-f63bada1f391.gif)
**claims optional** 
![mul-web4-idp](https://user-images.githubusercontent.com/17267130/62658864-a7fc5480-b91e-11e9-8e0d-3822e9904a7d.gif)
**totp** 
![mul-web4-totp-required](https://user-images.githubusercontent.com/17267130/62658865-a7fc5480-b91e-11e9-9ad9-9151c522e416.gif)


**Max enrolled**
<img width="428" alt="Screen Shot 2019-08-08 at 9 46 43 AM" src="https://user-images.githubusercontent.com/17267130/62721667-8e601900-b9c1-11e9-9618-9aff8007cdc0.png">
