### PR TITLE
fix: fixes bug where widget keeps auto sending magic link emails

### DIFF
--- a/src/v2/view-builder/views/email/RequiredFactorEmailView.js
+++ b/src/v2/view-builder/views/email/RequiredFactorEmailView.js
@@ -20,7 +20,7 @@ const ResendView = View.extend(
         className: 'button',
         title: 'Resend Email',
         click () {
-          this.options.appState.trigger('invokeAction', 'factor.send');
+          this.options.appState.trigger('invokeAction', 'factor.resend');
         }
       }));
     },
@@ -60,21 +60,11 @@ const Body = BaseForm.extend(Object.assign(
       // TODO: abort ongoing request. (https://oktainc.atlassian.net/browse/OKTA-244134)
     },
 
-    sendEmailLink () {
-      // auto send email magic link after page has rendered.
-      _.delay(_.bind(function () {
-        this.options.appState.trigger('invokeAction', 'factor.send');
-      }, this), 300);
-    },
-
     postRender () {
       this.add(ResendView, {
         selector: '.okta-form-subtitle',
         prepend: true,
       });
-
-      // auto send email magic link email on load
-      this.sendEmailLink();
 
       this.startPolling();
 


### PR DESCRIPTION
Resolves: OKTA-268169

- Backend is now going to do this optimization of auto sending the magic link email after factor selection.
- Removing the code from the widget.
- Also renamed the action link for resend.
- Note that this will be merged next week since we want to merge both backend and front end changes together.
- PR on release branch https://github.com/okta/okta-signin-widget/pull/1006