### PR TITLE
feat: minify node module entry, add no-polyfill bundle - OKTA-264040

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ After installing:
     // Use OktaSignIn
     var signIn = new OktaSignIn(/* configOptions */);
     ```
+
+    Source maps are provided as an external .map file. If you are using [Webpack](https://webpack.github.io/), these can be loaded using the [source-map-loader](https://github.com/webpack-contrib/source-map-loader) plugin.
+
     **Note:** If you use [Browserify](http://browserify.org/) to bundle your app, you'll need to use the `--noparse` option:
 
     ```bash
@@ -156,7 +159,9 @@ After installing:
     --noparse=$PWD/node_modules/@okta/okta-signin-widget/dist/js-okta-sign-in.entry.js \
     --outfile=bundle.js
     ```
+
 3. Make sure you include ES6 polyfills with your bundler if you need the broadest browser support. We recommend [`babel-polyfill`](https://babeljs.io/docs/en/babel-polyfill/).
+
 
 ## Usage guide
 

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -17,7 +17,7 @@
 var config  = require('./webpack.common.config');
 var plugins = require('./buildtools/webpack/plugins');
 
-// 1. entryConfig
+// 1. entryConfig (node module main entry. minified, no polyfill, external dependencies)
 var entryConfig = config('okta-sign-in.entry.js');
 entryConfig.output.filename = 'okta-sign-in.entry.js';
 entryConfig.externals = {
@@ -31,14 +31,18 @@ entryConfig.externals = {
   'u2f-api-polyfill': true,
   'underscore': true
 };
-entryConfig.plugins = plugins({ isProduction: false, analyzerFile: 'okta-sign-in.entry.analyzer' });
+entryConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in.entry.analyzer' });
 
-// 2. cdnConfig
+// 2. noPolyfillConfig
+var noPolyfillConfig = config('okta-sign-in.no-polyfill.min.js');
+noPolyfillConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in.no-polyfill.min.analyzer' });
+
+// 3. cdnConfig (with polyfill)
 var cdnConfig = config('okta-sign-in.min.js');
 cdnConfig.entry.unshift('babel-polyfill');
 cdnConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in.min.analyzer' });
 
-// 3. noJqueryConfig
+// 4. noJqueryConfig
 var noJqueryConfig = config('okta-sign-in-no-jquery.js');
 noJqueryConfig.entry = cdnConfig.entry;
 noJqueryConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in-no-jquery.analyzer' });
@@ -51,9 +55,9 @@ noJqueryConfig.externals = {
   }
 };
 
-// 4. devConfig
+// 5. devConfig (with polyfill, unminified)
 var devConfig = config('okta-sign-in.js');
 devConfig.entry.unshift('babel-polyfill');
 devConfig.plugins = plugins({ isProduction: false, analyzerFile: 'okta-sign-in.analyzer' });
 
-module.exports = [entryConfig, cdnConfig, noJqueryConfig, devConfig];
+module.exports = [entryConfig, noPolyfillConfig, cdnConfig, noJqueryConfig, devConfig];


### PR DESCRIPTION
- minifies node module entry. This will remove the console warning "The Okta Sign-In Widget is running in development mode." when importing/requiring the node module
- add instructions to README for using source maps with webpack
- For CDN users, build another bundle without polyfill (README should be updated after release to publicize this feature)

Related issue: https://oktainc.atlassian.net/browse/OKTA-264040