### PR TITLE
Use recovery link from password factor instead of remediation

### DIFF
--- a/playground/mocks/api/v1/idx/data/factor-enroll-email.json
+++ b/playground/mocks/api/v1/idx/data/factor-enroll-email.json
@@ -24,6 +24,16 @@
       }
     ]
   },
+  "factor": {
+    "type": "object",
+    "value": {
+      "factorType": "email",
+      "provider": "okta",
+      "profile": {
+        "email": "o*****m@abbott.dev"
+      }
+    }
+  },
   "user": {
     "type": "object",
     "value": {

--- a/playground/mocks/api/v1/idx/data/factor-required-email.json
+++ b/playground/mocks/api/v1/idx/data/factor-required-email.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.0",
     "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
     "expiresAt": "2018-09-17T23:08:56.000Z",
     "step": "FACTOR_REQUIRED",

--- a/playground/mocks/api/v1/idx/data/factor-required-password.json
+++ b/playground/mocks/api/v1/idx/data/factor-required-password.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.0",
     "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
     "expiresAt": "2018-09-17T23:08:56.000Z",
     "step": "FACTOR_REQUIRED",
@@ -37,7 +38,22 @@
         "profile": {
         },
         "provider": "OKTA",
-        "vendorName": "OKTA"
+        "vendorName": "OKTA",
+        "recovery": {
+          "name": "recovery",
+          "rel": [
+            "create-form"
+          ],
+          "href": "http://localhost:3000/api/v1/idx/recovery",
+          "method": "post",
+          "value": [
+            {
+              "name": "stateHandle",
+              "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+              "visible": false
+            }
+          ]
+        }
       }
     },
     "user": {

--- a/playground/mocks/api/v1/idx/data/factor-verification-email.json
+++ b/playground/mocks/api/v1/idx/data/factor-verification-email.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.0",
     "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
     "expiresAt": "2018-09-17T23:08:56.000Z",
     "step": "FACTOR_VERIFICATION_REQUIRED",
@@ -48,6 +49,7 @@
           "email": "o*****m@abbott.dev"
         },
         "resend": {
+          "name": "resend",
           "rel": [
             "create-form"
           ],

--- a/playground/mocks/api/v1/idx/index.js
+++ b/playground/mocks/api/v1/idx/index.js
@@ -20,7 +20,7 @@ const factorEnrollPassword = [
 ];
 const path = __dirname.slice(__dirname.indexOf('api') - 1);
 
-const testData = factorRequiredEmail;
+const testData = factorEnrollEmail;
 
 let index = 0;
 

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -148,45 +148,13 @@ const normalizeRemedation = (remedationValue) => {
 };
 
 /**
- * Insert Recovery action if step is "FACTOR_REQUIRED".
- */
-const insertRecoveryAction = (resp) => {
-  if (resp.step === 'FACTOR_REQUIRED' && !resp.recovery) {
-    // ASSUME that the recovery endpoint has similar pattern to 'cancel' endpoint.
-    // HOPEFULLY API has in the response.
-    const url = resp.cancel ? resp.cancel.href.replace('cancel', 'recovery') : '';
-
-    return Object.assign({
-      'recovery': {
-        'rel': [
-          'create-form'
-        ],
-        'name': 'recovery',
-        'href': url,
-        'method': 'POST',
-        'value': [
-          {
-            'name': 'stateHandle',
-            'value': resp.stateHandle,
-            'visible': false
-          }
-        ]
-      }
-    }, resp);
-  } else {
-    return resp;
-  }
-};
-
-/**
  *
  * @param {AuthnResponse} originalResp
  * @param {*} omitKeys
  * @returns {CurrentState} currentState
  */
 const createCurrentStateObject = (originalResp, omitKeys) => {
-  const updatedResp = insertRecoveryAction(originalResp);
-  const resp = _.omit.apply(_, [updatedResp].concat(omitKeys));
+  const resp = _.omit.apply(_, [originalResp].concat(omitKeys));
   const allCreateForms = getRelObjectByName(resp, ['create-form']);
   const actions = createActions(allCreateForms);
   const remediation = resp.remediation.value.map(normalizeRemedation);

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -2,7 +2,7 @@ import Logger from 'util/Logger';
 import IdentifierView from './views/IdentifierView';
 import SelectFactorView from './views/SelectFactorView';
 import EnrollFactorPasswordView from './views/EnrollFactorPasswordView';
-import EnrollFactorEmailView from './views/EnrollFactorPasswordView';
+import EnrollFactorEmailView from './views/EnrollFactorEmailView';
 import RequiredFactorEmailView from './views/RequiredFactorEmailView';
 import RequiredFactorPasswordView from './views/RequiredFactorPasswordView';
 import FactorPollVerificationView from './views/FactorPollVerificationView';

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -33,10 +33,10 @@ const Link = View.extend({
   },
 
   postRender () {
-    if (!this.options.href && this.options.actionName) {
+    if (!this.options.href && this.options.actionPath) {
       this.$el.click((event) => {
         event.preventDefault();
-        this.options.appState.trigger('invokeCurrentStateAction', this.options.actionName);
+        this.options.appState.trigger('invokeAction', this.options.actionPath);
       });
     }
   }

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -3,13 +3,13 @@ import Link from '../components/Link';
 
 /**
  * When `href` is present, the Link behaviors as normal web link.
- * When `actionName` is present, the Link behaviors as link button
- *    upon click, will trigger the action `actionName`.
+ * When `actionPath` is present, the Link behaviors as link button
+ *    upon click, will trigger the action `actionPath`.
  * @typedef {Object} Link
  * @property {string} label
  * @property {string} name
  * @property {string=} href
- * @property {string=} actionName
+ * @property {string=} actionPath
  */
 
 

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -12,15 +12,14 @@ export default Form.extend({
   save: loc('oform.next', 'login'),
 
   initialize: function () {
-    const remediationValue = this.options.remediationValue;
-    const inputOptions = remediationValue.uiSchema.map(FormInputFactory.create);
+    const inputOptions = this.createInputs();
 
     inputOptions.forEach(input => {
       this.addInputOrView(input);
     });
 
     this.listenTo(this, 'save', this.saveForm);
-    this.checkAndDoPolling(remediationValue, this.options.model);
+    this.checkAndDoPolling(this.options.remediationValue, this.options.model);
   },
 
 
@@ -40,9 +39,13 @@ export default Form.extend({
     this.options.appState.trigger('saveForm', model);
   },
 
+  createInputs () {
+    return this.options.remediationValue.uiSchema.map(FormInputFactory.create);
+  },
+
   addInputOrView (input) {
-    if (input.component) {
-      this.add(input.component, {
+    if (input.View) {
+      this.add(input.View, {
         options: input.options
       });
     } else {

--- a/src/v2/view-builder/internals/FormInputFactory.js
+++ b/src/v2/view-builder/internals/FormInputFactory.js
@@ -17,7 +17,7 @@ const create = function (uiSchemaObj) {
         return Object.assign({}, opt, FactorUtil.getFactorData(opt.value));
       });
     return {
-      component: FactorEnrollOptions,
+      View: FactorEnrollOptions,
       options: {
         minimize: true,
         listTitle: loc('enroll.choices.description', 'login'),

--- a/src/v2/view-builder/views/EnrollFactorEmailView.js
+++ b/src/v2/view-builder/views/EnrollFactorEmailView.js
@@ -1,25 +1,13 @@
-import { loc } from 'okta';
 import BaseView from '../internals//BaseView';
 import BaseForm from '../internals//BaseForm';
-import { validateFieldsMatch } from '../../util/ValidationUtil';
 
 const Body = BaseForm.extend({
-  title: loc('factor.password', 'login'),
-  save: loc('mfa.challenge.verify', 'login')
+  title () {
+    return `Email link sent to (${this.options.appState.get('factorEmail')})`;
+  },
+  save: 'Send Email Link',
 });
 
 export default BaseView.extend({
-
   Body,
-
-  createModelClass () {
-    const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
-    return ModelClass.extend({
-
-      validate: function (data) {
-        return validateFieldsMatch(data.password, data.confirmPassword);
-      }
-
-    });
-  }
 });

--- a/src/v2/view-builder/views/RequiredFactorPasswordView.js
+++ b/src/v2/view-builder/views/RequiredFactorPasswordView.js
@@ -16,7 +16,7 @@ const Footer = BaseFooter.extend({
       'type': 'link',
       'label': 'Forgot Password',
       'name': 'forgot-password',
-      'actionName': 'recovery',
+      'actionPath': 'factor.recovery',
     }
   ],
 });

--- a/test/unit/helpers/xhr/v2/FACTOR_REQUIRED_EMAIL.js
+++ b/test/unit/helpers/xhr/v2/FACTOR_REQUIRED_EMAIL.js
@@ -14,7 +14,7 @@ const data = {
 
           "rel": ["create-form"],
           "name": "submit-factor",
-          "href": "https://your-org.okta.com/api/v2/authn/",
+          "href": "http://localhost:3000/api/v1/idx/",
           "method": "POST",
           "value": [
             {
@@ -61,7 +61,7 @@ const data = {
     "cancel": {
       "rel": ["create-form"],
       "name": "cancel",
-      "href": "https://your-org.okta.com/api/v2/authn/cancel",
+      "href": "http://localhost:3000/api/v1/idx/cancel",
       "method": "POST",
       "value": [
         {
@@ -74,7 +74,7 @@ const data = {
     "context": {
       "rel": ["create-form"],
       "name": "context",
-      "href": "https://your-org.okta.com/api/v2/authn/context",
+      "href": "http://localhost:3000/api/v1/idx/context",
       "method": "POST",
       "value": [
         {

--- a/test/unit/helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_EMAIL.js
+++ b/test/unit/helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_EMAIL.js
@@ -6,6 +6,7 @@ const data = {
     "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
     "expiresAt": "2018-09-17T23:08:56.000Z",
     "step": "FACTOR_VERIFICATION_REQUIRED",
+    "intent": "login",
     "remediation": {
       "type": "array",
       "value": [
@@ -14,7 +15,7 @@ const data = {
             "create-form"
           ],
           "name": "factor-poll-verification",
-          "href": "https://your-org.okta.com/api/v2/authn/",
+          "href": "http://localhost:3000/api/v1/idx/",
           "method": "POST",
           "refresh": 2000,
           "value": [
@@ -24,41 +25,38 @@ const data = {
               "visible": false
             }
           ]
+        },
+        {
+          "rel": [
+            "create-form"
+          ],
+          "name": "otp",
+          "href": "http://localhost:3000/api/v1/idx/",
+          "method": "POST",
+          "value": [
+            {
+              "name": "otp",
+              "label": "Passcode",
+              "minLength": 4
+            }
+          ]
         }
       ]
     },
     "factor": {
       "type": "object",
       "value": {
-        "factorType": "push",
+        "factorType": "email",
         "provider": "okta",
         "profile": {
-          "email": "omgm@foo.dev"
-        },
-        "qr": {
-          "href": ":link/:to/:qrcode"
-        },
-        "refresh": {
-          "rel": [
-            "create-form"
-          ],
-          "href": "https://your-org.okta.com/api/v2/authn/refresh",
-          "name": "refresh",
-          "method": "POST",
-          "value": [
-            {
-              "name": "stateHandle",
-              "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
-              "visible": false
-            }
-          ]
+          "email": "o*****m@abbott.dev"
         },
         "resend": {
+          "name": "resend",
           "rel": [
             "create-form"
           ],
-          "href": "https://your-org.okta.com/api/v2/authn/resend",
-          "name": "resend",
+          "href": "http://localhost:3000/api/v1/idx/resend",
           "method": "POST",
           "value": [
             {
@@ -89,7 +87,7 @@ const data = {
         "create-form"
       ],
       "name": "cancel",
-      "href": "https://your-org.okta.com/api/v2/authn/cancel",
+      "href": "http://localhost:3000/api/v1/idx/cancel",
       "method": "POST",
       "value": [
         {
@@ -104,7 +102,7 @@ const data = {
         "create-form"
       ],
       "name": "context",
-      "href": "https://your-org.okta.com/api/v2/authn/context",
+      "href": "http://localhost:3000/api/v1/idx/context",
       "method": "POST",
       "value": [
         {

--- a/test/unit/spec/v2/ion/actionsTransformer_spec.js
+++ b/test/unit/spec/v2/ion/actionsTransformer_spec.js
@@ -2,7 +2,7 @@ import transformResponse from 'v2/ion/responseTransformer';
 import transformActions from 'v2/ion/actionsTransformer';
 import httpClient from 'v2/ion/httpClient';
 import XHRFactorRequiredEmail from '../../../helpers/xhr/v2/FACTOR_REQUIRED_EMAIL';
-import XHRFactorVerificationRequiredPush from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_OKTA_PUSH';
+import XHRFactorVerificationRequiredEmail from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_EMAIL';
 import { _ } from 'okta';
 
 describe('v2/ion/actionsTransformer', function () {
@@ -43,7 +43,6 @@ describe('v2/ion/actionsTransformer', function () {
         'submit-factor': jasmine.any(Function),
         'cancel': jasmine.any(Function),
         'context': jasmine.any(Function),
-        'recovery': jasmine.any(Function),
         'remediation': [
           {
             'name': 'submit-factor',
@@ -64,7 +63,7 @@ describe('v2/ion/actionsTransformer', function () {
     spyOn(httpClient, 'fetchRequest');
     result.currentState['submit-factor']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/',
+      'http://localhost:3000/api/v1/idx/',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -73,7 +72,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['submit-factor']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/',
+      'http://localhost:3000/api/v1/idx/',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
@@ -83,7 +82,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['cancel']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/cancel',
+      'http://localhost:3000/api/v1/idx/cancel',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -93,7 +92,7 @@ describe('v2/ion/actionsTransformer', function () {
     // cancel doesn't take additional data for http request
     result.currentState['cancel']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/cancel',
+      'http://localhost:3000/api/v1/idx/cancel',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -102,7 +101,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['context']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/context',
+      'http://localhost:3000/api/v1/idx/context',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -112,16 +111,7 @@ describe('v2/ion/actionsTransformer', function () {
     // context doesn't take additional data for http request
     result.currentState['context']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/context',
-      'POST',
-      {
-        stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
-      }
-    );
-
-    result.currentState['recovery']({ foo: 'bar' });
-    expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/recovery',
+      'http://localhost:3000/api/v1/idx/context',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -130,18 +120,14 @@ describe('v2/ion/actionsTransformer', function () {
   });
 
   it('converts factor verification require push', () => {
-    const result = _.compose(transformActions, transformResponse)(XHRFactorVerificationRequiredPush.response);
+    const result = _.compose(transformActions, transformResponse)(XHRFactorVerificationRequiredEmail.response);
     expect(result).toEqual({
       'factor': {
-        'factorType': 'push',
+        'factorType': 'email',
         'provider': 'okta',
         'profile': {
-          'email': 'omgm@foo.dev'
+          'email': 'o*****m@abbott.dev'
         },
-        'qr': {
-          'href': ':link/:to/:qrcode'
-        },
-        'refresh': jasmine.any(Function),
         'resend': jasmine.any(Function),
       },
       'user': {
@@ -160,33 +146,37 @@ describe('v2/ion/actionsTransformer', function () {
         'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
         'expiresAt': '2018-09-17T23:08:56.000Z',
         'step': 'FACTOR_VERIFICATION_REQUIRED',
+        'intent': 'login',
         'factor-poll-verification': jasmine.any(Function),
         'cancel': jasmine.any(Function),
         'context': jasmine.any(Function),
+        'otp': jasmine.any(Function),
         'remediation': [
           {
             'name': 'factor-poll-verification',
             'refresh': 2000,
             'value': [],
+          },
+          {
+            'name': 'otp',
+            'value': [
+              {
+                'name': 'otp',
+                'label': 'Passcode',
+                'minLength': 4
+              }
+            ],
           }
         ]
       },
-      __rawResponse: XHRFactorVerificationRequiredPush.response,
+      __rawResponse: XHRFactorVerificationRequiredEmail.response,
     });
 
     spyOn(httpClient, 'fetchRequest');
-    result.factor['refresh']();
-    expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/refresh',
-      'POST',
-      {
-        stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
-      }
-    );
 
     result.factor['resend']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/resend',
+      'http://localhost:3000/api/v1/idx/resend',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -195,7 +185,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['factor-poll-verification']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/',
+      'http://localhost:3000/api/v1/idx/',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -204,7 +194,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['factor-poll-verification']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/',
+      'http://localhost:3000/api/v1/idx/',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
@@ -213,7 +203,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['cancel']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/cancel',
+      'http://localhost:3000/api/v1/idx/cancel',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -223,7 +213,7 @@ describe('v2/ion/actionsTransformer', function () {
     // cancel doesn't take additional data for http request
     result.currentState['cancel']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/cancel',
+      'http://localhost:3000/api/v1/idx/cancel',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -232,7 +222,7 @@ describe('v2/ion/actionsTransformer', function () {
 
     result.currentState['context']();
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/context',
+      'http://localhost:3000/api/v1/idx/context',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
@@ -242,7 +232,7 @@ describe('v2/ion/actionsTransformer', function () {
     // context doesn't take additional data for http request
     result.currentState['factor-poll-verification']({ foo: 'bar' });
     expect(httpClient.fetchRequest).toHaveBeenCalledWith(
-      'https://your-org.okta.com/api/v2/authn/context',
+      'http://localhost:3000/api/v1/idx/context',
       'POST',
       {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -1,6 +1,6 @@
 import transformResponse from 'v2/ion/responseTransformer';
 import XHRFactorRequiredEmail from '../../../helpers/xhr/v2/FACTOR_REQUIRED_EMAIL';
-import XHRFactorVerificationRequiredPush from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_OKTA_PUSH';
+import XHRFactorVerificationRequiredEmail from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_EMAIL';
 
 describe('v2/ion/responseTransformer', function () {
   it('returns result when invokes with invalid resp', () => {
@@ -40,7 +40,6 @@ describe('v2/ion/responseTransformer', function () {
         'submit-factor': jasmine.any(Function),
         'cancel': jasmine.any(Function),
         'context': jasmine.any(Function),
-        'recovery': jasmine.any(Function),
         'remediation': [
           {
             'name': 'submit-factor',
@@ -60,7 +59,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['submit-factor']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/',
+      url: 'http://localhost:3000/api/v1/idx/',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -68,7 +67,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['submit-factor']({foo: 'bar'})).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/',
+      url: 'http://localhost:3000/api/v1/idx/',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
         foo: 'bar',
@@ -77,7 +76,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['cancel']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/cancel',
+      url: 'http://localhost:3000/api/v1/idx/cancel',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -86,7 +85,7 @@ describe('v2/ion/responseTransformer', function () {
     // cancel doesn't take additional data for http request
     expect(result.currentState['cancel']({ foo: 'bar' })).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/cancel',
+      url: 'http://localhost:3000/api/v1/idx/cancel',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -94,7 +93,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['context']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/context',
+      url: 'http://localhost:3000/api/v1/idx/context',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -103,34 +102,22 @@ describe('v2/ion/responseTransformer', function () {
     // context doesn't take additional data for http request
     expect(result.currentState['context']({ foo: 'bar' })).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/context',
-      data: {
-        stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
-      }
-    });
-
-    expect(result.currentState['recovery']({ foo: 'bar' })).toEqual({
-      method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/recovery',
+      url: 'http://localhost:3000/api/v1/idx/context',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
     });
   });
 
-  it('converts factor verification require push', () => {
-    const result = transformResponse(XHRFactorVerificationRequiredPush.response);
+  it('converts factor verification require email', () => {
+    const result = transformResponse(XHRFactorVerificationRequiredEmail.response);
     expect(result).toEqual({
       'factor': {
-        'factorType': 'push',
+        'factorType': 'email',
         'provider': 'okta',
         'profile': {
-          'email': 'omgm@foo.dev'
+          'email': 'o*****m@abbott.dev'
         },
-        'qr': {
-          'href': ':link/:to/:qrcode'
-        },
-        'refresh': jasmine.any(Function),
         'resend': jasmine.any(Function),
       },
       'user': {
@@ -149,31 +136,35 @@ describe('v2/ion/responseTransformer', function () {
         'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
         'expiresAt': '2018-09-17T23:08:56.000Z',
         'step': 'FACTOR_VERIFICATION_REQUIRED',
+        'intent': 'login',
         'factor-poll-verification': jasmine.any(Function),
         'cancel': jasmine.any(Function),
         'context': jasmine.any(Function),
+        'otp': jasmine.any(Function),
         'remediation': [
           {
             'name': 'factor-poll-verification',
             'refresh': 2000,
             'value': [],
+          },
+          {
+            'name': 'otp',
+            'value': [
+              {
+                'name': 'otp',
+                'label': 'Passcode',
+                'minLength': 4
+              }
+            ]
           }
         ]
       },
-      __rawResponse: XHRFactorVerificationRequiredPush.response,
-    });
-
-    expect(result.factor['refresh']()).toEqual({
-      method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/refresh',
-      data: {
-        stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
-      }
+      __rawResponse: XHRFactorVerificationRequiredEmail.response,
     });
 
     expect(result.factor['resend']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/resend',
+      url: 'http://localhost:3000/api/v1/idx/resend',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -181,7 +172,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['factor-poll-verification']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/',
+      url: 'http://localhost:3000/api/v1/idx/',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -189,7 +180,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['factor-poll-verification']({foo: 'bar'})).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/',
+      url: 'http://localhost:3000/api/v1/idx/',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
       }
@@ -197,7 +188,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['cancel']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/cancel',
+      url: 'http://localhost:3000/api/v1/idx/cancel',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -206,7 +197,7 @@ describe('v2/ion/responseTransformer', function () {
     // cancel doesn't take additional data for http request
     expect(result.currentState['cancel']({ foo: 'bar' })).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/cancel',
+      url: 'http://localhost:3000/api/v1/idx/cancel',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -214,7 +205,7 @@ describe('v2/ion/responseTransformer', function () {
 
     expect(result.currentState['context']()).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/context',
+      url: 'http://localhost:3000/api/v1/idx/context',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }
@@ -223,7 +214,7 @@ describe('v2/ion/responseTransformer', function () {
     // context doesn't take additional data for http request
     expect(result.currentState['context']({ foo: 'bar' })).toEqual({
       method: 'POST',
-      url: 'https://your-org.okta.com/api/v2/authn/context',
+      url: 'http://localhost:3000/api/v1/idx/context',
       data: {
         stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82'
       }

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -116,16 +116,16 @@ describe('v2/ion/uiSchemaTransformer', function () {
           'name': 'otp',
           'value': [
             {
-              "name": "otp",
-              "label": "Passcode",
-              "minLength": 4
+              'name': 'otp',
+              'label': 'Passcode',
+              'minLength': 4
             }
           ],
           'uiSchema': [
             {
-              "name": "otp",
-              "label": "Passcode",
-              "minLength": 4,
+              'name': 'otp',
+              'label': 'Passcode',
+              'minLength': 4,
               type: 'text',
             }
           ],

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -3,7 +3,7 @@ import responseTransformer from 'v2/ion/responseTransformer';
 import actionsTransformer from 'v2/ion/actionsTransformer';
 import uiSchemaTransformer from 'v2/ion/uiSchemaTransformer';
 import XHRFactorRequiredEmail from '../../../helpers/xhr/v2/FACTOR_REQUIRED_EMAIL';
-import XHRFactorVerificationRequiredPush from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_OKTA_PUSH';
+import XHRFactorVerificationRequiredEmail from '../../../helpers/xhr/v2/FACTOR_VERIFICATION_REQUIRED_EMAIL';
 import XHRFactorEnrollOptions from '../../../helpers/xhr/v2/FACTOR_ENROLL_OPTIONS';
 
 describe('v2/ion/uiSchemaTransformer', function () {
@@ -18,7 +18,6 @@ describe('v2/ion/uiSchemaTransformer', function () {
       'submit-factor': jasmine.any(Function),
       'cancel': jasmine.any(Function),
       'context': jasmine.any(Function),
-      'recovery': jasmine.any(Function),
       'remediation': [
         {
           'name': 'submit-factor',
@@ -94,14 +93,16 @@ describe('v2/ion/uiSchemaTransformer', function () {
     });
   });
 
-  it('converts factor verification require push', () => {
-    const result = _.compose(uiSchemaTransformer, actionsTransformer, responseTransformer)(XHRFactorVerificationRequiredPush.response);
+  it('converts factor verification require email', () => {
+    const result = _.compose(uiSchemaTransformer, actionsTransformer, responseTransformer)(XHRFactorVerificationRequiredEmail.response);
     expect(result.currentState).toEqual({
       'version': '1.0.0',
       'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
       'expiresAt': '2018-09-17T23:08:56.000Z',
       'step': 'FACTOR_VERIFICATION_REQUIRED',
+      'intent': 'login',
       'factor-poll-verification': jasmine.any(Function),
+      'otp': jasmine.any(Function),
       'cancel': jasmine.any(Function),
       'context': jasmine.any(Function),
       'remediation': [
@@ -110,6 +111,24 @@ describe('v2/ion/uiSchemaTransformer', function () {
           'refresh': 2000,
           'value': [],
           'uiSchema': [],
+        },
+        {
+          'name': 'otp',
+          'value': [
+            {
+              "name": "otp",
+              "label": "Passcode",
+              "minLength": 4
+            }
+          ],
+          'uiSchema': [
+            {
+              "name": "otp",
+              "label": "Passcode",
+              "minLength": 4,
+              type: 'text',
+            }
+          ],
         }
       ]
     });


### PR DESCRIPTION
- Add `factor` object in password verification and email enroll response
- Fixes the EnrollFactorEmailView which was identical to EnrollFactorPasswordView
- Change `component` to `View` in the input options.