### PR TITLE
feat: risk number challenge:

### DIFF
--- a/assets/sass/modules/_mfa-challenge-forms.scss
+++ b/assets/sass/modules/_mfa-challenge-forms.scss
@@ -67,3 +67,40 @@
     width: 100%;
   }
 }
+
+// number challenge Okta-verify push
+.number-challenge-view {
+  display: none;
+  text-align: center;
+  .phone {
+    margin: 20px 0;
+    .phone--body {
+      display: inline-block;
+      border-radius: 6px;
+      padding: 14px 3px 0;
+      margin: 0 auto;
+      background: #666;
+    }
+    .phone--screen {
+      min-width: 50px;
+      padding: 20px 0;
+      background: #e5edfb;
+    }
+    .phone--number {
+      padding: 10px;
+      font-size: 25px;
+      color: #1662dd;
+    }
+    .phone--home-button {
+      border-radius: 50%;
+      width: 10px;
+      height: 10px;
+      margin: 3px auto;
+      background: $white;
+    }
+  }
+  .challenge-number {
+    font-weight: bold;
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "~2.6.3",
+    "@okta/okta-auth-js": "2.9.0-alpha.g0a3ff20",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -22,10 +22,11 @@ define([
   'views/mfa-verify/PushForm',
   'views/mfa-verify/PasswordForm',
   'views/mfa-verify/InlineTOTPForm',
+  'views/mfa-verify/NumberChallengeView',
   'views/shared/FooterSignout'
 ],
 function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm, PassCodeForm,
-  EmailMagicLinkForm, PushForm, PasswordForm, InlineTOTPForm, FooterSignout) {
+  EmailMagicLinkForm, PushForm, PasswordForm, InlineTOTPForm, NumberChallengeView, FooterSignout) {
 
   var { CheckBox } = Okta.internal.views.forms.inputs;
 
@@ -84,13 +85,13 @@ function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm
       // which is rendered in an additional InlineTOTPForm
       if (factorType === 'push' && this.model.get('isOktaFactor')) {
         if (this.model.get('backupFactor')) {
-          this.add(InlineTOTPForm, {
+          this.inlineTotpForm = this.add(InlineTOTPForm, {
             options: { model: this.model.get('backupFactor') }
-          });
+          }).last();
         }
 
         if (this.settings.get('features.autoPush')) {
-          this.add(CheckBox, {
+          this.autoPushCheckBox = this.add(CheckBox, {
             options: {
               model: this.model,
               name: 'autoPush',
@@ -99,12 +100,12 @@ function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm
               'label-top': false,
               className: 'margin-btm-0'
             }
-          });
+          }).last();
         }
 
         // Remember Device checkbox resides outside of the Push and TOTP forms.
         if (this.options.appState.get('allowRememberDevice')) {
-          this.add(CheckBox, {
+          this.rememberDeviceCheckbox = this.add(CheckBox, {
             options: {
               model: this.model,
               name: 'rememberDevice',
@@ -113,7 +114,7 @@ function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm
               'label-top': true,
               className: 'margin-btm-0'
             }
-          });
+          }).last();
         }
         // Set rememberDevice on the backup factor (totp) if available
         if (this.model.get('backupFactor')) {
@@ -122,6 +123,20 @@ function (Okta, BaseLoginController, TOTPForm, YubikeyForm, SecurityQuestionForm
           });
         }
       }
+
+      this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge',
+        function (state, isWaitingForNumberChallenge) {
+          if (isWaitingForNumberChallenge || this.options.appState.get('lastAuthResponse').status === 'SUCCESS') {
+            this.autoPushCheckBox && this.autoPushCheckBox.$el.hide();
+            this.rememberDeviceCheckbox && this.rememberDeviceCheckbox.$el.hide();
+            this.inlineTotpForm && this.inlineTotpForm.$el.hide();
+          } else {
+            this.autoPushCheckBox && this.autoPushCheckBox.$el.show();
+            this.rememberDeviceCheckbox && this.rememberDeviceCheckbox.$el.show();
+            this.inlineTotpForm && this.inlineTotpForm.$el.show();
+          }
+        }
+      );
 
       if (!this.settings.get('features.hideSignOutLinkInMFA')) {
         this.add(new FooterSignout(this.toJSON()));

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -280,6 +280,17 @@ function (Okta, Q, Factor, BrowserFeatures, Errors) {
           return isMfaEnrollActivate && res.factorResult === 'WAITING';
         }
       },
+      'isWaitingForNumberChallenge': {
+        deps: ['lastAuthResponse'],
+        fn: function (res) {
+          if (res && res.factorResult === 'WAITING'
+              && res._embedded.factor._embedded
+              && res._embedded.factor._embedded.challenge) {
+            return true;
+          }
+          return false;
+        }
+      },
       'hasMultipleFactorsAvailable': {
         deps: ['factors', 'isMfaRequired', 'isMfaChallenge', 'isUnauthenticated'],
         fn: function (factors, isMfaRequired, isMfaChallenge, isUnauthenticated) {

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -301,7 +301,15 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
         return promise
           .then(function (trans) {
             var options = {
-              'delay': PUSH_INTERVAL
+              'delay': PUSH_INTERVAL,
+              'transactionCallBack': (transaction) => {
+                // transaction._embedded.factor._embedded = {
+                //   challenge : {
+                //     correctAnswer: 54
+                //   }
+                // };
+                self.options.appState.set('lastAuthResponse', transaction);
+              },
             };
             setTransaction(trans);
             // In Okta verify case we initiate poll.
@@ -325,6 +333,7 @@ function (Okta, Q, factorUtil, Util, Errors, BaseLoginModel) {
                   };
                 }
                 return trans.poll(options).then(function (trans) {
+                  self.options.appState.set('lastAuthResponse', trans.data);
                   setTransaction(trans);
                 });
               });

--- a/src/views/mfa-verify/NumberChallengeView.js
+++ b/src/views/mfa-verify/NumberChallengeView.js
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define([
+  'okta',
+], function (Okta) {
+
+  return Okta.View.extend({
+    className: 'number-challenge-view',
+    template: `
+      <p>On your phone tap, <span class="challenge-number">{{number}}</span> on Okta Verify prompt to continue.</p>
+      <div class="phone">
+        <div class="phone--body">
+          <div class="phone--screen">
+            <span class="phone--number">{{number}}</span>
+          </div>
+          <div class="phone--home-button"></div>
+        </div>        
+      </div>
+      <p>This extra step helps us make sure it's really you signing in.</p>
+    `,
+    initialize () {
+      this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', () => {
+        if (this.options.appState.get('lastAuthResponse').status !== 'SUCCESS') {
+          this.render();
+        }        
+      });
+    },
+    getTemplateData () {
+      const lastAuthResponse = this.options.appState.get('lastAuthResponse');
+      if (!this.options.appState.get('isWaitingForNumberChallenge')) {
+        return {
+          number: null
+        };
+      }
+      return {
+        number: lastAuthResponse._embedded.factor._embedded.challenge.correctAnswer,
+      };
+    } 
+  });
+
+});

