### PR TITLE
Fix testcafe test debt and update its eslint rule

### DIFF
--- a/playground/config/responseConfig.js
+++ b/playground/config/responseConfig.js
@@ -25,7 +25,7 @@ const idx = {
 // ===== AUTHN
 const authn = {
   '/api/v1/authn': [
-    // 'consent-required',
+    'unauthenticated',
     'success-001'
   ],
 };
@@ -118,8 +118,5 @@ const appleSsoExtension = {
 };
 
 module.exports = {
-  // TODO: some testcafe test rely on setting mocks to idx
-  // which is apparently bad. ideally, testcafe test shall pass even
-  // no mocks has been config.
-  mocks: idx,
+  mocks: authn,
 };

--- a/playground/mocks/api/v1/authn/data/unauthenticated.json
+++ b/playground/mocks/api/v1/authn/data/unauthenticated.json
@@ -1,0 +1,17 @@
+{
+  "stateToken": "aStateToken",
+  "status": "UNAUTHENTICATED",
+  "_embedded": {
+  },
+  "_links": {
+    "next": {
+      "name": "authenticate",
+      "href": "http://localhost:3000/api/v1/authn",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}

--- a/playground/mocks/idp/idx/data/success.json
+++ b/playground/mocks/idp/idx/data/success.json
@@ -44,6 +44,6 @@
     },
     "success": {
       "name": "success-redirect",
-      "href": "https://httpbin.org?stateToken=abc123"
+      "href": "http://localhost:3000/app/UserHome?stateToken=mockedStateToken123"
     }
 }

--- a/test/testcafe/.eslintrc.js
+++ b/test/testcafe/.eslintrc.js
@@ -1,5 +1,9 @@
+/* eslint-env node */
 module.exports = {
-  'extends': 'plugin:testcafe/recommended',
+  'extends': [
+    'eslint:recommended',
+    'plugin:testcafe/recommended'
+  ],
   'parserOptions': {
     'ecmaVersion': 2017,
     'sourceType': 'module'
@@ -7,5 +11,12 @@ module.exports = {
   'plugins': [
     'testcafe'
   ],
+  "env": {
+    "browser": true,
+  },
+  'rules': {
+    'semi': 2,
+    'max-len': 0,
+  },
   'root': true
 };

--- a/test/testcafe/README.md
+++ b/test/testcafe/README.md
@@ -6,8 +6,24 @@ All in once
 
 - `yarn test:testcafe-run chrome`
 
-Or start playground at one terminal and run the test in another terminal. 
+Or start playground at one terminal and run the test in another terminal.
 Useful at development time in order to get quicker feedback.
 
 - `yarn test:testcafe-setup`
 - `yarn testcafe chrome test/testcafe/spec`
+
+
+## Guideline for writting test
+
+Currently there are two patterns for writting test
+
+### Page level unit test
+
+The mindset is to
+  - bootstrap widget directly to the page you're testing
+  - verify the page elements
+  - and any interactions
+
+### Mulit-pages flow
+
+This is useful when you want to test sort of real world user flow.

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -1,6 +1,4 @@
-import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
-import BaseFormObject from './components/BaseFormObject';
 
 const passwordFieldName = 'credentials\\.passcode';
 const confirmPasswordFieldName = 'confirmPassword';

--- a/test/testcafe/framework/page-objects/SuccessPageObject.js
+++ b/test/testcafe/framework/page-objects/SuccessPageObject.js
@@ -6,8 +6,7 @@ export default class SuccessPageObject extends BasePageObject {
     super(t);
   }
   async getPageUrl() {
-    // success is redirect to httpbin.org
-    await this.t.expect(Selector('title').innerText).eql('httpbin.org');
+    await this.t.expect(Selector('h1').innerText).eql('Mock User Dashboard');
 
     const pageUrl = await ClientFunction(() => window.location.href)();
     return pageUrl;

--- a/test/testcafe/spec/ChallengeFactorEmail_MagicLink_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmail_MagicLink_spec.js
@@ -1,4 +1,3 @@
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import ChallengeFactorPageObject from '../framework/page-objects/ChallengeFactorPageObject';
 import { RequestMock, RequestLogger } from 'testcafe';
 import magicLinkReturnTab from '../../../playground/mocks/idp/idx/data/terminal-return-email';
@@ -7,52 +6,48 @@ import magicLinkEmailSent from '../../../playground/mocks/idp/idx/data/factor-ve
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 
 const magicLinkReturnTabMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx')
-  .respond(magicLinkReturnTab)
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(magicLinkReturnTab);
 
 const magicLinkExpiredMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx')
-  .respond(magicLinkExpired)
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(magicLinkExpired);
 
 const magicLinkEmailSentMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx')
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(magicLinkEmailSent)
-
-const resendEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/resend')
   .respond(magicLinkEmailSent)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(magicLinkEmailSent)
+;
 
 const logger = RequestLogger(/poll|resend/);
 
-fixture(`Challenge Email Magic Link Form Content`)
+fixture(`Challenge Email Magic Link Form Content`);
 
 async function setup(t) {
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.navigateToPage();
-  await identityPage.fillIdentifierField('Challenge Email');
-  await identityPage.clickNextButton();
-  return new ChallengeFactorPageObject(t);
+  const challengeFactorPageObject = new ChallengeFactorPageObject(t);
+  challengeFactorPageObject.navigateToPage();
+  return challengeFactorPageObject;
 }
 
 test
-  .requestHooks(magicLinkReturnTabMock)
-  (`challenge email factor with magic link`, async t => {
+  .requestHooks(magicLinkReturnTabMock)(`challenge email factor with magic link`, async t => {
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getFormSubtitle()).eql('To finish signing in, return to the screen where you requested the email link.');
   });
 
 test
-  .requestHooks(magicLinkExpiredMock)
-  (`challenge email factor with expired magic link`, async t => {
+  .requestHooks(magicLinkExpiredMock)(`challenge email factor with expired magic link`, async t => {
     const challengeFactorPageObject = await setup(t);
     const pageTitle = challengeFactorPageObject.getPageTitle();
     await t.expect(pageTitle).eql('This email link has expired. To resend it, return to the screen where you requested it.');
   });
 
-  test
-  .requestHooks(logger, resendEmailMock, magicLinkEmailSentMock)
-  (`challenge email factor with magic link sent renders and has resend link`, async t => {
+test
+  .requestHooks(logger, magicLinkEmailSentMock)(`challenge email factor with magic link sent renders and has resend link`, async t => {
     const challengeFactorPageObject = await setup(t);
     await t.expect(challengeFactorPageObject.resendEmailView().getStyleProperty('display')).eql('none');
     // wait for resend button to appear
@@ -73,4 +68,3 @@ test
       record.request.url.match(/poll|resend/)
     )).eql(17);
   });
-

--- a/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
@@ -26,11 +26,11 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:6512/launch-okta-verify')
   .respond(null, 200, { 'access-control-allow-origin': '*' })
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll')
-  .respond(identify)
+  .respond(identify);
 
 
 fixture(`Device Challenge Polling View with Loopback Failfast and Launch Okta Verify`)
-  .requestHooks(logger, mock)
+  .requestHooks(logger, mock);
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -38,8 +38,7 @@ async function setup(t) {
   return deviceChallengePollPage;
 }
 
-test
-(`loopback fails and falls back to custom uri`, async t => {
+test(`loopback fails and falls back to custom uri`, async t => {
   const deviceChallengePollPageObject = await setup(t);
   await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
   await t.expect(logger.count(
@@ -78,4 +77,4 @@ test
   const secondIdentityPage = new IdentityPageObject(t);
   await secondIdentityPage.fillIdentifierField('Test Identifier');
   await t.expect(secondIdentityPage.getIdentifierValue()).eql('Test Identifier');
-})
+});

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -31,10 +31,10 @@ const mock = RequestMock()
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept',
     'access-control-allow-methods': 'POST, OPTIONS'
-  })
+  });
 
 fixture(`Device Challenge Polling View with Successful Loopback Server`)
-  .requestHooks(logger, mock)
+  .requestHooks(logger, mock);
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -42,27 +42,26 @@ async function setup(t) {
   return deviceChallengePollPage;
 }
 
-test
-  (`probing and polling APIs are sent and responded`, async t => {
-    const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
+test(`probing and polling APIs are sent and responded`, async t => {
+  const deviceChallengePollPageObject = await setup(t);
+  await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
+  await t.expect(logger.count(
+    record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|6512/)
-    )).eql(3);
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
+  )).eql(3);
+  await t.expect(logger.count(
+    record => record.response.statusCode === 200 &&
       record.request.url.match(/challenge/) &&
       record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
-    )).eql(1);
-    failureCount = 2;
-    await t.expect(logger.count(
-      record => record.response.statusCode === 500 &&
+  )).eql(1);
+  failureCount = 2;
+  await t.expect(logger.count(
+    record => record.response.statusCode === 500 &&
       record.request.url.match(/2000|6511/)
-    )).eql(2);
-    await t.expect(logger.contains(record => record.request.url.match(/6513/))).eql(false);
+  )).eql(2);
+  await t.expect(logger.contains(record => record.request.url.match(/6513/))).eql(false);
 
-    const identityPage = new IdentityPageObject(t);
-    await identityPage.fillIdentifierField('Test Identifier');
-    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-  })
+  const identityPage = new IdentityPageObject(t);
+  await identityPage.fillIdentifierField('Test Identifier');
+  await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+});

