### PR TITLE
fix: configure authClient using "authParams" OKTA-240327

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ packages/@okta/courage-dist/*.map
 /dist
 .yalc
 .env
+testenv
 packages/@okta/i18n/dist/json/

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:dev": "grunt assets && karma start",
     "test:coverage": "yarn test --reporters=progress,coverage",
     "test": "yarn test:dev --single-run",
+    "start:app": "yarn build:webpack-e2e-app && grunt copy:e2e-pages && yarn start:basic",
     "start:basic": "PORT=3000 node test/e2e/basic/server.js & wait-on http-get://localhost:3000",
     "install:react": "yarn --cwd test/e2e/react-app install",
     "prestart:react": "kill -9 $(lsof -t -i:3001 -sTCP:LISTEN) || true",

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -107,7 +107,7 @@ var OktaSignIn = (function () {
       `
     );
 
-    var authClient = new OktaAuth({
+    var authParams = _.extend({
       url: options.baseUrl,
       transformErrorXHR: Util.transformErrorXHR,
       headers: {
@@ -115,7 +115,9 @@ var OktaSignIn = (function () {
       },
       clientId: options.clientId,
       redirectUri: options.redirectUri
-    });
+    }, options.authParams);
+
+    var authClient = new OktaAuth(authParams);
     _.extend(this, LoginRouter.prototype.Events, getProperties(authClient, LoginRouter, Util, options));
 
     // Triggers the event up the chain so it is available to the consumers of the widget.

--- a/test/e2e/angular-app/extra-webpack.config.js
+++ b/test/e2e/angular-app/extra-webpack.config.js
@@ -7,6 +7,7 @@ const env = {};
 [
   'PORT',
   'WIDGET_TEST_SERVER',
+  'WIDGET_AUTH_SERVER_ID',
   'WIDGET_CLIENT_ID'
 ].forEach(function (key) {
   env[key] = JSON.stringify(process.env[key]);

--- a/test/e2e/angular-app/src/app/app.module.ts
+++ b/test/e2e/angular-app/src/app/app.module.ts
@@ -16,11 +16,11 @@ import { ProtectedComponent } from './protected.component';
 import { LoginComponent } from './login.component';
 
 // See extra-webpack.config.js
-let { WIDGET_TEST_SERVER, WIDGET_CLIENT_ID, PORT } = process.env;
+let { WIDGET_TEST_SERVER, WIDGET_AUTH_SERVER_ID, WIDGET_CLIENT_ID, PORT } = process.env;
 PORT = PORT || '4200';
 
 const config = {
-  issuer: `${WIDGET_TEST_SERVER}/oauth2/default`,
+  issuer: `${WIDGET_TEST_SERVER}/oauth2/${WIDGET_AUTH_SERVER_ID}`,
   redirectUri: `http://localhost:${PORT}/implicit/callback`,
   clientId: `${WIDGET_CLIENT_ID}`
 };

--- a/test/e2e/app/app-using-osw-entry.js
+++ b/test/e2e/app/app-using-osw-entry.js
@@ -5,6 +5,11 @@
 // Options are currently not configurable - update this in the future if we
 // want more granularity in testing the npm artifact vs. the cdn artifact.
 
+// - To build, first copy to "target". Grunt will do variable substitution
+// grunt copy:e2e
+// - then webpack
+// yarn build:webpack-e2e-app
+
 var OktaSignIn = require('../../js/okta-sign-in.entry');
 
 var signIn = new OktaSignIn({

--- a/test/e2e/env.defaults.js
+++ b/test/e2e/env.defaults.js
@@ -1,6 +1,7 @@
 module.exports = {
   // Server / Client
   WIDGET_TEST_SERVER: '',
+  WIDGET_AUTH_SERVER_ID: 'default',
   WIDGET_CLIENT_ID: 'rW47c465c1wc3MKzHznu',
 
   // Basic user 1

--- a/test/e2e/env.js
+++ b/test/e2e/env.js
@@ -1,14 +1,23 @@
 /* eslint no-console: 0 */
 const path = require('path');
