### PR TITLE
chore: updates selenium script to include chrome 79 driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:testcafe-run": "wait-on http-get://localhost:3000 && testcafe",
     "test:testcafe": "run-p -r test:testcafe-setup \"test:testcafe-run {@} test/testcafe/spec/\" -- 2>/dev/null",
     "test:testcafe-ci": "yarn test:testcafe \"chrome:headless\"",
-    "webdriver:update": "./scripts/updateSeDrivers.sh",
+    "webdriver:update": "./scripts/update-se-drivers.sh",
     "protractor": "yarn webdriver:update && protractor target/e2e/conf.js",
     "build:dev": "grunt build:dev",
     "build:release": "grunt build:release",

--- a/scripts/update-se-drivers.sh
+++ b/scripts/update-se-drivers.sh
@@ -89,7 +89,10 @@ function setChromeDriverVersion() {
             78)
                 CHROME_DRIVER_VER=78.0.3904.70
             ;;
-            *)
+	    79)
+		CHROME_DRIVER_VER=79.0.3945.36
+            ;;
+	    *)
                 CHROME_DRIVER_VER=${DEFAULT_CHROME_DRIVER_VER}
             ;;
         esac


### PR DESCRIPTION
* Travis upgraded chrome to version 79 which will cause tests to fail (as we don't have chrome 79 driver support)
* This PR adds support for chrome 79 driver

Resolves: OKTA-266280