--- a/test/testcafe/spec/DeviceSSOExtensionView_spec.js
+++ b/test/testcafe/spec/DeviceSSOExtensionView_spec.js
@@ -1,4 +1,5 @@
-import { RequestLogger, RequestMock, ClientFunction } from 'testcafe';
+import { RequestLogger, RequestMock } from 'testcafe';
+import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import BasePageObject from '../framework/page-objects/BasePageObject';
 import identifyWithAppleSSOExtension from '../../../playground/mocks/idp/idx/data/identify-with-apple-sso-extension';
 import success from '../../../playground/mocks/idp/idx/data/success';
@@ -9,12 +10,11 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identifyWithAppleSSOExtension)
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/123/verify')
-  .respond(success)
+  .respond(success);
 
 fixture(`App SSO Extension View`)
-  .requestHooks(logger, mock)
+  .requestHooks(logger, mock);
 
-const getPageUrl = ClientFunction(() => window.location.href);
 test(`should have the correct content`, async t => {
   const ssoExtensionPage = new BasePageObject(t);
   await ssoExtensionPage.navigateToPage();
@@ -27,6 +27,8 @@ test(`should have the correct content`, async t => {
     record.request.method === 'post' &&
     record.request.url.match(/authenticators\/sso_extension\/transactions\/123\/verify/)
   )).eql(1);
-  const pageUrl = getPageUrl();
-  await t.expect(pageUrl).contains('stateToken=abc123');
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });

