### PR TITLE
fix: lable and style fixes to idx views

### DIFF
--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -1,3 +1,4 @@
+@import './forms';
 @import './footer';
 @import './beacon';
 @import './identify';
@@ -5,4 +6,4 @@
 @import './factor-poll-verification';
 @import './callout';
 @import './device-challenge';
-@import './webauthn-verify';
+@import './webauthn';

--- a/assets/sass/v2/_device-challenge.scss
+++ b/assets/sass/v2/_device-challenge.scss
@@ -17,6 +17,7 @@
     .o-form-content {
       .okta-form-subtitle {
         font-weight: 600;
+        text-align: center;
       }
     }
     .o-form-fieldset-container {

--- a/assets/sass/v2/_factor-poll-verification.scss
+++ b/assets/sass/v2/_factor-poll-verification.scss
@@ -1,8 +1,10 @@
 .siw-main-view {
   .resend-email-view {
     margin-bottom: 15px;
+    text-align: center;
 
     .infobox {
+      text-align: left;
       margin-bottom: 10px;
     }
   }

--- a/assets/sass/v2/_forms.scss
+++ b/assets/sass/v2/_forms.scss
@@ -1,0 +1,6 @@
+.siw-main-view {
+  .okta-form-subtitle {
+    margin: 25px 0 10px;
+    text-align: left;
+  }
+}

--- a/assets/sass/v2/_webauthn-verify.scss
+++ b/assets/sass/v2/_webauthn-verify.scss
@@ -1,3 +1,0 @@
-.idx-webauthn-verify-text {
-  margin-bottom: 20px;
-}

--- a/assets/sass/v2/_webauthn.scss
+++ b/assets/sass/v2/_webauthn.scss
@@ -1,0 +1,5 @@
+.siw-main-view {
+  .idx-webauthn-verify-text {
+    margin-bottom: 20px;
+  }
+}

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -279,6 +279,7 @@ recovery.mobile.hint = {0} can only be used if a mobile phone number has been co
 recovery.sms = SMS
 recovery.call = Voice Call
 recovery.smsOrCall = SMS or Voice Call
+verify.choices.description = Verify with one of the following factors.
 
 # Enroll Choices
 enroll.choices.title = Set up multifactor authentication
@@ -326,6 +327,7 @@ security.favorite_sports_player = Who is your favorite sports player?
 
 # Enroll Password
 enroll.password.setup = Select a password
+save.password = Save password
 
 # Enroll SMS
 enroll.sms.setup = Receive a code via SMS to authenticate
@@ -519,6 +521,7 @@ password.complexity.history = Your password cannot be any of your last {0} passw
 password.complexity.minAgeMinutes = At least {0} minute(s) must have elapsed since you last changed your password.
 password.complexity.minAgeHours = At least {0} hour(s) must have elapsed since you last changed your password.
 password.complexity.minAgeDays = At least {0} day(s) must have elapsed since you last changed your password.
+password.reset.verification = Verify with one of the following factors to reset your password.
 
 # The actual description consists of the password length message + one or more list elements
 password.complexity.length = at least {0} characters

--- a/playground/mocks/idp/idx/data/factor-enroll-options.json
+++ b/playground/mocks/idp/idx/data/factor-enroll-options.json
@@ -16,16 +16,16 @@
         "method": "POST",
         "value": [
           {
-            "name": "factorType",
+            "name": "factorProfileId",
             "type": "set",
             "options": [
               {
-                "label": "Password",
-                "value": "password"
+                "label": "Password Label",
+                "value": "00u2j17ObFUsbGfLg0g4"
               },
               {
-                "label": "E-mail",
-                "value": "email"
+                "label": "Email Label",
+                "value": "emf2j1ccd6CF4IWFY0g3"
               }
             ]
           },
@@ -35,6 +35,19 @@
             "visible": false
           }
         ]
+      }
+    ]
+  },
+  "factors": {
+    "type": "array",
+    "value": [
+      {
+        "factorType": "password",
+        "factorId": "00u2j17ObFUsbGfLg0g4"
+      },
+      {
+        "factorType": "email",
+        "factorId": "emf2j1ccd6CF4IWFY0g3"
       }
     ]
   },

