### PR TITLE
fix: stop setting stateHandle cookie from sign in widget

### DIFF
--- a/src/v2/view-builder/views/SSOExtensionView.js
+++ b/src/v2/view-builder/views/SSOExtensionView.js
@@ -14,7 +14,6 @@ const Body = BaseForm.extend({
 
   initialize () {
     BaseForm.prototype.initialize.apply(this, arguments);
-    document.cookie = `stateHandle=${this.options.appState.get('currentState').stateHandle};path=/`;
     Util.redirectWithFormGet(this.options.currentViewState.href);
   }
 });


### PR DESCRIPTION
After testing with Apple SSO Extension, we realized that the cookie we set from SIW is not received in server. We go with a different approach now to pass stateHandle. To avoid conflict, we are reverting the cookie change in SIW.

OKTA-278610