### PR TITLE
chore: Updates okta-auth-js to v2.6.3 (#790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prepublishOnly": "yarn build:release"
   },
   "devDependencies": {
-    "@okta/okta-auth-js": "~2.6.0",
+    "@okta/okta-auth-js": "~2.6.3",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1014,9 +1014,9 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           expect(params.get('prompt')).toBe(options.prompt);
         }
 
-        if (responseType === 'code') {
+        if (options.code_challenge_method) {
+          expect(params.get('code_challenge_method')).toBe(options.code_challenge_method);
           expect(params.get('code_challenge')).toBeTruthy();
-          expect(params.get('code_challenge_method')).toBe('S256');
         }
 
       }
@@ -1046,77 +1046,82 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             Expect.deprecated('Use "scopes" instead of "scope"');
           });
       });
-      itp('redirects instead of using an iframe if the responseType is "code"', function () {
+
+      itp('PKCE: redirects, sets the responseMode to "fragment" and sets a code_challenge', function () {
         return setupOAuth2({
           'authParams.responseType': 'code', 
           'authParams.grantType': 'authorization_code'
         })
-          .then(expectCodeRedirect({responseMode: 'fragment', responseType:'code'}));
+          .then(expectCodeRedirect({
+            responseMode: 'fragment',
+            responseType:'code',
+            code_challenge_method: 'S256'
+          }));
+      });
+      itp('redirects instead of using an iframe if the responseType is "code"', function () {
+        return setupOAuth2({
+          'authParams.responseType': 'code', 
+        })
+          .then(expectCodeRedirect({responseMode: 'query', responseType:'code'}));
       });
       itp('redirects to alternate authorizeUrl if the responseType is "code"', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.authorizeUrl': 'https://altfoo.com/oauth2/v1/authorize'
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://altfoo.com/oauth2/v1/authorize',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });
       itp('redirects to alternate authorizeUrl if an alternate issuer is provided', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.issuer': 'https://altfoo.com'
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://altfoo.com/oauth2/v1/authorize',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });
       itp('redirects to alternate authorizeUrl if an alternate issuer and alternate authorizeUrl is provided', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.issuer': 'https://altfoo.com',
           'authParams.authorizeUrl': 'https://reallyaltfoo.com/oauth2/v1/authorize'
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://reallyaltfoo.com/oauth2/v1/authorize',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });
       itp('redirects with alternate state provided', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.state': 'myalternatestate'
         })
           .then(expectCodeRedirect({
             state: 'myalternatestate',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });
       itp('redirects with alternate nonce provided', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.nonce': 'myalternatenonce'
         })
           .then(expectCodeRedirect({
             nonce: 'myalternatenonce',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });
       itp('redirects with alternate state and nonce provided', function () {
         return setupOAuth2({
-          'authParams.grantType': 'authorization_code',
           'authParams.responseType': 'code',
           'authParams.state': 'myalternatestate',
           'authParams.nonce': 'myalternatenonce'
@@ -1124,7 +1129,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           .then(expectCodeRedirect({
             state: 'myalternatestate',
             nonce: 'myalternatenonce',
-            responseMode: 'fragment',
+            responseMode: 'query',
             responseType:'code'
           }));
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,9 +153,10 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@okta/okta-auth-js@~2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.6.0.tgz#176091aac2054728ec6330d8efae6f4b8f4c91d8"
+"@okta/okta-auth-js@~2.6.3":
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.6.3.tgz#24ca6a1a4c2da6b6002bbf81bba97e667187e693"
+  integrity sha512-dy57KLURXRyN/AuJJh3GBAdg+XXP58WDwlruFchFGo5rq8VHooo9UggOqdYVc9wHFoubnJkh9ZS9mEqBGLYfow==
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"


### PR DESCRIPTION
### Description

- Fix tests involving authorization_code flow.
- Update to @okta/okta-auth-js@2.6.3

Backport of https://github.com/okta/okta-signin-widget/pull/790

Resolves: OKTA-242513

### Reviewers

@aarongranick-okta 
