### PR TITLE
fix: clears lastAuthResponse after a transaction is canceled

### DIFF
--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -200,6 +200,10 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
       this.set('lastAuthResponse', res);
     },
 
+    clearLastAuthResponse: function () {
+      this.set('lastAuthResponse', {});
+    },
+
     derived: {
       'isSuccessResponse': {
         deps: ['lastAuthResponse'],

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -127,6 +127,7 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
   fn.routeAfterAuthStatusChange = function (router, res) {
     // Other errors are handled by the function making the authClient request
     if (!res || !res.status) {
+      router.appState.clearLastAuthResponse();
       return;
     }
 

--- a/test/unit/helpers/xhr/CANCEL.js
+++ b/test/unit/helpers/xhr/CANCEL.js
@@ -1,0 +1,7 @@
+define({
+  "status": 200,
+  "responseType": "json",
+  "response": {
+    "_embedded": {}
+  }
+});

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -126,6 +126,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
     itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
       return setup()
         .then(function (test) {
+          spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           $.ajax.calls.reset();
           test.setNextResponse(res200);
           var $link = test.form.signoutLink();
@@ -141,6 +142,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
               stateToken: 'testStateToken'
             }
           });
+          expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           Expect.isPrimaryAuth(test.router.controller);
         });
     });
@@ -157,15 +159,16 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
+            spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
             expect($link.length).toBe(1);
             $link.click();
-            return tick();
+            return tick(test);
           })
-          .then(function () {
+          .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
             Expect.isJsonPost($.ajax.calls.argsFor(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
@@ -173,6 +176,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
                 stateToken: 'testStateToken'
               }
             });
+            expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
             expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -73,6 +73,7 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
     itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
       return setup()
         .then(function (test) {
+          spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           $.ajax.calls.reset();
           test.setNextResponse(res200);
           var $link = test.form.signoutLink();
@@ -88,6 +89,7 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
               stateToken: 'testStateToken'
             }
           });
+          expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           Expect.isPrimaryAuth(test.router.controller);
         });
     });
@@ -104,15 +106,16 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
+            spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
             expect($link.length).toBe(1);
             $link.click();
-            return tick();
+            return tick(test);
           })
-          .then(function () {
+          .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
             Expect.isJsonPost($.ajax.calls.argsFor(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
@@ -120,6 +123,7 @@ function (Okta, OktaAuth, Util, RecoveryChallengeForm, Beacon, Expect, Router,
                 stateToken: 'testStateToken'
               }
             });
+            expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
             expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -65,6 +65,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
     itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
       return setup()
         .then(function (test) {
+          spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           $.ajax.calls.reset();
           test.setNextResponse(res200);
           var $link = test.form.signoutLink();
@@ -80,6 +81,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
               stateToken: 'testStateToken'
             }
           });
+          expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           Expect.isPrimaryAuth(test.router.controller);
         });
     });
@@ -87,15 +89,16 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
       function () {
         return setup({ signOutLink: 'http://www.goodbye.com' })
           .then(function (test) {
+            spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
             $.ajax.calls.reset();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
             expect($link.length).toBe(1);
             $link.click();
-            return tick();
+            return tick(test);
           })
-          .then(function () {
+          .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
             Expect.isJsonPost($.ajax.calls.argsFor(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
@@ -103,6 +106,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
                 stateToken: 'testStateToken'
               }
             });
+            expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
             expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
           });
       });


### PR DESCRIPTION
After clicking on sign out during passwordless flow, we see that lastAuthResponse is not reset and the widget still thinks it is in UNAUTHENTICATED state which causes the issue. Clearing lastAuthResponse when !res || !res.status fixes it.

Resolves: OKTA-238146

before: 
![before](https://user-images.githubusercontent.com/26014318/63130143-567f4580-bf6e-11e9-993b-a0e825a65a62.gif)

after:
![after](https://user-images.githubusercontent.com/26014318/63130154-6008ad80-bf6e-11e9-8e12-19fe93ce8291.gif)
