### PR TITLE
build: add device probing/polling mock and implementation w/o UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "build:webpack-release": "webpack --config webpack.release.config.js",
     "build:webpack-e2e-app": "webpack target/e2e/app/app-using-osw-entry.js target/js/app-bundle.js",
     "prestart": "yarn build:dev",
-    "prepublishOnly": "yarn build:release"
+    "prepublishOnly": "yarn build:release",
+    "mock:authenticator": "dyson playground/mocks/authenticator/ 6512"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -4,6 +4,7 @@
 #
 ########################################
 signout = Sign Out
+signin = Sign In
 remember = Remember me
 rememberDevice = Trust this device
 rememberDevice.timebased = Do not challenge me on this device for the next {0}
@@ -615,6 +616,8 @@ deviceTrust.sso.expire.subtitle = Unfortunately the steps required to sign in to
 deviceTrust.sso.expire.button = Sign in using Okta Mobile
 deviceTrust.universalLink.fallback.getOktaMobile.title = Get Okta Mobile
 deviceTrust.universalLink.fallback.getOktaMobile.subtitle = Go to the {0}AppStore{1}, {0}search{1} for {0}Okta Mobile{1} and tap on {0}GET{1} Okta Mobile. Once installed, sign in to Okta Mobile and follow the instructions to secure your device.
+
+# Device Challenge Probing and Polling
 
 # Consent Required
 consent.required.text = <b>{0}</b> would like to:

--- a/playground/config/responseConfig.js
+++ b/playground/config/responseConfig.js
@@ -28,3 +28,37 @@ module.exports = {
 
   },
 };
+
+// ===== IDX
+// Windows authenticator with loopback server 
+// module.exports = {
+//   mocks: {
+//     '/idp/idx/introspect': [
+//       'identify-with-device-probing-loopback', // 1 (response order)
+//     ],
+//     '/idp/idx/authenticators/poll': [
+//       'identify-with-device-probing-loopback', // 2
+//       'identify-with-device-probing-loopback', // 3
+//       'identify-with-device-probing-loopback-challenge-not-received', // 4
+//       'identify-with-device-launch-authenticator', // 6
+//       'identify', // 7: as a signal of success
+//     ],
+//     '/idp/idx/authenticators/okta-verify/launch': [
+//       'identify-with-device-launch-authenticator', // 5
+//     ]
+//   },
+// };
+
+// Windows/Android authenticator with custom URI
+// module.exports = {
+//   mocks: {
+//     '/idp/idx/introspect': [
+//       'identify-with-device-launch-authenticator',
+//     ],
+//     '/idp/idx/authenticators/poll': [
+//       'identify-with-device-launch-authenticator',
+//       'identify-with-device-launch-authenticator',
+//       'identify', // as a signal of success
+//     ]
+//   },
+// };

--- a/playground/mocks/authenticator/challenge.js
+++ b/playground/mocks/authenticator/challenge.js
@@ -1,0 +1,7 @@
+// To use this mock,
+// in terminal, run `yarn authenticator` to start the authenticator mock server
+
+module.exports = {
+  path: '/challenge',
+  method: 'POST',
+};

--- a/playground/mocks/authenticator/probe.js
+++ b/playground/mocks/authenticator/probe.js
@@ -1,0 +1,7 @@
+// To use this mock,
+// in terminal, run `yarn authenticator` to start the authenticator mock server
+
+module.exports = {
+  path: '/probe',
+  method: 'GET',
+};

--- a/playground/mocks/idp/idx/authenticators-okta-verify-launch.js
+++ b/playground/mocks/idp/idx/authenticators-okta-verify-launch.js
@@ -1,0 +1,5 @@
+const templateHelper = require('../../../config/templateHelper');
+
+module.exports = templateHelper({
+  path: '/idp/idx/authenticators/okta-verify/launch',
+});

--- a/playground/mocks/idp/idx/authenticators-poll.js
+++ b/playground/mocks/idp/idx/authenticators-poll.js
@@ -1,0 +1,5 @@
+const templateHelper = require('../../../config/templateHelper');
+
+module.exports = templateHelper({
+  path: '/idp/idx/authenticators/poll',
+});