--- a/playground/mocks/idp/idx/data/select-factor-for-password-recovery.json
+++ b/playground/mocks/idp/idx/data/select-factor-for-password-recovery.json
@@ -16,27 +16,23 @@
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",
         "value": [
-          {
-            "name": "factorId",
-            "type": "set",
-            "options": [
-              {
-                "label": "Password Label",
-                "value": "00u2j17ObFUsbGfLg0g4"
-              },
-              {
-                "label": "Email Label",
-                "value": "emf2j1ccd6CF4IWFY0g3"
-              }
-            ]
-          },
-          {
+            {
+              "name": "factorId",
+              "type": "set",
+              "options": [
+                {
+                  "label": "Email Label",
+                  "value": "emf2j1ccd6CF4IWFY0g3"
+                }
+              ]
+            },
+            {
               "name": "stateHandle",
               "required": true,
               "value": "02h50hMLvmuZUuoKCShHKZytlDeFRnn8KG-rcd8Ay5",
               "visible": false,
               "mutable": false
-          }
+            }
         ]
       }
     ]
@@ -44,10 +40,6 @@
   "factors": {
     "type": "array",
     "value": [
-      {
-        "factorType": "password",
-        "factorId": "00u2j17ObFUsbGfLg0g4"
-      },
       {
         "factorType": "email",
         "factorId": "emf2j1ccd6CF4IWFY0g3"
@@ -79,21 +71,33 @@
     ]
   },
   "context": {
-      "rel": [
-        "create-form"
-      ],
-      "name": "context",
-      "href": "http://localhost:3000/idp/idx/context",
-      "method": "POST",
-      "accepts": "application/vnd.okta.v1+json",
-      "value": [
-        {
-          "name": "stateHandle",
-          "required": true,
-          "value": "02h50hMLvmuZUuoKCShHKZytlDeFRnn8KG-rcd8Ay5",
-          "visible": false,
-          "mutable": false
-        }
-      ]
+    "rel": [
+      "create-form"
+    ],
+    "name": "context",
+    "href": "http://localhost:3000/idp/idx/context",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02h50hMLvmuZUuoKCShHKZytlDeFRnn8KG-rcd8Ay5",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "recoveryFactor" : {
+    "type" : "object",
+    "value" : {
+      "factorType": "password",
+      "factorProfileId": "NON_NULL_VALUE",
+      "factorId": "NON_NULL_VALUE",
+      "profile" : {
+        "name" : "NON_NULL_VALUE"
+      }
+    }
   }
 }
+  

--- a/src/v2/view-builder/components/FactorOptions.js
+++ b/src/v2/view-builder/components/FactorOptions.js
@@ -57,10 +57,6 @@ export default ListView.extend({
     });
   },
 
-  template: `
-    <div class="list-title">
-    {{i18n code="enroll.choices.description" bundle="login"}}
-    </div>\
-    <div class="list-content"></div>`,
+  template: '<div class="list-content"></div>',
 
 });

--- a/src/v2/view-builder/views/SelectFactorAuthenticateView.js
+++ b/src/v2/view-builder/views/SelectFactorAuthenticateView.js
@@ -4,7 +4,20 @@ import { loc } from 'okta';
 
 const Body = BaseForm.extend({
   title: function () {
+    if (this.isPasswordRecoveryFlow())  {
+      return loc('password.reset.title.generic', 'login');
+    }
     return loc('mfa.factors.dropdown.title', 'login');
+  },
+  subtitle: function () {
+    if (this.isPasswordRecoveryFlow())  {
+      return loc('password.reset.verification', 'login');
+    }
+    return loc('verify.choices.description', 'login');
+  },
+  isPasswordRecoveryFlow () {
+    const recoveryFactor = this.options.appState.get('recoveryFactor');
+    return recoveryFactor && recoveryFactor.factorType === 'password';
   },
   noButtonBar: true,
 });

