### PR TITLE
chore: move commitlint to pre-push OKTA-264022

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "pre-push": "commitlint --from=master 1>&2"
     }
   },
   "main": "./dist/js/okta-sign-in.entry.js",


### PR DESCRIPTION
Currently, `commitlint` runs on every local commit. Many developers have complained that this is an impediment to their workflow which usually involves making one or more commits (with a temporary/throwaway message) and then performing a rebase/squash. This PR moves the `commitlint` enforcement to the PUSH step.

- If ANY commit message on the branch does not satisfy the rules, an error will be shown when trying to PUSH.
- Error will be visible whether push is done from the terminal or in Github Desktop
- Individual local commit messages will not be linted until PUSH. This allows temporary commit messages before rebase/squash/push
- Commit message linting can be bypassed locally with `--no-verify`, for example `git push -f --no-verify`
- Full linting is enforced on travis for PR builds only. "Push" builds will only validate the most recent commit message. (this behavior is not changed by this PR) https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/travis-cli/src/cli.js#L46