### PR TITLE
docs: update README for PKCE config (OKTA-257348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ var signIn = new OktaSignIn(
     redirectUri: '{{redirectUri configured in OIDC app}}',
     authParams: {
       display: 'page',
-      responseType: 'code',
-      grantType: 'authorization_code'
+      pkce: true
     }
   }
 );
@@ -946,6 +945,8 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     oAuthTimeout: 300000 // 5 minutes
     ```
 
+- **authParams.pkce:** Set to `true` to enable PKCE flow
+
 - **authParams.display:** Specify how to display the authentication UI for External Identity Providers. Defaults to `popup`.
 
     - `popup` - Opens a popup to the authorization server when an External Identity Provider button is clicked. `responseMode` will be set to `okta_post_message` and cannot be overridden.
@@ -958,20 +959,6 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     authParams: {
       display: 'page',
       responseType: 'token'
-    }
-    ```
-
-- **authParams.grantType:** Used only by Single-page applications. Specify a flow to be used when authenticating or renewing tokens.
-
-  - `implicit` - The default value. The tokens requested in `responseType` will be returned as parameters on the `redirectUri`
-  - `authorization_code` - Use PKCE client-side authorization code flow. Must be used in combination with `responseType: ['code']`
-
-    ```javascript
-    // Use PKCE flow
-    authParams: {
-      display: 'page',
-      responseType: 'code',
-      grantType: 'authorization_code'
     }
     ```
 

--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -55,7 +55,9 @@ define(['okta', './Enums', './Errors', './Util'], function (Okta, Enums, Errors,
       oauthParams,
       _.pick(options, 'clientId', 'redirectUri'),
       _.pick(options.authParams,
-        'pkce', 'grantType', 'responseType', 'responseMode',
+        'pkce',
+        'grantType', // deprecated
+        'responseType', 'responseMode',
         'display', 'scopes', 'state', 'nonce'),
       params
     );


### PR DESCRIPTION
The `grantType` authParams option was deprecated a couple months ago in favor of the much simpler `pkce: true` Somehow the README did not get updated to reflect this