### PR TITLE
fix: change mfa lockout message to be more generic

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -45,7 +45,7 @@ error.password.required = Please enter a password
 
 # ERROR MESSAGE OVERRIDES
 errors.E0000004 = Sign in failed!
-errors.E0000069 = Your account was locked due to excessive MFA attempts.
+errors.E0000069 = Your account is locked because of too many authentication attempts.
 errors.E0000047 = You exceeded the maximum number of requests. Try again in a while.
 
 # ERROR MESSAGE TRANSLATIONS

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -1384,7 +1384,7 @@ function (Okta,
           .then(function (test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorBox().length).toBe(1);
-            expect(test.form.errorMessage()).toBe('Your account was locked due to excessive MFA attempts.');
+            expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
             expectErrorEvent(
               test,
               403,
@@ -1396,7 +1396,7 @@ function (Okta,
                 responseText: '{"errorCode":"E0000069","errorSummary":"User Locked","errorLink":"E0000069","errorId":"oaeGLSGT-QCT_ijvM0RT6SV0A","errorCauses":[]}',
                 responseJSON: {
                   errorCode: 'E0000069',
-                  errorSummary: 'Your account was locked due to excessive MFA attempts.',
+                  errorSummary: 'Your account is locked because of too many authentication attempts.',
                   errorLink: 'E0000069',
                   errorId: 'oaeGLSGT-QCT_ijvM0RT6SV0A',
                   errorCauses: []
@@ -1694,7 +1694,7 @@ function (Okta,
           .then(function (test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorBox().length).toBe(1);
-            expect(test.form.errorMessage()).toBe('Your account was locked due to excessive MFA attempts.');
+            expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
             expectErrorEvent(
               test,
               403,
@@ -1706,7 +1706,7 @@ function (Okta,
                 responseText: '{"errorCode":"E0000069","errorSummary":"User Locked","errorLink":"E0000069","errorId":"oaeGLSGT-QCT_ijvM0RT6SV0A","errorCauses":[]}',
                 responseJSON: {
                   errorCode: 'E0000069',
-                  errorSummary: 'Your account was locked due to excessive MFA attempts.',
+                  errorSummary: 'Your account is locked because of too many authentication attempts.',
                   errorLink: 'E0000069',
                   errorId: 'oaeGLSGT-QCT_ijvM0RT6SV0A',
                   errorCauses: []
@@ -2772,7 +2772,7 @@ function (Okta,
             .then(function (test) {
               expect(test.form.hasErrors()).toBe(true);
               expect(test.form.errorBox().length).toBe(1);
-              expect(test.form.errorMessage()).toBe('Your account was locked due to excessive MFA attempts.');
+              expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
               expectErrorEvent(
                 test,
                 403,
@@ -2784,7 +2784,7 @@ function (Okta,
                   responseText: '{"errorCode":"E0000069","errorSummary":"User Locked","errorLink":"E0000069","errorId":"oaeGLSGT-QCT_ijvM0RT6SV0A","errorCauses":[]}',
                   responseJSON: {
                     errorCode: 'E0000069',
-                    errorSummary: 'Your account was locked due to excessive MFA attempts.',
+                    errorSummary: 'Your account is locked because of too many authentication attempts.',
                     errorLink: 'E0000069',
                     errorId: 'oaeGLSGT-QCT_ijvM0RT6SV0A',
                     errorCauses: []


### PR DESCRIPTION
OKTA-259534

Before Change:
![Screen Shot 2020-01-23 at 14 32 30](https://user-images.githubusercontent.com/39062292/73018490-bd433d80-3def-11ea-8e4b-837804979d96.png)


After Change:
![Screen Shot 2020-01-23 at 11 51 15](https://user-images.githubusercontent.com/39062292/73005779-86612d80-3dd7-11ea-8c7e-6f1a57d80e96.png)