--- a/test/testcafe/spec/EnrollFactorPassword_spec.js
+++ b/test/testcafe/spec/EnrollFactorPassword_spec.js
@@ -7,8 +7,8 @@ import xhrSuccess from '../../../playground/mocks/idp/idx/data/success';
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrFactorEnrollPassword)
-      .onRequestTo('http://localhost:3000/idp/idx')
-      .respond(xhrSuccess);
+  .onRequestTo('http://localhost:3000/idp/idx')
+  .respond(xhrSuccess);
 
 fixture(`Factor Enroll Password`)
   .requestHooks(mock);
@@ -49,5 +49,6 @@ test(`should succeed when fill same value`, async t => {
   await enrollPasswordPage.clickNextButton();
 
   const pageUrl = await successPage.getPageUrl();
-  await t.expect(pageUrl).contains('stateToken=abc123');
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });

--- a/test/testcafe/spec/IdentityOktaVerify_spec.js
+++ b/test/testcafe/spec/IdentityOktaVerify_spec.js
@@ -12,7 +12,7 @@ const mock = RequestMock()
   .respond(launchAuthenticatorOption);
 
 fixture(`Identity View with Okta Verify option`)
-  .requestHooks(logger, mock)
+  .requestHooks(logger, mock);
 
 async function setup(t) {
   const deviceChallengePollPage = new IdentityPageObject(t);
@@ -42,7 +42,7 @@ test(`should the correct title`, async t => {
   const identityPage = await setup(t);
   const pageTitle = identityPage.getPageTitle();
   await t.expect(pageTitle).eql('Sign In');
-})
+});
 
 test(`should the correct content`, async t => {
   const identityPage = await setup(t);
@@ -52,4 +52,4 @@ test(`should the correct content`, async t => {
   await identityPage.clickOktaVerifyButton();
   const header = new Selector('h2[data-se="o-form-head"]');
   await t.expect(header.textContent).eql('Verify account access');
-})
+});