--- a/src/v2/view-builder/views/SelectFactorEnrollView.js
+++ b/src/v2/view-builder/views/SelectFactorEnrollView.js
@@ -6,6 +6,7 @@ const Body = BaseForm.extend({
   title: function () {
     return loc('enroll.choices.setup', 'login');
   },
+  subtitle: loc('enroll.choices.description', 'login'),
   noButtonBar: true,
 });
 

--- a/src/v2/view-builder/views/email/RequiredFactorEmailView.js
+++ b/src/v2/view-builder/views/email/RequiredFactorEmailView.js
@@ -43,12 +43,10 @@ const Body = BaseForm.extend(Object.assign(
   {
     save: loc('mfa.challenge.verify', 'login'),
 
-    subtitle:
-    'An email has been sent to you. Please click the link in your email or enter the code from that email below.',
-
     initialize () {
       BaseForm.prototype.initialize.apply(this, arguments);
-
+      this.add(`<div class="email-verification-description">An email has been sent to you. 
+          Please click the link in your email or enter the code from that email below.</div>`);
       // polling has been killed when click save to avoid race conditions
       // hence resume if save failed.
       this.listenTo(this.options.model, 'error', this.startPolling.bind(this));
@@ -62,7 +60,7 @@ const Body = BaseForm.extend(Object.assign(
 
     postRender () {
       this.add(ResendView, {
-        selector: '.okta-form-subtitle',
+        selector: '.o-form-fieldset-container',
         prepend: true,
       });
 

--- a/src/v2/view-builder/views/password/EnrollFactorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollFactorPasswordView.js
@@ -4,8 +4,8 @@ import BaseForm from '../../internals/BaseForm';
 import BaseFactorView from '../shared/BaseFactorView';
 
 const Body = BaseForm.extend({
-  title: loc('factor.password', 'login'),
-  save: loc('mfa.challenge.verify', 'login'),
+  title: loc('enroll.password.setup', 'login'),
+  save: loc('save.password', 'login'),
 
   getUISchema () {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -1,10 +1,21 @@
+import BaseFormObject from './components/BaseFormObject';
+
 export default class BasePageObject {
   constructor(t) {
     this.t = t;
     this.url = '';
+    this.form = new BaseFormObject(t);
   }
 
   async navigateToPage() {
     await this.t.navigateTo(`http://localhost:3000${this.url}`);
+  }
+
+  getFormTitle() {
+    return this.form.getTitle();
+  }
+
+  getFormSubtitle() {
+    return this.form.getSubtitle();
   }
 }

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -1,4 +1,5 @@
 import BaseFormObject from './components/BaseFormObject';
+import { Selector } from 'testcafe';
 
 export default class BasePageObject {
   constructor(t) {
@@ -17,5 +18,9 @@ export default class BasePageObject {
 
   getFormSubtitle() {
     return this.form.getSubtitle();
+  }
+
+  getTextContent(selector) {
+    return Selector(selector).innerText;
   }
 }

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -1,11 +1,8 @@
-import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
-import BaseFormObject from './components/BaseFormObject';
 
 export default class ChallengeFactorPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-    this.form = new BaseFormObject(t);
   }
 
   verifyFactor(name, value) {

--- a/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeFactorPageObject.js
@@ -17,10 +17,6 @@ export default class ChallengeFactorPageObject extends BasePageObject {
     return this.form.getElement('.okta-form-title').textContent;
   }
 
-  getPageSubTitle(selector) {
-    return this.form.getElement(selector).textContent;
-  }
-
   waitForErrorBox() {
     return this.form.waitForErrorBox();
   }

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -12,12 +12,8 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
-  getSubtitle() {
-    return this.body.find('[data-se="o-form-explain"]').innerText;
-  }
-
   getContent() {
-    return this.body.find('[data-se="o-form-fieldset-container"]').innerText;
+    return this.getTextContent('[data-se="o-form-fieldset-container"]');
   }
 
   getFooterLink() {

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -8,7 +8,6 @@ const confirmPasswordFieldName = 'confirmPassword';
 export default class EnrollPasswordPageObject extends BasePageObject {
   constructor (t) {
     super(t);
-    this.form = new BaseFormObject(t);
   }
 
   fillPassword(value) {

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -1,13 +1,11 @@
 import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
-import BaseFormObject from './components/BaseFormObject';
 
 const CALLOUT_SELECTOR = '.infobox-warning > div';
 
 export default class IdentityPageObject extends BasePageObject {
   constructor (t) {
     super(t);
-    this.form = new BaseFormObject(t);
   }
 
   getPageTitle() {

--- a/test/testcafe/framework/page-objects/RegistrationPageObject.js
+++ b/test/testcafe/framework/page-objects/RegistrationPageObject.js
@@ -1,12 +1,10 @@
 import BasePageObject from './BasePageObject';
-import BaseFormObject from './components/BaseFormObject';
 
 const FIRSTNAME_FIELD = 'userProfile\\.firstName';
 const LASTNAME_FIELD = 'userProfile\\.lastName';
 export default class RegistrationPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-    this.form = new BaseFormObject(t);
   }
 
   fillFirstNameField(value) {

--- a/test/testcafe/framework/page-objects/SelectFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectFactorPageObject.js
@@ -1,17 +1,14 @@
 import BasePageObject from './BasePageObject';
-import BaseFormObject from './components/BaseFormObject';
 import { Selector } from 'testcafe';
 
 export default class SelectFactorPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-    this.form = new BaseFormObject(t);
   }
 
   hasPasswordSelectButton() {
     return this.form.elementExist('.enroll-factor-row > .enroll-factor-description > .enroll-factor-button');
   }
-
 
   hasPasswordIcon() {
     return this.form.elementExist('.enroll-factor-row > .enroll-factor-icon-container > .mfa-okta-password');
@@ -20,7 +17,6 @@ export default class SelectFactorPageObject extends BasePageObject {
   hasEmailIcon() {
     return this.form.elementExist('.enroll-factor-row > .enroll-factor-icon-container > .mfa-okta-email');
   }
-
 
   getPasswordLabel() {
     return Selector('.enroll-factor-row:first-child > .enroll-factor-description > .enroll-factor-label').textContent;

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -12,10 +12,6 @@ export default class TerminalPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
-  getSubtitle() {
-    return this.body.find('[data-se="o-form-explain"]').innerText;
-  }
-
   getFooterBackLink() {
     return this.footer.find('[data-se="back"]');
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -25,6 +25,14 @@ export default class BaseFormObject {
     return this.form.find(selector);
   }
 
+  getTitle() {
+    return this.form.find('[data-se="o-form-head"]').textContent; 
+  }
+
+  getSubtitle() {
+    return this.form.find('[data-se="o-form-explain"]').textContent;
+  }
+
   getSelectFormButtonLabel(selector) {
     return this.form.find(selector).textContent;
   }

--- a/test/testcafe/spec/ChallengeFactorEmail_MagicLink_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmail_MagicLink_spec.js
@@ -4,6 +4,7 @@ import { RequestMock, RequestLogger } from 'testcafe';
 import magicLinkReturnTab from '../../../playground/mocks/idp/idx/data/terminal-return-email';
 import magicLinkExpired from '../../../playground/mocks/idp/idx/data/terminal-return-expired-email';
 import magicLinkEmailSent from '../../../playground/mocks/idp/idx/data/factor-verification-email';
+import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 
 const magicLinkReturnTabMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx')
@@ -36,9 +37,9 @@ async function setup(t) {
 test
   .requestHooks(magicLinkReturnTabMock)
   (`challenge email factor with magic link`, async t => {
-    const challengeFactorPageObject = await setup(t);
-    const pageSubTitle = challengeFactorPageObject.getPageSubTitle('.okta-form-subtitle');
-    await t.expect(pageSubTitle).eql('To finish signing in, return to the screen where you requested the email link.');
+    await setup(t);
+    const terminalPageObject = await new TerminalPageObject(t);
+    await t.expect(terminalPageObject.getFormSubtitle()).eql('To finish signing in, return to the screen where you requested the email link.');
   });
 
 test

--- a/test/testcafe/spec/ChallengeFactorEmail_OTP_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmail_OTP_spec.js
@@ -33,8 +33,8 @@ test
     const challengeFactorPageObject = await setup(t);
     const pageTitle = challengeFactorPageObject.getPageTitle();
     await t.expect(pageTitle).contains('Email link');
-    const pageSubTitle = challengeFactorPageObject.getPageSubTitle('.okta-form-subtitle');
-    await t.expect(pageSubTitle).contains('An email has been sent to you. Please click the link in your email or enter the code from that email below.');
+    await t.expect(challengeFactorPageObject.getTextContent('.email-verification-description'))
+        .contains('An email has been sent to you. Please click the link in your email or enter the code from that email below.');
   });
 
 test

--- a/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
@@ -22,7 +22,7 @@ async function setup(t) {
 test(`should have the correct content`, async t => {
   const deviceChallengePollPageObject = await setup(t);
   await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
-  await t.expect(deviceChallengePollPageObject.getSubtitle()).eql('Launching Okta Verify...');
+  await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
   await t.expect(deviceChallengePollPageObject.getContent())
     .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
   await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Back to Sign In');

--- a/test/testcafe/spec/FactorEnrollPassword_spec.js
+++ b/test/testcafe/spec/FactorEnrollPassword_spec.js
@@ -22,6 +22,9 @@ async function setup(t) {
 test(`should have both password and confirmPassword fields and both are required`, async t => {
   const enrollPasswordPage = await setup(t);
 
+  // Check title 
+  await t.expect(enrollPasswordPage.getFormTitle()).eql('Select a password');
+
   // fields are required
   await enrollPasswordPage.clickNextButton();
   await enrollPasswordPage.waitForErrorBox();

--- a/test/testcafe/spec/SelectFactorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectFactorForEnroll_spec.js
@@ -1,0 +1,29 @@
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import SelectFactorPageObject from '../framework/page-objects/SelectFactorPageObject';
+import { RequestMock } from 'testcafe';
+import factorEnrollOptions from '../../../playground/mocks/idp/idx/data/factor-enroll-options';
+import identify from '../../../playground/mocks/idp/idx/data/identify';
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(factorEnrollOptions);
+
+fixture(`Select Factor to enroll Form`)
+  .requestHooks(mock);
+
+async function setup(t) {
+  const selectFactorPageObject = new SelectFactorPageObject(t);
+  await selectFactorPageObject.navigateToPage();
+  return selectFactorPageObject;
+}
+
+test(`should load select factor list with right text`, async t => {
+  const selectFactorPage = await setup(t);
+  await t.expect(selectFactorPage.getFormTitle()).eql('Setup');
+  await t.expect(selectFactorPage.getFormSubtitle()).eql(`Your company requires multifactor authentication to add an additional layer of security when signing in to your Okta account`);
+  await t.expect(selectFactorPage.hasPasswordSelectButton()).eql(true);
+  await t.expect(selectFactorPage.hasPasswordIcon()).eql(true);
+  await t.expect(selectFactorPage.hasEmailIcon()).eql(true);
+  await t.expect(selectFactorPage.getPasswordLabel()).eql('Password Label');
+  await t.expect(selectFactorPage.getEmailLabel()).eql('Email Label');
+});

--- a/test/testcafe/spec/SelectFactorForRecovery_spec.js
+++ b/test/testcafe/spec/SelectFactorForRecovery_spec.js
@@ -1,0 +1,26 @@
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import SelectFactorPageObject from '../framework/page-objects/SelectFactorPageObject';
+import { RequestMock } from 'testcafe';
+import selectFactorForPasswordRecovery from '../../../playground/mocks/idp/idx/data/select-factor-for-password-recovery';
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(selectFactorForPasswordRecovery);
+
+fixture(`Select Factor Form`)
+  .requestHooks(mock);
+
+async function setup(t) {
+  const selectFactorPageObject = new SelectFactorPageObject(t);
+  await selectFactorPageObject.navigateToPage();
+  return selectFactorPageObject;
+}
+
+test(`should load select factor list with right title and description`, async t => {
+  const selectFactorPage = await setup(t);
+  await t.expect(selectFactorPage.getFormTitle()).eql('Reset your password');
+  await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following factors to reset your password.');
+  await t.expect(selectFactorPage.hasEmailIcon()).eql(true);
+
+  await t.expect(selectFactorPage.getEmailLabel()).eql('Email Label');
+});

--- a/test/testcafe/spec/SelectFactorForVerification_spec.js
+++ b/test/testcafe/spec/SelectFactorForVerification_spec.js
@@ -4,22 +4,22 @@ import { RequestMock } from 'testcafe';
 import selectFactorAuthenticate from '../../../playground/mocks/idp/idx/data/select-factor-authenticate';
 
 const mock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx')
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(selectFactorAuthenticate);
 
-fixture(`Select Factor Form`)
+fixture(`Select Factor for verification Form`)
   .requestHooks(mock);
 
 async function setup(t) {
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.navigateToPage();
-  await identityPage.fillIdentifierField('Test Identifier');
-  await identityPage.clickNextButton();
-  return new SelectFactorPageObject(t);
+  const selectFactorPageObject = new SelectFactorPageObject(t);
+  await selectFactorPageObject.navigateToPage();
+  return selectFactorPageObject;
 }
 
 test(`should load select factor list`, async t => {
   const selectFactorPage = await setup(t);
+  await t.expect(selectFactorPage.getFormTitle()).eql('Select an authentication factor');
+  await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following factors.');
   await t.expect(selectFactorPage.hasPasswordSelectButton()).eql(true);
   await t.expect(selectFactorPage.hasPasswordIcon()).eql(true);
   await t.expect(selectFactorPage.hasEmailIcon()).eql(true);

--- a/test/testcafe/spec/TerminalReturnEmail_spec.js
+++ b/test/testcafe/spec/TerminalReturnEmail_spec.js
@@ -19,7 +19,7 @@ test
   (`show the correct content`, async t => {
     const terminalPageObject = await setup(t);
     await t.expect(terminalPageObject.getHeader()).eql('Email link (o*****m@abbott.dev)');
-    await t.expect(terminalPageObject.getSubtitle()).eql('To finish signing in, return to the screen where you requested the email link.');
+    await t.expect(terminalPageObject.getFormSubtitle()).eql('To finish signing in, return to the screen where you requested the email link.');
     await t.expect(terminalPageObject.getFooterBackLink().innerText).eql('Back to sign in');
     await t.expect(terminalPageObject.getFooterBackLink().getAttribute('href')).eql('/');
   });


### PR DESCRIPTION
* updated from subtitle styles to reflect mocks.
* updated description for factor list during verify and verify during reset.

RESOLVES: OKTA-274712, OKTA-274723

**Verify during reset password**

<img width="805" alt="Screen Shot 2020-01-30 at 2 50 21 PM" src="https://user-images.githubusercontent.com/17267130/73499618-6c928e00-4375-11ea-8559-dfd256bf4c9f.png">

**Verify during auth*

<img width="842" alt="Screen Shot 2020-01-30 at 3 05 22 PM" src="https://user-images.githubusercontent.com/17267130/73499619-6c928e00-4375-11ea-9031-9dcf5caefaf4.png">

**enroll factor list **

<img width="734" alt="Screen Shot 2020-01-30 at 3 18 40 PM" src="https://user-images.githubusercontent.com/17267130/73499620-6d2b2480-4375-11ea-9fc3-eac4773d977f.png">

**reset/first time password setup**

<img width="717" alt="Screen Shot 2020-01-30 at 3 24 02 PM" src="https://user-images.githubusercontent.com/17267130/73499621-6d2b2480-4375-11ea-9346-26a4fc788750.png">
