### PR TITLE
feat: use window location to open Okta Verify

### DIFF
--- a/playground/mocks/idp/idx/data/identify-with-device-launch-authenticator.json
+++ b/playground/mocks/idp/idx/data/identify-with-device-launch-authenticator.json
@@ -67,7 +67,7 @@
         "type": "object",
         "value": {
             "challengeMethod": "CUSTOM_URI",
-            "href": "http://localhost:6512/launch-okta-verify",
+            "href": "com.verify.okta://open",
             "cancel": {
                 "rel": [
                     "create-form"

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -6,6 +6,7 @@ import BaseFooter from '../internals//BaseFooter';
 import Logger from '../../../util/Logger';
 import DeviceFingerprint from '../../../util/DeviceFingerprint';
 import polling from './shared/polling';
+import Util from '../../../util/Util';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({
@@ -128,9 +129,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     doCustomURI () {
-      return request({
-        url: this.customURI,
-      });
+      this.customURI && Util.redirectWithFormGet(this.customURI);
     },
   },
 

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -23,8 +23,4 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   getSpinner() {
     return this.body.find('.spinner');
   }
-
-  async clickLaunchOktaVerifyLink() {
-    await this.t.click(this.body.find('#launch-ov'));
-  }
 }

--- a/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewOktaVerify_spec.js
@@ -1,36 +1,21 @@
-import { RequestLogger, RequestMock } from 'testcafe';
+import { RequestLogger, RequestMock, ClientFunction } from 'testcafe';
 import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
-import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
-import identify from '../../../playground/mocks/idp/idx/data/identify';
-import identifyWithDeviceProbingLoopback from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback';
-import loopbackChallengeNotReceived from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback-challenge-not-received';
 import identifyWithLaunchAuthenticator from '../../../playground/mocks/idp/idx/data/identify-with-device-launch-authenticator';
 
 const logger = RequestLogger(/introspect|probe|cancel|launch|launch-okta-verify|poll/);
+const identifyWithLaunchAuthenticatorHttpCustomUri = JSON.parse(JSON.stringify(identifyWithLaunchAuthenticator));
+const mockHttpCustomUri = 'http://localhost:3000/launch-okta-verify';
+// replace custom URI with http URL so that we can mock and verify
+identifyWithLaunchAuthenticatorHttpCustomUri.authenticatorChallenge.value.href = mockHttpCustomUri;
 
 const mock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(identifyWithDeviceProbingLoopback)
-  .onRequestTo('http://localhost:2000/probe')
-  .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6511/probe')
-  .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6512/probe')
-  .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6513/probe')
-  .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll/cancel')
-  .respond(loopbackChallengeNotReceived)
-  .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
-  .respond(identifyWithLaunchAuthenticator)
-  .onRequestTo('http://localhost:6512/launch-okta-verify')
-  .respond(null, 200, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll')
-  .respond(identify);
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri);
 
 
-fixture(`Device Challenge Polling View with Loopback Failfast and Launch Okta Verify`)
-  .requestHooks(logger, mock);
+fixture(`Device Challenge Polling View with custom URI launches Okta Verify`);
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -38,44 +23,9 @@ async function setup(t) {
   return deviceChallengePollPage;
 }
 
-test(`loopback fails and falls back to custom uri`, async t => {
-  const deviceChallengePollPageObject = await setup(t);
-  await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
-      record.request.url.match(/introspect/)
-  )).eql(1);
-  await t.expect(logger.count(
-    record => record.response.statusCode === 500 &&
-      record.request.url.match(/2000|6511|6512|6513/)
-  )).eql(4);
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
-      record.request.url.match(/authenticators\/poll\/cancel/)
-  )).eql(1);
-
-  const firstIdentityPage = new IdentityPageObject(t);
-  await firstIdentityPage.clickOktaVerifyButton();
-  await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
-  await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
-  await t.expect(deviceChallengePollPageObject.getContent())
-    .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
-  await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Back to Sign In');
-  await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
-      record.request.url.match(/\/okta-verify\/launch/)
-  )).eql(1);
-  await t.expect(logger.count(
-    record => record.request.url.match(/launch-okta-verify/) &&
-      record.request.method === 'get'
-  )).eql(1);
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
-    record.request.url.match(/poll/)
-  )).eql(1);
-
-  const secondIdentityPage = new IdentityPageObject(t);
-  await secondIdentityPage.fillIdentifierField('Test Identifier');
-  await t.expect(secondIdentityPage.getIdentifierValue()).eql('Test Identifier');
-});
+const getPageUrl = ClientFunction(() => window.location.href);
+test
+  .requestHooks(logger, mock)(`load the custom URI`, async t => {
+    await setup(t);
+    await t.expect(getPageUrl()).contains(mockHttpCustomUri);
+  });

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -3,15 +3,15 @@ import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChall
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import identify from '../../../playground/mocks/idp/idx/data/identify';
 import identifyWithDeviceProbingLoopback from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback';
