### PR TITLE
Add sign out link to footer

### DIFF
--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -1,3 +1,4 @@
+@import './footer';
 @import './beacon';
 @import './enroll-profile';
 @import './factor-poll-verification';

--- a/assets/sass/v2/_footer.scss
+++ b/assets/sass/v2/_footer.scss
@@ -1,8 +1,7 @@
 .siw-main-footer {
   .auth-footer {
     .js-cancel {
-      display: block;
-      text-align: right;
+      float: right;
     }
   }
 }

--- a/assets/sass/v2/_footer.scss
+++ b/assets/sass/v2/_footer.scss
@@ -1,0 +1,8 @@
+.siw-main-footer {
+  .auth-footer {
+    .js-cancel {
+      display: block;
+      text-align: right;
+    }
+  }
+}

--- a/playground/mocks/api/v1/idx/cancel/data/cancel.json
+++ b/playground/mocks/api/v1/idx/cancel/data/cancel.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "status": "TERMINAL",
+  "message": {
+    "value": "You are logged out!"
+  }
+}

--- a/playground/mocks/api/v1/idx/cancel/index.js
+++ b/playground/mocks/api/v1/idx/cancel/index.js
@@ -1,0 +1,10 @@
+const data  = require('./data/cancel.json');
+const path = __dirname.slice(__dirname.indexOf('api') - 1);
+
+module.exports = {
+  path,
+  delay: [1000, 300],
+  proxy: false,
+  method: 'POST',
+  template: data,
+};

--- a/playground/mocks/api/v1/idx/enroll/data/enroll-profile.json
+++ b/playground/mocks/api/v1/idx/enroll/data/enroll-profile.json
@@ -35,22 +35,6 @@
       }
     ]
   },
-  "cancel": {
-    "rel": [
-      "create-form"
-    ],
-    "name": "cancel",
-    "href": "http://localhost:3000/api/v1/idx/cancel",
-    "method": "POST",
-    "accepts": "application/vnd.okta.v1+json",
-    "value": [
-      {
-        "name": "stateHandle",
-        "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
-        "visible": false
-      }
-    ]
-  },
   "context": {
     "rel": [
       "create-form"

--- a/playground/mocks/api/v1/idx/index.js
+++ b/playground/mocks/api/v1/idx/index.js
@@ -21,7 +21,7 @@ const factorEnrollPassword = [
 ];
 const path = __dirname.slice(__dirname.indexOf('api') - 1);
 
-const testData = factorRequiredEmail;
+const testData = factorRequiredPassword;
 
 let index = 0;
 

--- a/playground/mocks/api/v1/idx/introspect/data/identify.json
+++ b/playground/mocks/api/v1/idx/introspect/data/identify.json
@@ -29,22 +29,6 @@
         }
       ]
     },
