### PR TITLE
fix: should not show windows mobile or blackberry in totp authenticator enroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,8 +1079,6 @@ features: {
 
 - **features.callRecovery** - Allow users with a configured mobile phone number to recover their password using a voice call. Defaults to `false`.
 
-- **features.windowsVerify** - Display instructions for enrolling a windows device with Okta Verify. Defaults to `false`.
-
 - **features.webauthn** - Display and use factors supported by the FIDO 2.0 (Web Authentication) security standard. Enabling this feature will prevent the widget from invoking the legacy Windows Hello factor. Defaults to `false`.
 
 - **features.selfServiceUnlock** - Display the "Unlock Account" link to allow users to unlock their accounts. Defaults to `false`.

--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -242,66 +242,9 @@
 }
 
 /* TOTP Factor Enrollment */
-.device-type-input {
-
-  .o-form-input {
-    display: table;
-    width: 100%;
-
-    > span {
-      display: table-row;
-
-      > div {
-        display: table-cell;
-      }
-    }
-  }
-
-  label,
-  label.checked,
-  label.hover,
-  label.focus {
-    height: 60px;
-    width: 60px;
-    margin: 0 auto;
-    padding: 0;
-    background-position: 50% 50%;
-  }
-
-  [value="APPLE"] + label {
-    background-image: url('../img/icons/mfa/iOS_60x60.png');
-  }
-
-  [value="ANDROID"] + label {
-    background-image: url('../img/icons/mfa/android_60x60.png');
-  }
-
-  [value="WINDOWS"] + label {
-    background-image: url('../img/icons/mfa/windows_60x60.png');
-  }
-
-  [value="BLACKBERRY"] + label {
-    background-image: url('../img/icons/mfa/blackberry_60x60.png');
-  }
-
-  [value="APPLE"] + label.checked,
-  [value="APPLE"] + label.hover {
-    background-image: url('../img/icons/mfa/iOSActive_60x60.png');
-  }
-
-  [value="ANDROID"] + label.checked,
-  [value="ANDROID"] + label.hover {
-    background-image: url('../img/icons/mfa/androidActive_60x60.png');
-  }
-
-  [value="WINDOWS"] + label.checked,
-  [value="WINDOWS"] + label.hover {
-    background-image: url('../img/icons/mfa/windowsActive_60x60.png');
-  }
-
-  [value="BLACKBERRY"] + label.checked,
-  [value="BLACKBERRY"] + label.hover {
-    background-image: url('../img/icons/mfa/blackberryActive_60x60.png');
+.enroll-totp {
+  .okta-form-subtitle.o-form-explain {
+    text-align: left;
   }
 }
 

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -15,6 +15,8 @@ goback = Back to Sign In
 forgotpassword = Forgot password?
 help = Help
 retry = Retry
+iphone = iPhone
+android = Android
 
 # time units
 minutes.oneMinute = minute
@@ -353,7 +355,6 @@ enroll.yubikey.subtitle = Insert your YubiKey into a USB port and tap it to gene
 enroll.totp.title = Setup {0}
 enroll.totp.selectDevice = Select your device type
 enroll.totp.downloadApp = Download <a href="{0}" class="inline-link">{1} from the {2}</a> onto your mobile device.
-enroll.totp.installApp = Install {0}
 
 # Enroll HOTP
 enroll.hotp.restricted = Contact your administrator to continue enrollment.

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -35,7 +35,6 @@ function (Okta, FactorUtil, FormController, FormType,
     attributes: { 'data-se': 'app-download-instructions' },
     className: 'app-download-instructions',
     template: '\
-      <p class="instructions-title">{{title}}</p>\
       <span class="app-logo {{appIcon}}"></span>\
       <p class="instructions">{{{appStoreLinkText}}}</p>\
     ',
@@ -54,7 +53,6 @@ function (Okta, FactorUtil, FormController, FormType,
         appIcon = 'okta-verify-38';
       }
       return {
-        title: Okta.loc('enroll.totp.installApp', 'login', [factorName]),
         appStoreLinkText: Okta.loc('enroll.totp.downloadApp',
           'login', [appStoreLink, factorName, appStoreName]),
         appIcon: appIcon
@@ -95,21 +93,15 @@ function (Okta, FactorUtil, FormController, FormType,
 
       formChildren: function () {
         var inputOptions = {
-          APPLE: '',
-          ANDROID: ''
+          APPLE: Okta.loc('iphone', 'login'),
+          ANDROID: Okta.loc('android', 'login')
         };
-        if (this.settings.get('features.windowsVerify') && this.model.get('__provider__') === 'OKTA') {
-          inputOptions.WINDOWS = '';
-        } else if (this.model.get('__provider__') === 'GOOGLE') {
-          inputOptions.BLACKBERRY = '';
-        }
 
         var children = [
           FormType.Input({
             name: '__deviceType__',
             type: 'radio',
-            options: inputOptions,
-            className: 'device-type-input'
+            options: inputOptions
           }),
 
           FormType.Divider({showWhen: showWhenDeviceTypeSelected}),

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -74,7 +74,6 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.smsRecovery': ['boolean', true, false],
       'features.callRecovery': ['boolean', true, false],
       'features.emailRecovery': ['boolean', false, true],
-      'features.windowsVerify': ['boolean', true, false],
       'features.webauthn': ['boolean', true, false],
       'features.selfServiceUnlock': ['boolean', true, false],
       'features.multiOptionalFactorEnroll': ['boolean', true, false],

--- a/src/util/StoreLinks.js
+++ b/src/util/StoreLinks.js
@@ -13,18 +13,14 @@
 define({
   OKTA: {
     APPLE: 'https://itunes.apple.com/us/app/okta-verify/id490179405',
-    ANDROID: 'https://play.google.com/store/apps/details?id=com.okta.android.auth',
-    WINDOWS: 'http://www.windowsphone.com/en-us/store/app/okta-verify/9df0e2c4-7301-411f-80e5-62fcf6679666'
+    ANDROID: 'https://play.google.com/store/apps/details?id=com.okta.android.auth'
   },
   GOOGLE: {
     APPLE: 'https://itunes.apple.com/us/app/google-authenticator/id388497605',
-    ANDROID: 'https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2',
-    BLACKBERRY: 'https://support.google.com/accounts/answer/1066447'
+    ANDROID: 'https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2'
   },
   STORE: {
     APPLE: 'App Store',
-    ANDROID: 'Google Play Store',
-    WINDOWS: 'Windows Store',
-    BLACKBERRY: 'Blackberry World Store'
+    ANDROID: 'Google Play Store'
   }
 });

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -226,26 +226,13 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
           expect(test.form.deviceTypeOptions().length).toBe(2);
           expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
           expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
-          expect(test.form.deviceTypeOptionLabel('WINDOWS').length).toBe(0);
-          expect(test.form.deviceTypeOptionLabel('BLACKBERRY').length).toBe(0);
-        });
-      });
-      itp('has Windows Phone option for Okta Verify when feature is on', function () {
-        return setupOktaTotpFn({ 'features.windowsVerify': true }).then(function (test) {
-          expect(test.form.deviceTypeOptions().length).toBe(3);
-          expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
-          expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
-          expect(test.form.deviceTypeOptionLabel('WINDOWS').length).toBe(1);
-          expect(test.form.deviceTypeOptionLabel('BLACKBERRY').length).toBe(0);
         });
       });
       itp('has correct device type options for Google Authenticator', function () {
         return setupGoogleTotpFn().then(function (test) {
-          expect(test.form.deviceTypeOptions().length).toBe(3);
+          expect(test.form.deviceTypeOptions().length).toBe(2);
           expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
           expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
-          expect(test.form.deviceTypeOptionLabel('WINDOWS').length).toBe(0);
-          expect(test.form.deviceTypeOptionLabel('BLACKBERRY').length).toBe(1);
         });
       });
       itp('has app download instructions not displayed until device type is selected', function () {


### PR DESCRIPTION
* We do not support windows mobile / blackberry OS with okta verify/Google authenticator. Removing them from SIW.

* Removed images/styles that hid the radio button.

RESOLVES: OKTA-262244

Original commit when feature was added - https://github.com/okta/okta-core/commit/597737549e2da70e671286a5f97389c4762cc99f

**After removal** 
<img width="597" alt="Screen Shot 2019-12-04 at 10 07 25 AM" src="https://user-images.githubusercontent.com/17267130/70168718-3ccd4f80-167e-11ea-8299-2a5d4a8a433e.png">
<img width="593" alt="Screen Shot 2019-12-04 at 10 07 28 AM" src="https://user-images.githubusercontent.com/17267130/70168719-3ccd4f80-167e-11ea-9765-b727bbd61e0b.png">
<img width="630" alt="Screen Shot 2019-12-04 at 10 07 34 AM" src="https://user-images.githubusercontent.com/17267130/70168721-3ccd4f80-167e-11ea-991b-1fa92a056a3b.png">
<img width="628" alt="Screen Shot 2019-12-04 at 10 07 38 AM" src="https://user-images.githubusercontent.com/17267130/70168722-3ccd4f80-167e-11ea-8b80-8f6f8900bdd6.png">