--- a/test/testcafe/spec/IdentityRegistration_spec.js
+++ b/test/testcafe/spec/IdentityRegistration_spec.js
@@ -1,7 +1,17 @@
+import { RequestMock } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import RegistrationPageObject from '../framework/page-objects/RegistrationPageObject';
+import identify from '../../../playground/mocks/idp/idx/data/identify';
+import enrollProfile from '../../../playground/mocks/idp/idx/data/enroll-profile';
 
-fixture(`Registration Form`);
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identify)
+  .onRequestTo('http://localhost:3000/idp/idx/enroll')
+  .respond(enrollProfile);
+
+fixture(`Registration Form`)
+  .requestHooks(mock);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/IdentityUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentityUnknownUser_spec.js
@@ -1,10 +1,13 @@
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
-import unknownUser from '../../../playground/mocks/idp/idx/data/unknown-user'
+import unknownUser from '../../../playground/mocks/idp/idx/data/unknown-user';
+import identify from '../../../playground/mocks/idp/idx/data/identify';
 import { RequestMock } from 'testcafe';
 
 const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identify)
   .onRequestTo('http://localhost:3000/idp/idx')
-  .respond(unknownUser)
+  .respond(unknownUser);
 
 fixture(`Unknown user form`)
   .requestHooks(mock);
@@ -18,6 +21,7 @@ async function setup(t) {
 test(`should show messages callout for unknown user`, async t => {
   const identityPage = await setup(t);
   await identityPage.fillIdentifierField('unknown');
-  await identityPage.clickNextButton();  
-  await t.expect(identityPage.getUnknownUserCalloutContent()).eql('There is no account with the email  test@rain.com .  Sign up  for an account');
+  await identityPage.clickNextButton();
+  await t.expect(identityPage.getUnknownUserCalloutContent())
+    .eql('There is no account with the email  test@rain.com .  Sign up  for an account');
 });

--- a/test/testcafe/spec/Identity_spec.js
+++ b/test/testcafe/spec/Identity_spec.js
@@ -1,6 +1,13 @@
+import { RequestMock } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import identify from '../../../playground/mocks/idp/idx/data/identify';
 
-fixture(`Identity Form`);
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identify);
+
+fixture(`Identity Form`)
+  .requestHooks(mock);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/SelectFactorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectFactorForEnroll_spec.js
@@ -1,8 +1,6 @@
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import SelectFactorPageObject from '../framework/page-objects/SelectFactorPageObject';
 import { RequestMock } from 'testcafe';
 import factorEnrollOptions from '../../../playground/mocks/idp/idx/data/factor-enroll-options';
-import identify from '../../../playground/mocks/idp/idx/data/identify';
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')

--- a/test/testcafe/spec/SelectFactorForRecovery_spec.js
+++ b/test/testcafe/spec/SelectFactorForRecovery_spec.js
@@ -1,4 +1,3 @@
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import SelectFactorPageObject from '../framework/page-objects/SelectFactorPageObject';
 import { RequestMock } from 'testcafe';
 import selectFactorForPasswordRecovery from '../../../playground/mocks/idp/idx/data/select-factor-for-password-recovery';

--- a/test/testcafe/spec/SelectFactorForVerification_spec.js
+++ b/test/testcafe/spec/SelectFactorForVerification_spec.js
@@ -1,4 +1,3 @@
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import SelectFactorPageObject from '../framework/page-objects/SelectFactorPageObject';
 import { RequestMock } from 'testcafe';
 import selectFactorAuthenticate from '../../../playground/mocks/idp/idx/data/select-factor-authenticate';