+const fs = require('fs');
+const dotenv = require('dotenv');
+
 var DEFAULTS = require('./env.defaults');
 var VALUES = {};
 
 function config () {
-  require('dotenv').config({
-    path: path.resolve(__dirname, '../..', '.env')
-  });
 
+  // Read environment variables from "testenv". Override environment vars if they are already set.
+  const TESTENV = path.resolve(__dirname, '../..', 'testenv');
+  if (fs.existsSync(TESTENV)) {
+    const envConfig = dotenv.parse(fs.readFileSync(TESTENV));
+    Object.keys(envConfig).forEach((k) => {
+      process.env[k] = envConfig[k];
+    });
+  }
 
+  // Set defaults, populate VALUES
   Object.keys(DEFAULTS).forEach(function (key) {
     if (!process.env[key]) {
       // Allow use of default value

--- a/test/e2e/layouts/cdn.tpl
+++ b/test/e2e/layouts/cdn.tpl
@@ -14,6 +14,11 @@
   <script type="text/javascript">
     {{> @partial-block }}
   </script>
+
+  {{#> body-block}}
+    {{!-- body content goes here. --}}
+  {{/body-block}}
+
 </body>
 
 </html>

--- a/test/e2e/react-app/config-overrides.js
+++ b/test/e2e/react-app/config-overrides.js
@@ -17,6 +17,7 @@ const env = {};
 [
   'PORT',
   'WIDGET_TEST_SERVER',
+  'WIDGET_AUTH_SERVER_ID',
   'WIDGET_CLIENT_ID'
 ].forEach(function (key) {
   env[key] = JSON.stringify(process.env[key]);

--- a/test/e2e/react-app/src/App.js
+++ b/test/e2e/react-app/src/App.js
@@ -13,12 +13,12 @@ function onAuthRequired({history}) {
 }
 
 // See config-overrides.js
-/* global WIDGET_TEST_SERVER, WIDGET_CLIENT_ID */
+/* global WIDGET_TEST_SERVER, WIDGET_AUTH_SERVER_ID, WIDGET_CLIENT_ID */
 class App extends Component {
   render() {
     return (
       <Router>
-        <Security issuer={WIDGET_TEST_SERVER + '/oauth2/default'}
+        <Security issuer={`${WIDGET_TEST_SERVER}/oauth2/${WIDGET_AUTH_SERVER_ID}`}
                   client_id={WIDGET_CLIENT_ID}
                   redirect_uri={window.location.origin + '/implicit/callback'}
                   onAuthRequired={onAuthRequired} >

--- a/test/e2e/templates/oidc.tpl
+++ b/test/e2e/templates/oidc.tpl
@@ -1,4 +1,44 @@
 {{#> cdnLayout}}
+
+function _initialize(event) {
+  event.preventDefault();
+  var config = JSON.parse(document.getElementById('config-textarea').value);
+  initialize(config);
+}
+
+var CONFIG = {
+  baseUrl: '{{{WIDGET_TEST_SERVER}}}',
+  clientId: '{{{WIDGET_CLIENT_ID}}}',
+  redirectUri: 'http://localhost:3000/done',
+  authParams: {
+    issuer: '{{WIDGET_TEST_SERVER}}/oauth2/{{WIDGET_AUTH_SERVER_ID}}',
+    responseType: 'id_token',
+    scope: ['openid', 'email', 'profile', 'address', 'phone']
+  },
+  idps: [
+    {
+      'type': 'FACEBOOK',
+      'id': '0oa85bk5q6KOPeHCT0h7'
+    }
+  ]
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  var formattedConfig = JSON.stringify(CONFIG, null, 2);
+  formattedConfig = formattedConfig.replace(/\n/g, '\r\n');
+  document.getElementById('config-textarea').value = formattedConfig;
+});
+
+  {{#*inline "body-block"}}
+    <div>
+      <a href="#" onclick="_initialize(event);">Initialize</a>
+    </div>
+
+    <textarea id="config-textarea" rows="20" cols="80" wrap="hard"></textarea>
+  {{/inline}}
+
+
+
 var CONTAINER_ID = 'okta-login-container';
 
 function addMessageToPage(id, msg) {

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -64,6 +64,33 @@ function (Widget, Expect, Logger, $sandbox) {
     });
 
     Expect.describe('Auth Client', function () {
+      Expect.describe('Config', function () {
+        it('has an options object', function () {
+          expect(signIn.authClient.options).toBeDefined();
+        });
+        
+        it('SIW passes all config within authParams to OktaAuth', function () {
+          const authParams = {
+            // known params
+            issuer: 'my-issuer',
+            authorizeUrl: 'fake-url',
+            pkce: true,
+            // unknown
+            a: 'b',
+            x: [],
+            y: function () {},
+          };
+          signIn = new Widget({
+            baseUrl: url,
+            authParams,
+          });
+
+          Object.keys(authParams).forEach(function (key) {
+            expect(signIn.authClient.options[key]).toBe(authParams[key]);
+          });
+        });
+      });
+
       Expect.describe('Session', function () {
         it('has a session method', function () {
           expect(signIn.authClient.session).toBeDefined();


### PR DESCRIPTION
See github issue for more details: https://github.com/okta/okta-signin-widget/issues/760

Customers are expecting to be able to use the `authClient` instance from the SIW to do other operations. However, this instance is incompletely configured. Currently only a minimum of parameters are passed to `OktaAuthJS` at construction and the other "authParams" are cherry picked and passed to the `authClient` as needed.

With this change, the entire `authParams` object will be passed to `OktaAuthJS`. This has no negative effect on `OktaAuthJS` or the SIW but it will allow other operations such as `getWithRedirect` to be called without requiring extra parameters. `OktaAuthJS` will generally use, by default, the configuration passed in at construction.


Also adds some test infrastructure updates/housekeeping that I found necessary for local testing:
- Adds support for `testenv` file (deprecates `.env`) - this matches convention in our other repos such as `okta-ui`
- Enhances "basic" OIDC test app (which can be run with `yarn start:app` with a textarea to edit config. This allows manual testing of scenarios using arbitrary config

