### PR TITLE
fix: add excludeCredentials support to EnrollWebauthnController.js

### DIFF
--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -27,6 +27,17 @@ function (Okta, Errors, FormType, FormController, CryptoUtil, webauthn, Footer, 
 
   var _ = Okta._;
 
+  function getExcludeCredentials (credentials) {
+    var excludeCredentials = [];
+    _.each(credentials, function (credential) {
+      excludeCredentials.push({
+        type: 'public-key',
+        id: CryptoUtil.strToBin(credential.id)
+      });
+    });
+    return excludeCredentials;
+  }  
+
   return FormController.extend({
     className: 'enroll-webauthn',
     Model: {
@@ -65,7 +76,8 @@ function (Okta, Errors, FormType, FormController, CryptoUtil, webauthn, Footer, 
                 id: CryptoUtil.strToBin(activation.user.id),
                 name: activation.user.name,
                 displayName: activation.user.displayName
-              }
+              },
+              excludeCredentials: getExcludeCredentials(activation.excludeCredentials)
             });
             return new Q(navigator.credentials.create({publicKey: options}))
               .then(function (newCredential) {

--- a/test/unit/helpers/xhr/MFA_ENROLL_ACTIVATE_webauthn.js
+++ b/test/unit/helpers/xhr/MFA_ENROLL_ACTIVATE_webauthn.js
@@ -44,7 +44,11 @@ define({
             },
             "u2fParams": {
               "appid": "https://test.okta.com"
-            }
+            },
+            "excludeCredentials": [{
+              "type": 'public-key',
+              "id": "vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt"
+            }]            
           }
         }
       }

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -237,7 +237,11 @@ function (Okta,
                 },
                 u2fParams: {
                   appid: 'https://test.okta.com'
-                }
+                },
+                excludeCredentials: [{
+                  type: 'public-key',
+                  id: CryptoUtil.strToBin('vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZt')
+                }]
               }
             });
             expect($.ajax.calls.count()).toBe(2);


### PR DESCRIPTION
Just convert excludeCredentials' public key credential object's `id` when it comes in from the backend. This fixes a bug where we would allow duplicate WebAuthn authenticator enrollments.

Resolves: OKTA-245259