### PR TITLE
fix: Prevents redirect when app is in background (#787)

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -89,6 +89,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.trackTypingPattern': ['boolean', false, false],
       'features.redirectByFormSubmit': ['boolean', false, false],
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
+      'features.restrictRedirectToForeground': ['boolean', true, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/test/unit/spec/EnrollPassword_spec.js
+++ b/test/unit/spec/EnrollPassword_spec.js
@@ -8,13 +8,14 @@ define([
   'helpers/dom/Beacon',
   'helpers/util/Expect',
   'LoginRouter',
+  'util/RouterUtil',
   'util/Util',
   'sandbox',
   'helpers/xhr/FACTOR_ENROLL_allFactors',
   'helpers/xhr/FACTOR_ENROLL_password_error',
   'helpers/xhr/SUCCESS'
 ],
-function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, LoginUtil, $sandbox,
+function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, LoginUtil, $sandbox,
   resAllFactors, resError, resSuccess) {
 
   var { $ } = Okta;
@@ -23,7 +24,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, LoginUtil, $san
 
   Expect.describe('EnrollPassword', function () {
 
-    function setup (startRouter) {
+    function setup (startRouter, restrictRedirectToForeground) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({ url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -34,6 +35,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, LoginUtil, $san
         baseUrl: baseUrl,
         authClient: authClient,
         'features.router': startRouter,
+        'features.restrictRedirectToForeground': restrictRedirectToForeground,
         globalSuccessFn: successSpy,
       });
       router.on('afterError', afterErrorHandler);
@@ -101,10 +103,13 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, LoginUtil, $san
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');
         test.setNextResponse(resSuccess);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callThrough();
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy, test);
       })
         .then(function () {
+          // restrictRedirectToForeground Flag is not enabled
+          expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
           expect($.ajax.calls.count()).toBe(1);
           Expect.isJsonPost($.ajax.calls.argsFor(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -119,6 +124,48 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, LoginUtil, $san
           });
         });
     });
+
+    itp(`calls enroll with the right arguments when save is clicked in android chrome
+      in restrictRedirectToForeground flow`, function () {
+      return setup(false, true).then(function (test) {
+        $.ajax.calls.reset();
+        test.form.setPassword('somepassword');
+        test.form.setConfirmPassword('somepassword');
+        test.setNextResponse(resSuccess);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
+          return true;
+        });
+        spyOn(document, 'addEventListener').and.callFake(function (type, fn){
+          fn();
+        });
+        spyOn(document, 'removeEventListener').and.callThrough();
+        test.form.submit();
+
+        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function () {
+          return true;
+        });
+        return Expect.waitForSpyCall(test.successSpy, test);
+      })
+        .then(function () {
+          expect(RouterUtil.isHostBackgroundChromeTab).toHaveBeenCalled();
+          expect(RouterUtil.isDocumentVisible).toHaveBeenCalled();
+          expect(document.removeEventListener).toHaveBeenCalled();
+          expect(document.addEventListener).toHaveBeenCalled();
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn/factors',
+            data: {
+              factorType: 'password',
+              provider: 'OKTA',
+              profile: {
+                password: 'somepassword'
+              },
+              stateToken: '01testStateToken'
+            }
+          });
+        });
+    });
+
     itp('validates password and confirmPassword cannot be empty', function () {
       return setup().then(function (test) {
         $.ajax.calls.reset();

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 18] */
+/* eslint max-params: [2, 19] */
 define([
   'q',
   'okta',
@@ -8,6 +8,7 @@ define([
   'helpers/dom/Beacon',
   'helpers/util/Expect',
   'LoginRouter',
+  'util/RouterUtil',
   'util/BrowserFeatures',
   'util/Util',
   'sandbox',
@@ -19,7 +20,7 @@ define([
   'helpers/xhr/labels_login_ja',
   'helpers/xhr/labels_country_ja'
 ],
-function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, BrowserFeatures, LoginUtil,
+function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, BrowserFeatures, LoginUtil,
   $sandbox, resAllFactors, resFactorEnrollAllFactors, resQuestions, resError, resSuccess, labelsLoginJa, labelsCountryJa) {
 
   var { _, $ } = Okta;
@@ -181,10 +182,13 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, BrowserFeatures
         test.form.selectQuestion('favorite_security_question');
         test.form.setAnswer('No question! Hah!');
         test.setNextResponse(resSuccess);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callThrough();
         test.form.submit();
         return tick();
       })
         .then(function () {
+          // restrictRedirectToForeground Flag is not enabled
+          expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
           expect($.ajax.calls.count()).toBe(1);
           Expect.isJsonPost($.ajax.calls.argsFor(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -200,6 +204,49 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, BrowserFeatures
           });
         });
     });
+
+    itp('calls enroll with the right arguments when save is clicked in restrictRedirectToForeground flow', function () {
+      return setup(allFactors).then(function (test) {
+        $.ajax.calls.reset();
+        test.form.selectQuestion('favorite_security_question');
+        test.form.setAnswer('No question! Hah!');
+        test.setNextResponse(resSuccess);
+        // Set flag
+        test.router.settings.set('features.restrictRedirectToForeground', true);
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
+          return true;
+        });
+        spyOn(document, 'addEventListener').and.callFake(function (type, fn){
+          fn();
+        });
+        spyOn(document, 'removeEventListener').and.callThrough();
+        test.form.submit();
+        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function () {
+          return true;
+        });
+        return tick();
+      })
+        .then(function () {
+          expect(RouterUtil.isHostBackgroundChromeTab).toHaveBeenCalled();
+          expect(RouterUtil.isDocumentVisible).toHaveBeenCalled();
+          expect(document.removeEventListener).toHaveBeenCalled();
+          expect(document.addEventListener).toHaveBeenCalled();
+          expect($.ajax.calls.count()).toBe(1);
+          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            url: 'https://foo.com/api/v1/authn/factors',
+            data: {
+              factorType: 'question',
+              provider: 'OKTA',
+              profile: {
+                question: 'favorite_security_question',
+                answer: 'No question! Hah!'
+              },
+              stateToken: expectedStateToken
+            }
+          });
+        });
+    });
+
     itp('validates answer field and errors before the request', function () {
       return setup(allFactors).then(function (test) {
         $.ajax.calls.reset();


### PR DESCRIPTION
### Description

Introduces a flag to check if SIW host is in background before redirecting.

This is to overcome the issue where Chrome on android prevents app url redirects when not in foreground. This is currently happening in chrome but not on firefox on android. IOS is not an issue as safari takes care of it.

Backport of https://github.com/okta/okta-signin-widget/pull/787

Resolves: [OKTA-235748](https://oktainc.atlassian.net/browse/OKTA-235748)

### Reviewers

@magizh-okta 