--- a/test/testcafe/spec/Success_spec.js
+++ b/test/testcafe/spec/Success_spec.js
@@ -1,8 +1,12 @@
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
-import { ClientFunction, RequestMock } from 'testcafe';
+import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
+import { RequestMock } from 'testcafe';
 import success from '../../../playground/mocks/idp/idx/data/success';
+import identify from '../../../playground/mocks/idp/idx/data/identify';
 
 const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identify)
   .onRequestTo('http://localhost:3000/idp/idx')
   .respond(success);
 
@@ -14,13 +18,14 @@ async function setup(t) {
   await identityPage.navigateToPage();
   return identityPage;
 }
-const getPageUrl = ClientFunction(() => window.location.href);
 
 test(`should navigate to redirect link google.com after success`, async t => {
   const identityPage = await setup(t);
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.clickNextButton();
-  const pageUrl = getPageUrl();
-  await t.expect(pageUrl).contains('stateToken=abc123');
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 

--- a/test/testcafe/spec/TerminalReturnEmail_spec.js
+++ b/test/testcafe/spec/TerminalReturnEmail_spec.js
@@ -4,10 +4,10 @@ import terminalReturnEmail from '../../../playground/mocks/idp/idx/data/terminal
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(terminalReturnEmail)
+  .respond(terminalReturnEmail);
 
 fixture(`Return Email Terminal`)
-  .requestHooks(mock)
+  .requestHooks(mock);
 
 async function setup(t) {
   const terminalPage = new TerminalPageObject(t);
@@ -15,8 +15,7 @@ async function setup(t) {
   return terminalPage;
 }
 
-test
-  (`show the correct content`, async t => {
+test(`show the correct content`, async t => {
     const terminalPageObject = await setup(t);
     await t.expect(terminalPageObject.getHeader()).eql('Email link (o*****m@abbott.dev)');
     await t.expect(terminalPageObject.getFormSubtitle()).eql('To finish signing in, return to the screen where you requested the email link.');

--- a/test/testcafe/spec/TerminalTransferedEmail_spec.js
+++ b/test/testcafe/spec/TerminalTransferedEmail_spec.js
@@ -1,14 +1,13 @@
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 import { RequestMock } from 'testcafe';
 import terminalTransferedEmail from '../../../playground/mocks/idp/idx/data/terminal-transfered-email';
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(terminalTransferedEmail)
+  .respond(terminalTransferedEmail);
 
 fixture(`Transfered Email Terminal`)
-  .requestHooks(mock)
+  .requestHooks(mock);
 
 async function setup(t) {
   const terminalPage = new TerminalPageObject(t);
@@ -16,10 +15,9 @@ async function setup(t) {
   return terminalPage;
 }
 
-test
-  (`show the correct content`, async t => {
-    const terminalPageObject = await setup(t);
-    await t.expect(terminalPageObject.getHeader()).eql('Flow continued in a new tab.');
-    await t.expect(terminalPageObject.getFooterBackLink().innerText).eql('Back to sign in');
-    await t.expect(terminalPageObject.getFooterBackLink().getAttribute('href')).eql('/');
-  });
+test(`show the correct content`, async t => {
+  const terminalPageObject = await setup(t);
+  await t.expect(terminalPageObject.getHeader()).eql('Flow continued in a new tab.');
+  await t.expect(terminalPageObject.getFooterBackLink().innerText).eql('Back to sign in');
+  await t.expect(terminalPageObject.getFooterBackLink().getAttribute('href')).eql('/');
+});

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -71,8 +71,11 @@ module.exports = {
     open: true,
     before (app) {
       app.get('/app/UserHome', (req, res) => {
-        res.status(200)
-          .send('<h1>Mock User Dashboard</h1><a href="/">Back to Login</a>');
+        const respHtml = `
+          <h1>Mock User Dashboard</h1>
+          <pre id="preview-query">${JSON.stringify(req.query, null, 2)}</pre>
+          <a href="/">Back to Login</a>`;
+        res.status(200).send(respHtml);
       });
 
       // ================================= dyson mock setup


### PR DESCRIPTION
- Refactoring existing testcafe test to be self contained instead of depending on the mock server config
- Change redirect URI to `localhost:3000/app/UserHome` instead of httpbin
- Update `.eslintrc` for test files