### PR TITLE
chore: extra lint rules for unit tests - OKTA-260043

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.26.0",
     "cross-fetch": "^3.0.4",
+    "eslint-plugin-jasmine": "^4.1.0",
     "handlebars": "^4.5.1",
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.3",

--- a/test/unit/.eslintrc.js
+++ b/test/unit/.eslintrc.js
@@ -1,12 +1,23 @@
 module.exports = {
-  'env': {
-    'node': true,
-    'jasmine': true
+  extends: 'plugin:jasmine/recommended',
+  plugins: [
+    'jasmine'
+  ],
+  env: {
+    node: true,
+    jasmine: true
   },
-  'rules': {
+  rules: {
     'max-len': 0,
     'complexity': 0,
     'max-params': 0,
-    'max-statements': 0
+    'max-statements': 0,
+  
+    'jasmine/new-line-before-expect': 0,
+    'jasmine/new-line-between-declarations': 0,
+
+    // Consider enabling these
+    'jasmine/no-unsafe-spy': 0,
+    'jasmine/prefer-toHaveBeenCalledWith': 0
   }
 };

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -41,16 +41,12 @@ function (Expect, $sandbox, DeviceFingerprint) {
       expect(window.addEventListener).toHaveBeenCalledWith('message', jasmine.any(Function), false);
     });
 
-    it('returns a fingerprint if the communication with the iframe is successfull', function (done) {
+    it('returns a fingerprint if the communication with the iframe is successfull', function () {
       mockIFrameMessages(true);
       bypassMessageSourceCheck();
-      DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
+      return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
         .then(function (fingerprint) {
           expect(fingerprint).toBe('thisIsTheFingerprint');
-          done();
-        })
-        .fail(function (reason) {
-          done.fail('Fingerprint promise incorrectly failed. ' + reason);
         });
     });
 
@@ -61,7 +57,7 @@ function (Expect, $sandbox, DeviceFingerprint) {
         .then(function () {
           done.fail('Fingerprint promise should have been rejected');
         })
-        .fail(function (reason) {
+        .catch(function (reason) {
           expect(reason).toBe('no data');
           var $iFrame = $sandbox.find('iframe');
           expect($iFrame).not.toExist();
@@ -76,7 +72,7 @@ function (Expect, $sandbox, DeviceFingerprint) {
         .then(function () {
           done.fail('Fingerprint promise should have been rejected');
         })
-        .fail(function (reason) {
+        .catch(function (reason) {
           expect(reason).toBe('no data');
           var $iFrame = $sandbox.find('iframe');
           expect($iFrame).not.toExist();
@@ -91,7 +87,7 @@ function (Expect, $sandbox, DeviceFingerprint) {
         .then(function () {
           done.fail('Fingerprint promise should have been rejected');
         })
-        .fail(function (reason) {
+        .catch(function (reason) {
           var $iFrame = $sandbox.find('iframe');
           expect($iFrame).not.toExist();
           expect(reason).toBe('user agent is not defined');
@@ -106,7 +102,7 @@ function (Expect, $sandbox, DeviceFingerprint) {
         .then(function () {
           done.fail('Fingerprint promise should have been rejected');
         })
-        .fail(function (reason) {
+        .catch(function (reason) {
           expect(reason).toBe('device fingerprint is not supported on Windows phones');
           var $iFrame = $sandbox.find('iframe');
           expect($iFrame).not.toExist();

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -233,10 +233,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
       config.supportedLanguages.filter(function (lang) {
         return lang !== 'en'; // no bundles are loaded for english
       }).forEach(function (lang) {
-        // TODO: the key 'password.expired.title' has changed in 3.0 - all strings are untranslated
-        // See PasswordExpiredController
-        // https://oktainc.atlassian.net/browse/OKTA-233498
-        xit(`for language: "${lang}"`, function () {
+        it(`for language: "${lang}"`, function () {
           var loadingSpy = jasmine.createSpy('loading');
           spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(false);
           return setup({
@@ -1183,12 +1180,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             responseMode: 'query',
             responseType:'code'
           }));
-      });
-
-      // TODO: "hybrid" flows like these are explicitly disallowed. Rewrite or trash this test?
-      xit('redirects if there are multiple responseTypes, and one is "code"', function () {
-        return setupOAuth2({'authParams.responseType': ['id_token', 'code']})
-          .then(expectCodeRedirect({responseMode: 'fragment', 'responseType': 'id_token%20code'}));
       });
 
       itp('redirects instead of using an iframe if display is "page"', function () {

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -3419,9 +3419,6 @@ function (Okta,
               });
             });
           });
-
-          // Do this when we have implemented push errors in OktaAuth and have an example
-          xit('shows an error if error response from authClient');
         });
         Expect.describe('TOTP', function () {
           itp('has a link to enter code', function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1278,8 +1278,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
               expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
             });
         });
-        // TODO: FIXME
-        xit('does not show beacon-loading animation when password expires', function () {
+        itp('does not show beacon-loading animation when password expires', function () {
           return setup({ features: { securityImage: true }})
             .then(function (test) {
               test.securityBeacon = test.router.header.currentBeacon.$el;
@@ -1293,7 +1292,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
               test.setNextResponse(resPwdExpired);
               test.form.setPassword('pass');
               test.form.submit();
-              return Expect.waitForSpyCall(test.afterErrorHandler, test);
+              return Expect.waitForSpyCall(test.securityBeacon.toggleClass, test);
             })
             .then(function (test) {
               var spyCalls = test.securityBeacon.toggleClass.calls;
@@ -1350,15 +1349,14 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
               expect(test.beacon.beacon().length).toBe(0);
             });
         });
-        // TODO: FIXME
-        xit('does not show beacon-loading animation when password expires (no security image)', function () {
+        itp('does not show beacon-loading animation when password expires (no security image)', function () {
           return setup().then(function (test) {
             Q.stopUnhandledRejectionTracking();
             test.setNextResponse(resPwdExpired);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
             test.form.submit();
-            return Expect.waitForSpyCall(test.afterErrorHandler, test);
+            return Expect.waitForPasswordExpired(test);
           })
             .then(function (test) {
               expect(test.beacon.isLoadingBeacon()).toBe(false);
@@ -1538,8 +1536,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
             expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
           });
       });
-      // TODO: FIXME
-      xit('updates security beacon immediately if rememberMe is available', function () {
+      itp('updates security beacon immediately if rememberMe is available', function () {
         Util.mockGetCookie('ln', 'testuser');
         var options = {
           features: {
@@ -1548,6 +1545,11 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
           }
         };
         return setup(options, [resSecurityImage])
+          .then(function (test) {
+            return Expect.wait(function () {
+              return test.form.accessibilityText() === 'a single pixel';
+            }, test);
+          })
           .then(function (test) {
             expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
             expect(test.form.accessibilityText()).toBe('a single pixel');
@@ -2711,6 +2713,7 @@ function (Q, OktaAuth, LoginUtil, Okta, Util, AuthContainer, PrimaryAuthForm, Be
       // Reminder: Think about how to mock this out in the future - currently
       // cannot mock it because we defer to AuthJs to do set window.location.
       // On the plus side, there is an e2e test that covers this.
+      // eslint-disable-next-line jasmine/no-disabled-tests
       xit('redirects to the correct url in the social idp redirect flow');
     });
 

--- a/test/unit/spec/RegistrationSchema_spec.js
+++ b/test/unit/spec/RegistrationSchema_spec.js
@@ -1,15 +1,14 @@
 /* eslint max-params:[2, 28], max-statements:[2, 40], camelcase:0, max-len:[2, 180] */
 define([
-  'models/RegistrationSchema',
-  'helpers/util/Expect'
+  'models/RegistrationSchema'
 ],
-function (RegistrationSchema, Expect) {
+function (RegistrationSchema) {
 
-  Expect.describe('RegistrationSchema', function () {
+  describe('RegistrationSchema', function () {
 
-    Expect.describe('properties', function () {
+    describe('properties', function () {
 
-      Expect.describe('string field', function () {
+      describe('string field', function () {
         beforeEach(function () {
           var jsonResponse = {
             'profileSchema': {
@@ -59,7 +58,7 @@ function (RegistrationSchema, Expect) {
         });
       });
 
-      Expect.describe('email field', function () {
+      describe('email field', function () {
         beforeEach(function () {
           var jsonResponse = {
             profileSchema: {
@@ -79,6 +78,7 @@ function (RegistrationSchema, Expect) {
 
         });
 
+        // eslint-disable-next-line jasmine/no-spec-dupes
         it('is a string type', function () {
           expect(this.schema.properties.first().get('type')).toEqual('string');
         });
@@ -88,7 +88,7 @@ function (RegistrationSchema, Expect) {
         });
       });
 
-      Expect.describe('enum field', function () {
+      describe('enum field', function () {
         beforeEach(function () {
           var jsonResponse = {
             profileSchema: {
@@ -107,6 +107,7 @@ function (RegistrationSchema, Expect) {
           this.schema.parse(jsonResponse);
         });
 
+        // eslint-disable-next-line jasmine/no-spec-dupes
         it('is a string type', function () {
           expect(this.schema.properties.first().get('type')).toEqual('string');
         });
@@ -116,7 +117,7 @@ function (RegistrationSchema, Expect) {
         });
       });
 
-      Expect.describe('required fields', function () {
+      describe('required fields', function () {
         beforeEach(function () {
           var jsonResponse = {
             policyId: '1234',
@@ -165,7 +166,7 @@ function (RegistrationSchema, Expect) {
         });
       });
 
-      Expect.describe('sorting order', function () {
+      describe('sorting order', function () {
         beforeEach(function () {
           var jsonResponse = {
             profileSchema: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,10 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-jasmine@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.0.tgz#4f6d41b1a8622348c97559cbcd29badffa74dbfa"
+
 eslint-plugin-testcafe@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testcafe/-/eslint-plugin-testcafe-0.2.1.tgz#4089f646dadb69b1376a01d7e608184907e6036b"
@@ -4460,7 +4464,6 @@ handlebars@^4.0.1:
 handlebars@^4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.1.tgz#8a01c382c180272260d07f2d1aa3ae745715c7ba"
-  integrity sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
- "fdescribe" or "fit" will cause lint error
- "xit" will cause lint warning
- fixed a couple of tests which were disabled