-    "cancel": {
-      "rel": [
-        "create-form"
-      ],
-      "name": "cancel",
-      "href": "http://localhost:3000/api/v1/idx/cancel",
-      "method": "POST",
-      "accepts": "application/vnd.okta.v1+json",
-      "value": [
-        {
-          "name": "stateHandle",
-          "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
-          "visible": false
-        }
-      ]
-    },
     "enroll": {
       "rel": [
         "create-form"

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -19,7 +19,6 @@ export default BaseLoginController.extend({
   initialize: function () {
     BaseLoginController.prototype.initialize.call(this);
 
-    this.listenTo(this.options.appState, 'change:currentState', this.render);
     this.listenTo(this.options.appState, 'change:currentFormName', this.render);
     this.listenTo(this.options.appState, 'invokeAction', this.invokeAction);
     this.listenTo(this.options.appState, 'saveForm', this.handleFormSave);

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -24,7 +24,25 @@ export default View.extend({
 
   initialize () {
     const links = _.resultCtx(this, 'links', this);
+    let cancelFn = this.options.appState.get('currentState').cancel;
+    let cancelObj = {
+      'actionPath': 'cancel',
+      'label': 'Sign out',
+      'name': 'cancel',
+      'type': 'link'
+    };
+    const cancelInLinks = links.find(obj => obj.name === 'cancel');
+    const isTerminalState = this.options.appState.get('currentState').status === 'TERMINAL';
 
+    if (cancelFn && _.isFunction(cancelFn) && !cancelInLinks) {
+      //add cancel/signout link
+      links.push(cancelObj);
+    }
+
+    //remove cancel/signout link if TERMINAL state that were previously added in other states
+    if (isTerminalState && cancelInLinks) {
+      links.pop();
+    }
     links.forEach(link => {
       this.add(Link, {
         options: link,

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -33,7 +33,7 @@ export default View.extend({
     };
     const isTerminalState = this.options.appState.get('currentState').status === 'TERMINAL';
 
-    if (cancelFn && _.isFunction(cancelFn) && !isTerminalState) {
+    if (_.isFunction(cancelFn) && !isTerminalState) {
       //add cancel/signout link
       links.push(cancelObj);
     }

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -31,18 +31,13 @@ export default View.extend({
       'name': 'cancel',
       'type': 'link'
     };
-    const cancelInLinks = links.find(obj => obj.name === 'cancel');
     const isTerminalState = this.options.appState.get('currentState').status === 'TERMINAL';
 
-    if (cancelFn && _.isFunction(cancelFn) && !cancelInLinks) {
+    if (cancelFn && _.isFunction(cancelFn) && !isTerminalState) {
       //add cancel/signout link
       links.push(cancelObj);
     }
 
-    //remove cancel/signout link if TERMINAL state that were previously added in other states
-    if (isTerminalState && cancelInLinks) {
-      links.pop();
-    }
     links.forEach(link => {
       this.add(Link, {
         options: link,

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -2,6 +2,7 @@ import { View } from 'okta';
 import BaseForm from './BaseForm';
 import BaseModel from './BaseModel';
 import BaseHeader from './BaseHeader';
+import BaseFooter from './BaseFooter';
 
 export default View.extend({
 
@@ -9,7 +10,7 @@ export default View.extend({
 
   Body: BaseForm,
 
-  Footer: '',
+  Footer: BaseFooter,
 
   className: 'siw-main-view',
 

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -1,5 +1,6 @@
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
+import BaseFooter from '../internals/BaseFooter';
 
 const Body = BaseForm.extend({
   title () {
@@ -9,6 +10,20 @@ const Body = BaseForm.extend({
   noButtonBar: true,
 });
 
+const Footer = BaseFooter.extend({
+  links () {
+    return [
+      {
+        'type': 'link',
+        'label': 'Back to sign in',
+        'name': 'back',
+        'href': '/'
+      }
+    ];
+  }
+});
+
 export default BaseView.extend({
   Body,
+  Footer
 });


### PR DESCRIPTION
Add sign out to all views with cancel action 
 
<img width="432" alt="Screen Shot 2019-08-12 at 7 42 43 PM" src="https://user-images.githubusercontent.com/23267876/62913444-e6d84300-bd40-11e9-9bbf-6f23ecab0d26.png">

<img width="424" alt="Screen Shot 2019-08-12 at 7 42 48 PM" src="https://user-images.githubusercontent.com/23267876/62913447-ecce2400-bd40-11e9-873b-78493be28728.png">

Clicking on cancel will take users to terminal state for ( LEA). Add back to sign in to `Terminal` state. Note that this flow of taking users to the terminal state on sign out still needs to discussed with PM.

<img width="422" alt="Screen Shot 2019-08-12 at 8 39 12 PM" src="https://user-images.githubusercontent.com/23267876/62913535-58b08c80-bd41-11e9-916f-365e55c9c407.png">

Sign out link with recovery link  
<img width="456" alt="Screen Shot 2019-08-13 at 9 47 48 AM" src="https://user-images.githubusercontent.com/23267876/62960408-71578b80-bdaf-11e9-9076-760b73364d32.png">

@taylorlaubach-okta 
