### PR TITLE
fix: replace tick() with wait conditions OKTA-257628

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -45,6 +45,7 @@ module.exports = (config) => {
       // but this works only with `karma start`, not `karma run`.
       test: config.test,
       jasmine: {
+        timeoutInterval: 10000, // increased timeout for Travis
         random: false
       }
     },

--- a/test/unit/spec/ConsentRequired_spec.js
+++ b/test/unit/spec/ConsentRequired_spec.js
@@ -175,7 +175,9 @@ function (Okta, OktaAuth, LoginUtil, Util, ConsentRequiredForm, Expect, Router,
           $.ajax.calls.reset();
           test.setNextResponse(resCancel);
           test.form.cancelButton().click();
-          return tick(test);
+          return Expect.wait(function () {
+            return $.ajax.calls.count() > 0;
+          }, test);
         })
           .then(function (test) {
             expect($.ajax.calls.count()).toBe(1);
@@ -185,6 +187,11 @@ function (Okta, OktaAuth, LoginUtil, Util, ConsentRequiredForm, Expect, Router,
                 stateToken: 'testStateToken'
               }
             });
+            return Expect.wait(function () {
+              return test.router.controller.options.appState.clearLastAuthResponse.calls.count() > 0;
+            }, test);
+          })
+          .then(function (test) {
             expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
             expect(cancel).toHaveBeenCalled();
           });


### PR DESCRIPTION
Fixes some "flakey" tests by replacing uses of `tick()` with specific wait conditions
Corrects 2 instances of live network traffic being sent, because tests ended too early, while an operation was in progress. (LoginRouter)