### PR TITLE
fix: fixed browser checks when displaying webauthn enroll instructions

### DIFF
--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -156,9 +156,9 @@ function (Okta, Errors, FormType, FormController, CryptoUtil, webauthn, Footer, 
               ',
               getTemplateData: function () {
                 return {
-                  isEdge: BrowserFeatures.isEdge,
-                  onlySupportsSecurityKey: (BrowserFeatures.isFirefox || BrowserFeatures.isSafari)
-                    && (BrowserFeatures.isMac)
+                  isEdge: BrowserFeatures.isEdge(),
+                  onlySupportsSecurityKey: (BrowserFeatures.isFirefox() || BrowserFeatures.isSafari())
+                    && (BrowserFeatures.isMac())
                 };
               }
             })

--- a/src/util/BrowserFeatures.js
+++ b/src/util/BrowserFeatures.js
@@ -58,7 +58,9 @@ define(function () {
   };
 
   fn.isSafari = function () {
-    return navigator.userAgent.toLowerCase().indexOf('safari') > -1;
+    // Chrome has safari in its useragent string so adding this extra check.
+    return navigator.userAgent.toLowerCase().indexOf('safari') > -1 &&
+      navigator.userAgent.toLowerCase().indexOf('chrome') === -1;
   };
 
   fn.isMac = function () {

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -174,6 +174,7 @@ function (Okta,
           expect(test.form.enrollEdgeInstructions().text()).toEqual('Note: If you are enrolling a security key and' +
           ' Windows Hello or PIN is enabled, you will need to select \'Cancel\' in the prompt before continuing.');
           Expect.isVisible(test.form.submitButton());
+          expect(BrowserFeatures.isEdge).toHaveBeenCalled();
         });
       });
 
@@ -187,6 +188,9 @@ function (Okta,
           Expect.isVisible(test.form.enrollRestrictions());
           expect(test.form.enrollRestrictions().text()).toEqual('Note: Some browsers may not support biometric authenticators.');
           Expect.isVisible(test.form.submitButton());
+          expect(BrowserFeatures.isFirefox).toHaveBeenCalled();
+          expect(BrowserFeatures.isSafari).not.toHaveBeenCalled();
+          expect(BrowserFeatures.isMac).toHaveBeenCalled();
         });
       });
 
@@ -200,6 +204,9 @@ function (Okta,
           Expect.isVisible(test.form.enrollRestrictions());
           expect(test.form.enrollRestrictions().text()).toEqual('Note: Some browsers may not support biometric authenticators.');
           Expect.isVisible(test.form.submitButton());
+          expect(BrowserFeatures.isFirefox).toHaveBeenCalled();
+          expect(BrowserFeatures.isSafari).toHaveBeenCalled();
+          expect(BrowserFeatures.isMac).toHaveBeenCalled();
         });
       });
       


### PR DESCRIPTION
* We do some browser checks to display some messages to guide users enrolling into webauthn.
The check partly work today because handlebars evaluates the function for us. But when we combine checks handlebars doesnt handle it.

* Also the check for safari needs to be enhanced since Chrome's UA string has safari it as well.

RESOLVES: OKTA-260148


Previously we had returned functions that was executed by handlebars.

<img width="628" alt="Screen Shot 2019-11-06 at 1 14 46 PM" src="https://user-images.githubusercontent.com/17267130/68344354-abc97f80-00a3-11ea-9c7b-9f57c2631bf9.png">



Chrome UA 
![Screen Shot 2019-11-06 at 2 43 14 PM](https://user-images.githubusercontent.com/17267130/68344396-c865b780-00a3-11ea-9c6d-e04dc6bac54d.png)


**Fix**
![Screen Shot 2019-11-06 at 3 04 23 PM](https://user-images.githubusercontent.com/17267130/68345674-c51ffb00-00a6-11ea-9cb4-5bd7196eabd4.png)