--- a/playground/mocks/idp/idx/data/identify-with-device-launch-authenticator.json
+++ b/playground/mocks/idp/idx/data/identify-with-device-launch-authenticator.json
@@ -1,0 +1,78 @@
+{
+    "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+    "version": "1.0.0",
+    "expiresAt": "2020-10-15T17:28:11.000Z",
+    "step": "IDENTIFY",
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                  "rel": ["create-form"],
+                  "name": "device-challenge-poll",
+                  "relatesTo": "authenticatorChallenge",
+                  "href": "http://localhost:3000/idp/idx/authenticators/poll",
+                  "method": "POST",
+                  "accepts": "application/ion+json;okta-version=1",
+                  "produces": "application/ion+json;okta-version=1",
+                  "refresh": 2000,
+                  "value": [{
+                      "name": "stateHandle",
+                      "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                      "required": true,
+                      "visible": false
+                  }]
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "authenticatorChallenge": {
+        "challengeMethod": "custom-scheme",
+        "href": "oktaAuthenticator:/deviceChallenge?challengeRequest=<...Base64URL-Encoded Device Challenge JWT... >",
+        "cancel": {
+            "rel": ["create-form"],
+            "name": "cancel-polling-transaction",
+            "href": "http://your-org.okta.com/idp/idx/authenticators/poll/cancel",
+            "method": "POST",
+            "accepts": "application/ion+json;okta-version=1",
+            "produces": "application/ion+json;okta-version=1",
+            "value": [{
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }]
+        }       
+    }
+}

--- a/playground/mocks/idp/idx/data/identify-with-device-probing-loopback-challenge-not-received.json
+++ b/playground/mocks/idp/idx/data/identify-with-device-probing-loopback-challenge-not-received.json
@@ -1,0 +1,82 @@
+{
+    "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+    "version": "1.0.0",
+    "expiresAt": "2020-10-15T17:28:11.000Z",
+    "step": "IDENTIFY",
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": ["create-form"],
+                "name": "identifier",
+                "href": "http://localhost:3000/idp/idx/identify",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "value": [
+                    {
+                       "name": "identifier",
+                       "label": "Enter your username",
+                       "required": true                         
+                    },
+                    {
+                       "name": "stateHandle",
+                       "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                       "required": true,
+                       "visible": false
+                    }       
+                ]       
+            },
+            {
+                "rel": ["create-form"],   
+                "name": "authenticator",
+                "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "value": [
+                    {
+                        "name": "stateHandle",
+                        "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                        "required": true,
+                        "visible": false
+                    }         
+                ]       
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false,
+                "mutable": false
+            }
+        ]
+    }
+}