--- a/src/views/mfa-verify/PushForm.js
+++ b/src/views/mfa-verify/PushForm.js
@@ -10,7 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta', 'util/CookieUtil', 'util/Util'], function (Okta, CookieUtil, Util) {
+define([
+  'okta',
+  'util/CookieUtil',
+  'util/Util',
+  './NumberChallengeView',
+],
+function (Okta, CookieUtil, Util, NumberChallengeView) {
 
   var _ = Okta._;
   // deviceName is escaped on BaseForm (see BaseForm's template)
@@ -40,6 +46,19 @@ define(['okta', 'util/CookieUtil', 'util/Util'], function (Okta, CookieUtil, Uti
           this.setSubmitState(isMfaRejectedByUser);
           if (isMfaRejectedByUser) {
             this.showError(Okta.loc('oktaverify.rejected', 'login'));
+          }
+        }
+      );
+
+      this.numberChallengeView = this.add(NumberChallengeView).last();
+      this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge',
+        function (state, isWaitingForNumberChallenge) {
+          if (isWaitingForNumberChallenge || this.options.appState.get('lastAuthResponse').status === 'SUCCESS') {
+            this.$el.find('.button').hide();
+            this.numberChallengeView.$el.show();
+          } else {
+            this.numberChallengeView.$el.hide();
+            this.$el.find('.button').show();
           }
         }
       );
@@ -110,7 +129,9 @@ define(['okta', 'util/CookieUtil', 'util/Util'], function (Okta, CookieUtil, Uti
         });
         this.trigger('save', this.model);
         warningTimeout = Util.callAfterTimeout(_.bind(function () {
-          this.showWarning(Okta.loc('oktaverify.warning', 'login'));
+          if (!this.options.appState.get('isWaitingForNumberChallenge')) {
+            this.showWarning(Okta.loc('oktaverify.warning', 'login'));
+          }          
         }, this), WARNING_TIMEOUT);
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,10 +284,10 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@okta/okta-auth-js@~2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.6.3.tgz#24ca6a1a4c2da6b6002bbf81bba97e667187e693"
-  integrity sha512-dy57KLURXRyN/AuJJh3GBAdg+XXP58WDwlruFchFGo5rq8VHooo9UggOqdYVc9wHFoubnJkh9ZS9mEqBGLYfow==
+
+"@okta/okta-auth-js@2.9.0-alpha.g0a3ff20":
+  version "2.9.0-alpha.g0a3ff20"
+  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta/@okta/okta-auth-js/-/@okta/okta-auth-js-2.9.0-alpha.g0a3ff20.tgz#4a1e2ba3ecc887a77cff1abdb6968625b6ba2d4d"
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"


### PR DESCRIPTION
* adds Number challenge screen in okta-verify challenge flow. 
* adds callback to update lastauthResponse when poll is happening.

The thing is there is no state change for factorResult/status. The only thing that changes is that during the poll the authn response has extra embedded info. 
https://user-images.githubusercontent.com/51595754/63372918-eab92600-c33b-11e9-8ecc-786e431db66b.png

I am using the same push form to display the number challenge view and hide the save button because the poll would still happen and things like timeout/cancel will be taken care automatically. 





Auth js change 
https://github.com/okta/okta-auth-js/pull/245