### PR TITLE
fix: add check for introspect in refreshauth

### DIFF
--- a/src/RefreshAuthStateController.js
+++ b/src/RefreshAuthStateController.js
@@ -27,22 +27,20 @@ define(['q', 'okta', 'util/FormController'], function (Q, Okta, FormController) 
       var token = this.options.token;
       this.model.startTransaction(function (authClient) {
         appState.trigger('loading', true);
-        if (token && (token === this.settings.get('stateToken'))) {
-          // widget bootstrapped with statetoken via settings
-          // check if stateToken in url is same as settings
-          //unset stateToken to prevent the baseloginrouter controller from calling it again on render
+        if (this.options.appState.get('introspectSuccess') ||
+            this.options.appState.get('introspectError')) {
+          // Also handles the case when we hit introspect and are on the oldpipeline
           this.settings.unset('stateToken');
           var trans = this.options.appState.get('introspectSuccess');
           var transError = this.options.appState.get('introspectError');
-          if (trans || transError) {
-            if (trans && trans.data) {
-              return Q.resolve(trans);
-            } else {
-              return Q.reject(transError);
-            }
+          if (trans && trans.data) {
+            return Q.resolve(trans);
+          } else {
+            return Q.reject(transError);
           }
         } else if (token) {
           // widget bootstrapped with statetoken only in the url and not in settings
+          // used for mobile flows
           return authClient.tx.resume({
             stateToken: token
           });
@@ -54,7 +52,6 @@ define(['q', 'okta', 'util/FormController'], function (Q, Okta, FormController) 
           }
           appState.trigger('navigate', '');
         }
-
       });
     },
 


### PR DESCRIPTION
Resolves: OKTA-271959

- Backporting to master 
- Original patch PR https://github.com/okta/okta-signin-widget/pull/1012 
- I left out the selenium script commit from this backport PR because that change is already in master https://github.com/okta/okta-signin-widget/pull/1031
- The test files in the PR are also updated in master hence they are not showing up here.