### PR TITLE
fix: increase /probe timeout to 3000 ms for Android

### DIFF
--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -17,6 +17,9 @@ define(['q', 'okta'], function (Q, Okta) {
     getUserAgent: function () {
       return navigator.userAgent;
     },
+    isAndroid: function () {
+      return /Android/i.test(this.getUserAgent());
+    },
     isMessageFromCorrectSource: function ($iframe, event) {
       return event.source === $iframe[0].contentWindow;
     },

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -4,6 +4,7 @@ import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
 import BaseFooter from '../internals//BaseFooter';
 import Logger from '../../../util/Logger';
+import DeviceFingerprint from '../../../util/DeviceFingerprint';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({
@@ -71,7 +72,10 @@ const Body = BaseForm.extend({
     const checkPort = () => {
       return request({
         url: getAuthenticatorUrl('probe'),
-        timeout: 1000 // if authenticator & its probing endpoint exist, it should respond within 1000ms
+        // in loopback server, SSL handshake sometimes takes more than 1000 ms and thus needs additional timeout
+        // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
+        // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
+        timeout: DeviceFingerprint.isAndroid() ? 3000 : 1000
       });
     };
 


### PR DESCRIPTION
Resolves: OKTA-278180

Demo: https://okta.box.com/s/qipbtx3i6yr7cwrehh68ul9zwvms1vpx

Demo displayed timeouts for different platforms. Note that the console message in above video is just for testing purpose and is not included in this PR.

@jhe-okta @nikhilvenkatraman-okta @haishengwu-okta 