--- a/playground/mocks/idp/idx/data/identify-with-device-probing-loopback.json
+++ b/playground/mocks/idp/idx/data/identify-with-device-probing-loopback.json
@@ -1,0 +1,82 @@
+{
+    "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+    "version": "1.0.0",
+    "expiresAt": "2020-10-15T17:28:11.000Z",
+    "step": "IDENTIFY",
+    "intent": "LOGIN",
+    "remediation": {
+        "type": "array",
+        "value": [
+            {
+                "rel": ["create-form"],
+                "name": "device-challenge-poll",
+                "relatesTo": "authenticatorChallenge",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "refresh": 2000,
+                "value": [{
+                    "name": "stateHandle",
+                    "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                    "required": true,
+                    "visible": false
+                }]
+            }
+        ]
+    },
+    "cancel": {
+        "rel": ["create-form"],
+        "name": "cancel",
+        "href": "http://localhost:3000/idp/idx/cancel",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "context": {
+        "rel": ["create-form"],
+        "name": "context",
+        "href": "http://localhost:3000/idp/idx/context",
+        "method": "POST",
+        "accepts": "application/ion+json;okta-version=1",
+        "produces": "application/ion+json;okta-version=1",
+        "value": [
+            {
+                "name": "stateHandle",
+                "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                "required": true,
+                "visible": false
+            }
+        ]
+    },
+    "authenticatorChallenge": {
+        "challengeMethod": "LOOPBACK",
+        "challengeRequest": "eyJraWQiOiI1aTZaQW5TTlZ4RHlNYlNLS0NDcUhpUDdaNG92Q1Fab0thYlFYVE4zVnFjIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJhdWQiOiJodHRwczovL2lkeC5va3RhMS5jb206ODAiLCJleHAiOjE1NzUxNDY0NDEsImlhdCI6MTU3NTE0NjE0MSwibm9uY2UiOiJzYW1wbGVOb25jZSIsInNpZ25hbHMiOlsic2NyZWVuTG9jayIsInJvb3RQcml2aWxlZ2VzIiwiZnVsbERpc2tFbmNyeXB0aW9uIiwiaWQiLCJwbGF0Zm9ybSIsIm9zVmVyc2lvbiIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwiZGV2aWNlQXR0ZXN0YXRpb24iXSwidXNlclZlcmlmaWNhdGlvblJlcXVpcmVtZW50IjpmYWxzZSwidmVyaWZpY2F0aW9uVXJpIjoiaHR0cHM6Ly9yYWluLm9rdGExLmNvbS8vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dGhlbnRpY2F0b3JJZC90cmFuc2FjdGlvbnMvdHJhbnNhY3Rpb25JZC92ZXJpZnkiLCJ2ZXIiOjB9.JEXKJAQE95ANX5u1CEPA7HtH1n4YcHquhee4nd5fCRtD6rvu49OSZhJo7mpd9UjF1UNLBxkektTetpvmq7IXaf0WQ-a0EqMHELbdqmpsLl9jQd7lmVpXN6nrjI-YjxZzgTNqj5GEw_Of_3eMkHo_SM4Em4YYxf8XdQHmtPJUima9gHoGbShZ-XjD1K0feEl1ybCFyflxHXa6qvhqSbhxB0wD81Khb7T-T9-GUmfDGh9FlrypIhexjDghC52puY6N-m9kuJI5IllxeW_ggFD0cB6lx8VImFrbn5CETlFCwvDqZzhbAYWh0v-Nt59w-W-DlyPp-ap0meU4pdyfcGqisQ",
+        "domain": "http://localhost",
+        "ports": [ "2000", "6511", "6512", "6513" ],
+        "cancel": {
+            "rel": ["create-form"],
+            "name": "cancel-polling-transaction",
+            "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+            "method": "POST",
+            "accepts": "application/ion+json;okta-version=1",
+            "produces": "application/ion+json;okta-version=1",
+            "value": [
+                {
+                    "name": "stateHandle",
+                    "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cK",
+                    "required": true,
+                    "visible": false
+                }
+            ]
+        }  
+    }  
+}

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -3,6 +3,7 @@ import BaseView from './internals/BaseView';
 
 // factor ignostic views
 import IdentifierView from './views/IdentifierView';
+import DeviceChallengePollView from './views/DeviceChallengePollView';
 import SelectFactorEnrollView from './views/SelectFactorEnrollView';
 import SelectFactorAuthenticateView from './views/SelectFactorAuthenticateView';
 import EnrollProfileView from './views/EnrollProfileView';
@@ -24,6 +25,9 @@ const DEFAULT = '_';
 const VIEWS_MAPPING = {
   'identify': {
     [DEFAULT]: IdentifierView,
+  },
+  'device-challenge-poll': {
+    [DEFAULT]: DeviceChallengePollView,
   },
   //select-factor-authenticate is used to show the list of factors before challenge flow
   //select-factor-enroll is used to show the list of factors before enroll flows

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -1,0 +1,109 @@
+/* global Promise */
+import { _, $, loc } from 'okta';
+import BaseView from '../internals/BaseView';
+import BaseForm from '../internals/BaseForm';
+import Logger from '../../../util/Logger';
+
+const request = (url, method = 'GET', body = null, timeout = 1000) => {
+  return $.ajax({
+    url,
+    method,
+    timeout,
+    contentType: 'application/json',
+    data: body,
+  });
+};
+
+const Body = BaseForm.extend({
+  noButtonBar: true,
+
+  className: 'ion-form device-challenge-poll',
+
+  title: loc('signin', 'login'),
+
+  initialize () {
+    BaseForm.prototype.initialize.apply(this, arguments);
+    this.deviceChallengePollRemediation = this.options.appState.getCurrentViewState();
+    this.doChallenge();
+    this.startPolling();
+  },
+
+  remove () {
+    BaseForm.prototype.remove.apply(this, arguments);
+    this.stopPolling();
+  },
+
+  doChallenge () {
+    const deviceChallenge = this.options.appState.get('currentState')[
+      this.deviceChallengePollRemediation.relatesTo
+    ];
+    switch (deviceChallenge.challengeMethod) {
+    case 'LOOPBACK':
+      this.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
+      break;
+    case 'CUSTOM_URI':
+      this.doCustomURI(deviceChallenge.href);
+      break;
+    }
+  },
+
+  doLoopback (authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
+    let currentPort;
+    let foundPort = false;
+
+    const getAuthenticatorUrl = (path) => {
+      return `${authenticatorDomainUrl}:${currentPort}/${path}`;
+    };
+
+    const checkPort = () => {
+      return request(getAuthenticatorUrl('probe'));
+    };
+
+    const onPortFound = () => {
+      foundPort = true;
+      return request(getAuthenticatorUrl('challenge'), 'POST', JSON.stringify({ challengeRequest }) , 3000);
+    };
+
+    const onFailure = () => {};
+
+    const doProbing = () => {
+      return checkPort()
+        .done(onPortFound)
+        .fail(onFailure);
+    };
+
+    let probeChain = Promise.resolve();
+    ports.forEach(port => {
+      probeChain = probeChain
+        .then(() => {
+          if (!foundPort) {
+            currentPort = port;
+            return doProbing();
+          }
+        })
+        .catch(() => {
+          Logger.error('Something unexpected happened during device probing.');
+        });
+    });
+  },
+
+  startPolling () {
+    const deviceChallengePollingInterval = this.deviceChallengePollRemediation.refresh;
+    if (_.isNumber(deviceChallengePollingInterval)) {
+      // TODO: how to show spinner to indicating action in progress?
+      this.polling = setInterval(() => {
+        this.options.appState.trigger('saveForm', this.model);
+      }, deviceChallengePollingInterval);
+    }
+  },
+
+  stopPolling () {
+    if (this.polling) {
+      clearInterval(this.polling);
+    }
+  },
+});
+
+export default BaseView.extend({
+  Body,
+});

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -1,0 +1,21 @@
+import { Selector } from 'testcafe';
+import BasePageObject from './BasePageObject';
+
+export default class DeviceChallengePollViewPageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+    this.body = new Selector('.device-challenge-poll');
+  }
+
+  getHeader() {
+    return this.body.find('[data-se="o-form-head"]').innerText;
+  }
+
+  getSubtitle() {
+    return this.body.find('[data-se="o-form-explain"]').innerText;
+  }
+
+  getFooterBackLink() {
+    return this.footer.find('[data-se="back"]');
+  }
+}

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -1,0 +1,61 @@
+import { RequestLogger, RequestMock, Selector } from 'testcafe';
+import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
+import identifyWithDeviceProbingLoopback from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback';
+import loopbackChallengeNotReceived from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback-challenge-not-received';
+
+let failureCount = 0;
+
+const logger = RequestLogger(/introspect|probe|challenge/);
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identifyWithDeviceProbingLoopback)
+  .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll')
+  .respond((req, res) => {
+    res.statusCode = '200';
+    if (failureCount === 2) {
+      res.setBody(loopbackChallengeNotReceived);
+    } else {
+      res.setBody(identifyWithDeviceProbingLoopback);
+    }
+  })
+  .onRequestTo('http://localhost:2000/probe')
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo('http://localhost:6511/probe')
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo('http://localhost:6512/probe')
+  .respond(null, 200, { 'access-control-allow-origin': '*' })
+  .onRequestTo('http://localhost:6512/challenge')
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  })
+
+fixture(`Device Challenge Polling View`)
+  .requestHooks(logger, mock)
+
+async function setup(t) {
+  const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
+  await deviceChallengePollPage.navigateToPage();
+  return deviceChallengePollPage;
+}
+
+test
+  (`probing and polling APIs are sent and responded`, async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/introspect|6512/)
+    )).eql(3);
+    failureCount = 2;
+    await t.expect(logger.count(
+      record => record.response.statusCode === 500 &&
+      record.request.url.match(/2000|6511/)
+    )).eql(2);
+    await t.expect(logger.contains(record => record.request.url.match(/6513/))).eql(false);
+    // replace with custom uri page object OKTA-258116
+    const form = new Selector('.o-form').nth(0);
+    await t.expect(form.find('input[name="identifier"]').exists).eql(true);
+  })


### PR DESCRIPTION
OKTA-258151
OKTA-258152

started a server to handle request of /probe and /challenge from localhost:4000 when `yarn authenticator` is running
<img width="1328" alt="Screen Shot 2019-12-03 at 3 18 51 PM" src="https://user-images.githubusercontent.com/5066836/70102205-41e1be80-15ec-11ea-8815-d43a39fadebb.png">
