### PR TITLE
test: do not "Wait a tick for the tests to clean up" - OKTA-261467

### DIFF
--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -24,7 +24,6 @@ define([
       };
       window.addEventListener('error', errListener);
       testFn.call(this)
-        .then(fn.tick) // Wait a tick for the tests to clean up
         .then(function () {
           expect(Q.getUnhandledReasons()).toEqual([]);
           // Reset unhandled exceptions (which in the normal case come from the


### PR DESCRIPTION
This is the last use of `tick()` in shared code. Removing this will simplify the task of purging `tick` from individual test specs .