+import loopbackChallengeNotReceived from '../../../playground/mocks/idp/idx/data/identify-with-device-probing-loopback-challenge-not-received';
+import identifyWithLaunchAuthenticator from '../../../playground/mocks/idp/idx/data/identify-with-device-launch-authenticator';
 
 let failureCount = 0;
-
-const logger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
-
-const mock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+const loopbackSuccessLogger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
+const loopbackSuccesskMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithDeviceProbingLoopback)
-  .onRequestTo('http://localhost:3000/idp/idx/authenticators/poll')
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond((req, res) => {
     res.statusCode = '200';
     if (failureCount === 2) {
@@ -20,48 +20,92 @@ const mock = RequestMock()
       res.setBody(identifyWithDeviceProbingLoopback);
     }
   })
-  .onRequestTo('http://localhost:2000/probe')
+  .onRequestTo(/2000|6511\/probe/)
   .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6511/probe')
-  .respond(null, 500, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6512/probe')
+  .onRequestTo(/6512\/probe/)
   .respond(null, 200, { 'access-control-allow-origin': '*' })
-  .onRequestTo('http://localhost:6512/challenge')
+  .onRequestTo(/6512\/challenge/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept',
     'access-control-allow-methods': 'POST, OPTIONS'
   });
 
-fixture(`Device Challenge Polling View with Successful Loopback Server`)
-  .requestHooks(logger, mock);
+const loopbackFallbackLogger = RequestLogger(/introspect|probe|cancel|launch|launch-okta-verify|poll/);
+const loopbackFallbackMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithDeviceProbingLoopback)
+  .onRequestTo(/2000|6511|6512|6513\/probe/)
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
+  .respond(loopbackChallengeNotReceived)
+  .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(identifyWithLaunchAuthenticator)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithLaunchAuthenticator);
 
-async function setup(t) {
+fixture(`Device Challenge Polling View with the Loopback Server and Custom URI approaches`);
+
+async function setupLoopbackSuccess(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
   await deviceChallengePollPage.navigateToPage();
   return deviceChallengePollPage;
 }
 
-test(`probing and polling APIs are sent and responded`, async t => {
-  const deviceChallengePollPageObject = await setup(t);
-  await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
+async function setupLoopbackFallback(t) {
+  const deviceChallengeFalllbackPage = new IdentityPageObject(t);
+  await deviceChallengeFalllbackPage.navigateToPage();
+  return deviceChallengeFalllbackPage;
+}
+
+test
+  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)(`in loopback server approach, probing and polling requests are sent and responded`, async t => {
+    const deviceChallengePollPageObject = await setupLoopbackSuccess(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|6512/)
-  )).eql(3);
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
+    )).eql(3);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
       record.request.url.match(/challenge/) &&
       record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
-  )).eql(1);
-  failureCount = 2;
-  await t.expect(logger.count(
-    record => record.response.statusCode === 500 &&
+    )).eql(1);
+    failureCount = 2;
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 500 &&
       record.request.url.match(/2000|6511/)
-  )).eql(2);
-  await t.expect(logger.contains(record => record.request.url.match(/6513/))).eql(false);
+    )).eql(2);
+    await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
 
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.fillIdentifierField('Test Identifier');
-  await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-});
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
+
+test
+  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)(`loopback fails and falls back to custom uri`, async t => {
+    loopbackFallbackLogger.clear();
+    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/introspect/)
+    )).eql(1);
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/2000|6511|6512|6513/)
+    )).eql(4);
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/authenticators\/poll\/cancel/)
+    )).eql(1);
+    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
+    await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
+    await t.expect(deviceChallengePollPageObject.getContent())
+      .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Back to Sign In');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
+  });


### PR DESCRIPTION
- Use window.location to open custom URI to launch app from browser.
- Update the mock where custom URI is with non-http scheme so that we can mimic the flow in test. Otherwise we will have to mock the http request then the UI will be updated so we cannot test the UI.
OKTA-279056