### PR TITLE
feat: added webauthn verify UI on idx

### DIFF
--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -5,3 +5,4 @@
 @import './factor-poll-verification';
 @import './callout';
 @import './device-challenge';
+@import './webauthn-verify';

--- a/assets/sass/v2/_webauthn-verify.scss
+++ b/assets/sass/v2/_webauthn-verify.scss
@@ -1,0 +1,3 @@
+.idx-webauthn-verify-text {
+  margin-bottom: 20px;
+}

--- a/playground/mocks/idp/idx/data/factor-verification-webauthn.json
+++ b/playground/mocks/idp/idx/data/factor-verification-webauthn.json
@@ -1,0 +1,188 @@
+{
+    "stateHandle": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+    "version": "1.0.0",
+    "expiresAt": "2020-01-23T21:29:08.000Z",
+    "step": "AUTHENTICATE",
+    "intent": "LOGIN",
+    "remediation": {
+      "type": "array",
+      "value": [
+        {
+          "rel": [
+            "create-form"
+          ],
+          "name": "challenge-factor",
+          "href": "https://idp.okta1.com:80/idp/idx/challenge/answer",
+          "method": "POST",
+          "accepts": "application/vnd.okta.v1+json",
+          "value": [
+            {
+              "name": "credentials",
+              "form": {
+                "value": [
+                  {
+                    "name": "clientData",
+                    "label": "Client Data",
+                    "visible": false
+                  },
+                  {
+                    "name": "authenticatorData",
+                    "label": "Authenticator Data",
+                    "visible": false
+                  },
+                  {
+                    "name": "signatureData",
+                    "label": "Signature Data",
+                    "visible": false
+                  }
+                ]
+              }
+            },
+            {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+              "visible": false,
+              "mutable": false
+            }
+          ]
+        },
+        {
+          "rel": [
+            "create-form"
+          ],
+          "name": "select-factor",
+          "href": "https://idp.okta1.com:80/idp/idx/challenge",
+          "method": "POST",
+          "accepts": "application/vnd.okta.v1+json",
+          "value": [
+            {
+              "name": "factorId",
+              "type": "set",
+              "options": [
+                {
+                  "label": "Email",
+                  "value": "emf2l3dQNerbaVZge0g4"
+                },
+                {
+                  "label": "Email",
+                  "value": "emf2l39lFQA7Lu6fo0g4"
+                },
+                {
+                  "label": "WebAuthn_N6ax6",
+                  "value": "fwf2l3a8EhFJYVXo80g4"
+                }
+              ]
+            },
+            {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+              "visible": false,
+              "mutable": false
+            }
+          ]
+        }
+      ]
+    },
+    "factor": {
+      "type": "object",
+      "value": {
+        "factorType": "webauthn",
+        "factorProfileId": "fpr2jwmgGmB2cWCvn0g4",
+        "factorId": "fwf2l3a8EhFJYVXo80g4",
+        "recover": {
+          "rel": [
+            "create-form"
+          ],
+          "name": "recover",
+          "href": "https://idp.okta1.com:80/idp/idx/recover",
+          "method": "POST",
+          "accepts": "application/vnd.okta.v1+json",
+          "value": [
+            {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+              "visible": false,
+              "mutable": false
+            }
+          ]
+        },
+        "contextualData": {
+          "challengeData": {
+            "challenge": "-Z-DmiGoI_QxWLYA52Bo",
+            "userVerification": "preferred",
+            "extensions": {}
+          },
+          "profile": {
+            "credentialId": "17lwnR1dSirrn0jXokTug_y92bEyiUWYeSW1px20AYB2Tdtby1TLlKuOHfuKnKmhRWzDo4u4Q3aSmM8qhumWFg",
+            "appId": null,
+            "version": null,
+            "authenticatorName": "YubiKey"
+          }
+        }
+      }
+    },
+    "factors": {
+      "type": "array",
+      "value": [
+        {
+          "factorType": "email",
+          "factorProfileId": "fpr2ibuGKdxOPT75r0g4",
+          "factorId": "emf2l3dQNerbaVZge0g4"
+        },
+        {
+          "factorType": "email",
+          "factorId": "emf2l39lFQA7Lu6fo0g4"
+        },
+        {
+          "factorType": "webauthn",
+          "factorProfileId": "fpr2jwmgGmB2cWCvn0g4",
+          "factorId": "fwf2l3a8EhFJYVXo80g4"
+        }
+      ]
+    },
+    "user": {
+      "type": "object",
+      "value": {
+        "id": "00u2i9upjr9rKYLx50g4"
+      }
+    },
+    "cancel": {
+      "rel": [
+        "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://idp.okta1.com:80/idp/idx/cancel",
+      "method": "POST",
+      "accepts": "application/vnd.okta.v1+json",
+      "value": [
+        {
+          "name": "stateHandle",
+          "required": true,
+          "value": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+          "visible": false,
+          "mutable": false
+        }
+      ]
+    },
+    "context": {
+      "rel": [
+        "create-form"
+      ],
+      "name": "context",
+      "href": "https://idp.okta1.com:80/idp/idx/context",
+      "method": "POST",
+      "accepts": "application/vnd.okta.v1+json",
+      "value": [
+        {
+          "name": "stateHandle",
+          "required": true,
+          "value": "02M2crb7cM5t5rtgx3IrE1jjQ7K2FzNH_0GPT-KTlo",
+          "visible": false,
+          "mutable": false
+        }
+      ]
+    }
+  }

--- a/src/v2/util/FactorUtil.js
+++ b/src/v2/util/FactorUtil.js
@@ -23,6 +23,12 @@ const factorData = {
     description: '',
     iconClassName: 'mfa-okta-password',
   },
+
+  'webauthn': {
+    label: loc('factor.webauthn', 'login'),
+    description: '',
+    iconClassName: 'mfa-webauthn',
+  },
 };
 
 const getFactorData = function (factorName) {

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -14,6 +14,9 @@ import SuccessView from './views/SuccessView';
 import EnrollFactorPasswordView from './views/password/EnrollFactorPasswordView';
 import RequiredFactorPasswordView from './views/password/RequiredFactorPasswordView';
 
+//webauthn
+import RequiredFactorWebauthnView from './views/webauthn/RequiredFactorWebauthnView';
+
 // email
 // import EnrollFactorEmailView from './views/email/EnrollFactorEmailView';
 import RequiredFactorEmailView from './views/email/RequiredFactorEmailView';
@@ -48,11 +51,12 @@ const VIEWS_MAPPING = {
   },
   'enroll-factor': {
     email: RequiredFactorEmailView, // TODO EnrollFactorEmailView is unimplemented
-    password: EnrollFactorPasswordView
+    password: EnrollFactorPasswordView,
   },
   'challenge-factor': {
     email: RequiredFactorEmailView,
     password: RequiredFactorPasswordView,
+    webauthn: RequiredFactorWebauthnView,
   },
   'terminal-transferred': {
     [DEFAULT]: TerminalView,

--- a/src/v2/view-builder/views/webauthn/RequiredFactorWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/RequiredFactorWebauthnView.js
@@ -1,0 +1,136 @@
+import { loc, _, createButton } from 'okta';
+import BaseForm from '../../internals/BaseForm';
+import BaseFooter from '../../internals/BaseFooter';
+import BaseFactorView from '../shared/BaseFactorView';
+import CryptoUtil from '../../../../util/CryptoUtil';
+import webauthn from '../../../../util/webauthn';
+
+const Body = BaseForm.extend({
+
+  title: loc('factor.webauthn.biometric', 'login'),
+
+  getUISchema () {
+    const schema = [];
+    // Returning custom array so no input fields are displayed for webauthn
+    if (webauthn.isNewApiAvailable()) {
+      const retryButton = createButton({
+        className: 'retry-webauthn button-primary default-custom-button',
+        title: loc('retry', 'login'),
+        click: () => {
+          this.getCredentialsAndSave();
+        }
+      });
+
+      schema.push({
+        View:
+            '<div class="webauthn-verify-text idx-webauthn-verify-text">\
+              <p>{{i18n code="verify.webauthn.biometric.instructions" bundle="login"}}</p>\
+              <div data-se="webauthn-waiting" class="okta-waiting-spinner"></div>\
+            </div>'
+      }, {
+        View: retryButton,
+      });
+    }
+    return schema;
+  },
+
+  remove () {
+    BaseForm.prototype.remove.apply(this, arguments);
+    if (this.webauthnAbortController) {
+      this.webauthnAbortController.abort();
+      this.webauthnAbortController = null;
+    }
+  },
+
+  noButtonBar: true,
+
+  modelEvents: {
+    'error': '_stopVerification'
+  },
+
+  getCredentialsAndSave () {
+    this.clearErrors();
+    this._startVerification();
+    this.webauthnAbortController = new AbortController();
+    const factor = this.options.appState.get('factor');
+    const allowCredentials = [{
+      type: 'public-key',
+      id: CryptoUtil.strToBin(factor.contextualData.profile.credentialId)
+    }];
+    const options = {
+      allowCredentials,
+      challenge: CryptoUtil.strToBin(factor.contextualData.challengeData.challenge)
+    };
+    navigator.credentials.get({
+      publicKey: options,
+      signal: this.webauthnAbortController.signal
+    }).then((assertion) => {
+      this.model.set({
+        credentials : {
+          clientData: CryptoUtil.binToStr(assertion.response.clientDataJSON),
+          authenticatorData: CryptoUtil.binToStr(assertion.response.authenticatorData),
+          signatureData: CryptoUtil.binToStr(assertion.response.signature),
+        }
+      });
+      this.saveForm(this.model);
+    }, (error) => {
+      // Do not display if it is abort error triggered by code when switching.
+      // this.webauthnAbortController would be null if abort was triggered by code.
+      if (this.webauthnAbortController) {
+        this.model.trigger('error', this.model, { responseJSON: { errorSummary: error.message } });
+      }
+    }).finally(() => {
+      // unset webauthnAbortController on successful authentication or error
+      this.webauthnAbortController = null;
+    });
+  },
+
+  postRender: function () {
+    _.defer(() => {
+      if (webauthn.isNewApiAvailable()) {
+        this.getCredentialsAndSave();
+      }
+      else {
+        this.model.trigger('error', this.model, {
+          responseJSON: {
+            errorSummary: loc('webauthn.biometric.error.factorNotSupported', 'login')
+          }
+        });
+        this.$('[data-se="webauthn-waiting"]').hide();
+      }
+    });
+  },
+
+  _startVerification: function () {
+    this.$('.okta-waiting-spinner').show();
+    this.$('.retry-webauthn').hide();
+  },
+
+  _stopVerification: function () {
+    this.$('.okta-waiting-spinner').hide();
+    this.$('.retry-webauthn').show();
+  }
+});
+
+const Footer = BaseFooter.extend({
+  links: function () {
+    // recovery link
+    const links = [];
+
+    // check if we have a select-factor form in remediation, if so add a link
+    if (this.options.appState.hasRemediationForm('select-factor')) {
+      links.push({
+        'type': 'link',
+        'label': 'Switch Factor',
+        'name': 'switchFactor',
+        'formName': 'select-factor',
+      });
+    }
+    return links;
+  }
+});
+
+export default BaseFactorView.extend({
+  Body,
+  Footer,
+});


### PR DESCRIPTION
 * Added webauthn verify UI on idx.
 * Added error handling for
       * browser doesn't support webauthn
       * user abort
       * code abort (when user switches form on webauthn prompt)

**Browser doesnt support webauthn**
![Screen Shot 2020-01-29 at 10 16 04 AM](https://user-images.githubusercontent.com/17267130/73385182-91a5d480-4281-11ea-8b30-254b5802ab7f.png)

**signout aborts webauthn** 
![idx-web2](https://user-images.githubusercontent.com/17267130/73385196-966a8880-4281-11ea-9ed9-e09420bf9a60.gif)
**cancel + success flow**
![idx-web](https://user-images.githubusercontent.com/17267130/73385197-966a8880-4281-11ea-9487-0f4341b6f688.gif)


RESOLVES: OKTA-271900

Original PR: https://github.com/okta/okta-signin-widget/pull/1024