### PR TITLE
resolve issue #969

### DIFF
--- a/src/views/mfa-verify/NumberChallengeView.js
+++ b/src/views/mfa-verify/NumberChallengeView.js
@@ -41,7 +41,7 @@ define([
       const lastAuthResponse = this.options.appState.get('lastAuthResponse');
       if (!this.options.appState.get('isWaitingForNumberChallenge')) {
         return {
-          number: null
+          number: ''
         };
       }
       return {


### PR DESCRIPTION
type: fix

There is an issue in NumberChallengeView, I noticed the issue when I upgrade my okta-sign-in-widget to version 3.6. The issue is, on OKTA verify screen(NumberChallengeView), i18n is expecting a number in order to generate an instruction, but current code returns null and causes i18n throws an error:

L10N_ERROR[oktaverify.numberchallenge.instruction] 

Changing it to an empty string fix the issue. Please review my change, thanks.

Resolves: Issue #969