### PR TITLE
fix: supports password factor explain

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -198,6 +198,13 @@ define(['q', 'okta', './Logger', './Enums'], function (Q, Okta, Logger, Enums) {
     return explain;
   };
 
+  Util.isPropertyCustomized = function (settings, property) {
+    var language = settings.get('language');
+    var i18n = settings.get('i18n');
+    var customizedProperty = i18n && i18n[language] && i18n[language][property];
+    return !!customizedProperty;
+  };
+
   Util.introspectToken = function (authClient, widgetOptions) {
     var deferred = Q.defer();
     var trans = authClient.tx.introspect({

--- a/src/views/mfa-verify/PasswordForm.js
+++ b/src/views/mfa-verify/PasswordForm.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-define(['okta'], function (Okta) {
+define(['okta', 'util/Util'], function (Okta, Util) {
 
   var _ = Okta._;
 
@@ -32,6 +32,18 @@ define(['okta'], function (Okta) {
         className: 'auth-passcode',
         name: 'password',
         type: 'password',
+        explain: () => {
+          // Show explain only if it is customized (there is no default value)
+          if (!Util.isPropertyCustomized(this.settings, 'mfa.challenge.password.tooltip')) {
+            return false;
+          }
+
+          return Util.createInputExplain(
+            'mfa.challenge.password.tooltip',
+            'mfa.challenge.password.placeholder',
+            'login');
+        },
+        'explain-top': true,
         params: {
           showPasswordToggle: true
         }

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -105,7 +105,7 @@ define([
         'label-top': true,
         explain: () => {
           if (this.settings.get('features.hideDefaultTip') &&
-            !this.isCustomized('primaryauth.username.tooltip')) {
+            !Util.isPropertyCustomized(this.settings, 'primaryauth.username.tooltip')) {
             return false;
           }
 
@@ -132,7 +132,7 @@ define([
         'label-top': true,
         explain: () => {
           if (this.settings.get('features.hideDefaultTip') &&
-            !this.isCustomized('primaryauth.password.tooltip')) {
+            !Util.isPropertyCustomized(this.settings, 'primaryauth.password.tooltip')) {
             return false;
           }
 
@@ -152,13 +152,6 @@ define([
         passwordFieldObject.params.showPasswordToggle = true;
       }
       return passwordFieldObject;
-    },
-
-    isCustomized: function (property) {
-      var language = this.settings.get('language');
-      var i18n = this.settings.get('i18n');
-      var customizedProperty = i18n && i18n[language] && i18n[language][property];
-      return !!customizedProperty;
     },
 
     getRemeberMeCheckbox: function () {

--- a/test/unit/helpers/dom/MfaVerifyForm.js
+++ b/test/unit/helpers/dom/MfaVerifyForm.js
@@ -34,7 +34,7 @@ define(['./Form'], function (Form) {
     isCall: function () {
       return this.el('factor-call').length === 1;
     },
-    
+
     isEmail: function () {
       return this.el('factor-email').length === 1;
     },
@@ -83,6 +83,10 @@ define(['./Form'], function (Form) {
 
     passwordField: function () {
       return this.input(PASSWORD_FIELD);
+    },
+
+    passwordExplain: function () {
+      return this.explain(PASSWORD_FIELD);
     },
 
     setPassword: function (val) {
@@ -162,7 +166,7 @@ define(['./Form'], function (Form) {
     makeCall: function () {
       return this.el('make-call');
     },
-    
+
     emailSendCode: function () {
       return this.el('email-send-code');
     },


### PR DESCRIPTION
- Adding explain to password factor field (similar to password in primary auth)
- explain will only be rendered if it is a custom i18n property (no default value)

Resolves: OKTA-250443