### PR TITLE
fix: fixes bug where widget keeps auto sending magic link emails

### DIFF
--- a/playground/mocks/idp/idx/challenge-resend.js
+++ b/playground/mocks/idp/idx/challenge-resend.js
@@ -1,5 +1,5 @@
 const templateHelper = require('../../../config/templateHelper');
 
 module.exports = templateHelper({
-  path: '/idp/idx/challenge/send',
+  path: '/idp/idx/challenge/resend',
 });

--- a/playground/mocks/idp/idx/data/factor-verification-email.json
+++ b/playground/mocks/idp/idx/data/factor-verification-email.json
@@ -93,12 +93,12 @@
       "profile": {
         "email": "inca@clouditude.net"
       },
-      "send": {
+      "resend": {
         "rel": [
           "create-form"
         ],
-        "name": "send",
-        "href": "http://localhost:3000/idp/idx/challenge/send",
+        "name": "resend",
+        "href": "http://localhost:3000/idp/idx/challenge/resend",
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",
         "value": [

--- a/src/v2/view-builder/views/email/RequiredFactorEmailView.js
+++ b/src/v2/view-builder/views/email/RequiredFactorEmailView.js
@@ -20,7 +20,7 @@ const ResendView = View.extend(
         className: 'button',
         title: 'Resend Email',
         click () {
-          this.options.appState.trigger('invokeAction', 'factor.send');
+          this.options.appState.trigger('invokeAction', 'factor.resend');
         }
       }));
     },
@@ -60,21 +60,11 @@ const Body = BaseForm.extend(Object.assign(
       // TODO: abort ongoing request. (https://oktainc.atlassian.net/browse/OKTA-244134)
     },
 
-    sendEmailLink () {
-      // auto send email magic link after page has rendered.
-      _.delay(_.bind(function () {
-        this.options.appState.trigger('invokeAction', 'factor.send');
-      }, this), 300);
-    },
-
     postRender () {
       this.add(ResendView, {
         selector: '.okta-form-subtitle',
         prepend: true,
       });
-
-      // auto send email magic link email on load
-      this.sendEmailLink();
 
       this.startPolling();
 

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
 import BaseFormObject from './components/BaseFormObject';
 
-export default class FactorRequiredPageObject extends BasePageObject {
+export default class ChallengeFactorPageObject extends BasePageObject {
   constructor(t) {
     super(t);
     this.form = new BaseFormObject(t);
@@ -31,4 +31,17 @@ export default class FactorRequiredPageObject extends BasePageObject {
   getInvalidOTPError() {
     return this.form.getErrorBoxText();
   }
+
+  getResendEmailViewCallout() {
+    return this.form.getElement('.resend-email-view p').textContent;
+  }
+
+  resendEmailView() {
+    return this.form.getElement('.resend-email-view');
+  }
+
+  async clickResendEmailButton() {
+    await this.form.clickElement('.resend-email-view a.button');
+  }
+
 }


### PR DESCRIPTION
Resolves: OKTA-268169

- Backend is now going to do this optimization of auto sending the magic link email after factor selection.
- Removing the code from the widget.
- Also renamed the action link for resend.
- **Note that this will be merged next week since** we want to merge both backend and front end changes together.