### PR TITLE
fix: fix OKTA-251844

### DIFF
--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -14,9 +14,10 @@ define([
   'okta',
   'models/PrimaryAuth',
   'util/CookieUtil',
-  'util/Enums'
+  'util/Enums',
+  'util/Util',
 ],
-function (Okta, PrimaryAuthModel, CookieUtil, Enums) {
+function (Okta, PrimaryAuthModel, CookieUtil, Enums, Util) {
 
   var _ = Okta._;
 
@@ -64,7 +65,10 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums) {
             if(res.links[0].properties['okta:idp:type'] === 'OKTA') {
               this.trigger('goToPrimaryAuth');
             } else if (res.links[0].href) {
-              var redirectFn = this.settings.get('redirectUtilFn');
+              //override redirectFn to only use Util.redirectWithFormGet if OKTA_INVALID_SESSION_REPOST is included
+              //it will be encoded since it will be included in the encoded fromURI
+              var redirectFn = res.links[0].href.includes('OKTA_INVALID_SESSION_REPOST%3Dtrue') ? 
+                Util.redirectWithFormGet.bind(Util) : this.settings.get('redirectUtilFn');
               redirectFn(res.links[0].href);
             }
           }

--- a/test/unit/helpers/xhr/IDPDiscoverySuccessRepost_IWA.js
+++ b/test/unit/helpers/xhr/IDPDiscoverySuccessRepost_IWA.js
@@ -1,0 +1,15 @@
+define({
+  "links": [
+    {
+      "href": "http://demo.okta1.com:1802/login/sso_iwa?fromURI=%2Fapp%2Finstance%2Fkey%3FSAMLRequest%3Dencoded%26RelayState%3DrelayState%26OKTA_INVALID_SESSION_REPOST%3Dtrue",
+      "properties": {
+        "okta:idp:type": "IWA"
+      },
+      "rel": "okta:idp",
+      "titles": {
+        "und": "IWA"
+      }
+    }
+  ],
+  "subject": "acct:test@okta.com"
+});

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -21,11 +21,12 @@ define([
   'helpers/xhr/IDPDiscoverySuccess_OktaIDP',
   'helpers/xhr/ERROR_webfinger',
   'helpers/xhr/PASSWORDLESS_UNAUTHENTICATED',
+  'helpers/xhr/IDPDiscoverySuccessRepost_IWA',
   'sandbox'
 ],
 function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, Beacon, IDPDiscovery,
   Router, BrowserFeatures, DeviceFingerprint, Errors, Expect, resSecurityImage,
-  resSecurityImageFail, resSuccessIWA, resSuccessSAML, resSuccessOktaIDP, resError, resPasswordlessUnauthenticated, $sandbox) {
+  resSecurityImageFail, resSuccessIWA, resSuccessSAML, resSuccessOktaIDP, resError, resPasswordlessUnauthenticated, resSuccessRepostIWA, $sandbox) {
 
   var { _, $ } = Okta;
   var SharedUtil = Okta.internal.util.Util;
@@ -1328,6 +1329,21 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           .then(function () {
             expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
               'http://demo.okta1.com:1802/login/sso_iwa'
+            );
+          });
+      });
+      itp('redirects using form GET to idp when OKTA_INVALID_SESSION_REPOST=true', function () {
+        spyOn(WidgetUtil, 'redirectWithFormGet');
+        return setup()
+          .then(function (test) {
+            test.setNextWebfingerResponse(resSuccessRepostIWA);
+            test.form.setUsername('testuser@clouditude.net');
+            test.form.submit();
+            return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
+          })
+          .then(function () {
+            expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
+              'http://demo.okta1.com:1802/login/sso_iwa?fromURI=%2Fapp%2Finstance%2Fkey%3FSAMLRequest%3Dencoded%26RelayState%3DrelayState%26OKTA_INVALID_SESSION_REPOST%3Dtrue'
             );
           });
       });


### PR DESCRIPTION
Making redirect do a "form get" when `OKTA_INVALID_SESSION_REPOST=true` is present in the webfinger response.  This resolves an issue where IE truncates the URL on a 302 redirect.

OKTA-251844

@haishengwu-okta @nikhilvenkatraman-okta 