### PR TITLE
chore: updates for okta-auth-js@3.0 - OKTA-276557

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- '8'
+- '10'
 
 install:
 - TMPDIR=/tmp yarn install

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,53 @@
 
 This library uses semantic versioning and follows Okta's [library version policy](https://developer.okta.com/code/library-versions/). In short, we don't make breaking changes unless the major version changes!
 
+## Migrating from 3.x to 4.x
+
+### PKCE is `true` by default
+
+For SPA OIDC applications, PKCE flow will now be used by default. Implicit flow can still be used by setting `pkce: false` in the `authParams`:
+
+```javascript
+var signIn = new OktaSignIn(
+  {
+    baseUrl: 'https://{yourOktaDomain}',
+    authParams: {
+      pkce: false
+    }
+  }
+);
+```
+
+The default `responseMode` for PKCE flow is `query`. By default, the authorization code will be returned as a query parameter, not a hash fragment. The code can be returned in a fragment by setting `responseMode` to `fragment`:
+
+```javascript
+var signIn = new OktaSignIn(
+  {
+    baseUrl: 'https://{yourOktaDomain}',
+    authParams: {
+      responseMode: 'fragment'
+    }
+  }
+);
+```
+
+### showSignInToGetTokens() options changed
+
+See [showSignInToGetTokens](README.md#showsignintogettokens) for updated documentation on this method.
+
+- getAccessToken is now `true` by default
+- `authorizationServerId` option has been removed from To specificy a custom authorization server, use `authParams.issuer`. The issuer should be specified as a full URI, not just the server ID.
+
+### @okta/okta-auth-js has been upgraded to version 3.0.0
+
+See the [okta-auth-js CHANGELOG](https://github.com/okta/okta-auth-js/blob/master/CHANGELOG.md#300) for details on all the changes.
+
+- [authClient.token.parseFromUrl()](https://github.com/okta/okta-auth-js#tokenparsefromurloptions) now returns tokens in an object hash, not an array.
+
+### Other changes
+
+- `authParams.grantType` has been removed
+
 ## Migrating From 2.x to 3.x
 
 ### Consolidated CSS Files

--- a/README.md
+++ b/README.md
@@ -185,11 +185,16 @@ You can also browse the full [API reference documentation](#api-reference).
 
 ## Usage examples
 
-## PKCE (Proof Key for Code Exchange) flow
+### OIDC login flow using PKCE (Proof Key for Code Exchange)
 
-- Configure your Single-page application in the Okta Admin UI to allow the `Authorization code` grant type.
-
-- To complete the flow, your client application must handle the code passed to `redirectUri`. This is most easily accomplished using [okta-auth-js](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) or with one of our [Javascript OIDC SDKs](https://github.com/okta/okta-oidc-js)
+- PKCE is enabled by default for new SPA (Single-page) applications
+- You can configure your existing Single-page application to use `PKCE` under the `General Settings` for your application in the Okta Admin UI.
+- To complete the flow, your client application should handle the code passed to `redirectUri` and use it to obtain tokens. You can test for a code in the URL using [hasTokensInUrl()](#hastokensinurl). The [okta-auth-js](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) library is used to retreive the code from the URL and exchange it for tokens. An instance of `okta-auth-js` is used by the Signin Widget and exposed as `authClient`.
+- We also provide higher-level [Javascript OIDC SDKs](https://github.com/okta/okta-oidc-js) for several frameworks, including [React](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-react), [Angular](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-angular) and [Vue](https://github.com/okta/okta-oidc-js/tree/master/packages/okta-vue). These SDKs are built on `okta-auth-js` and are fully compatible with the Signin Widget.
+- Complete samples are available for:
+  - [React](https://github.com/okta/samples-js-react/tree/master/custom-login)
+  - [Angular](https://github.com/okta/samples-js-angular/tree/master/custom-login)
+  - [Vue](https://github.com/okta/samples-js-vue/tree/master/custom-login).
 
 ```javascript
 var signIn = new OktaSignIn(
@@ -197,12 +202,39 @@ var signIn = new OktaSignIn(
     baseUrl: 'https://{yourOktaDomain}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
     authParams: {
-      display: 'page',
-      pkce: true
+      display: 'page'
     }
   }
 );
+
+if (signIn.hasTokensInUrl()) {
+  // The user has just successfully completed a redirect
+  // Retrieve tokens from the URL and store them in the internal TokenManager
+  // https://github.com/okta/okta-auth-js#tokenparsefromurloptions
+  signIn.authClient.token.parseFromUrl()
+    .then(function (res) {
+      oktaSignIn.authClient.tokenManager.add('idToken', res.tokens.idToken);
+      oktaSignIn.authClient.tokenManager.add('accessToken', res.tokens.accessToken);
+    })
+}
+else {
+  // There are no tokens in the URL, render the Sign-In Widget.
+}
 ```
+
+### OIDC login flow using Authorization Code
+
+- Available for Native and server-side Web applications
+- Samples are available for:
+  - [Asp.Net Core 2.x](https://github.com/okta/samples-aspnetcore/tree/master/samples-aspnetcore-2x/self-hosted-login)
+  - [ASP.Net Core 3.x](https://github.com/okta/samples-aspnetcore/tree/master/samples-aspnetcore-3x/self-hosted-login)
+  - [ASP.Net 4.x](https://github.com/okta/samples-aspnet/tree/master/self-hosted-login)
+  - [ASP.Net Webforms](https://github.com/okta/samples-aspnet-webforms/tree/master/self-hosted-login)
+  - [Golang](https://github.com/okta/samples-golang/tree/develop/custom-login)
+  - [Java/Spring Boot](https://github.com/okta/samples-java-spring/tree/master/custom-login)
+  - [NodeJS/Express](https://github.com/okta/samples-nodejs-express-4/tree/master/custom-login)
+  - [PHP](https://github.com/okta/samples-php/tree/develop/custom-login)
+  - [Python/Flask](https://github.com/okta/samples-python-flask/tree/master/custom-login)
 
 ## API Reference
 
@@ -310,10 +342,9 @@ signIn.renderEl(
 Renders the widget to the DOM to prompt the user to sign in. On successful authentication, users are redirected back to the application via the `redirectUri` with an Okta SSO session in the browser, and access and/or identity tokens in the fragment identifier.
 
 * `options`
-  * `authorizationServerId` *(optional)* - Specify a custom authorization server to perform the OIDC flow. Defaults to `default`.
   * `clientId` *(optional)* - Client Id pre-registered with Okta for the OIDC authentication flow. If omitted, defaults to the value passed in during the construction of the Widget.
   * `redirectUri` *(optional)* - The url that is redirected to after authentication. This must be pre-registered as part of client registration. Defaults to the current origin.
-  * `getAccessToken` *(optional)* - Return an access token from the authorization server. Defaults to `false`.
+  * `getAccessToken` *(optional)* - Return an access token from the authorization server. Defaults to `true`.
   * `getIdToken` *(optional)* - Return an ID token from the authorization server. Defaults to `true`.
   * `scope` *(optional)* - Specify what information to make available in the returned access or ID token. If omitted, defaults to the value passed in during construction of the Widget.
 
@@ -394,9 +425,7 @@ signIn.off('ready', onReady);
 
 ### authClient
 
-Returns the underlying [`@okta/okta-auth-js`](https://github.com/okta/okta-auth-js) object used by the Sign-in Widget.
-
-Before version 3.0, the Sign-in Widget contained `session` and `tokenManager` properties, and methods like `tokenManager.get`. These were just proxies to identical objects and methods in the [AuthJS](https://github.com/okta/okta-auth-js#api-reference) base library. These proxies have been removed in favor of direct access to the authClient object which allows you to call any of these methods. All the methods are documented in the [AuthJS](https://github.com/okta/okta-auth-js#api-reference) base library.
+Returns the underlying [`@okta/okta-auth-js`](https://github.com/okta/okta-auth-js) object used by the Sign-in Widget. All methods are documented in the [AuthJS](https://github.com/okta/okta-auth-js#api-reference) base library.
 
 ```javascript
 // Check for an existing authClient transaction
@@ -415,6 +444,13 @@ Synchronous method to check for access or ID Tokens in the url. This is used whe
 ```javascript
 if (signIn.hasTokensInUrl()) {
   // The user has just successfully completed a redirect
+  // Retrieve tokens from the URL and store them in the internal TokenManager
+  // https://github.com/okta/okta-auth-js#tokenparsefromurloptions
+  signIn.authClient.token.parseFromUrl()
+    .then(function (res) {
+      oktaSignIn.authClient.tokenManager.add('idToken', res.tokens.idToken);
+      oktaSignIn.authClient.tokenManager.add('accessToken', res.tokens.accessToken);
+    })
 }
 else {
   // There are no tokens in the URL, render the Sign-In Widget.
@@ -439,6 +475,9 @@ var config = {
   },
   helpLinks: {
     help: 'https://acme.com/help'
+  },
+  authParams: {
+    // Configuration for authClient. See https://github.com/okta/okta-auth-js#configuration-options
   }
 };
 
@@ -960,20 +999,29 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     oAuthTimeout: 300000 // 5 minutes
     ```
 
-- **authParams.pkce:** Set to `true` to enable PKCE flow
+- **authParams:** An object containing configuration which is passed directly to the `authClient`. Selected options are described below. See the full set of [Configuration options](https://github.com/okta/okta-auth-js#configuration-options)
+
+- **authParams.pkce:** Set to `false` to disable PKCE flow
 
 - **authParams.display:** Specify how to display the authentication UI for External Identity Providers. Defaults to `popup`.
 
     - `popup` - Opens a popup to the authorization server when an External Identity Provider button is clicked. `responseMode` will be set to `okta_post_message` and cannot be overridden.
 
-    - `page` - Redirect to the authorization server when an External Identity Provider button is clicked. If `responseMode` is not specified, it will default to `query` if `responseType = 'code'`, and `fragment` for other values of `responseType`.
-
+    - `page` - Redirect to the authorization server when an External Identity Provider button is clicked.
+  
     ```javascript
     // Redirects to authorization server when the IDP button is clicked, and
-    // returns an access_token in the url hash
+    // returns an access_token in the url hash (Implicit flow)
     authParams: {
       display: 'page',
-      responseType: 'token'
+      responseType: 'token',
+      pkce: false
+    }
+
+    // With PKCE flow, you should leave responseType blank.
+    // An authorization code will be returned in the query which can be exchanged for tokens.
+    authParams: {
+      display: 'page'
     }
     ```
 
@@ -981,9 +1029,9 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
 
     - `okta_post_message` - Used when `authParams.display = 'popup'`. Uses [postMessage](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) to send the response from the popup to the origin window.
 
-    - `fragment` - Used when `authParams.display = 'page'`. Returns the authorization response in the hash fragment of the URL after the authorization redirect. `fragment` is the default for Single-page applications and for standard web applications where `responseType != 'code'`.
+    - `fragment` - Used when `authParams.display = 'page'`. Returns the authorization response in the hash fragment of the URL after the authorization redirect. `fragment` is the default for Single-page applications using the implicit OIDC flow and for standard web applications where `responseType != 'code'`. SPA Applications using PKCE flow can set `responseMode = 'fragment'` to receive the authorization code in the hash fragment instead of the query.
 
-    - `query` - Used when `authParams.display = 'page'`. Returns the authorization response in the query string of the URL after the authorization redirect. `query` is the default value for standard web applications where `authParams.responseType = 'code'`.
+    - `query` - Used when `authParams.display = 'page'`. Returns the authorization response in the query string of the URL after the authorization redirect. `query` is the default value for standard web applications where `authParams.responseType = 'code'`. For SPA applications, the default will be `query` if using PKCE, or `fragment` for implicit OIDC flow.
 
     - `form_post` - Returns the authorization response as a form POST after the authorization redirect. Use this when `authParams.display = page` and you do not want the response returned in the URL.
 
@@ -996,7 +1044,7 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     }
     ```
 
-- **authParams.responseType:** Specify the response type for OIDC authentication. Defaults to `id_token`.
+- **authParams.responseType:** Specify the response type for OIDC authentication. Defaults to `['id_token', 'token']`.
 
     Valid response types are `id_token`, `access_token`, and `code`. Note that `code` goes through the Authorization Code flow, which requires the server to exchange the Authorization Code for tokens.
 
@@ -1023,7 +1071,7 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     }
     ```
 
-- **authParams.state:** Specify a state that will be validated in an OAuth response. This is usually only provided during redirect flows to obtain an authorization code. Defaults to a random string.
+- **authParams.state:** Specify a state that will be validated in an OAuth response. This is usually only provided during redirect flows to obtain an authorization code. Defaults to a random string. This value can be retrieved on the login callback. It will be returned along with tokens from [authClient.token.parseFromUrl()](https://github.com/okta/okta-auth-js#tokenparsefromurloptions)
 
     ```javascript
     authParams: {
@@ -1039,7 +1087,7 @@ Options for the [OpenID Connect](http://developer.okta.com/docs/api/resources/oi
     }
     ```
 
-- **authParams.issuer:** Specify a custom issuer to perform the OIDC flow. Defaults to the baseUrl.
+- **authParams.issuer:** Specify a custom issuer to perform the OIDC flow. Defaults to the baseUrl plus "/oauth2/default". See the guide on setting up an [Authourization Server](https://developer.okta.com/docs/guides/customize-authz-server/overview/) for more information.
 
     ```javascript
     authParams: {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "2.13.2",
+    "@okta/okta-auth-js": "3.0.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install required node version
+setup_service node v12.13.0
+
 cd ${OKTA_HOME}/${REPO}
 
 # ---------------------------------------------------------------------

--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -132,7 +132,7 @@ define([
             return factor.enroll({
               profile: profileData
             })
-              .fail(function (error) {
+              .catch(function (error) {
                 if(error.errorCode === 'E0000098') { // E0000098: "This phone number is invalid."
                   self.set('skipPhoneValidation', true);
                   error.xhr.responseJSON.errorSummary = Okta.loc('enroll.sms.try_again', 'login');
@@ -161,7 +161,7 @@ define([
             self.set('lastEnrolledPhoneNumber', phoneNumber);
             self.limitResending();
           })
-          .fail(function () {
+          .catch(function () {
             self.set('ableToResend', true);
             self.set('trapEnrollment', false);
           });

--- a/src/EnrollCustomFactorController.js
+++ b/src/EnrollCustomFactorController.js
@@ -41,7 +41,7 @@ function (Okta, FormController, Footer) {
                 Util.redirect(url);
               }
             })
-            .fail(function (err) {
+            .catch(function (err) {
               throw err;
             });
         });

--- a/src/EnrollDuoController.js
+++ b/src/EnrollDuoController.js
@@ -68,7 +68,7 @@ function (Okta, Duo, Q, FormController, Footer) {
               return transaction.poll();
             });
           })
-          .fail(function (err) {
+          .catch(function (err) {
             self.trigger('error', self, err.xhr);
           });
       }

--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -96,7 +96,7 @@ function (Okta, Errors, FormType, FormController, CryptoUtil, webauthn, Footer, 
                   clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON)
                 });
               })
-              .fail(function (error) {
+              .catch(function (error) {
                 self.trigger('errors:clear');
                 // Do not display if it is abort error triggered by code when switching.
                 // self.webauthnAbortController would be null if abort was triggered by code. 

--- a/src/EnrollWindowsHelloController.js
+++ b/src/EnrollWindowsHelloController.js
@@ -82,7 +82,7 @@ function (Okta, FormController, FormType, webauthn, Spinner, Footer, HtmlErrorMe
                 attestation: null
               });
             })
-            .fail(function (error) {
+            .catch(function (error) {
               switch (error.message) {
               case 'AbortError':
               case 'NotFoundError':

--- a/src/ForgotPasswordController.js
+++ b/src/ForgotPasswordController.js
@@ -85,7 +85,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, Util, ContactSu
             relayState: relayState
           });
         })
-          .fail(function () {
+          .catch(function () {
           //need empty fail handler on model to display errors on form
           });
       }

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -89,7 +89,7 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
               self.options.appState.set('deviceFingerprint', fingerprint);
               self.options.appState.set('username', self.model.get('username'));
             })
-            .fail(function () {
+            .catch(function () {
             // Keep going even if device fingerprint fails
               self.options.appState.set('username', self.model.get('username'));
             });

--- a/src/RecoveryLoadingController.js
+++ b/src/RecoveryLoadingController.js
@@ -27,7 +27,7 @@ define(['okta', 'util/FormController'], function (Okta, FormController) {
           recoveryToken: options.token
         });
       })
-        .fail(function () {
+        .catch(function () {
           self.options.appState.trigger('loading', false);
           self.options.appState.trigger('removeLoading');
         });

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -11,6 +11,7 @@
  */
 define([
   'okta',
+  'q',
   'models/RegistrationSchema',
   'models/LoginModel',
   'util/BaseLoginController',
@@ -22,6 +23,7 @@ define([
 ],
 function (
   Okta,
+  Q,
   RegistrationSchema,
   LoginModel,
   BaseLoginController,
@@ -100,6 +102,7 @@ function (
     registerUser: function (postData) {
       var self = this;
       this.model.attributes = postData;
+      // Model.save returns a jqXHR
       Backbone.Model.prototype.save.call(this.model).then(function () {
         var activationToken = self.model.get('activationToken');
         var postSubmitData = activationToken ? activationToken : self.model.get('email');
@@ -210,8 +213,8 @@ function (
           form.add(requiredFieldsLabel);
         }
       });
-      // fetch schema from API
-      return this.state.get('schema').fetch();
+      // fetch schema from API, returns a jqXHR. Wrap it in a Q
+      return Q(this.state.get('schema').fetch());
     },
     Footer: Footer,
   });

--- a/src/UnlockAccountController.js
+++ b/src/UnlockAccountController.js
@@ -78,7 +78,7 @@ function (Okta, FormController, Enums, FormType, Util, ValidationUtil, ContactSu
             factorType: self.get('factorType')
           });
         })
-          .fail(function () {
+          .catch(function () {
           //need empty fail handler on model to display errors on form
           });
       }

--- a/src/VerifyCustomFactorController.js
+++ b/src/VerifyCustomFactorController.js
@@ -57,7 +57,7 @@ function (Okta, FormController, FormType, FooterSignout, FactorUtil, HtmlErrorMe
                 Util.redirect(url);
               }
             })
-            .fail(function (err) {
+            .catch(function (err) {
               throw err;
             });
         });

--- a/src/VerifyDuoController.js
+++ b/src/VerifyDuoController.js
@@ -58,11 +58,11 @@ function (Okta, Duo, Q, FactorUtil, FormController, Enums, FormType, FooterSigno
             factorType: 'web'
           });
           return factor.verify(data)
-            .fail(function (err) {
+            .catch(function (err) {
             // Clean up the cookie on failure.
               throw err;
             });
-        });
+        }, true /* rethrow errors */);
       },
 
       verify: function (signedResponse) {

--- a/src/VerifyDuoController.js
+++ b/src/VerifyDuoController.js
@@ -92,7 +92,7 @@ function (Okta, Duo, Q, FactorUtil, FormController, Enums, FormType, FooterSigno
               return transaction.poll(data);
             });
           })
-          .fail(function (err) {
+          .catch(function (err) {
             self.trigger('error', self, err.xhr);
           });
       }

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -110,7 +110,7 @@ function (Okta, Errors, FormController, FormType, CryptoUtil, webauthn, FooterSi
                   rememberDevice: rememberDevice
                 });
               })
-              .fail(function (error) {
+              .catch(function (error) {
                 self.trigger('errors:clear');
                 // Do not display if it is abort error triggered by code when switching.
                 // self.webauthnAbortController would be null if abort was triggered by code.

--- a/src/VerifyWindowsHelloController.js
+++ b/src/VerifyWindowsHelloController.js
@@ -64,7 +64,7 @@ function (Okta, FormController, FormType, webauthn, Spinner, FooterSignout, Html
                   model.trigger('signIn');
                   return data;
                 })
-                .fail(function (error) {
+                .catch(function (error) {
                   switch (error.message) {
                   case 'AbortError':
                   case 'NotFoundError':

--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -33,7 +33,7 @@ function (Okta, Q, Enums) {
           self.trigger('setTransaction', trans);
           return trans;
         })
-        .fail(function (err) {
+        .catch(function (err) {
         // Q may still consider AuthPollStopError to be unhandled
           if (err.name === 'AuthPollStopError' ||
             err.name === Enums.AUTH_STOP_POLL_INITIATION_ERROR ||
@@ -54,7 +54,7 @@ function (Okta, Q, Enums) {
 
       // If it's a promise, listen for failures
       if (Q.isPromiseAlike(res)) {
-        return res.fail(function (err) {
+        return res.catch(function (err) {
           if (err.name === 'AuthPollStopError' ||
               err.name === Enums.AUTH_STOP_POLL_INITIATION_ERROR ||
               err.name === Enums.WEBAUTHN_ABORT_ERROR) {
@@ -78,7 +78,7 @@ function (Okta, Q, Enums) {
           self.trigger('setTransaction', trans);
           return trans;
         })
-          .fail(function (err) {
+          .catch(function (err) {
             self.trigger('error', self, err.xhr);
             self.trigger('setTransactionError', err);
             throw err;

--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -26,6 +26,7 @@ function (Okta, Q, Enums) {
   ];
 
   return Okta.Model.extend({
+    // May return either a "standard" promise or a Q promise
     doTransaction: function (fn, rethrow) {
       var self = this;
       return fn.call(this, this.appState.get('transaction'))

--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -73,14 +73,14 @@ function (Okta, PrimaryAuthModel, CookieUtil, Enums, Util) {
             }
           }
         }, this))
-        .fail(_.bind(function () {
+        .catch(_.bind(function () {
           this.trigger('error');
           // Specific event handled by the Header for the case where the security image is not
           // enabled and we want to show a spinner. (Triggered only here and handled only by Header).
           this.appState.trigger('removeLoading');
           CookieUtil.removeUsernameCookie();
         }, this))
-        .fin(_.bind(function () {
+        .finally(_.bind(function () {
           this.appState.trigger('loading', false);
         }, this));
     }

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -127,13 +127,13 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       }
 
       return primaryAuthPromise
-        .fail(_.bind(function () {
+        .catch(_.bind(function () {
           // Specific event handled by the Header for the case where the security image is not
           // enabled and we want to show a spinner. (Triggered only here and handled only by Header).
           this.appState.trigger('removeLoading');
           CookieUtil.removeUsernameCookie();
         }, this))
-        .fin(_.bind(function () {
+        .finally(_.bind(function () {
           this.appState.trigger('loading', false);
         }, this));
     },
@@ -188,7 +188,7 @@ function (Okta, BaseLoginModel, CookieUtil, Enums) {
       }
       var self = this;
       return func(signInArgs)
-        .fin(function () {
+        .finally(function () {
           if (deviceFingerprintEnabled) {
             delete authClient.options.headers['X-Device-Fingerprint'];
             self.appState.unset('deviceFingerprint'); //Fingerprint can only be used once

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -10,11 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint max-params: [2, 15], max-statements: [2, 18] */
+/* eslint max-params: [2, 16], max-statements: [2, 18] */
 // BaseLoginRouter contains the more complicated router logic - rendering/
 // transition, etc. Most router changes should happen in LoginRouter (which is
 // responsible for adding new routes)
 define([
+  'q',
   'okta',
   './BrowserFeatures',
   'models/Settings',
@@ -31,7 +32,7 @@ define([
   'util/Bundles',
   'util/Logger'
 ],
-function (Okta, BrowserFeatures, Settings,
+function (Q, Okta, BrowserFeatures, Settings,
   Header, SecurityBeacon, AuthContainer, AppState, ColorsUtil, RouterUtil, Animations,
   Errors, Util, Enums, Bundles, Logger) {
 
@@ -225,7 +226,7 @@ function (Okta, BrowserFeatures, Settings,
       // First run fetchInitialData, in case the next controller needs data
       // before it's initial render. This will leave the current page in a
       // loading state.
-      this.controller.fetchInitialData()
+      return Q(this.controller.fetchInitialData())
         .then(_.bind(function () {
 
           // Beacon transition occurs in parallel to page swap
@@ -278,8 +279,7 @@ function (Okta, BrowserFeatures, Settings,
             oldController.remove();
             oldController.$el.remove();
           }
-        })
-        .done();
+        });
 
     },
 

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -15,7 +15,6 @@
 // transition, etc. Most router changes should happen in LoginRouter (which is
 // responsible for adding new routes)
 define([
-  'q',
   'okta',
   './BrowserFeatures',
   'models/Settings',
@@ -32,7 +31,7 @@ define([
   'util/Bundles',
   'util/Logger'
 ],
-function (Q, Okta, BrowserFeatures, Settings,
+function (Okta, BrowserFeatures, Settings,
   Header, SecurityBeacon, AuthContainer, AppState, ColorsUtil, RouterUtil, Animations,
   Errors, Util, Enums, Bundles, Logger) {
 
@@ -205,8 +204,7 @@ function (Q, Okta, BrowserFeatures, Settings,
           this.settings.get('assets.baseUrl'),
           this.settings.get('assets.rewrite')
         )
-          .then(_.bind(this.render, this, Controller, options))
-          .done();
+          .then(_.bind(this.render, this, Controller, options));
       }
 
       // Load the custom colors only on the first render
@@ -226,7 +224,7 @@ function (Q, Okta, BrowserFeatures, Settings,
       // First run fetchInitialData, in case the next controller needs data
       // before it's initial render. This will leave the current page in a
       // loading state.
-      return Q(this.controller.fetchInitialData())
+      return this.controller.fetchInitialData()
         .then(_.bind(function () {
 
           // Beacon transition occurs in parallel to page swap
@@ -268,7 +266,7 @@ function (Q, Okta, BrowserFeatures, Settings,
           });
 
         }, this))
-        .fail(function () {
+        .catch(function () {
         // OKTA-69665 - if an error occurs in fetchInitialData, we're left in
         // a state with two active controllers. Therefore, we clean up the
         // old one. Note: This explicitly handles the invalid token case -

--- a/src/util/Bundles.js
+++ b/src/util/Bundles.js
@@ -186,7 +186,7 @@ define([
         }
         return { login: loginJson, country: countryJson };
       })
-      .fail(function () {
+      .catch(function () {
       // If there is an error, this will default to the bundled language and
       // we will no longer try to load the language this session.
         Logger.warn('Unable to load language: ' + language);

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -241,7 +241,8 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
       router.appState.get('transaction').prev()
         .then(function (trans) {
           router.appState.set('transaction', trans);
-        }).done();
+        });
+      // TODO: catch/handle error here?
       return;
     case 'MFA_ENROLL':
     case 'FACTOR_ENROLL':

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -56,6 +56,10 @@ define(['q', 'okta', './Logger', './Enums', 'idx'], function (Q, Okta, Logger, E
     return /((id|access)_token=)/i.test(hash);
   };
 
+  Util.hasCodeInUrl = function (hashOrSearch) {
+    return /(code=)/i.test(hashOrSearch);
+  };
+
   Util.transformErrorXHR = function (xhr) {
     // Handle network connection error
     if (xhr.status === 0 && _.isEmpty(xhr.responseJSON)) {

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -129,8 +129,7 @@ export default Router.extend({
         this.settings.get('assets.baseUrl'),
         this.settings.get('assets.rewrite')
       )
-        .then(_.bind(this.render, this, Controller, options))
-        .done();
+        .then(_.bind(this.render, this, Controller, options));
     }
 
     // Load the custom colors only on the first render

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -104,6 +104,7 @@ const Body = BaseForm.extend(Object.assign(
 
       const doProbing = () => {
         return checkPort()
+          // TODO: can we use standard ES6 promise methods, then/catch?
           .done(onPortFound)
           .fail(onFailure);
       };

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -66,7 +66,7 @@ define([
               .then(function (fingerprint) {
                 self.options.appState.set('deviceFingerprint', fingerprint);
               })
-              .fail(function () {
+              .catch(function () {
                 // Keep going even if device fingerprint fails
               });
           })

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -121,7 +121,7 @@ function (Okta, Animations, LoadingBeacon) {
           .then(function () {
             removeBeacon(self);
           })
-          .done();
+          .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
       case 'fade':
         // Other transitions are performed on the beacon container,
         // but this transition is on the content inside the beacon.
@@ -139,7 +139,7 @@ function (Okta, Animations, LoadingBeacon) {
             removeBeacon(self);
             addBeacon(self, NextBeacon, selector, options);
           })
-          .done();
+          .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
       case 'swap':
         return Animations.swapBeacons({
           $el: container,
@@ -155,7 +155,7 @@ function (Okta, Animations, LoadingBeacon) {
             addBeacon(self, NextBeacon, selector, options);
           }
         })
-          .done();
+          .done(); // TODO: can this be removed if Animations.swapBeacons returns standard ES6 Promise?
       case 'load':
         // Show the loading beacon. Add a couple of classes
         // before triggering the add beacon code.
@@ -188,7 +188,7 @@ function (Okta, Animations, LoadingBeacon) {
           removeBeacon(self);
           container.removeClass(LOADING_BEACON_CLS);
         })
-        .done();
+        .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
     },
 
     getTemplateData: function () {

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -46,7 +46,7 @@ var OktaSignIn = (function () {
             }
             router.appState.set('introspectSuccess', response);
             router.start();
-          }, this)).fail(_.bind(function (err) {
+          }, this)).catch(_.bind(function (err) {
           // Introspect API error.
           // Incase of an error we want to just load the LoginRouter
             router = bootstrapRouter.call(this, Router, authClient, widgetOptions, renderOptions, successFn, errorFn);

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -20,11 +20,11 @@ var OktaSignIn = (function () {
        * When the page loads, provide a helpful message to remind the developer that
        * tokens have not been removed from the hash fragment.
        */
-      if (hasTokensInUrl()) {
+      if (this.hasTokensInUrl()) {
         Util.debugMessage(
           `
             Looks like there are still tokens in the URL! Don't forget to parse and store them.
-            See: https://github.com/okta/okta-signin-widget/#oidc-tokenparsetokensfromurlsuccess-error.
+            See: https://github.com/okta/okta-signin-widget/#hastokensinurl
           `
         );
       }
@@ -83,10 +83,18 @@ var OktaSignIn = (function () {
     }
 
     /**
-     * Check if tokens have been passed back into the url, which happens in
+     * Check if tokens or a code have been passed back into the url, which happens in
      * the social auth IDP redirect flow.
      */
     function hasTokensInUrl () {
+      var authParams = this.authClient.options;
+      if (authParams.pkce || authParams.responseType === 'code' || authParams.responseMode === 'query') {
+        // Look for code
+        return authParams.responseMode === 'fragment' ? 
+          Util.hasCodeInUrl(window.location.hash) :
+          Util.hasCodeInUrl(window.location.search);
+      }
+      // Look for tokens (Implicit OIDC flow)
       return Util.hasTokensInHash(window.location.hash);
     }
 
@@ -144,7 +152,6 @@ var OktaSignIn = (function () {
     var OktaAuth = require('@okta/okta-auth-js');
 
     var authParams = _.extend({
-      url: options.baseUrl,
       transformErrorXHR: Util.transformErrorXHR,
       headers: {
         'X-Okta-User-Agent-Extended': 'okta-signin-widget-' + config.version
@@ -152,6 +159,10 @@ var OktaSignIn = (function () {
       clientId: options.clientId,
       redirectUri: options.redirectUri
     }, options.authParams);
+
+    if (!authParams.issuer) {
+      authParams.issuer = options.baseUrl + '/oauth2/default';
+    }
 
     var authClient = new OktaAuth(authParams);
 

--- a/test/e2e/app/app-using-osw-entry.js
+++ b/test/e2e/app/app-using-osw-entry.js
@@ -9,6 +9,10 @@
 // grunt copy:e2e
 // - then webpack
 // yarn build:webpack-e2e-app
+//
+// To run locally, outside of tests, run
+// grunt connect:dev
+//
 
 var OktaSignIn = require('../../js/okta-sign-in.entry');
 

--- a/test/e2e/env.defaults.js
+++ b/test/e2e/env.defaults.js
@@ -3,6 +3,7 @@ module.exports = {
   WIDGET_TEST_SERVER: '',
   WIDGET_AUTH_SERVER_ID: 'default',
   WIDGET_CLIENT_ID: 'rW47c465c1wc3MKzHznu',
+  WIDGET_IDP_FACEBOOK_ID: '0oa85bk5q6KOPeHCT0h7',
 
   // Basic user 1
   WIDGET_BASIC_USER: '',

--- a/test/e2e/page-objects/OIDCAppPage.js
+++ b/test/e2e/page-objects/OIDCAppPage.js
@@ -19,6 +19,8 @@ class AppPage {
     this.pageEl = $('#page');
     this.idTokenUserEl = $('#idtoken_user');
     this.accessTokenTypeEl = $('#accesstoken_type');
+    this.locationSearch = $('#location_search');
+    this.locationHash = $('#location_hash');
   }
 
   getIdTokenUser () {
@@ -32,13 +34,20 @@ class AppPage {
   }
 
   getCodeFromQuery () {
-    browser.wait(EC.presenceOf(this.pageEl));
-    return browser.getCurrentUrl().then(function (url) {
-      var matches = url.match(/code=([^&]+)/i);
+    browser.wait(EC.presenceOf(this.locationSearch));
+    return this.locationSearch.getText().then(function (search) {
+      var matches = search.match(/code=([^&]+)/i);
       return matches && matches[1];
     });
   }
 
+  getCodeFromHash () {
+    browser.wait(EC.presenceOf(this.locationHash));
+    return this.locationHash.getText().then(function (hash) {
+      var matches = hash.match(/code=([^&]+)/i);
+      return matches && matches[1];
+    });
+  }
 }
 
 module.exports = AppPage;

--- a/test/e2e/specs/OIDC_spec.js
+++ b/test/e2e/specs/OIDC_spec.js
@@ -49,6 +49,7 @@ describe('OIDC flows', function () {
         clientId: '{{{WIDGET_CLIENT_ID}}}',
         redirectUri: 'http://localhost:3000/done',
         authParams: {
+          pkce: false,
           responseType: 'id_token',
           scope: ['openid', 'email', 'profile', 'address', 'phone']
         },
@@ -70,6 +71,7 @@ describe('OIDC flows', function () {
         clientId: '{{{WIDGET_CLIENT_ID}}}',
         redirectUri: 'http://localhost:3000/done',
         authParams: {
+          pkce: false,
           responseType: 'id_token',
           scope: ['openid', 'email', 'profile', 'address', 'phone']
         }
@@ -84,6 +86,7 @@ describe('OIDC flows', function () {
         clientId: '{{{WIDGET_CLIENT_ID}}}',
         redirectUri: 'http://localhost:3000/done',
         authParams: {
+          pkce: false,
           responseType: ['id_token', 'token'],
           scope: ['openid', 'email', 'profile', 'address', 'phone']
         },
@@ -100,13 +103,14 @@ describe('OIDC flows', function () {
       expect(oidcApp.getAccessTokenType()).toBe('Bearer');
     });
 
-    // https://oktainc.atlassian.net/browse/OKTA-246000
+    // https://oktainc.atlassian.net/browse/OKTA-283816
     xit('logs in and uses the redirect flow for responseType "code"', function () {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_CLIENT_ID}}}',
         redirectUri: 'http://localhost:3000/done',
         authParams: {
+          pkce: false,
           responseType: 'code',
           scope: ['openid', 'email', 'profile', 'address', 'phone']
         }
@@ -116,14 +120,14 @@ describe('OIDC flows', function () {
       expect(oidcApp.getCodeFromQuery()).not.toBeNull();
     });
 
-
-    it('PKCE login flow', function () {
+    // https://oktainc.atlassian.net/browse/OKTA-246000
+    xit('PKCE login flow', function () {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_CLIENT_ID}}}',
         redirectUri: 'http://localhost:3000/done',
         authParams: {
-          pkce: true,
+          display: 'page',
           scope: ['openid', 'email', 'profile', 'address', 'phone']
         }
       });
@@ -132,6 +136,22 @@ describe('OIDC flows', function () {
       expect(oidcApp.getCodeFromQuery()).not.toBeNull();
     });
 
+    // https://oktainc.atlassian.net/browse/OKTA-246000
+    xit('PKCE login flow (fragment)', function () {
+      setup({
+        baseUrl: '{{{WIDGET_TEST_SERVER}}}',
+        clientId: '{{{WIDGET_CLIENT_ID}}}',
+        redirectUri: 'http://localhost:3000/done',
+        authParams: {
+          display: 'page',
+          responseMode: 'fragment',
+          scope: ['openid', 'email', 'profile', 'address', 'phone']
+        }
+      });
+      Expect.toBeA11yCompliant();
+      primaryAuth.loginToForm('{{{WIDGET_BASIC_USER_4}}}', '{{{WIDGET_BASIC_PASSWORD_4}}}');
+      expect(oidcApp.getCodeFromHash()).not.toBeNull();
+    });
 
   });
 

--- a/test/e2e/specs/dev_spec.js
+++ b/test/e2e/specs/dev_spec.js
@@ -94,7 +94,7 @@ describe('Dev Mode flows', function () {
     var el = element(by.css('#okta-sign-in'));
     expect(el.isDisplayed()).toBe(true);
 
-    // Reload the page with a token in the URL
+    // Reload the page with tokens in the URL
     browser.executeScript('window.location = window.location + "#id_token=abc"');
     browser.refresh(true);
 

--- a/test/e2e/templates/basic-dev.tpl
+++ b/test/e2e/templates/basic-dev.tpl
@@ -1,8 +1,10 @@
 {{#> devLayout}}
 var options = {
   'baseUrl': '{{{WIDGET_TEST_SERVER}}}',
-  'el': '#okta-login-container'
-
+  'el': '#okta-login-container',
+  authParams: {
+    pkce: false
+  }
 };
 var oktaSignIn = new OktaSignIn(options);
 {{/devLayout}}

--- a/test/e2e/templates/basic.tpl
+++ b/test/e2e/templates/basic.tpl
@@ -1,6 +1,9 @@
 {{#> cdnLayout}}
 var options = {
-  'baseUrl': '{{{WIDGET_TEST_SERVER}}}'
+  'baseUrl': '{{{WIDGET_TEST_SERVER}}}',
+  authParams: {
+    pkce: false
+  }
 };
 var oktaSignIn = new OktaSignIn(options);
 oktaSignIn.on('afterError', function () {

--- a/test/e2e/templates/done.tpl
+++ b/test/e2e/templates/done.tpl
@@ -2,6 +2,9 @@
 // OIDC Redirect Flow - this is the page that is redirected to with
 // tokens in the parameters
 
+// PKCE cannot be enabled because the test app is a "web" type. OKTA-246000 
+var pkce = false;
+
 function addMessageToPage(id, msg) {
   var appNode = document.createElement('div');
   appNode.setAttribute('id', id);
@@ -9,20 +12,32 @@ function addMessageToPage(id, msg) {
   document.body.appendChild(appNode);
 }
 
+// auto-detect responseMode (when responseType is code)
+var responseMode;
+if (window.location.search.indexOf('code') >= 0) {
+  responseMode = 'query';
+} else if (window.location.hash.indexOf('code') >= 0) {
+  responseMode = 'fragment';
+}
+
 var oktaSignIn = new OktaSignIn({
   'baseUrl': '{{{WIDGET_TEST_SERVER}}}',
-  'clientId': '{{{WIDGET_CLIENT_ID}}}'
+  'clientId': '{{{WIDGET_CLIENT_ID}}}',
+  authParams: {
+    pkce: pkce,
+    responseMode: responseMode
+  }
 });
 addMessageToPage('page', 'oidc_app');
 
 if (oktaSignIn.hasTokensInUrl()) {
+  addMessageToPage('location_hash', window.location.hash);
+  addMessageToPage('location_search', window.location.search);
   oktaSignIn.authClient.token.parseFromUrl()
     .then(function (res) {
-      var tokens = Array.isArray(res) ? res : [res];
-      for (var i = 0; i < tokens.length; ++i) {
-        if (tokens[i].idToken) {
-          addMessageToPage('idtoken_user', tokens[i].claims.name);
-        }
+      var idToken = res.tokens.idToken;
+      if (idToken) {
+        addMessageToPage('idtoken_user', idToken.claims.name);
       }
     })
     .catch(function (err) {

--- a/test/e2e/templates/oidc.tpl
+++ b/test/e2e/templates/oidc.tpl
@@ -11,6 +11,7 @@ var CONFIG = {
   clientId: '{{{WIDGET_CLIENT_ID}}}',
   redirectUri: 'http://localhost:3000/done',
   authParams: {
+    pkce: false,
     issuer: '{{WIDGET_TEST_SERVER}}/oauth2/{{WIDGET_AUTH_SERVER_ID}}',
     responseType: 'id_token',
     scope: ['openid', 'email', 'profile', 'address', 'phone']
@@ -18,7 +19,7 @@ var CONFIG = {
   idps: [
     {
       'type': 'FACEBOOK',
-      'id': '0oa85bk5q6KOPeHCT0h7'
+      'id': '{{WIDGET_IDP_FACEBOOK_ID}}'
     }
   ]
 }
@@ -61,21 +62,17 @@ function initialize(options) {
       if (res.status !== 'SUCCESS') {
         return;
       }
+      
+      var idToken = res.tokens.idToken;
+      var accessToken = res.tokens.accessToken;
 
-      if (Array.isArray(res)) {
-        res.forEach(function(token) {
-          if (token.idToken) {
-            addMessageToPage('idtoken_user', token.claims.name);
-          } else if (token.accessToken) {
-            addMessageToPage('accesstoken_type', token.tokenType);
-          }
-        });
-      } else {
-        // Simple idToken test case will just unpack the name and add it
-        // to the page
-        addMessageToPage('idtoken_user', res.claims.name);
+      if (idToken) {
+        addMessageToPage('idtoken_user', idToken.claims.name);
+      } 
+      
+      if (accessToken) {
+        addMessageToPage('accesstoken_type', accessToken.tokenType);
       }
-
     },
     function (err) {
       addMessageToPage('oidc_error', JSON.stringify(err));

--- a/test/unit/helpers/mocks/AuthClient.js
+++ b/test/unit/helpers/mocks/AuthClient.js
@@ -16,7 +16,7 @@ define(['q'], function (Q) {
         });
       }
       else if (mock.__nextRes.isRejected() && mock.__globalSubscribeFn) {
-        mock.__nextRes.fail(function (err) {
+        mock.__nextRes.catch(function (err) {
           mock.__globalSubscribeFn(err, null);
         });
       }

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -1,3 +1,5 @@
+import 'jasmine-ajax';
+
 define([
   'okta',
   'q',
@@ -15,17 +17,30 @@ define([
   var WAIT_MAX_TIME = 2000;
   var WAIT_INTERVAL = 20;
 
+  var unhandledRejectionListener = function (event) {
+    // We've thrown an unexpected error in the test - setup a fake
+    // expectation to expose it to the developer
+    expect('Unhandled promise rejection').toEqual(event.reason);
+  };
+
   function runTest (jasmineFn, desc, testFn) {
-    jasmineFn(desc, function (done) {
+    jasmineFn(desc, function () {
       var errListener = function (err) {
         // We've thrown an unexpected error in the test - setup a fake
         // expectation to expose it to the developer
         expect('Unexpected error thrown').toEqual(err.message);
       };
       window.addEventListener('error', errListener);
-      testFn.call(this)
+      window.addEventListener('unhandledrejection', unhandledRejectionListener);
+      
+      return testFn.call(this)
         .then(function () {
-          expect(Q.getUnhandledReasons()).toEqual([]);
+          const unhandledFailures = Q.getUnhandledReasons();
+          if (unhandledFailures.length) {
+            // eslint-disable-next-line no-console
+            console.error('Unhandled Q failures: ', unhandledFailures);
+          }
+          expect(unhandledFailures).toEqual([]);
           // Reset unhandled exceptions (which in the normal case come from the
           // error tests we're running) so that this array does not get
           // unreasonably large (and subsequently slow down our tests)
@@ -34,11 +49,14 @@ define([
           // back on.
           Q.resetUnhandledRejections();
           window.removeEventListener('error', errListener);
-          done();
-        })
-        .done();
+          window.removeEventListener('unhandledrejection', unhandledRejectionListener);
+        });
     });
   }
+
+  fn.allowUnhandledPromiseRejection = function () {
+    window.removeEventListener('unhandledrejection', unhandledRejectionListener);
+  };
 
   function wrapDescribe (_describe, desc, fn) {
     return _describe(desc, function () {
@@ -136,6 +154,20 @@ define([
     return fn.wait(condition, resolveValue);
   };
 
+  fn.waitForAjaxRequest = function (resolveValue) {
+    var condition = function () {
+      return jasmine.Ajax.requests.count() > 0;
+    };
+    return fn.wait(condition, resolveValue);
+  };
+
+  fn.waitForAjaxRequests = function (numRequests, resolveValue) {
+    var condition = function () {
+      return jasmine.Ajax.requests.count() === numRequests;
+    };
+    return fn.wait(condition, resolveValue);
+  };
+
   /**
    * Use this function to wait for an error view which has top level class '.okta-form-infobox-error'.
    */
@@ -215,8 +247,9 @@ define([
 
   // Convenience function to test a json post - pass in url and data, and it
   // will test the rest. Note: We JSON.stringify data here so you don't have to
-  fn.isJsonPost = function (ajaxArgs, expected) {
-    var args = ajaxArgs[0];
+  // JSON posts are done using fetch
+  fn.isJsonPost = function (args, expected) {
+    // var args = ajaxArgs[0];
 
     // Jasmine times out if args doesn't exist when we try to retrieve
     // its properties. This makes it fail faster.
@@ -225,12 +258,29 @@ define([
       return;
     }
     expect(args.url).toBe(expected.url);
-    expect(args.type).toBe('POST');
-    expect(args.headers).toEqual(jasmine.objectContaining({
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
+    expect(args.method).toBe('POST');
+    expect(args.requestHeaders).toEqual(jasmine.objectContaining({
+      'accept': 'application/json',
+      'content-type': 'application/json'
     }));
-    expect(JSON.parse(args.data)).toEqual(expected.data);
+    const data = args.data();
+    expect(data).toEqual(expected.data);
+  };
+
+  // Form post is done using $.post
+  fn.isFormPost = function (args, expected) {
+    if (!args) {
+      expect(args).not.toBeUndefined();
+      return;
+    }
+    expect(args.url).toBe(expected.url);
+    expect(args.method).toBe('POST');
+    expect(args.requestHeaders).toEqual(jasmine.objectContaining({
+      'Accept': '*/*',
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+    }));
+    const data = args.data();
+    expect(data).toEqual(expected.data);
   };
 
   // --------------------------------------------------------------------------

--- a/test/unit/spec/EnrollActivateClaimsFactor_spec.js
+++ b/test/unit/spec/EnrollActivateClaimsFactor_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params:[2, 15] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollCustomFactorForm',
@@ -37,7 +37,7 @@ function (Okta,
       var initResponse = getInitialResponse(options);
       var setNextResponse = Util.mockAjax([initResponse]);
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router({

--- a/test/unit/spec/EnrollChoices_spec.js
+++ b/test/unit/spec/EnrollChoices_spec.js
@@ -2,7 +2,7 @@
 /*global JSON */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/EnrollChoicesForm',
   'helpers/dom/Beacon',
@@ -27,7 +27,7 @@ function (Okta, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, FactorUtil, R
   resMultipleOktaVerify, resMultipleWebauthn, resMultipleWebauthnProfile, resEnrolledHotp,
   resSuccess) {
 
-  var { $, _ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
   var tick = Expect.tick;
   var factorEnrollList = {
@@ -109,7 +109,7 @@ function (Okta, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, FactorUtil, R
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({
-        url: baseUrl
+        issuer: baseUrl
       });
       var router = new Router(_.extend({
         el: $sandbox,
@@ -566,14 +566,14 @@ function (Okta, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, FactorUtil, R
         });
         itp('it uses the finish link to finish enrollment if Finish is clicked', function () {
           return setupWithAllOptionalSomeEnrolled().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resAllFactors);
             test.form.submit();
             return tick();
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/skip',
                 data: {
                   stateToken: 'testStateToken'
@@ -715,7 +715,7 @@ function (Okta, OktaAuth, Util, EnrollChoicesForm, Beacon, Expect, FactorUtil, R
         itp('redirects straight to finish link when all factors are enrolled \
           and OktaVerify softtoken factor enrolled while push is on', function () {
           return setupWithAllEnrolledButOktaVerifyPushWithSofttokenEnrolled().then(function () {
-            Expect.isJsonPost($.ajax.calls.mostRecent().args, {
+            Expect.isJsonPost(Util.lastAjaxRequest(), {
               url: 'https://foo.com/api/v1/authn/skip',
               data: {
                 stateToken: 'testStateToken'

--- a/test/unit/spec/EnrollCustomFactor_spec.js
+++ b/test/unit/spec/EnrollCustomFactor_spec.js
@@ -1,8 +1,7 @@
 /* eslint max-params:[2, 16] */
 define([
   'okta',
-  'q',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollCustomFactorForm',
@@ -18,7 +17,6 @@ define([
   'helpers/xhr/SUCCESS'
 ],
 function (Okta,
-  Q,
   OktaAuth,
   LoginUtil,
   Util,
@@ -42,7 +40,7 @@ function (Okta,
     function setup (factorType) {
       var setNextResponse = Util.mockAjax([responseMfaEnrollAll]);
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router({

--- a/test/unit/spec/EnrollEmail_spec.js
+++ b/test/unit/spec/EnrollEmail_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/AuthContainer',
@@ -21,7 +21,6 @@ define([
   EnrollEmailForm, EnrollActivateEmailForm, Beacon, Expect, $sandbox, Router,
   xhrEnrollEmail, xhrEnrollActivateEmail, xhrSUCCESS, xhrResendError) {
 
-  var { $ } = Okta;
   var itp = Expect.itp;
 
   Expect.describe('EnrollEmail', function () {
@@ -30,7 +29,7 @@ define([
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'http://localhost:3000';
       var authClient = new OktaAuth({
-        url: baseUrl,
+        issuer: baseUrl,
         transformErrorXHR: LoginUtil.transformErrorXHR
       });
       var successSpy = jasmine.createSpy('successSpy');
@@ -73,15 +72,15 @@ define([
         })
         .then(function (test) {
           // 2. mock data and click send button.
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrEnrollActivateEmail);
           test.form.submit();
-          return Expect.waitForSpyCall($.ajax);
+          return Expect.waitForAjaxRequest();
         })
         .then(function () {
           // 3. verify request has been made
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'http://localhost:3000/api/v1/authn/factors',
             data: {
               provider: 'OKTA',
@@ -96,7 +95,7 @@ define([
       return setup(xhrEnrollEmail)
         .then(function (test) {
           // 1. click 'send to email' button
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrEnrollActivateEmail);
           test.form.submit();
           return Expect.waitForEnrollActivateEmail(test);
@@ -118,7 +117,7 @@ define([
         })
         .then(function (test) {
           // 3. submit verification code
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrSUCCESS);
           test.form.setVerificationCode('1209876');
           test.form.submit();
@@ -126,8 +125,8 @@ define([
         })
         .then(function (test) {
           // 4. enroll successfully
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'http://localhost:3000/api/v1/authn/factors/eml198rKSEWOSKRIVIFT/lifecycle/activate',
             data: {
               passCode: '1209876',
@@ -160,7 +159,7 @@ define([
       return setup(xhrEnrollEmail)
         .then(function (test) {
           // 1. click 'send to email' button
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrEnrollActivateEmail);
           test.form.submit();
           return Expect.waitForEnrollActivateEmail(test);
@@ -172,18 +171,18 @@ define([
           expect(form.getResendButton().length).toBe(1);
 
           // 3. click resend link
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrEnrollActivateEmail);
           form.clickResend();
           expect(form.getResendEmailMessage().length).toBe(0);
           expect(form.getResendButton().length).toBe(0);
           expect(form.getResendEmailView().attr('class'))
             .toBe('resend-email-infobox hide');
-          return Expect.waitForSpyCall($.ajax, Object.assign(test, {form}));
+          return Expect.waitForAjaxRequest(Object.assign(test, {form}));
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'http://localhost:3000/api/v1/authn' +
               '/factors/eml198rKSEWOSKRIVIFT/lifecycle/resend',
             data: {
@@ -205,7 +204,7 @@ define([
       return setup(xhrEnrollEmail)
         .then(function (test) {
           // 1. click 'send to email' button
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrEnrollActivateEmail);
           test.form.submit();
           return Expect.waitForEnrollActivateEmail(test);
@@ -217,7 +216,7 @@ define([
           expect(form.getResendButton().length).toBe(1);
 
           // 3. click resend link
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(xhrResendError);
           form.clickResend();
           expect(form.getResendEmailMessage().length).toBe(0);
@@ -231,8 +230,8 @@ define([
           expect(test.form.errorBox().length).toBe(1);
           expect(test.form.errorMessage())
             .toBe('You do not have permission to perform the requested action');
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'http://localhost:3000/api/v1/authn' +
               '/factors/eml198rKSEWOSKRIVIFT/lifecycle/resend',
             data: {

--- a/test/unit/spec/EnrollHotpController_spec.js
+++ b/test/unit/spec/EnrollHotpController_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 16] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/EnrollHotpForm',
   'helpers/dom/Beacon',
@@ -27,7 +27,7 @@ function (Okta,
     function setup () {
       const setNextResponse = Util.mockAjax();
       const baseUrl = 'https://foo.com';
-      const authClient = new OktaAuth({url: baseUrl});
+      const authClient = new OktaAuth({issuer: baseUrl});
       const successSpy = jasmine.createSpy('success');
       const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       const router = new Router({

--- a/test/unit/spec/EnrollOnPrem_spec.js
+++ b/test/unit/spec/EnrollOnPrem_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 15] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/EnrollTokenFactorForm',
   'helpers/dom/Beacon',
@@ -17,7 +17,7 @@ define([
 function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
   resAllFactors, resAllFactorsOnPrem, resEnrollError, resRSAChangePin, resSuccess, Router) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -26,7 +26,7 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
     function setup (response, includeOnPrem, startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl});
+      var authClient = new OktaAuth({issuer: baseUrl});
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router({
         el: $sandbox,
@@ -150,11 +150,11 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         });
         itp('does not send request and shows error if code is not entered', function () {
           return setup().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.submit();
             expect(test.form.hasErrors()).toBe(true);
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
           });
         });
         itp('shows error in case of an error response', function () {
@@ -212,7 +212,7 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         });
         itp('calls activate with the right params', function () {
           return setup().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.setCode(123456);
             test.setNextResponse(resSuccess);
@@ -220,8 +220,8 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
             return tick();
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors',
                 data: {
                   factorType: 'token',
@@ -295,11 +295,11 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         });
         itp('does not send request and shows error if code is not entered', function () {
           return setupOnPrem().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.submit();
             expect(test.form.hasErrors()).toBe(true);
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
           });
         });
         itp('shows error in case of an error response', function () {
@@ -357,7 +357,7 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
         });
         itp('calls activate with the right params', function () {
           return setupOnPrem().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.setCode(123456);
             test.setNextResponse(resSuccess);
@@ -365,8 +365,8 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
             return tick();
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors',
                 data: {
                   factorType: 'token',

--- a/test/unit/spec/EnrollPassword_spec.js
+++ b/test/unit/spec/EnrollPassword_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/EnrollPasswordForm',
   'helpers/dom/Beacon',
@@ -18,7 +18,6 @@ define([
 function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, LoginUtil, $sandbox,
   resAllFactors, resError, resSuccess) {
 
-  var { $ } = Okta;
   var itp = Expect.itp;
 
   Expect.describe('EnrollPassword', function () {
@@ -26,7 +25,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
     function setup (startRouter, restrictRedirectToForeground) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({ url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+      var authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var successSpy = jasmine.createSpy('success');
       var router = new Router({
@@ -106,7 +105,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
     });
     itp('calls enroll with the right arguments when save is clicked', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');
         test.setNextResponse(resSuccess);
@@ -117,8 +116,8 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
         .then(function () {
           // restrictRedirectToForeground Flag is not enabled
           expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
             data: {
               factorType: 'password',
@@ -135,7 +134,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
     itp(`calls enroll with the right arguments when save is clicked in android chrome
       in restrictRedirectToForeground flow`, function () {
       return setup(false, true).then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');
         test.setNextResponse(resSuccess);
@@ -158,8 +157,8 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
           expect(RouterUtil.isDocumentVisible).toHaveBeenCalled();
           expect(document.removeEventListener).toHaveBeenCalled();
           expect(document.addEventListener).toHaveBeenCalled();
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
             data: {
               factorType: 'password',
@@ -175,7 +174,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
 
     itp('validates password and confirmPassword cannot be empty', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.submit();
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.hasPasswordFieldErrors()).toBe(true);
@@ -183,12 +182,12 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
         expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         expect(test.form.passwordFieldErrorMessage()).toBe('This field cannot be left blank');
         expect(test.form.confirmPasswordFieldErrorMessage()).toBe('This field cannot be left blank');
-        expect($.ajax).not.toHaveBeenCalled();
+        expect(Util.numAjaxRequests()).toBe(0);
       });
     });
     itp('validates password and confirmPassword fields match and errors before the request', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('someotherpassword');
         test.form.submit();
@@ -197,7 +196,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
         expect(test.form.hasConfirmPasswordFieldErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         expect(test.form.confirmPasswordFieldErrorMessage()).toBe('Passwords must match');
-        expect($.ajax).not.toHaveBeenCalled();
+        expect(Util.numAjaxRequests()).toBe(0);
       });
     });
     itp('shows error if error response on enrollment', function () {

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/AuthContainer',
@@ -33,7 +33,7 @@ define([
     function setup (resp, startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router({
         el: $sandbox,
@@ -174,14 +174,14 @@ define([
       itp('visits previous link if phone is enrolled, but not activated', function () {
         return sendValidCodeFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resAllFactors);
             test.form.backLink().click();
             return Expect.waitForEnrollChoices();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/previous',
               type: 'POST',
               data: {
@@ -265,12 +265,12 @@ define([
 
       itp('sends sms when return key is pressed in phoneNumber field', function () {
         return setup(allFactorsRes).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           return sendCodeOnEnter(test, successRes, 'US', '4151111111');
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -317,7 +317,7 @@ define([
           })
           .then(function (test) {
             // Re-send will clear the warning
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.sendCodeButton().click();
             expectSentButton(test);
@@ -337,14 +337,14 @@ define([
         return sendCodeFn(successRes, 'AQ', '12345678900')
           .then(waitForEnrollActivateSuccess)
           .then(function () {
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn',
               data: {
                 stateToken: 'dummy-token'
               }
             });
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -404,12 +404,12 @@ define([
       });
       itp('uses send code button with updatePhone=true, if user has an existing phone', function () {
         return setup(existingPhoneRes).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           return sendCode(test, successRes, 'US', '4151234567');
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors?updatePhone=true',
               data: {
                 factorType: 'sms',
@@ -425,13 +425,13 @@ define([
       itp('uses send code button with validatePhone:false if user has retried with invalid phone number', function () {
         return setup(allFactorsRes)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -447,13 +447,13 @@ define([
             expect(test.form.errorMessage())
               .toEqual('The number you entered seems invalid. If the number is correct, please try again.');
 
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
-            return Expect.waitForSpyCall($.ajax, test);
+            return Expect.waitForAjaxRequest(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -470,13 +470,13 @@ define([
       itp('does not set validatePhone:false if the error is not a validation error (E0000098).', function () {
         return setup(allFactorsRes)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             sendCode(test, resEnrollError, 'PF', '12345678');
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -492,13 +492,13 @@ define([
             expect(test.form.errorMessage())
               .toEqual('Invalid Phone Number.');
 
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             sendCode(test, resEnrollError, 'PF', '12345678');
-            return Expect.waitForSpyCall($.ajax, test);
+            return Expect.waitForAjaxRequest(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'sms',
@@ -515,14 +515,14 @@ define([
         Util.speedUpDelay();
         return sendValidCodeFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.sendCodeButton().click();
-            return Expect.waitForSpyCall($.ajax);
+            return Expect.waitForAjaxRequest();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
               data: {
                 stateToken: expectedStateToken
@@ -540,20 +540,20 @@ define([
               Expect.isVisible(test.form.codeField());
               enterCode(test, 'US', '4151112222');
               expectSendButton(test);
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse([allFactorsRes, successRes]);
               test.form.sendCodeButton().click();
               return Expect.wait(() => {
-                return $.ajax.calls.count() === 2;
+                return Util.numAjaxRequests() === 2;
               }, test);
             })
             .then(function (test) {
-              expect($.ajax.calls.count()).toBe(2);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(2);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/previous',
                 data: { stateToken: expectedStateToken }
               });
-              Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              Expect.isJsonPost(Util.getAjaxRequest(1), {
                 url: 'https://foo.com/api/v1/authn/factors?updatePhone=true',
                 data: {
                   factorType: 'sms',
@@ -594,15 +594,15 @@ define([
           })
           .then(function (test) {
             // resubmit the 'US' number
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.sendCodeButton().click();
             expectSentButton(test);
-            return Expect.waitForSpyCall($.ajax);
+            return Expect.waitForAjaxRequest();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
               data: {
                 'stateToken': expectedStateToken
@@ -627,25 +627,25 @@ define([
       });
       itp('does not send request and shows error if code is not entered', function () {
         return sendValidCodeFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.submit();
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.hasErrors()).toBe(true);
         });
       });
       itp('calls activate with the right params if passes validation', function () {
         return sendValidCodeFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             expect(test.form.codeField().attr('type')).toBe('tel');
             test.form.setCode(123456);
             test.setNextResponse(successRes);
             test.form.submit();
-            return Expect.waitForSpyCall($.ajax);
+            return Expect.waitForAjaxRequest();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/activate',
               data: {
                 passCode: '123456',

--- a/test/unit/spec/EnrollSymantecVip_spec.js
+++ b/test/unit/spec/EnrollSymantecVip_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 15] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollTokenFactorForm',
@@ -16,7 +16,6 @@ define([
 function (Okta, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
   resAllFactors, resEnrollError, Router, resSuccess) {
 
-  var { $ } = Okta;
   var itp = Expect.itp;
 
   Expect.describe('EnrollSymantecVip', function () {
@@ -24,7 +23,7 @@ function (Okta, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
     function setup (startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router({
         el: $sandbox,
@@ -110,11 +109,11 @@ function (Okta, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
       });
       itp('does not send request and shows error if codes are not entered', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setCredentialId('Cred_Id');
           test.form.submit();
           expect(test.form.hasErrors()).toBe(true);
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
         });
       });
       itp('shows error in case of an error response', function () {
@@ -159,14 +158,14 @@ function (Okta, OktaAuth, LoginUtil, Util, Form, Beacon, Expect, $sandbox,
       });
       itp('calls activate with the right params', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setCredentialId('Cred_Id');
           test.form.setCode(123456);
           test.form.setSecondCode(654321);
           test.setNextResponse(resSuccess);
           test.form.submit();
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
             data: {
               factorType: 'token',

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 31] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollTotpDeviceTypeForm',
@@ -29,7 +29,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
   $sandbox, resAllFactors, resFactorsWithPush, resTotpEnrollSuccess, resPushEnrollSuccess, resPushEnrollSuccessNewQR, resActivateError, resActivatePushEmail,
   resActivatePushSms, resActivatePushTimeout, resSuccess, Router) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -38,7 +38,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
     function setup (res, selectedFactor, settings, startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router(_.extend({
         el: $sandbox,
@@ -216,8 +216,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       });
       itp('sends enroll request with correct params for Okta totp', function () {
         return setupAndEnrollOktaTotpFn().then(function () {
-          expect($.ajax.calls.count()).toBe(2);
-          Expect.isJsonPost($.ajax.calls.argsFor(1), {
+          expect(Util.numAjaxRequests()).toBe(2);
+          Expect.isJsonPost(Util.getAjaxRequest(1), {
             url: 'https://foo.com/api/v1/authn/factors',
             data: {
               factorType: 'token:software:totp',
@@ -229,8 +229,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       });
       itp('sends enroll request with correct params for Google totp', function () {
         return setupAndEnrollGoogleTotpFn().then(function () {
-          expect($.ajax.calls.count()).toBe(2);
-          Expect.isJsonPost($.ajax.calls.argsFor(1), {
+          expect(Util.numAjaxRequests()).toBe(2);
+          Expect.isJsonPost(Util.getAjaxRequest(1), {
             url: 'https://foo.com/api/v1/authn/factors',
             data: {
               factorType: 'token:software:totp',
@@ -245,10 +245,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
     function testOktaVerify (setupAndEnrollOktaPushFn, setupOktaPushFn, activatePushSmsRes, activatePushTimeoutRes, expectedStateToken) {
 
       function setupPolling (test, finalResponse) {
-        $.ajax.calls.reset();
-
-        // Mock calls to startVerifyFactorPoll to include a faster poll
-        Util.speedUpPolling(test.ac);
+        Util.resetAjaxRequests();
 
         // 1: Set for first enrollFactor
         // 2: Set for startEnrollFactorPoll
@@ -259,9 +256,15 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
         test.form.selectDeviceType('APPLE');
         test.form.submit();
 
-        return tick(test)    // 1: submit enrollFactor
-          .then(function () { return tick(test); }) // 2: submit enrollFactor poll
-          .then(function () { return tick(test); }); // Final response tick
+        return Expect.waitForAjaxRequests(1, test) // 1: submit enrollFactor
+          .then(() => {
+            Util.callAllTimeouts();
+            return Expect.waitForAjaxRequests(2, test); // 2: submit enrollFactor poll
+          })
+          .then(() => {
+            Util.callAllTimeouts();
+            return Expect.waitForAjaxRequests(3, test); // Final response tick
+          });
       }
       itp('has qrcode image', function () {
         return setupAndEnrollOktaPushFn().then(function (test) {
@@ -322,10 +325,10 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
           return setupPolling(test, resSuccess);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(3);
+            expect(Util.numAjaxRequests()).toBe(3);
 
             // initial enrollFactor call
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 'factorType': 'push',
@@ -335,7 +338,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             });
 
             // first startEnrollFactorPoll call
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate/poll',
               data: {
                 stateToken: expectedStateToken
@@ -343,7 +346,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             });
 
             // last startEnrollFactorPoll call
-            Expect.isJsonPost($.ajax.calls.argsFor(2), {
+            Expect.isJsonPost(Util.getAjaxRequest(2), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate/poll',
               data: {
                 stateToken: expectedStateToken
@@ -355,15 +358,41 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
         // Simulate polling with Auth SDK's exponential backoff (6 failed requests)
         function setupFailurePolling (test) {
           var failureResponse = { status: 0, response: {} };
-          Util.speedUpPolling(test.ac);
+
+          Util.resetAjaxRequests();
           test.setNextResponse([activatePushSmsRes, activatePushSmsRes,
             failureResponse, failureResponse, failureResponse, failureResponse, failureResponse, failureResponse]);
           test.form.selectDeviceType('APPLE');
           test.form.submit();
-          return tick(test)    // 1: submit enrollFactor
-            .then(function () { return tick(test); }) // 2: submit enrollFactor poll
-            .then(function () { return tick(test); }) // 3: Failure requests
-            .then(function () { return tick(test); }); // 4: Error from Auth SDK
+          return Expect.waitForAjaxRequests(1, test) // 1: submit enrollFactor
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(2, test); // 2: submit enrollFactor poll
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(3, test); // Failure request
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(4, test); // Failure request
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(5, test); // Failure request
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(6, test); // Failure request
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(7, test); // Failure request
+            })
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(8, test); // 4: Error from Auth SDK
+            });
         }
         return setupOktaPushFn().then(function (test) {
           spyOn(test.router.settings, 'callGlobalError');
@@ -373,7 +402,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return test.scanCodeForm.waitForRefreshQrcodeLink(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(9);
+            expect(Util.numAjaxRequests()).toBe(8);
             expect(test.scanCodeForm.hasManualSetupLink()).toBe(false);
             expect(test.scanCodeForm.hasRefreshQrcodeLink()).toBe(true);
             expect(test.scanCodeForm.hasErrors()).toBe(true);
@@ -382,10 +411,10 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
 
             // on "Refresh code" link click
             // it sends reactivation request and starts polling again
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse([activatePushSmsRes, resSuccess]);
             test.scanCodeForm.clickrefreshQrcodeLink();
-            return tick(test);
+            return Expect.waitForAjaxRequests(2, test);
           })
           .then(function (test) {
             // errors cleared
@@ -395,15 +424,15 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             expect(test.router.settings.callGlobalError.calls.count()).toBe(1);
 
             // polled until success
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate/poll',
               data: {
                 'stateToken': expectedStateToken
               }
             });
 
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate/poll',
               data: {
                 stateToken: expectedStateToken
@@ -413,8 +442,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       });
       itp('allows refresh after TIMEOUT', function () {
         return setupOktaPushFn().then(function (test) {
-          $.ajax.calls.reset();
-          Util.speedUpPolling(test.ac);
+          Util.resetAjaxRequests();
 
           // 1: Set for first enrollFactor
           // 2: Set for activateFactor
@@ -425,23 +453,23 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
           test.form.selectDeviceType('APPLE');
           test.form.submit();
 
-          return tick()       // 1: submit enrollFactor
-            .then(tick)   // 2: submit enrollFactor poll
-            .then(function () {
-              return test;
+          return Expect.waitForAjaxRequests(1, test) // 1: submit enrollFactor
+            .then(() => {
+              Util.callAllTimeouts();
+              return Expect.waitForAjaxRequests(2, test); // 2: submit enrollFactor poll
             });
         })
           .then(function (test) {
             // After TIMEOUT, refresh the QR code
             Expect.isVisible(test.scanCodeForm.refreshLink());
             test.scanCodeForm.clickRefreshLink();
-            return tick();
+            return Expect.waitForAjaxRequests(3, test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(3);
+            expect(Util.numAjaxRequests()).toBe(3);
 
             // initial enrollFactor call
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 'factorType': 'push',
@@ -451,7 +479,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             });
 
             // first startEnrollFactorPoll call
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate/poll',
               data: {
                 stateToken: expectedStateToken
@@ -459,7 +487,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             });
 
             // last startEnrollFactorPoll call
-            Expect.isJsonPost($.ajax.calls.argsFor(2), {
+            Expect.isJsonPost(Util.getAjaxRequest(2), {
               url: 'https://foo.com/api/v1/authn/factors/opfiilf0vAdzHVmic0g3/lifecycle/activate',
               data: {
                 stateToken: expectedStateToken
@@ -544,12 +572,12 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       itp('goes to previous link and then enrolls in totp when choosing manual', function () {
         return enrollOktaPushUseManualTotpFn()
           .then(function () {
-            expect($.ajax.calls.count()).toBe(4);
-            Expect.isJsonPost($.ajax.calls.argsFor(2), {
+            expect(Util.numAjaxRequests()).toBe(4);
+            Expect.isJsonPost(Util.getAjaxRequest(2), {
               url: 'https://foo.com/api/v1/authn/previous',
               data: { stateToken: expectedStateToken }
             });
-            Expect.isJsonPost($.ajax.calls.argsFor(3), {
+            Expect.isJsonPost(Util.getAjaxRequest(3), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'token:software:totp',
@@ -562,19 +590,19 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       itp('goes to previous link and enrolls in push when coming from manual', function () {
         return enrollOktaPushUseManualTotpFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             expect(test.manualSetupForm.sharedSecretFieldValue()).toEqual('superSecretSharedSecret');
             test.setNextResponse([factorsWithPushRes, pushEnrollSuccessRes]);
             test.manualSetupForm.selectSmsOption();
             return test.manualSetupForm.waitForSms(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/previous',
               data: { stateToken: expectedStateToken }
             });
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'push',
@@ -588,25 +616,25 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       itp('does not do re-enroll when switches between sms and email options', function () {
         return enrollOktaPushGoCannotScanFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.manualSetupForm.selectEmailOption();
             return test.manualSetupForm.waitForEmail(test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             Expect.isNotVisible(test.manualSetupForm.phoneNumberField());
             test.manualSetupForm.selectSmsOption();
             return test.manualSetupForm.waitForSms(test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             Expect.isVisible(test.manualSetupForm.phoneNumberField());
           });
       });
       itp('sends sms activation link request with correct params and shows confirmation', function () {
         return enrollOktaPushGoCannotScanFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             Expect.isVisible(test.manualSetupForm.form());
             test.manualSetupForm.setPhoneNumber('4152554668');
             test.setNextResponse(resActivatePushSms);
@@ -614,8 +642,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return Expect.waitForEnrollmentLinkSent(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/activate/sms',
               data: {
                 stateToken: expectedStateToken,
@@ -631,13 +659,12 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       itp('removes the sms activation form on successful activation response', function () {
         return enrollOktaPushGoCannotScanFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             Expect.isVisible(test.manualSetupForm.form());
             test.manualSetupForm.setPhoneNumber('4152554668');
             test.setNextResponse(resActivatePushSms);
             test.manualSetupForm.submit();
 
-            Util.speedUpPolling(test.ac);
             test.originalAjax = Util.stallEnrollFactorPoll(test.ac, test.originalAjax);
             return Expect.waitForEnrollmentLinkSent(test);
           })
@@ -645,6 +672,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             Expect.isVisible(test.linkSentConfirmation.smsSentMsg());
             expect(test.linkSentConfirmation.getMsgText().indexOf('+14152554668') >= 0).toBe(true);
             test.originalAjax = Util.resumeEnrollFactorPoll(test.ac, test.originalAjax, resAllFactors);
+            Util.callAllTimeouts();
             return Expect.waitForEnrollChoices(test);
           })
           .then(function (test) {
@@ -654,7 +682,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       itp('sends email activation link request with correct params and shows confirmation', function () {
         return enrollOktaPushGoCannotScanFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             Expect.isVisible(test.manualSetupForm.form());
             test.manualSetupForm.selectEmailOption();
             test.setNextResponse(resActivatePushEmail);
@@ -662,8 +690,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return Expect.waitForEnrollmentLinkSent(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/activate/email',
               data: {
                 stateToken: expectedStateToken
@@ -677,7 +705,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
           and sends activation request with correct params on pass code submit', function () {
         return enrollOktaPushUseManualTotpFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.manualSetupForm.nextButtonClick();
             return Expect.waitForEnterPasscodePushFlow(test);
           })
@@ -693,8 +721,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return tick(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/id1234/lifecycle/activate',
               data: {
                 passCode: '1234',
@@ -707,7 +735,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       when Back link clicked on pass code step', function () {
         return enrollOktaPushUseManualTotpFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.manualSetupForm.nextButtonClick();
             return Expect.waitForEnterPasscodePushFlow(test);
           })
@@ -720,7 +748,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return test.manualSetupForm.waitForCountryCodeSelect(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(0);
+            expect(Util.numAjaxRequests()).toBe(0);
             Expect.isVisible(test.manualSetupForm.form());
             Expect.isNotVisible(test.manualSetupForm.countryCodeSelect());
             Expect.isNotVisible(test.manualSetupForm.phoneNumberField());
@@ -738,7 +766,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return Expect.waitForManualSetupPush(test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             Expect.isVisible(test.manualSetupForm.form());
             test.setNextResponse(pushEnrollSuccessNewQRRes);
             Util.mockSDKCookie(test.ac);
@@ -746,8 +774,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return Expect.waitForBarcodePush(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn',
               data: {
                 stateToken: 'testStateToken'
@@ -854,7 +882,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       });
       itp('refreshes authStatus and goes back to scan barcode screen on "Scan barcode" link click', function () {
         return setupAndEnrollOktaTotpFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupTotp(test);
         })
@@ -866,8 +894,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             return Expect.waitForBarcodeTotp(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn',
               data: { stateToken: 'testStateToken' }
             });
@@ -930,7 +958,7 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
       });
       itp('calls activate with the right params', function () {
         return setupAndEnrollOktaTotpFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
@@ -939,8 +967,8 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
             test.passCodeForm.setCode(123456);
             test.setNextResponse(resSuccess);
             test.passCodeForm.submit();
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/id1234/lifecycle/activate',
               data: {
                 passCode: '123456',

--- a/test/unit/spec/EnrollUser_spec.js
+++ b/test/unit/spec/EnrollUser_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 13], max-len: [2, 160] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollUserForm',
@@ -16,7 +16,7 @@ define([
 function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
   $sandbox, resProfileRequiredUpdate, resProfileRequiredNew, resSuccess, resUnauthenticatedIdx) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
 
   function setup (isUnauthenticated) {
@@ -27,7 +27,7 @@ function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
     setNextResponse(nextResponse);
     var baseUrl = 'https://example.okta.com';
     var logoUrl = 'https://logo.com';
-    var authClient = new OktaAuth({ url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    var authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
@@ -92,7 +92,7 @@ function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
         test.form.$('.registration-link').click();
         return Expect.waitForEnrollUser(test);
       }).then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         expect(test.form.formInputs('streetAddress').length).toEqual(1);
         expect(test.form.formInputs('streetAddress').hasClass('okta-form-input-field input-fix')).toBe(true);
@@ -105,8 +105,8 @@ function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
         model.save();
         return Expect.waitForEnrollUser(test);
       }).then(function () {
-        expect($.ajax.calls.count()).toBe(1);
-        Expect.isJsonPost($.ajax.calls.argsFor(0), {
+        expect(Util.numAjaxRequests()).toBe(1);
+        Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.okta.com/api/v1/authn/enroll',
           data: {
             'registration': {
@@ -123,7 +123,7 @@ function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
     });
     itp('enroll user form submit makes the correct post call', function () {
       return setupEnroll().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         var model = test.router.controller.model;
         model.set('streetAddress', 'street address');
@@ -132,8 +132,8 @@ function (Okta, OktaAuth, LoginUtil, Util, EnrollUserForm, Expect, Router,
         model.save();
         return Expect.waitForEnrollUser(test);
       }).then(function () {
-        expect($.ajax.calls.count()).toBe(1);
-        Expect.isJsonPost($.ajax.calls.argsFor(0), {
+        expect(Util.numAjaxRequests()).toBe(1);
+        Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.okta.com/api/v1/authn/enroll',
           data: {
             'registration': {

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -2,7 +2,7 @@
 define([
   'okta',
   'q',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/CryptoUtil',
   'util/webauthn',
   'util/BrowserFeatures',
@@ -34,7 +34,7 @@ function (Okta,
   resEnrollActivateWebauthn,
   resSuccess) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
   var testAttestationObject = 'c29tZS1yYW5kb20tYXR0ZXN0YXRpb24tb2JqZWN0';
   var testClientData = 'c29tZS1yYW5kb20tY2xpZW50LWRhdGE=';
@@ -47,7 +47,7 @@ function (Okta,
 
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl});
+      var authClient = new OktaAuth({issuer: baseUrl});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = new Router(_.extend({
@@ -215,12 +215,12 @@ function (Okta,
       itp('calls abort on appstate when switching to factor list after clicking enroll', function () {
         mockWebauthnSuccessRegistration(false);
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn]);
           test.form.submit();
           return Expect.waitForSpyCall(navigator.credentials.create, test);
         }).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.webauthnAbortController = test.router.controller.model.webauthnAbortController;
           expect(test.webauthnAbortController).toBeDefined();
           spyOn(test.webauthnAbortController, 'abort').and.callThrough();
@@ -250,14 +250,14 @@ function (Okta,
       itp('sends enroll request after submitting the form', function () {
         mockWebauthnSuccessRegistration(true);
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 stateToken: 'testStateToken',
@@ -271,7 +271,7 @@ function (Okta,
       itp('calls navigator.credentials.create and activates the factor', function () {
         mockWebauthnSuccessRegistration(true);
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
@@ -307,8 +307,8 @@ function (Okta,
               },
               signal: jasmine.any(Object)
             });
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://test.okta.com/api/v1/authn/factors/fuf52dhWPdJAbqiUU0g4/lifecycle/activate',
               data: {
                 attestation: testAttestationObject,
@@ -325,7 +325,7 @@ function (Okta,
 
         mockWebauthnFailureRegistration();
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(navigator.credentials.create, test);

--- a/test/unit/spec/EnrollWindowsHello_spec.js
+++ b/test/unit/spec/EnrollWindowsHello_spec.js
@@ -2,7 +2,7 @@
 define([
   'okta',
   'q',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/EnrollWindowsHelloForm',
@@ -30,7 +30,6 @@ function (Okta,
   responseMfaEnrollActivateWindowsHello,
   responseSuccess) {
 
-  var { $ } = Okta;
   var itp = Expect.itp;
 
   Expect.describe('EnrollWindowsHello', function () {
@@ -38,7 +37,7 @@ function (Okta,
     function setup () {
       var setNextResponse = Util.mockAjax([responseMfaEnrollAll, responseMfaEnrollActivateWindowsHello]);
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var router = new Router({
         el: $sandbox,
@@ -164,8 +163,8 @@ function (Okta,
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'webauthn',
@@ -186,8 +185,8 @@ function (Okta,
           })
           .then(function () {
             expect(webauthn.makeCredential).toHaveBeenCalled();
-            expect($.ajax.calls.count()).toBe(3);
-            Expect.isJsonPost($.ajax.calls.argsFor(2), {
+            expect(Util.numAjaxRequests()).toBe(3);
+            Expect.isJsonPost(Util.getAjaxRequest(2), {
               url: 'https://foo.com/api/v1/authn/factors/factorId1234/lifecycle/activate',
               data: {
                 credentialId: 'credentialId',
@@ -211,7 +210,7 @@ function (Okta,
             }, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(2);
+            expect(Util.numAjaxRequests()).toBe(2);
             expect(test.form.subtitleText()).toBe('Click below to enroll Windows Hello as a second form of authentication');
             expect(test.form.hasErrorHtml()).toBe(false);
           });
@@ -229,7 +228,7 @@ function (Okta,
             }, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(2);
+            expect(Util.numAjaxRequests()).toBe(2);
             expect(test.form.subtitleText()).toBe('Click below to enroll Windows Hello as a second form of authentication');
             expect(test.form.hasErrorHtml()).toBe(true);
           });

--- a/test/unit/spec/EnrollYubikey_spec.js
+++ b/test/unit/spec/EnrollYubikey_spec.js
@@ -1,6 +1,6 @@
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/EnrollTokenFactorForm',
   'helpers/dom/Beacon',
@@ -13,7 +13,6 @@ define([
 function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
   resAllFactors, resSuccess, Router) {
 
-  var { $ } = Okta;
   var itp = Expect.itp;
   var tick = Expect.tick;
 
@@ -22,7 +21,7 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
     function setup (startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl});
+      var authClient = new OktaAuth({issuer: baseUrl});
       var router = new Router({
         el: $sandbox,
         baseUrl: baseUrl,
@@ -99,23 +98,23 @@ function (Okta, OktaAuth, Util, Form, Beacon, Expect, $sandbox,
       });
       itp('does not send request and shows error if code is not entered', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.submit();
           expect(test.form.hasErrors()).toBe(true);
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
         });
       });
       itp('calls enroll with the right params', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setCode(123456);
           test.setNextResponse(resSuccess);
           test.form.submit();
           return tick();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
               data: {
                 factorType: 'token:hardware',

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/AccountRecoveryForm',
   'helpers/dom/PrimaryAuthForm',
@@ -21,13 +21,13 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
   Router, $sandbox, resError, resChallengeEmail, resChallengeSms, resChallengeCall,
   resMfaRequired, resSuccess) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
 
   function setup (settings, startRouter) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl});
+    var authClient = new OktaAuth({issuer: baseUrl});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
@@ -226,9 +226,9 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
     Expect.describe('events', function () {
       itp('shows an error if username is empty and request email', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.sendEmail();
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.usernameErrorField().length).toBe(1);
         });
       });
@@ -242,17 +242,17 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('does not send email and show error when username is all whitespace', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setUsername('  ');
           test.form.sendEmail();
-          expect($.ajax.calls.count()).toBe(0);
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.usernameErrorField().length).toBe(1);
           expect(test.form.usernameErrorField().text()).toBe('This field cannot be left blank');
         });
       });
       itp('sends email', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
@@ -261,8 +261,8 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           .then(function (test) {
             expect(test.form.hasErrors()).toBeFalsy();
             expect(test.form.titleText()).toBe('Email sent!');
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -274,15 +274,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       itp('sends email with relayState', function () {
         return setupWithRedirect()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.setUsername('foo');
             test.form.sendEmail();
             return Expect.waitForPwdResetEmailSent();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -294,15 +294,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('sends email when pressing enter if Email is the only factor', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForPwdResetEmailSent();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -346,15 +346,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       itp('appends the suffix returned by the transformUsername function to the username', function () {
         return setupWithTransformUsername()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.setUsername('foo');
             test.form.sendEmail();
             return Expect.waitForPwdResetEmailSent(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo@example.com',
@@ -366,7 +366,7 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       itp('updates appState username after sending email', function () {
         return setup()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.setUsername('foo');
             expect(test.router.appState.get('username')).toBeUndefined();
@@ -439,7 +439,7 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       itp('shows an error if sending email results in an error', function () {
         return setup()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             Q.stopUnhandledRejectionTracking();
             test.setNextResponse(resError);
             test.form.setUsername('foo');
@@ -453,23 +453,23 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('shows an error if username is empty and request sms', function () {
         return setupWithSms().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.sendSms();
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.usernameErrorField().length).toBe(1);
         });
       });
       itp('sends sms', function () {
         return setupWithSms().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -482,15 +482,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
         return setupWithSmsWithoutEmail().then(function (test) {
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -501,15 +501,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('sends sms when pressing enter if SMS is the only factor', function () {
         return setupWithSmsWithoutEmail().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -523,15 +523,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -597,14 +597,14 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.sendEmail();
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -615,23 +615,23 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('shows an error if username is empty and request Voice Call', function () {
         return setupWithCall().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.makeCall();
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.usernameErrorField().length).toBe(1);
         });
       });
       itp('makes a Voice Call', function () {
         return setupWithCall().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -644,15 +644,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
         return setupWithCallWithoutEmail().then(function (test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -663,15 +663,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('makes a Voice Call when pressing enter if Voice Call is the only factor', function () {
         return setupWithCallWithoutEmail().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -684,15 +684,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
         return setupWithCall().then(function (test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -758,14 +758,14 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.sendEmail();
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -808,15 +808,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
             return Expect.waitForForgotPassword(test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setUsername('foo');
             test.form.sendEmail();
-            return Expect.waitForSpyCall($.ajax);
+            return Expect.waitForAjaxRequest();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -827,15 +827,15 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       });
       itp('sends email, goes back to login page and allows resending', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -857,7 +857,7 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           })
           .then(function (test) {
           // Submit the user name again
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.setUsername('foo');
             test.form.sendEmail();
@@ -865,8 +865,8 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           })
           .then(function () {
           // Expect the same request as before
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 'username': 'foo',
@@ -917,14 +917,14 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           return Expect.waitForRecoveryChallenge(test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForPwdResetEmailSent();
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 username: 'foo@bar',
@@ -961,7 +961,7 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
             return Expect.waitForRecoveryChallenge(test);
           })
             .then(function (test) {
-              Q.stopUnhandledRejectionTracking();
+              Expect.allowUnhandledPromiseRejection();
               test.setNextResponse(resError);
               test.form.clickSendEmailLink();
               return Expect.waitForFormError(test.form, test);
@@ -1003,14 +1003,14 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
           return Expect.waitForRecoveryChallenge(test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForPwdResetEmailSent(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/recovery/password',
               data: {
                 username: 'foo@bar',
@@ -1041,7 +1041,7 @@ function (Q, Okta, OktaAuth, Util, AccountRecoveryForm, PrimaryAuthForm, Beacon,
       itp('shows an error if sending email via "Reset via email" link results in an error, after making a Voice Call',
         function () {
           return setupWithCall().then(function (test) {
-            Q.stopUnhandledRejectionTracking();
+            Expect.allowUnhandledPromiseRejection();
             test.setNextResponse(resChallengeCall);
             test.form.setUsername('foo');
             test.form.makeCall();

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params:[2, 28], max-statements:[2, 41], camelcase:0, max-len:[2, 180] */
 define([
   'q',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'okta',
   'helpers/mocks/Util',
@@ -47,7 +47,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
 
     var setNextResponse = Util.mockAjax(requests);
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: WidgetUtil.transformErrorXHR, headers: {}});
+    var authClient = new OktaAuth({issuer: baseUrl, pkce: false, transformErrorXHR: WidgetUtil.transformErrorXHR, headers: {}});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
 
@@ -627,11 +627,8 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           })
           .then(function (test) {
             expect(test.router.settings.transformUsername.calls.count()).toBe(0);
-            expect($.ajax.calls.count()).toBe(1);
-            expect($.ajax.calls.argsFor(0)[0]).toEqual({
-              url: 'https://foo.com/login/getimage?username=testuser%40clouditude.net',
-              dataType: 'json'
-            });
+            expect(Util.numAjaxRequests()).toBe(1);
+            expect(Util.getAjaxRequest(0).url).toBe('https://foo.com/login/getimage?username=testuser%40clouditude.net');
           });
       });
       itp('changs the suffix of the username', function () {
@@ -683,7 +680,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             });
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(0);
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
           });
       });
@@ -701,10 +698,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
-            var ajaxArgs = $.ajax.calls.argsFor(0);
-            expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
+            var ajaxArgs = Util.getAjaxRequest(0);
+            expect(ajaxArgs.requestHeaders['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
           });
       });
       itp(`contains fingerprint header in get security image request if both features(
@@ -722,10 +719,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
-            var ajaxArgs = $.ajax.calls.argsFor(0);
-            expect(ajaxArgs[0].headers['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
+            var ajaxArgs = Util.getAjaxRequest(0);
+            expect(ajaxArgs.requestHeaders['X-Device-Fingerprint']).toBe('thisIsTheDeviceFingerprint');
           });
       });
       itp(`does not contain fingerprint header in get security image request if deviceFingerprinting
@@ -739,10 +736,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
-            var ajaxArgs = $.ajax.calls.argsFor(0);
-            expect(ajaxArgs[0].headers).toBeUndefined();
+            var ajaxArgs = Util.getAjaxRequest(0);
+            expect(ajaxArgs.requestHeaders['X-Device-Fingerprint']).toBeUndefined();
           });
       });
       itp(`does not contain fingerprint header in get security image request if deviceFingerprinting
@@ -755,10 +752,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
-            var ajaxArgs = $.ajax.calls.argsFor(0);
-            expect(ajaxArgs[0].headers).toBeUndefined();
+            var ajaxArgs = Util.getAjaxRequest(0);
+            expect(ajaxArgs.requestHeaders['X-Device-Fingerprint']).toBeUndefined();
           });
       });
       itp('does not contain fingerprint header in get security image request if feature is disabled', function () {
@@ -770,10 +767,10 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
-            var ajaxArgs = $.ajax.calls.argsFor(0);
-            expect(ajaxArgs[0].headers).toBeUndefined();
+            var ajaxArgs = Util.getAjaxRequest(0);
+            expect(ajaxArgs.requestHeaders['X-Device-Fingerprint']).toBeUndefined();
           });
       });
     });
@@ -861,7 +858,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             });
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(0);
+            expect(Util.numAjaxRequests()).toBe(0);
           });
       });
       itp('has default security image on page load and no rememberMe', function () {
@@ -881,11 +878,8 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            expect($.ajax.calls.argsFor(0)[0]).toEqual({
-              url: 'https://foo.com/login/getimage?username=testuser%40clouditude.net',
-              dataType: 'json'
-            });
+            expect(Util.numAjaxRequests()).toBe(1);
+            expect(Util.getAjaxRequest(0).url).toBe('https://foo.com/login/getimage?username=testuser%40clouditude.net');
             expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
             expect(test.form.accessibilityText()).toBe('a single pixel');
           });
@@ -900,7 +894,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             return waitForBeaconChange(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
           });
       });
       itp('undefined username does not make API call', function () {
@@ -922,7 +916,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
             }, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(0);
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.router.appState.get('securityImage')).toContain('/img/security/default.png');
             expect(test.router.appState.get('securityImageDescription')).toBe('');
             expect(test.form.securityBeacon()[0].className).toContain('undefined-user');
@@ -1045,7 +1039,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           }
         };
         return setup(options, [resSecurityImage])
-          .then(Expect.waitForSpyCall($.ajax))
+          .then(Expect.waitForAjaxRequest())
           .then(waitForSecurityBeaconLoaded)
           .then(function (test) {
             expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
@@ -1385,14 +1379,14 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
     describe('Passwordless Auth', function () {
       itp('automatically calls authClient.signIn when idp is Okta', function () {
         return setupPasswordlessAuth().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn',
               data: {
                 username: 'testuser@test.com',

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -8,7 +8,7 @@ define([
   'util/Util',
   'util/Bundles',
   'config/config.json',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/util/Expect',
   'LoginRouter',
@@ -76,7 +76,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
       settings = settings || {};
       var setNextResponse = settings.mockAjax === false ? function () {} : Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, headers: {}});
+      var usePKCE = settings['authParams.pkce'] || false;
+      var authClient = new OktaAuth({issuer: baseUrl, pkce: usePKCE, headers: {}});
       var eventSpy = jasmine.createSpy('eventSpy');
       var afterRenderHandler = jasmine.createSpy('afterRenderHandler');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
@@ -157,6 +158,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
       spyOn(BrowserFeatures, 'getUserLanguages').and.returnValue(options.userLanguages || []);
       spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(options.localStorageIsNotSupported);
 
+      var setNextJSONPResponse = Util.mockJSONP();
       return setup(options.settings)
         .then(function (test) {
           test.router.appState.on('loading', loadingSpy);
@@ -167,7 +169,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           if (options.mockLanguageRequest) {
             switch (options.mockLanguageRequest) {
             case 'ja':
-              test.setNextResponse([
+              setNextJSONPResponse([
                 _.extend({ delay: delay }, labelsLoginJa),
                 _.extend({ delay: delay }, labelsCountryJa)
               ]);
@@ -291,9 +293,9 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
       expect(err.name).toBe('CONFIG_ERROR');
       expect(err.message).toEqual('"el" is a required widget parameter');
     });
-    it('throws a ConfigError if baseUrl is not passed as a widget param', function () {
-      var fn = function () { setup({ authClient: new OktaAuth({baseUrl: undefined }) }); };
-      expect(fn).toThrowError('No url passed to constructor. Required usage: new OktaAuth({url: "https://{yourOktaDomain}.com"})');
+    it('throws a ConfigError if issuer is not passed as a widget param', function () {
+      var fn = function () { setup({ authClient: new OktaAuth({issuer: undefined }) }); };
+      expect(fn).toThrowError('No issuer passed to constructor. Required usage: new OktaAuth({issuer: "https://{yourOktaDomain}.com/oauth2/{authServerId}"})');
     });
     itp('renders the primary autenthentication form when no globalSuccessFn and globalErrorFn are passed as widget params', function () {
       return expectPrimaryAuthRender({ globalSuccessFn: undefined, globalErrorFn: undefined });
@@ -693,8 +695,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForRecoveryQuestion();
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'testStateToken'
@@ -713,8 +715,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForRecoveryQuestion();
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'dummy-token'
@@ -790,8 +792,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForPrimaryAuth(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'dummy-token'
@@ -811,8 +813,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForIDPDiscovery(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'dummy-token'
@@ -859,20 +861,21 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForPrimaryAuth(test);
         })
         .then(function (test) {
-          Q.stopUnhandledRejectionTracking();
+          Expect.allowUnhandledPromiseRejection();
           test.setNextResponse([resMfaRequiredDuo, errorInvalidToken]);
           var form = new PrimaryAuthForm($sandbox);
           form.setUsername('testuser');
           form.setPassword('pass');
           form.submit();
-          return Expect.wait(() => {
-            return $.ajax.calls.count() === 2;
-          }, test);
+          return Expect.waitForAjaxRequests(2, test);
         })
         .then(function () {
-        // If we don't have our fix, there will be two PrimaryAuth forms
-          var form = new PrimaryAuthForm($sandbox);
-          expect(form.usernameField().length).toBe(1);
+          // 2nd form will appear until the fail() handler is called in BaseLoginRouter. With Q this happens on the next tick.
+          return Expect.wait(() => {
+            // If we don't have our fix, there will be two PrimaryAuth forms
+            var form = new PrimaryAuthForm($sandbox);
+            return form.usernameField().length === 1;
+          });
         });
     });
 
@@ -891,7 +894,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           var form = new MfaVerifyForm($sandbox);
           expect(form.isSecurityQuestion()).toBe(true);
           return Expect.wait(() => {
-            return $.ajax.calls.count() === 2;
+            return Util.numAjaxRequests() === 2;
           });
         });
     });
@@ -919,13 +922,13 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           expect(form.autoPushCheckbox().length).toBe(1);
           expect(form.isAutoPushChecked()).toBe(true);
           return Expect.wait(() => {
-            return $.ajax.calls.count() === 2;
+            return Util.numAjaxRequests() === 2;
           }, form);
         })
         .then(function (form) {
           expect(form.isPushSent()).toBe(true);
-          expect($.ajax.calls.count()).toBe(2);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(2);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               password: 'pass',
@@ -937,7 +940,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
               }
             }
           });
-          Expect.isJsonPost($.ajax.calls.argsFor(1), {
+          Expect.isJsonPost(Util.getAjaxRequest(1), {
             url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?autoPush=true&rememberDevice=false',
             data: {
               stateToken: 'testStateToken'
@@ -985,8 +988,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           return Expect.waitForMfaVerify(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               password: 'pass',
@@ -998,15 +1001,15 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
               }
             }
           });
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resMfaChallengePush);
           var form = new MfaVerifyForm($sandbox);
           form.submit();
-          return Expect.waitForSpyCall($.ajax);
+          return Expect.waitForAjaxRequest();
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?autoPush=false&rememberDevice=false',
             data: {
               stateToken: 'testStateToken'
@@ -1036,7 +1039,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         expect(params.get('client_id')).toBe(clientId);
         expect(params.get('redirect_uri')).toBe(redirectUri);
         expect(params.get('response_type')).toBe(responseType);
-        expect(params.get('response_mode')).toBe(responseMode);
+        expect(params.get('response_mode')).toBe(responseMode || null);
         expect(params.get('sessionToken')).toBe(sessionToken);
         expect(params.get('scope')).toBe(scope);
 
@@ -1081,22 +1084,35 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           });
       });
 
-      itp('PKCE: redirects, sets the responseMode to "fragment" and sets a code_challenge', function () {
+      itp('PKCE: redirects, sets a code_challenge', function () {
         return setupOAuth2({
           'authParams.pkce': true,
           'authParams.responseType': 'code',
         })
           .then(expectCodeRedirect({
-            responseMode: 'fragment',
             responseType:'code',
             code_challenge_method: 'S256'
           }));
       });
+
+      itp('PKCE: redirects, can set the responseMode to "fragment"', function () {
+        return setupOAuth2({
+          'authParams.pkce': true,
+          'authParams.responseType': 'code',
+          'authParams.responseMode': 'fragment'
+        })
+          .then(expectCodeRedirect({
+            responseType:'code',
+            responseMode: 'fragment',
+            code_challenge_method: 'S256'
+          }));
+      });
+
       itp('redirects instead of using an iframe if the responseType is "code"', function () {
         return setupOAuth2({
           'authParams.responseType': 'code', 
         })
-          .then(expectCodeRedirect({responseMode: 'query', responseType:'code'}));
+          .then(expectCodeRedirect({responseType:'code'}));
       });
       itp('redirects to alternate authorizeUrl if the responseType is "code"', function () {
         return setupOAuth2({
@@ -1105,7 +1121,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://altfoo.com/oauth2/v1/authorize',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1116,7 +1131,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://altfoo.com/oauth2/v1/authorize',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1128,7 +1142,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         })
           .then(expectCodeRedirect({
             authorizeUrl: 'https://reallyaltfoo.com/oauth2/v1/authorize',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1139,7 +1152,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         })
           .then(expectCodeRedirect({
             state: 'myalternatestate',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1150,7 +1162,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
         })
           .then(expectCodeRedirect({
             nonce: 'myalternatenonce',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1163,7 +1174,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           .then(expectCodeRedirect({
             state: 'myalternatestate',
             nonce: 'myalternatenonce',
-            responseMode: 'query',
             responseType:'code'
           }));
       });
@@ -1171,7 +1181,6 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
       itp('redirects instead of using an iframe if display is "page"', function () {
         return setupOAuth2({'authParams.display': 'page'})
           .then(expectCodeRedirect({
-            responseMode: 'fragment',
             responseType: 'id_token',
             display: 'page'
           }));
@@ -1196,6 +1205,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             var callback = args[1];
             expect(type).toBe('message');
             expect($sandbox.find('#' + OIDC_IFRAME_ID).length).toBe(1);
+            Util.loadWellKnownAndKeysCache();
             callback.call(null, {
               origin: 'https://foo.com',
               data: {
@@ -1231,8 +1241,8 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             expect(successSpy.calls.count()).toBe(1);
             var data = successSpy.calls.argsFor(0)[0];
             expect(data.status).toBe('SUCCESS');
-            expect(data.idToken).toBe(VALID_ID_TOKEN);
-            expect(data.claims).toEqual({
+            expect(data.tokens.idToken.value).toBe(VALID_ID_TOKEN);
+            expect(data.tokens.idToken.claims).toEqual({
               amr: ['pwd'],
               aud: 'someClientId',
               auth_time: 1451606400,
@@ -1562,7 +1572,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             form.setUsername('testuser');
             form.setPassword('testpassword');
             form.submit();
-            expect($.ajax.calls.mostRecent().args[0].headers['Accept-Language']).toBe('en');
+            expect(Util.lastAjaxRequest().requestHeaders['accept-language']).toBe('en');
 
             // Wait for login success
             return Expect.waitForSpyCall(success, test);
@@ -1589,7 +1599,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
             form.setUsername('testuser');
             form.setPassword('testpassword');
             form.submit();
-            expect($.ajax.calls.mostRecent().args[0].headers['Accept-Language']).toBe('ja');
+            expect(Util.lastAjaxRequest().requestHeaders['accept-language']).toBe('ja');
 
             // Wait for login success
             return Expect.waitForSpyCall(success, test);
@@ -1600,7 +1610,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
     Expect.describe('Config: "assets"', function () {
 
       function expectBundles (baseUrl, login, country) {
-        expect($.ajax.calls.count()).toBe(3);
+        expect($.ajax.calls.count()).toBe(2);
         var loginCall = $.ajax.calls.argsFor(0)[0];
         var countryCall = $.ajax.calls.argsFor(1)[0];
         expect(loginCall).toEqual({

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -4,7 +4,7 @@ define([
   'okta',
   'q',
   'duo',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/MfaVerifyForm',
@@ -149,8 +149,9 @@ function (Okta,
 
     function setup (res, selectedFactorProps, settings, languagesResponse, useResForIntrospect) {
       var setNextResponse = Util.mockAjax();
+      var setNextJSONPResponse = Util.mockJSONP();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = createRouter(baseUrl, authClient, successSpy, settings);
@@ -158,7 +159,7 @@ function (Okta,
       var resp = resAllFactors;
       setNextResponse(res);
       if (languagesResponse) {
-        setNextResponse(languagesResponse);
+        setNextJSONPResponse(languagesResponse);
       }
       router.refreshAuthState('dummy-token');
       return Expect.waitForMfaVerify()
@@ -224,7 +225,7 @@ function (Okta,
     function setupNoProvider (res, selectedFactorProps, settings) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = createRouter(baseUrl, authClient, successSpy, settings);
@@ -265,7 +266,7 @@ function (Okta,
     function setupWindowsHelloOnly () {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var router = createRouter(baseUrl, authClient, successSpy);
       setNextResponse([resRequiredWindowsHello, resChallengeWindowsHello, resSuccess]);
@@ -325,7 +326,7 @@ function (Okta,
       { factorType: 'assertion:oidc', provider: 'GENERIC_OIDC' });
     var setupClaimsProviderFactorWithIntrospect = _.partial(setup, resAllFactors,
       { factorType: 'claims_provider', provider: 'CUSTOM', });
-    var setupAllFactorsWithRouter = _.partial(setup, resAllFactors, null, { 'features.router': true });
+    var setupAllFactorsWithRouter = _.partial(setup, resAllFactors, null, { 'features.router': true, 'features.securityImage': true });
     function setupSecurityQuestionLocalized (options) {
       spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(options.localStorageIsNotSupported);
       spyOn(BrowserFeatures, 'getUserLanguages').and.returnValue(['ja', 'en']);
@@ -416,7 +417,7 @@ function (Okta,
 
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = createRouter(baseUrl, authClient, successSpy);
@@ -455,7 +456,7 @@ function (Okta,
       //get MFA_CHALLENGE, and routerUtil calls prev, to set state to MFA_REQUIRED
       var setNextResponse = Util.mockAjax([initResponse, resAllFactors]);
       var baseUrl = 'https://foo.com';
-      var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+      var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
       var successSpy = jasmine.createSpy('success');
       var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
       var router = createRouter(baseUrl, authClient, successSpy, options.settings);
@@ -609,10 +610,7 @@ function (Okta,
       spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
         return setTimeout(arguments[0]);
       });
-      $.ajax.calls.reset();
-
-      // Mock calls to startVerifyFactorPoll to include a faster poll
-      Util.speedUpPolling(test.ac);
+      Util.resetAjaxRequests();
 
       // 1: Set for first verifyFactor
       // 2: Set for startVerifyFactorPoll
@@ -625,13 +623,20 @@ function (Okta,
         test.form = test.form[0];
       }
       test.form.submit();
- 
-      // First tick - submit verifyFactor
-      // Second tick - start verifyFactor poll
-      // The next tick will trigger the final response
-      return Expect.wait(function () {
-        return JSON.stringify(test.router.controller.model.appState.get('lastAuthResponse')) === JSON.stringify(finalResponse.response);
-      }, test);
+      return Expect.waitForAjaxRequests(1, test) // First tick - submit verifyFactor
+        .then(() => {
+          Util.callAllTimeouts();
+          return Expect.waitForAjaxRequests(2, test); // Second tick - start verifyFactor poll
+        })
+        .then(() => {
+          Util.callAllTimeouts();
+          return Expect.waitForAjaxRequests(3, test); // The next tick will trigger the final response
+        })
+        .then(() => {
+          return Expect.wait(function () {
+            return JSON.stringify(test.router.controller.model.appState.get('lastAuthResponse')) === JSON.stringify(finalResponse.response);
+          }, test);
+        });
     }
 
     function expectHasRightBeaconImage (test, desiredClassName) {
@@ -775,7 +780,7 @@ function (Okta,
       itp('is able to switch between factors even when the auth status is MF_CHALLENGE', function () {
         spyOn(Duo, 'init');
         return setup(allFactorsRes).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeDuo);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'DUO');
@@ -810,7 +815,7 @@ function (Okta,
             return Expect.waitForVerifyQuestion(test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             // We cannot use test.form here since refers to SMS form,
             // so query for the security question form.
@@ -820,8 +825,8 @@ function (Okta,
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=false',
               data: {
                 answer: 'food',
@@ -853,7 +858,7 @@ function (Okta,
             return tick(test);
           })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             // We cannot use test.form here since refers to SMS form,
             // so query for the google TOTP form.
@@ -863,8 +868,8 @@ function (Okta,
             return tick(test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=false',
               data: {
                 passCode: '123456',
@@ -940,7 +945,7 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with correct args when submitted', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('food');
           test.form.setRememberDevice(true);
           test.setNextResponse(resSuccess);
@@ -948,8 +953,8 @@ function (Okta,
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=true',
               data: {
                 answer: 'food',
@@ -960,7 +965,7 @@ function (Okta,
       });
       itp('disables the "verify button" when clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('who cares');
           test.setNextResponse(resInvalid);
           test.form.submit();
@@ -993,13 +998,13 @@ function (Okta,
       itp('shows errors if verify button is clicked and answer is empty', function () {
         return setupFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1009,7 +1014,7 @@ function (Okta,
         return setupFn()
           .then(function (test) {
             mockTransactions(test.router.controller);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('food');
             test.setNextResponse(resSuccess);
             test.form.submit();
@@ -1023,7 +1028,7 @@ function (Okta,
         return setupFn()
           .then(function (test) {
             mockTransactions(test.router.controller);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('food');
             test.setNextResponse(resInvalid);
             test.form.submit();
@@ -1107,14 +1112,14 @@ function (Okta,
       });
       itp('calls verifyFactor with empty code if send code button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
               data: {
                 passCode: '',
@@ -1124,8 +1129,8 @@ function (Okta,
           });
       });
 
-      it('posts resend if send code button is clicked second time', function () {
-        Util.speedUpPolling();
+      itp('posts resend if send code button is clicked second time', function () {
+        Util.mockQDelay();
         return setupFn().then(function (test) {
           test.setNextResponse(challengeSmsRes);
           expect(test.form.smsSendCode().text()).toBe('Send code');
@@ -1136,7 +1141,7 @@ function (Okta,
         })
           .then(function (test) {
             expect(test.form.submitButton().prop('disabled')).toBe(false);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(challengeSmsRes);
             test.form.smsSendCode().click();
             return Expect.wait(function () {
@@ -1149,9 +1154,9 @@ function (Okta,
             }, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(test.form.submitButton().prop('disabled')).toBe(false);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify/resend',
               data: {
                 stateToken: expectedStateToken
@@ -1160,7 +1165,7 @@ function (Okta,
           });
       });
       it('shows warning message to click "Re-send" after 30s', function () {
-        Util.speedUpPolling();
+        Util.mockQDelay();
         return setupFn().then(function (test) {
           test.setNextResponse(challengeSmsRes);
           expect(test.form.smsSendCode().text()).toBe('Send code');
@@ -1175,7 +1180,7 @@ function (Okta,
               'Haven\'t received an SMS? To try again, click Re-send code.');
 
             // Re-send will clear the warning
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(challengeSmsRes);
             test.form.smsSendCode().click();
             expect(test.form.smsSendCode().text()).toBe('Sent');
@@ -1193,15 +1198,15 @@ function (Okta,
       });
       itp('calls verifyFactor with rememberDevice URL param', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick();
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=true',
               data: {
                 passCode: '',
@@ -1212,20 +1217,20 @@ function (Okta,
       });
       itp('calls verifyFactor with empty code if verify button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setAnswer('');
             test.form.submit();
             return tick(test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1233,21 +1238,21 @@ function (Okta,
       });
       itp('calls verifyFactor with given code if verify button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setAnswer('123456');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
               data: {
                 passCode: '123456',
@@ -1259,13 +1264,13 @@ function (Okta,
       itp('shows errors if verify button is clicked and answer is empty', function () {
         return setupFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1273,22 +1278,22 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with rememberDevice URL param', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setAnswer('123456');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=true',
               data: {
                 passCode: '123456',
@@ -1397,9 +1402,12 @@ function (Okta,
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorBox().length).toBe(1);
             test.setNextResponse(challengeSmsRes);
+            Util.mockQDelay();
             test.form.smsSendCode().click();
+            expect(test.form.hasErrors()).toBe(false);
+            expect(test.form.smsSendCode().hasClass('disabled')).toBe(true);
             return Expect.wait(function () {
-              return test.form.hasErrors() === false;
+              return test.form.smsSendCode().hasClass('disabled') === false;
             }, test);
           })
           .then(function (test) {
@@ -1474,56 +1482,62 @@ function (Okta,
       });
       itp('calls verifyFactor with empty code if call button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
-          return Expect.wait(function () {
-            return $.ajax.calls.count() > 0;
-          }, test);
-        })
-          .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
-              url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=false',
-              data: {
-                passCode: '',
-                stateToken: expectedStateToken
-              }
-            });
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
+            url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=false',
+            data: {
+              passCode: '',
+              stateToken: expectedStateToken
+            }
           });
+          expect(test.form.makeCall().hasClass('disabled')).toBe(true);
+          // Wait for PassCodeForm save logic to finish up
+          Util.mockQDelay();
+          return Expect.wait(function () {
+            return test.form.makeCall().hasClass('disabled') === false;
+          }, test);
+        });
       });
       itp('calls verifyFactor with rememberDevice URL param', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
-          return Expect.wait(function () {
-            return $.ajax.calls.count() > 0;
-          }, test);
-        })
-          .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
-              url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=true',
-              data: {
-                passCode: '',
-                stateToken: expectedStateToken
-              }
-            });
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
+            url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=true',
+            data: {
+              passCode: '',
+              stateToken: expectedStateToken
+            }
           });
+          expect(test.form.makeCall().hasClass('disabled')).toBe(true);
+          // Wait for PassCodeForm save logic to finish up
+          Util.mockQDelay();
+          return Expect.wait(function () {
+            return test.form.makeCall().hasClass('disabled') === false;
+          }, test);
+        });
       });
       itp('calls verifyFactor with empty code if verify button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
+          expect(Util.numAjaxRequests()).toBe(1);
+          expect(test.form.makeCall().hasClass('disabled')).toBe(true);
+          // Wait for PassCodeForm save logic to finish up
+          Util.mockQDelay();
           return Expect.wait(function () {
-            return $.ajax.calls.count() > 0;
+            return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.setAnswer('');
             expect(test.form.hasErrors()).toBe(false);
@@ -1531,7 +1545,7 @@ function (Okta,
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1539,23 +1553,23 @@ function (Okta,
       });
       itp('calls verifyFactor with given code if verify button is clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
           return Expect.wait(function () {
-            return $.ajax.calls.count() > 0;
+            return Util.numAjaxRequests() > 0;
           }, test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.setAnswer('123456');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=false',
               data: {
                 passCode: '123456',
@@ -1566,24 +1580,24 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with rememberDevice URL param', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
           return Expect.wait(function () {
-            return $.ajax.calls.count() > 0;
+            return Util.numAjaxRequests() > 0;
           }, test);
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(successRes);
             test.form.setAnswer('123456');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=true',
               data: {
                 passCode: '123456',
@@ -1595,13 +1609,13 @@ function (Okta,
       itp('shows errors if verify button is clicked and answer is empty', function () {
         return setupFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -1708,8 +1722,10 @@ function (Okta,
             test.setNextResponse(challengeCallRes);
             test.form.makeCall().click();
             expect(test.form.makeCall().hasClass('disabled')).toBe(true);
+            // Wait for PassCodeForm save logic to finish up
+            Util.mockQDelay();
             return Expect.wait(function () {
-              return test.form.hasErrors() === false;
+              return test.form.makeCall().hasClass('disabled') === false;
             }, test);
           })
           .then(function (test) {
@@ -1719,7 +1735,7 @@ function (Okta,
       });
 
       itp('shows warning message to click "Redial" after 30s', function () {
-        Util.speedUpPolling();
+        Util.mockQDelay();
         return setupFn().then(function (test) {
           test.setNextResponse(challengeCallRes);
           expect(test.form.makeCall().text()).toBe('Call');
@@ -1735,7 +1751,7 @@ function (Okta,
               'Haven\'t received a voice call? To try again, click Redial.');
 
             // Re-send will clear the warning
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(challengeCallRes);
             test.form.makeCall().click();
             expect(test.form.makeCall().text()).toBe('Calling');
@@ -1753,7 +1769,7 @@ function (Okta,
           });
       });
       itp('posts to resend link if call button is clicked for the second time', function () {
-        Util.speedUpPolling();
+        Util.mockQDelay();
         return setupCall().then(function (test) {
           test.setNextResponse(challengeCallRes);
           expect(test.form.makeCall().text()).toBe('Call');
@@ -1764,7 +1780,7 @@ function (Okta,
         })
           .then(function (test) {
             expect(test.form.submitButton().prop('disabled')).toBe(false);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(challengeCallRes);
             test.form.makeCall().click();
             return Expect.wait(function () {
@@ -1778,8 +1794,8 @@ function (Okta,
           })
           .then(function (test) {
             expect(test.form.submitButton().prop('disabled')).toBe(false);
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               data: { stateToken: expectedStateToken },
               url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify/resend'
             });
@@ -1827,15 +1843,15 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with correct args when submitted', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=false',
               data: {
                 passCode: '123456',
@@ -1846,7 +1862,7 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with rememberDevice URL param', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.form.setRememberDevice(true);
           test.setNextResponse(resSuccess);
@@ -1854,8 +1870,8 @@ function (Okta,
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=true',
               data: {
                 passCode: '123456',
@@ -1866,7 +1882,7 @@ function (Okta,
       });
       itp('disables the "verify button" when clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('who cares');
           test.setNextResponse(resInvalid);
           test.form.submit();
@@ -1879,7 +1895,7 @@ function (Okta,
           .then(function (test) {
             var button = test.form.submitButton();
             var buttonClass = button.attr('class');
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
             expect(buttonClass).not.toContain('link-button-disabled');
             expect(button.prop('disabled')).toBe(false);
           });
@@ -1916,13 +1932,13 @@ function (Okta,
       itp('shows errors if verify button is clicked and answer is empty', function () {
         return setupFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passCodeErrorField().length).toBe(1);
             expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -2000,7 +2016,7 @@ function (Okta,
       });
       itp('calls authClient verifyFactor with correct args when submitted', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
           test.form.setRememberDevice(true);
           test.setNextResponse(resSuccess);
@@ -2008,8 +2024,8 @@ function (Okta,
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'http://rain.okta1.com:1802/api/v1/authn/factors/password/verify?rememberDevice=true',
               data: {
                 password: 'Abcd1234',
@@ -2020,7 +2036,7 @@ function (Okta,
       });
       itp('disables the "verify button" when clicked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setPassword('Abcd');
           test.setNextResponse(resInvalidPassword);
           test.form.submit();
@@ -2075,13 +2091,13 @@ function (Okta,
       itp('shows errors if verify button is clicked and password is empty', function () {
         return setupFn()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setPassword('');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
           .then(function (test) {
-            expect($.ajax).not.toHaveBeenCalled();
+            expect(Util.numAjaxRequests()).toBe(0);
             expect(test.form.passwordErrorField().length).toBe(1);
             expect(test.form.passwordErrorField().text()).toBe('Please enter a password');
             expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
@@ -2091,7 +2107,7 @@ function (Okta,
         return setupFn()
           .then(function (test) {
             mockTransactions(test.router.controller);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setPassword('Abcd1234');
             test.setNextResponse(resSuccess);
             test.form.submit();
@@ -2105,7 +2121,7 @@ function (Okta,
         return setupFn()
           .then(function (test) {
             mockTransactions(test.router.controller);
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setPassword('Abcd1234');
             test.setNextResponse(resInvalidPassword);
             test.form.submit();
@@ -2170,14 +2186,14 @@ function (Okta,
             .then(function (test) {
               spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
               spyOn(RouterUtil, 'routeAfterAuthStatusChange').and.callThrough();
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resCancel);
               test.form.signoutLink($sandbox).click();
               return Expect.waitForPrimaryAuth(test);
             })
             .then(function (test) {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/cancel',
                 data: {
                   stateToken: 'testStateToken'
@@ -2196,7 +2212,7 @@ function (Okta,
                 spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
                 spyOn(RouterUtil, 'routeAfterAuthStatusChange').and.callThrough();
                 spyOn(SharedUtil, 'redirect');
-                $.ajax.calls.reset();
+                Util.resetAjaxRequests();
                 test.setNextResponse(resCancel);
                 test.form.signoutLink($sandbox).click();
                 return Expect.wait(function () {
@@ -2204,8 +2220,8 @@ function (Okta,
                 }, test);
               })
               .then(function (test) {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/cancel',
                   data: {
                     stateToken: 'testStateToken'
@@ -2400,7 +2416,7 @@ function (Okta,
         });
         itp('disables the "verify button" when clicked', function () {
           return setupYubikey().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('who cares');
             test.setNextResponse(resInvalid);
             test.form.submit();
@@ -2419,15 +2435,15 @@ function (Okta,
         });
         itp('calls authClient verifyFactor with correct args when submitted', function () {
           return setupYubikey().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/ykf2l0aUIe5VBplDj0g4/verify?rememberDevice=false',
                 data: {
                   passCode: '123456',
@@ -2438,7 +2454,7 @@ function (Okta,
         });
         itp('calls authClient verifyFactor with rememberDevice URL param', function () {
           return setupYubikey().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.form.setRememberDevice(true);
             test.setNextResponse(resSuccess);
@@ -2446,8 +2462,8 @@ function (Okta,
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/ykf2l0aUIe5VBplDj0g4/verify?rememberDevice=true',
                 data: {
                   passCode: '123456',
@@ -2564,17 +2580,17 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with correct args when submitted', function () {
             return setupOktaPushWithIntrospect().then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               setRememberDeviceForPushForm(test, true);
               test.setNextResponse(resSuccess);
               test.form.submit();
               return Expect.wait(function () {
-                return $.ajax.calls.count() > 0;
+                return Util.numAjaxRequests() > 0;
               }, test);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?rememberDevice=true',
                   data: {
                     stateToken: 'testStateToken'
@@ -2584,17 +2600,17 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with correct args when autoPush is checked', function () {
             return setupOktaPushWithRefreshAuth({'features.autoPush': true}).then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               setAutoPushCheckbox(test, true);
               test.setNextResponse(resSuccess);
               test.form.submit();
               return Expect.wait(function () {
-                return $.ajax.calls.count() > 0;
+                return Util.numAjaxRequests() > 0;
               }, test);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                 '?autoPush=true&rememberDevice=false',
                   data: {
@@ -2605,17 +2621,17 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with correct args when autoPush is not checked', function () {
             return setupOktaPushWithRefreshAuth({'features.autoPush': true}).then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               setAutoPushCheckbox(test, false);
               test.setNextResponse(resSuccess);
               test.form.submit();
               return Expect.wait(function () {
-                return $.ajax.calls.count() > 0;
+                return Util.numAjaxRequests() > 0;
               }, test);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                 '?autoPush=false&rememberDevice=false',
                   data: {
@@ -2630,9 +2646,9 @@ function (Okta,
                 setRememberDeviceForPushForm(test, true);
                 return setupPolling(test, resSuccess)
                   .then(function () {
-                    expect($.ajax.calls.count()).toBe(3);
+                    expect(Util.numAjaxRequests()).toBe(3);
                     // initial verifyFactor call
-                    Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                    Expect.isJsonPost(Util.getAjaxRequest(0), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?rememberDevice=true',
                       data: {
                         stateToken: 'testStateToken'
@@ -2640,7 +2656,7 @@ function (Okta,
                     });
 
                     // first startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                    Expect.isJsonPost(Util.getAjaxRequest(1), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify',
                       data: {
                         stateToken: 'testStateToken'
@@ -2648,7 +2664,7 @@ function (Okta,
                     });
 
                     // last startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                    Expect.isJsonPost(Util.getAjaxRequest(2), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify',
                       data: {
                         stateToken: 'testStateToken'
@@ -2662,9 +2678,9 @@ function (Okta,
                 setAutoPushCheckbox(test, true);
                 return setupPolling(test, resSuccess)
                   .then(function () {
-                    expect($.ajax.calls.count()).toBe(3);
+                    expect(Util.numAjaxRequests()).toBe(3);
                     // initial verifyFactor call
-                    Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                    Expect.isJsonPost(Util.getAjaxRequest(0), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=false',
                       data: {
@@ -2673,7 +2689,7 @@ function (Okta,
                     });
 
                     // first startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                    Expect.isJsonPost(Util.getAjaxRequest(1), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=false',
                       data: {
@@ -2682,7 +2698,7 @@ function (Okta,
                     });
 
                     // last startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                    Expect.isJsonPost(Util.getAjaxRequest(2), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=false',
                       data: {
@@ -2697,9 +2713,9 @@ function (Okta,
                 setAutoPushCheckbox(test, false);
                 return setupPolling(test, resSuccess)
                   .then(function () {
-                    expect($.ajax.calls.count()).toBe(3);
+                    expect(Util.numAjaxRequests()).toBe(3);
                     // initial verifyFactor call
-                    Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                    Expect.isJsonPost(Util.getAjaxRequest(0), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=false&rememberDevice=false',
                       data: {
@@ -2708,7 +2724,7 @@ function (Okta,
                     });
 
                     // first startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                    Expect.isJsonPost(Util.getAjaxRequest(1), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=false&rememberDevice=false',
                       data: {
@@ -2717,7 +2733,7 @@ function (Okta,
                     });
 
                     // last startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                    Expect.isJsonPost(Util.getAjaxRequest(2), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=false&rememberDevice=false',
                       data: {
@@ -2733,9 +2749,9 @@ function (Okta,
                 setRememberDeviceForPushForm(test, true);
                 return setupPolling(test, resSuccess)
                   .then(function () {
-                    expect($.ajax.calls.count()).toBe(3);
+                    expect(Util.numAjaxRequests()).toBe(3);
                     // initial verifyFactor call
-                    Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                    Expect.isJsonPost(Util.getAjaxRequest(0), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=true',
                       data: {
@@ -2744,7 +2760,7 @@ function (Okta,
                     });
 
                     // first startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                    Expect.isJsonPost(Util.getAjaxRequest(1), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=true',
                       data: {
@@ -2753,7 +2769,7 @@ function (Okta,
                     });
 
                     // last startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                    Expect.isJsonPost(Util.getAjaxRequest(2), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                     '?autoPush=true&rememberDevice=true',
                       data: {
@@ -2770,9 +2786,9 @@ function (Okta,
                   setRememberDeviceForPushForm(test, true);
                   return setupPolling(test, resSuccess)
                     .then(function () {
-                      expect($.ajax.calls.count()).toBe(3);
+                      expect(Util.numAjaxRequests()).toBe(3);
                       // initial verifyFactor call
-                      Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                      Expect.isJsonPost(Util.getAjaxRequest(0), {
                         url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                       '?autoPush=false&rememberDevice=true',
                         data: {
@@ -2781,7 +2797,7 @@ function (Okta,
                       });
 
                       // first startVerifyFactorPoll call
-                      Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                      Expect.isJsonPost(Util.getAjaxRequest(1), {
                         url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                       '?autoPush=false&rememberDevice=true',
                         data: {
@@ -2790,7 +2806,7 @@ function (Okta,
                       });
 
                       // last startVerifyFactorPoll call
-                      Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                      Expect.isJsonPost(Util.getAjaxRequest(2), {
                         url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
                       '?autoPush=false&rememberDevice=true',
                         data: {
@@ -2806,12 +2822,12 @@ function (Okta,
                   .then(function () {
                     expect(test.form.submitButton().attr('class')).toMatch('link-button-disabled');
                     expect(test.form.submitButton().prop('disabled')).toBe(true);
-                    $.ajax.calls.reset();
+                    Util.resetAjaxRequests();
                     test.form.submit();
                     return tick(test); // Final tick - SUCCESS
                   })
                   .then(function () {
-                    expect($.ajax.calls.count()).toBe(0);
+                    expect(Util.numAjaxRequests()).toBe(0);
                   });
               });
             });
@@ -2832,7 +2848,7 @@ function (Okta,
             });
             itp('sets transaction state to MFA_CHALLENGE before poll', function () {
               return setupOktaPushWithIntrospect().then(function (test) {
-                $.ajax.calls.reset();
+                Util.resetAjaxRequests();
                 test.setNextResponse(resChallengePush);
                 test.form.submit();
                 return Expect.wait(function () {
@@ -2851,7 +2867,7 @@ function (Okta,
                     };
                   });
 
-                  $.ajax.calls.reset();
+                  Util.resetAjaxRequests();
                   test.setNextResponse(resChallengePush);
                   test.form.submit();
 
@@ -2883,8 +2899,8 @@ function (Okta,
                   // reducing the timeout to 100 so that test is fast.
                   return setTimeout(arguments[0], 100);
                 });
-                $.ajax.calls.reset();
-                test.setNextResponse([resChallengePush, resAllFactors]);
+                Util.resetAjaxRequests();
+                test.setNextResponse([resChallengePush, resAllFactors, resInvalid]);
                 test.form[0].submit();
                 return Expect.wait(function () {
                   return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
@@ -2913,7 +2929,7 @@ function (Okta,
               return setupOktaPushWithIntrospect().then(function (test) {
                 appState =  test.router.controller.model.appState;
                 stopListening = spyOn(test.router.controller.model, 'stopListening').and.callThrough();
-                test.setNextResponse(resChallengePush);
+                test.setNextResponse([resChallengePush, resInvalid]);
                 test.form.submit();
                 expect(test.form.submitButton().prop('disabled')).toBe(true);
                 return Expect.wait(function () {
@@ -2935,22 +2951,27 @@ function (Okta,
                     expect(test.form.submitButton().prop('disabled')).toBe(false);
 
                     // Setup responses
-                    $.ajax.calls.reset();
+                    Util.resetAjaxRequests();
                     test.setNextResponse([resChallengePush, resChallengePush, resSuccess]);
 
                     // Click submit
                     test.form.submit();
+
+                    return Expect.waitForAjaxRequests(1, test) // 1: resChallengePush
+                      .then(() => {
+                        Util.callAllTimeouts();
+                        return Expect.waitForAjaxRequests(2, test); // 2: resChallengePush
+                      })
+                      .then(() => {
+                        Util.callAllTimeouts();
+                        return Expect.waitForAjaxRequests(3, test); // 3: resSuccess
+                      });
                   })
                   .then(function () {
-                    return Expect.wait(function () {
-                      return $.ajax.calls.count() === 3;
-                    }, test);
-                  })
-                  .then(function () {
-                    expect($.ajax.calls.count()).toBe(3);
+                    expect(Util.numAjaxRequests()).toBe(3);
 
                     // initial resendByName call
-                    Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                    Expect.isJsonPost(Util.getAjaxRequest(0), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify/resend',
                       data: {
                         stateToken: 'testStateToken'
@@ -2958,7 +2979,7 @@ function (Okta,
                     });
 
                     // first startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(1), {
+                    Expect.isJsonPost(Util.getAjaxRequest(1), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify',
                       data: {
                         stateToken: 'testStateToken'
@@ -2966,7 +2987,7 @@ function (Okta,
                     });
 
                     // last startVerifyFactorPoll call
-                    Expect.isJsonPost($.ajax.calls.argsFor(2), {
+                    Expect.isJsonPost(Util.getAjaxRequest(2), {
                       url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify',
                       data: {
                         stateToken: 'testStateToken'
@@ -2992,12 +3013,42 @@ function (Okta,
                   return setTimeout(arguments[0]);
                 });
                 var failureResponse = {status: 0, response: {}};
-                $.ajax.calls.reset();
-                Util.speedUpPolling(test.ac);
+                Util.resetAjaxRequests();
                 test.setNextResponse([resChallengePush, resChallengePush, failureResponse, failureResponse,
                   failureResponse, failureResponse, failureResponse, failureResponse]);
                 test.form.submit();
-                return Expect.waitForFormError(test.form, test);
+                return Expect.waitForAjaxRequests(1, test) // 1: resChallengePush
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(2, test); // 2: resChallengePush
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(3, test); // 3: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(4, test); // 4: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(5, test); // 5: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(6, test); // 6: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(7, test); // 7: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(8, test); // 8: failureResponse
+                  })
+                  .then(() => {
+                    return Expect.waitForFormError(test.form, test);
+                  });
               }
               return setupOktaPushWithIntrospect().then(function (test) {
                 spyOn(test.router.settings, 'callGlobalError');
@@ -3027,14 +3078,40 @@ function (Okta,
                   return setTimeout(arguments[0]);
                 });
                 var failureResponse = {status: 0, response: {}};
-                $.ajax.calls.reset();
-                Util.speedUpPolling(test.ac);
+                Util.resetAjaxRequests();
                 test.setNextResponse([resChallengePush, resChallengePush, failureResponse, failureResponse,
                   failureResponse, failureResponse, failureResponse, failureResponse]);
                 test.form.submit();
-                return Expect.wait(function () {
-                  return test.form.hasWarningMessage();
-                }, test);
+                return Expect.waitForAjaxRequests(1, test) // 1: resChallengePush
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(2, test); // 2: resChallengePush
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(3, test); // 3: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(4, test); // 4: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(5, test); // 5: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(6, test); // 6: failureResponse
+                  })
+                  .then(() => {
+                    Util.callAllTimeouts();
+                    return Expect.waitForAjaxRequests(7, test); // 7: failureResponse
+                  })
+                  .then(() => {
+                    return Expect.wait(function () {
+                      return test.form.hasWarningMessage();
+                    }, test);
+                  });
               }
               return setupOktaPushWithIntrospect().then(function (test) {
                 spyOn(test.router.settings, 'callGlobalError');
@@ -3045,6 +3122,7 @@ function (Okta,
                     expect(test.form.submitButtonText()).toBe('Push sent!');
                     expect(test.form.warningMessage()).toBe(
                       'Haven\'t received a push notification yet? Try opening the Okta Verify App on your phone.');
+                    Util.callAllTimeouts();
                     return Expect.waitForFormError(test.form, test);
                   })
                   .then(function (test) {
@@ -3076,18 +3154,18 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with correct args when submitted', function () {
             return setupOktaPushWithTOTP().then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
               test.setNextResponse(resSuccess);
               test.form[1].inlineTOTPVerify().click();
               return Expect.wait(function () {
-                return $.ajax.calls.count() > 0;
+                return Util.numAjaxRequests() > 0;
               }, test);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=false',
                   data: {
                     passCode: '654321',
@@ -3104,7 +3182,7 @@ function (Okta,
                 return setupPolling(test, resRejectedPush)
                   .then(function () {
                     return Expect.wait(function () {
-                      return $.ajax.calls.count() === 3;
+                      return Util.numAjaxRequests() === 3;
                     }, test);
                   })
                   // Final response - REJECTED
@@ -3129,19 +3207,19 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with rememberDevice URL param', function () {
             return setupOktaPushWithTOTP().then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
               setRememberDeviceForPushForm(test, true);
               test.setNextResponse(resSuccess);
               test.form[1].inlineTOTPVerify().click();
               return Expect.wait(function () {
-                return $.ajax.calls.count() > 0;
+                return Util.numAjaxRequests() > 0;
               }, test);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=true',
                   data: {
                     passCode: '654321',
@@ -3172,13 +3250,13 @@ function (Okta,
             return setupOktaPushWithTOTP()
               .then(function (test) {
                 var form = test.form[1];
-                $.ajax.calls.reset();
+                Util.resetAjaxRequests();
                 form.inlineTOTPAdd().click();
                 form.inlineTOTPVerify().click();
                 return Expect.waitForFormError(form, form);
               })
               .then(function (form) {
-                expect($.ajax).not.toHaveBeenCalled();
+                expect(Util.numAjaxRequests()).toBe(0);
                 expect(form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
                 expect(form.passCodeErrorField().text()).toBe('This field cannot be left blank');
               });
@@ -3248,8 +3326,8 @@ function (Okta,
         });
         itp('makes the right init request', function () {
           return setupDuo().then(function () {
-            expect($.ajax.calls.count()).toBe(2);
-            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+            expect(Util.numAjaxRequests()).toBe(2);
+            Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify?rememberDevice=false',
               data: {
                 stateToken: 'testStateToken'
@@ -3260,7 +3338,7 @@ function (Okta,
         itp('makes the correct request when rememberDevice is checked', function () {
           return setupDuo()
             .then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.form.setRememberDevice(true);
               test.setNextResponse(resSuccess);
               // Duo callback (returns an empty response)
@@ -3274,8 +3352,8 @@ function (Okta,
               return Expect.waitForSpyCall(test.successSpy, test);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(2);
-              Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              expect(Util.numAjaxRequests()).toBe(2);
+              Expect.isJsonPost(Util.getAjaxRequest(1), {
                 url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify?rememberDevice=true',
                 data: {
                   stateToken: 'testStateToken'
@@ -3295,7 +3373,7 @@ function (Okta,
         itp('notifies okta when duo is done, and completes verification', function () {
           return setupDuo()
             .then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               // Duo callback (returns an empty response)
               test.setNextResponse({
@@ -3308,16 +3386,16 @@ function (Okta,
               return Expect.waitForSpyCall(test.successSpy, test);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(2);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(2);
+              Expect.isFormPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify/response',
                 data: {
-                  id: 'ost947vv5GOSPjt9C0g4',
-                  stateToken: 'testStateToken',
-                  sig_response: 'someSignedResponse'
+                  id: ['ost947vv5GOSPjt9C0g4'],
+                  stateToken: ['testStateToken'],
+                  sig_response: ['someSignedResponse']
                 }
               });
-              Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              Expect.isJsonPost(Util.getAjaxRequest(1), {
                 url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify',
                 data: {
                   stateToken: 'testStateToken'
@@ -3367,8 +3445,8 @@ function (Okta,
                 'NONCE',
                 [{ id: 'credentialId' }]
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/webauthnFactorId/verify',
                 data: {
                   authenticatorData: 'authenticatorData1234',
@@ -3390,7 +3468,7 @@ function (Okta,
             })
             .then(function (test) {
               expect(test.form.el('o-form-error-html').length).toBe(0);
-              expect($.ajax.calls.count()).toBe(2);
+              expect(Util.numAjaxRequests()).toBe(2);
             });
         });
 
@@ -3408,7 +3486,7 @@ function (Okta,
               expect(test.form.errorBox().text().trim())
                 .toBe('Windows Hello is not configured. Select the Start button, ' +
                     'then select Settings - Accounts - Sign-in to configure Windows Hello.');
-              expect($.ajax.calls.count()).toBe(2);
+              expect(Util.numAjaxRequests()).toBe(2);
             });
         });
 
@@ -3426,7 +3504,7 @@ function (Okta,
               expect(test.form.errorBox().text().trim())
                 .toBe('Your Windows Hello enrollment does not match our records. ' +
                     'Select another factor or contact your administrator for assistance.');
-              expect($.ajax.calls.count()).toBe(2);
+              expect(Util.numAjaxRequests()).toBe(2);
             });
         });
 
@@ -3569,8 +3647,8 @@ function (Okta,
                 [ { version: 'U2F_V2', keyHandle: 'someCredentialId' } ],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2fFactorId/verify?rememberDevice=false',
                 data: {
                   clientData: 'someClientData',
@@ -3602,8 +3680,8 @@ function (Okta,
                 [ { version: 'U2F_V2', keyHandle: 'someCredentialId' } ],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2fFactorId/verify?rememberDevice=true',
                 data: {
                   clientData: 'someClientData',
@@ -3615,7 +3693,7 @@ function (Okta,
         });
 
         itp('shows an error if u2f.sign fails', function () {
-          Q.stopUnhandledRejectionTracking();
+          Expect.allowUnhandledPromiseRejection();
           var signStub = function (appId, nonce, registeredKeys, callback) {
             callback({ errorCode: 2 });
           };
@@ -3717,15 +3795,15 @@ function (Okta,
         });
         itp('calls authClient verifyFactor with rememberDevice URL param', function () {
           return setupCustomSAMLFactor().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'http://rain.okta1.com:1802/api/v1/authn/factors/customFactorId/verify?rememberDevice=true',
                 data: {
                   stateToken: 'testStateToken'
@@ -3802,15 +3880,15 @@ function (Okta,
         });
         itp('calls authClient verifyFactor with rememberDevice URL param', function () {
           return setupCustomOIDCFactor().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'http://rain.okta1.com:1802/api/v1/authn/factors/customFactorId/verify?rememberDevice=true',
                 data: {
                   stateToken: 'testStateToken'
@@ -3897,15 +3975,15 @@ function (Okta,
         });
         itp('calls authClient verifyFactor with rememberDevice URL param', function () {
           return setupClaimsProviderFactorWithIntrospect().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'http://rain.okta1.com:1802/api/v1/authn/factors/claimsProviderFactorId/verify?rememberDevice=true',
                 data: {
                   stateToken: 'testStateToken'
@@ -4000,15 +4078,15 @@ function (Okta,
           });
           itp('calls authClient verifyFactor with rememberDevice URL param', function () {
             return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               test.form.setRememberDevice(true);
               test.form.submit();
               return Expect.waitForSpyCall(test.successSpy);
             })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'http://rain.okta1.com:1802/api/v1/authn/factors/claimsProviderFactorId/verify?rememberDevice=true',
                   data: {
                     stateToken: 'testStateToken'
@@ -4069,7 +4147,7 @@ function (Okta,
               return Expect.waitForVerifyQuestion(test);
             })
               .then(function (test) {
-                $.ajax.calls.reset();
+                Util.resetAjaxRequests();
                 test.setNextResponse(resSuccess);
                 test.questionForm = new MfaVerifyForm($sandbox.find('.o-form'));
                 test.questionForm.setAnswer('food');
@@ -4077,8 +4155,8 @@ function (Okta,
                 return Expect.waitForSpyCall(test.successSpy);
               })
               .then(function () {
-                expect($.ajax.calls.count()).toBe(1);
-                Expect.isJsonPost($.ajax.calls.argsFor(0), {
+                expect(Util.numAjaxRequests()).toBe(1);
+                Expect.isJsonPost(Util.getAjaxRequest(0), {
                   url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=false',
                   data: {
                     answer: 'food',
@@ -4156,15 +4234,15 @@ function (Okta,
 
       itp('calls authClient verifyFactor with correct args when submitted', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g2/verify?rememberDevice=false',
               data: {
                 passCode: '123456',
@@ -4176,7 +4254,7 @@ function (Okta,
 
       itp('calls authClient verifyFactor with correct args when submitted when rememberDevice is checked', function () {
         return setupFn().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.form.setRememberDevice(true);
           test.setNextResponse(resSuccess);
@@ -4184,8 +4262,8 @@ function (Okta,
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g2/verify?rememberDevice=true',
               data: {
                 passCode: '123456',
@@ -4204,7 +4282,7 @@ function (Okta,
       switchFactorTest(setupSMS, setupOktaPushWithTOTP, setupGoogleTOTPAutoPushTrue, resAllFactors, resSuccess, resChallengeSms, 'testStateToken');
       itp('Verify DUO after switching from SMS MFA_CHALLENGE', function () {
         return setupSMS().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.smsSendCode().click();
           return Expect.wait(function () {
@@ -4227,7 +4305,7 @@ function (Okta,
           return setupPolling(test, resRejectedPush)
             .then(function () { return tick(test); }) // Final response - REJECTED
             .then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse([resAllFactors, resSuccess]);
               test.totpForm = new MfaVerifyForm($($sandbox.find('.o-form')[1]));
               // click or enter code in the the Totp form
@@ -4235,19 +4313,19 @@ function (Okta,
               test.totpForm.setAnswer('654321');
               test.totpForm.inlineTOTPVerify().click();
               return Expect.wait(function () {
-                return $.ajax.calls.count() === 2;
+                return Util.numAjaxRequests() === 2;
               }, test);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(2);
+              expect(Util.numAjaxRequests()).toBe(2);
               // MFA_CHALLENGE to MFA_REQUIRED
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/previous',
                 data: {
                   stateToken: 'testStateToken'
                 }
               });
-              Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              Expect.isJsonPost(Util.getAjaxRequest(1), {
                 url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=false',
                 data: {
                   passCode: '654321',
@@ -4287,7 +4365,7 @@ function (Okta,
           // during polling).
           return setupPolling(test, resTimeoutPush)
             .then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse([resAllFactors, resSuccess]);
               test.totpForm = new MfaVerifyForm($($sandbox.find('.o-form')[1]));
               // click or enter code in the the Totp form
@@ -4295,12 +4373,12 @@ function (Okta,
               test.totpForm.setAnswer('654321');
               test.totpForm.inlineTOTPVerify().click();
               return Expect.wait(function () {
-                return $.ajax.calls.count() === 2;
+                return Util.numAjaxRequests() === 2;
               }, test);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(2);
-              Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              expect(Util.numAjaxRequests()).toBe(2);
+              Expect.isJsonPost(Util.getAjaxRequest(1), {
                 url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=false',
                 data: {
                   passCode: '654321',
@@ -4406,6 +4484,9 @@ function (Okta,
           })
           .then(function (test) {
             expectHasRightBeaconImage(test, 'mfa-u2f');
+            return Expect.waitForSpyCall(window.addEventListener, test);
+          })
+          .then(function (test) {
             Util.triggerBrowserBackButton();
             return tick(test);
           })
@@ -4421,7 +4502,7 @@ function (Okta,
       itp('is NOT TRAPPED when Mfa verify follows password re-auth', function () {
         return setupPassword().then(function (test) {
           spyOn(RouterUtil, 'handleResponseStatus').and.callThrough();
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
           test.form.setRememberDevice(true);
           test.setNextResponse(resAllFactors);
@@ -4562,8 +4643,8 @@ function (Okta,
                   { version: 'U2F_V2', keyHandle: 'someCredentialId3' }],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2f/verify?rememberDevice=false',
                 data: {
                   clientData: 'someClientData',
@@ -4597,8 +4678,8 @@ function (Okta,
                   { version: 'U2F_V2', keyHandle: 'someCredentialId3' }],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2f/verify?rememberDevice=true',
                 data: {
                   clientData: 'someClientData',
@@ -4610,7 +4691,7 @@ function (Okta,
         });
 
         itp('shows an error if u2f.sign fails', function () {
-          Q.stopUnhandledRejectionTracking();
+          Expect.allowUnhandledPromiseRejection();
           var signStub = function (appId, nonce, registeredKeys, callback) {
             callback({ errorCode: 2 });
           };
@@ -4709,8 +4790,8 @@ function (Okta,
                   { version: 'U2F_V2', keyHandle: 'someCredentialId3' }],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2f/verify?rememberDevice=false',
                 data: {
                   clientData: 'someClientData',
@@ -4744,8 +4825,8 @@ function (Okta,
                   { version: 'U2F_V2', keyHandle: 'someCredentialId3' }],
                 jasmine.any(Function)
               );
-              expect($.ajax.calls.count()).toBe(3);
-              Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              expect(Util.numAjaxRequests()).toBe(3);
+              Expect.isJsonPost(Util.getAjaxRequest(2), {
                 url: 'https://foo.com/api/v1/authn/factors/u2f/verify?rememberDevice=true',
                 data: {
                   clientData: 'someClientData',
@@ -4757,7 +4838,7 @@ function (Okta,
         });
 
         itp('shows an error if u2f.sign fails', function () {
-          Q.stopUnhandledRejectionTracking();
+          Expect.allowUnhandledPromiseRejection();
           var signStub = function (appId, nonce, registeredKeys, callback) {
             callback({ errorCode: 2 });
           };
@@ -4824,15 +4905,15 @@ function (Okta,
 
         itp('calls factorType-url with correct args', function () {
           return setupMultipleOktaTOTP().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
                 data: {
                   passCode: '123456',
@@ -4844,7 +4925,7 @@ function (Okta,
 
         itp('calls factorType-url with correct args and rememberDevice URL param', function () {
           return setupMultipleOktaTOTP().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.form.setRememberDevice(true);
             test.setNextResponse(resSuccess);
@@ -4852,8 +4933,8 @@ function (Okta,
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=true',
                 data: {
                   passCode: '123456',
@@ -4907,14 +4988,14 @@ function (Okta,
 
         itp('calls verifyFactor with correct args for 1st push on the list', function () {
           return setupMultipleOktaPush().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush1/verify?rememberDevice=false',
                 data: {
                   stateToken: 'testStateToken'
@@ -4931,14 +5012,14 @@ function (Okta,
           })
             .then(function (test) {
               test.form = getPageForm();
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               test.form.submit();
               return Expect.waitForSpyCall(test.successSpy);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush2/verify?rememberDevice=false',
                 data: {
                   stateToken: 'testStateToken'
@@ -5044,7 +5125,7 @@ function (Okta,
 
         itp('calls factorType-url with correct args for 1st TOTP on the list', function () {
           return setupMultipleOktaVerify().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form[1].inlineTOTPAdd().click();
             test.form[1].setAnswer('654321');
             test.setNextResponse(resSuccess);
@@ -5052,8 +5133,8 @@ function (Okta,
             return tick();
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
                 data: {
                   passCode: '654321',
@@ -5065,14 +5146,14 @@ function (Okta,
 
         itp('calls verifyFactor with correct args for 1st push on the list', function () {
           return setupMultipleOktaVerify().then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form[0].submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush1/verify?rememberDevice=false',
                 data: {
                   stateToken: 'testStateToken'
@@ -5088,7 +5169,7 @@ function (Okta,
             return tick(test);
           })
             .then(function (test) {
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.form = getPageForm();
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
@@ -5097,8 +5178,8 @@ function (Okta,
               return tick();
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
                 data: {
                   passCode: '654321',
@@ -5116,14 +5197,14 @@ function (Okta,
           })
             .then(function (test) {
               test.form = getPageForm();
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               test.form[0].submit();
               return Expect.waitForSpyCall(test.successSpy);
             })
             .then(function () {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush2/verify?rememberDevice=false',
                 data: {
                   stateToken: 'testStateToken'

--- a/test/unit/spec/OAuth2Util_spec.js
+++ b/test/unit/spec/OAuth2Util_spec.js
@@ -4,10 +4,9 @@ define(['util/OAuth2Util'], function (Util) {
   function assertAuthParams (response, extras) {
     // Contains default key/value pairs
     var defaults = {
-      issuer: 'default',
       display: 'page',
-      responseMode: 'fragment',
-      responseType: ['id_token']
+      responseType: ['id_token', 'token'],
+      scopes: ['email', 'openid']
     };
 
     expect(response.authParams).toEqual(jasmine.objectContaining(Object.assign(defaults, extras)));
@@ -56,29 +55,25 @@ define(['util/OAuth2Util'], function (Util) {
     });
 
     describe('getResponseType', function () {
-      it('returns an array containing "id_token" when getIdToken is set to true', function () {
+      it('returns an array containing "id_token" and "token" by deault', function () {
         expect(Util.getResponseType({
-          getIdToken: true
-        })).toEqual(['id_token']);
-      });
-      it('returns an array containing "id_token" by default', function () {
-        expect(Util.getResponseType({})).toEqual(['id_token']);
-      });
-      it('returns an empty Array when getIdToken is set to false', function () {
-        expect(Util.getResponseType({
-          getIdToken: false
-        })).toEqual([]);
-      });
-      it('returns an array containing "id_token" and "token" when getAccessToken is set to true', function () {
-        expect(Util.getResponseType({
-          getAccessToken: true
         })).toEqual(['id_token', 'token']);
       });
-      it('returns an array containing "token" when getAccessToken is set to true and getIdToken is false', function () {
+      it('returns an array containing "token" when getIdToken is set to false', function () {
         expect(Util.getResponseType({
-          getAccessToken: true,
           getIdToken: false
         })).toEqual(['token']);
+      });
+      it('returns an array containing "id_token" when getAccessToken is set to false', function () {
+        expect(Util.getResponseType({
+          getAccessToken: false
+        })).toEqual(['id_token']);
+      });
+      it('returns an empty array when getAccessToken is set to false and getIdToken is false', function () {
+        expect(Util.getResponseType({
+          getAccessToken: false,
+          getIdToken: false
+        })).toEqual([]);
       });
     });
 
@@ -118,32 +113,22 @@ define(['util/OAuth2Util'], function (Util) {
         assertAuthParams(renderOptions, { scopes: ['foo', 'openid'] });
       });
 
-      it('updates the responseType given getAccessToken key', function () {
+      it('updates the responseType if getAccessToken=false', function () {
         var options = {
           clientId: 'foo',
-          getAccessToken: true
+          getAccessToken: false
         };
         var renderOptions = Util.transformShowSignInToGetTokensOptions(options);
-        assertAuthParams(renderOptions, { responseType: ['id_token', 'token'], scopes: ['openid'] });
+        assertAuthParams(renderOptions, { responseType: ['id_token'] });
       });
 
-      it('updates the responseType given getAccessToken is truthy and getIdToken is falsey', function () {
+      it('updates the responseType and scope if getIdToken is falsey', function () {
         var options = {
           clientId: 'foo',
-          getAccessToken: true,
           getIdToken: false
         };
         var renderOptions = Util.transformShowSignInToGetTokensOptions(options);
-        assertAuthParams(renderOptions, { responseType: ['token'] });
-      });
-
-      it('maps the authorizationServerId key to issuer', function () {
-        var options = {
-          clientId: 'foo',
-          authorizationServerId: 'abc123'
-        };
-        var renderOptions = Util.transformShowSignInToGetTokensOptions(options);
-        assertAuthParams(renderOptions, { issuer: 'abc123' });
+        assertAuthParams(renderOptions, { responseType: ['token'], scopes: ['email'] });
       });
 
       it('returns a complex object, overriding the basic Widget configuration options', function () {

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -81,9 +81,9 @@ function (Widget, Expect, Logger, Util, $sandbox, idxResponse, introspectRespons
         it('SIW passes all config within authParams to OktaAuth', function () {
           const authParams = {
             // known params
-            issuer: 'my-issuer',
+            issuer: 'https://my-issuer',
             authorizeUrl: 'fake-url',
-            pkce: true,
+            pkce: false,
           };
           signIn = new Widget({
             baseUrl: url,
@@ -251,6 +251,7 @@ function (Widget, Expect, Logger, Util, $sandbox, idxResponse, introspectRespons
     });
 
     function setupIntrospect (responseData) {
+      spyOn(window.history, 'pushState');
       spyOn(signIn.authClient.tx, 'introspect').and.callFake(function () {
         if (responseData.status !== 200) {
           return Q.reject(responseData.response);
@@ -268,6 +269,7 @@ function (Widget, Expect, Logger, Util, $sandbox, idxResponse, introspectRespons
     Expect.describe('Introspects token and loads primary auth view for old pipeline', function () {
       it('calls introspect API on page load using authjs as client', function () {
         return setupIntrospect(introspectResponse).then(function () {
+          expect(window.history.pushState.calls.argsFor(0)[2]).toBe('/signin/refresh-auth-state/00stateToken');
           expect(signIn.authClient.tx.introspect).toHaveBeenCalledWith({ stateToken: '00stateToken'});
           expect(form.isPrimaryAuth()).toBe(true);
           var password = form.passwordField();
@@ -287,6 +289,7 @@ function (Widget, Expect, Logger, Util, $sandbox, idxResponse, introspectRespons
 
       it('calls introspect API on page load and handles error using authjs as client', function () {
         return setupIntrospect(errorResponse).then(function () {
+          expect(window.history.pushState.calls.argsFor(0)[2]).toBe('/signin/refresh-auth-state/00stateToken');
           expect(signIn.authClient.tx.introspect).toHaveBeenCalledWith({ stateToken: '00stateToken'});
           expect(form.isPrimaryAuth()).toBe(true);
           var password = form.passwordField();

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 19], max-statements: [2, 25] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/PasswordExpiredForm',
@@ -22,7 +22,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
   $sandbox, resPassWarn, resPassExpired, resErrorComplexity,
   resErrorOldPass, resCustomPassWarn, resCustomPassExpired, resSuccess, resCancel) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
 
@@ -36,7 +36,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+    var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
@@ -175,10 +175,10 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
           .then(function (test) {
             spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resCancel);
             test.form.signout();
-            return Expect.waitForSpyCall($.ajax, test);
+            return Expect.waitForAjaxRequest(test);
           })
           .then(test => {
             // `clearLastAuthResponse` will be invoked when response has no `status`
@@ -186,8 +186,8 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
             return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
               data: {
                 stateToken: 'testStateToken'
@@ -203,10 +203,10 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
             .then(function (test) {
               spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
               spyOn(SharedUtil, 'redirect');
-              $.ajax.calls.reset();
+              Util.resetAjaxRequests();
               test.setNextResponse(resCancel);
               test.form.signout();
-              return Expect.waitForSpyCall($.ajax, test);
+              return Expect.waitForAjaxRequest(test);
             })
             .then(test => {
               // `clearLastAuthResponse` will be invoked when response has no `status`
@@ -214,8 +214,8 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
               return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
             })
             .then(function (test) {
-              expect($.ajax.calls.count()).toBe(1);
-              Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              expect(Util.numAjaxRequests()).toBe(1);
+              Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/cancel',
                 data: {
                   stateToken: 'testStateToken'
@@ -229,7 +229,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
         var processCredsSpy = jasmine.createSpy('processCredsSpy');
         return setup({ processCreds: processCredsSpy })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
             return Expect.waitForSpyCall(test.successSpy);
@@ -240,7 +240,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
               username: 'inca@clouditude.net',
               password: 'newpwd'
             });
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
           });
       });
       itp('calls async processCreds function before saving a model', function () {
@@ -252,7 +252,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
           }
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
             return Expect.waitForSpyCall(test.successSpy);
@@ -263,7 +263,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
               username: 'inca@clouditude.net',
               password: 'newpwd'
             }, jasmine.any(Function));
-            expect($.ajax.calls.count()).toBe(1);
+            expect(Util.numAjaxRequests()).toBe(1);
           });
       });
       itp('calls async processCreds function and can prevent saving a model', function () {
@@ -274,7 +274,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
           }
         })
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
             return Expect.waitForSpyCall(processCredsSpy);
@@ -285,19 +285,19 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
               username: 'inca@clouditude.net',
               password: 'newpwd'
             }, jasmine.any(Function));
-            expect($.ajax.calls.count()).toBe(0);
+            expect(Util.numAjaxRequests()).toBe(0);
           });
       });
       itp('saves the new password successfully', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpassyo', 'boopity', 'boopity');
           return Expect.waitForSpyCall(test.successSpy);
         })
           .then(function () {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/credentials/change_password',
               data: {
                 oldPassword: 'oldpassyo',
@@ -310,7 +310,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       itp('makes submit button disable when form is submitted', function () {
         return setup()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             submitNewPass(test, 'oldpass', 'newpass', 'newpass');
             return Expect.waitForSpyCall(test.successSpy, test);
@@ -324,7 +324,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       itp('makes submit button enabled after error response', function () {
         return setup()
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(resErrorOldPass);
             submitNewPass(test, 'wrongoldpass', 'boo', 'boo');
             test.form.submit();
@@ -418,9 +418,9 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       });
       itp('validates that fields are not empty', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.submit();
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.hasErrors()).toBe(true);
           Expect.isEmptyFieldError(test.form.oldPassFieldError());
           Expect.isEmptyFieldError(test.form.newPassFieldError());
@@ -430,9 +430,9 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
 
       itp('validates that new password is equal to confirm password', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           submitNewPass(test, 'newpass', 'differentnewpass');
-          expect($.ajax).not.toHaveBeenCalled();
+          expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.confirmPassFieldError().text())
             .toBe('New passwords must match');
@@ -538,11 +538,11 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       });
       itp('goToLink is called with the correct args on skip', function () {
         return setupWarn(4).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.skip();
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/skip',
             data: {
               stateToken: 'testStateToken'
@@ -553,14 +553,14 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       itp('goToLink is called with the correct args on sign out', function () {
         return setupWarn(4).then(function (test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resCancel);
           test.form.signout();
           return Expect.waitForPrimaryAuth(test);
         })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
               data: {
                 stateToken: 'testStateToken'

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -1,7 +1,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'helpers/mocks/Util',
   'helpers/dom/PasswordResetForm',
@@ -18,7 +18,7 @@ define([
 function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect, Router,
   $sandbox, resPasswordReset, resPasswordResetWithComplexity, resError, res200, resSuccess) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
 
@@ -84,7 +84,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
 
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+    var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
@@ -126,7 +126,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       return setup()
         .then(function (test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(res200);
           var $link = test.form.signoutLink();
           expect($link.length).toBe(1);
@@ -134,8 +134,8 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
           return Expect.waitForPrimaryAuth(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/cancel',
             data: {
               stateToken: 'testStateToken'
@@ -160,12 +160,12 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
           .then(function (test) {
             spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
             expect($link.length).toBe(1);
             $link.click();
-            return Expect.waitForSpyCall($.ajax, test);
+            return Expect.waitForAjaxRequest(test);
           })
           .then(test => {
             // `clearLastAuthResponse` will be invoked when response has no `status`
@@ -173,8 +173,8 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
             return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
               data: {
                 stateToken: 'testStateToken'
@@ -343,7 +343,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       var processCredsSpy = jasmine.createSpy('processCredsSpy');
       return setup({ processCreds: processCredsSpy })
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setNewPassword('newpwd');
           test.form.setConfirmPassword('newpwd');
@@ -356,7 +356,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
             username: 'administrator1@clouditude.net',
             password: 'newpwd'
           });
-          expect($.ajax.calls.count()).toBe(1);
+          expect(Util.numAjaxRequests()).toBe(1);
         });
     });
 
@@ -369,7 +369,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
         }
       })
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setNewPassword('newpwd');
           test.form.setConfirmPassword('newpwd');
@@ -382,7 +382,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
             username: 'administrator1@clouditude.net',
             password: 'newpwd'
           }, jasmine.any(Function));
-          expect($.ajax.calls.count()).toBe(1);
+          expect(Util.numAjaxRequests()).toBe(1);
         });
     });
 
@@ -394,7 +394,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
         }
       })
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setNewPassword('newpwd');
           test.form.setConfirmPassword('newpwd');
@@ -407,14 +407,14 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
             username: 'administrator1@clouditude.net',
             password: 'newpwd'
           }, jasmine.any(Function));
-          expect($.ajax.calls.count()).toBe(0);
+          expect(Util.numAjaxRequests()).toBe(0);
         });
     });
 
     itp('makes the right auth request when form is submitted', function () {
       return setup()
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setNewPassword('imsorrymsjackson');
           test.form.setConfirmPassword('imsorrymsjackson');
           test.setNextResponse(resSuccess);
@@ -422,8 +422,8 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
           return Expect.waitForSpyCall(test.successSpy);
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/credentials/reset_password',
             data: {
               newPassword: 'imsorrymsjackson',
@@ -437,7 +437,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       var dummySaveEventHnadler = jasmine.createSpy();
       return setup()
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           // Submit form will trigger `save` event and its handler will
           // 'disable' the button. Thus when the `dummySaveEventHnadler`
           // has been invoked, we could reason the `save` event has been
@@ -462,7 +462,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
     itp('makes submit button enabled after error response', function () {
       return setup()
         .then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setNewPassword('pwd');
           test.form.setConfirmPassword('pwd');
           test.setNextResponse(resError);
@@ -478,9 +478,9 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
 
     itp('validates that the fields are not empty before submitting', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.submit();
-        expect($.ajax).not.toHaveBeenCalled();
+        expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.hasErrors()).toBe(true);
         Expect.isEmptyFieldError(test.form.newPassFieldError());
         Expect.isEmptyFieldError(test.form.confirmPassFieldError());
@@ -489,11 +489,11 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
 
     itp('validates that the passwords match before submitting', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setNewPassword('a');
         test.form.setConfirmPassword('z');
         test.form.submit();
-        expect($.ajax).not.toHaveBeenCalled();
+        expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.hasErrors()).toBe(true);
       });
     });

--- a/test/unit/spec/RecoveryLoading_spec.js
+++ b/test/unit/spec/RecoveryLoading_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/Beacon',
   'helpers/dom/RecoveryQuestionForm',
@@ -16,13 +16,13 @@ define([
 function (Q, Okta, OktaAuth, Util, Beacon, RecoveryFormView, PrimaryAuthFormView,
   Expect, Router, resRecovery, resError, $sandbox) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
 
   function setup (settings, callRecoveryLoading, fail = false) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl});
+    var authClient = new OktaAuth({issuer: baseUrl});
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
       el: $sandbox,
@@ -65,8 +65,8 @@ function (Q, Okta, OktaAuth, Util, Beacon, RecoveryFormView, PrimaryAuthFormView
           return Expect.waitForRecoveryQuestion(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/token',
             data: {
               recoveryToken: 'SOMETOKEN'
@@ -82,8 +82,8 @@ function (Q, Okta, OktaAuth, Util, Beacon, RecoveryFormView, PrimaryAuthFormView
           return Expect.waitForRecoveryQuestion(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/token',
             data: {
               recoveryToken: 'SETTINGSTOKEN'
@@ -117,8 +117,8 @@ function (Q, Okta, OktaAuth, Util, Beacon, RecoveryFormView, PrimaryAuthFormView
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/token',
             data: {
               recoveryToken: 'foo'

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 16] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/RecoveryQuestionForm',
   'helpers/dom/Beacon',
@@ -17,14 +17,14 @@ define([
 function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
   $sandbox, resRecovery, resError, res200, resSuccess, resSuccessUnlock) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var SharedUtil = Okta.internal.util.Util;
   var itp = Expect.itp;
 
   function setup (settings, res) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl});
+    var authClient = new OktaAuth({issuer: baseUrl});
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
       el: $sandbox,
@@ -66,7 +66,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
       return setup()
         .then(function (test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.setNextResponse(res200);
           var $link = test.form.signoutLink();
           expect($link.length).toBe(1);
@@ -74,8 +74,8 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
           return Expect.waitForPrimaryAuth(test);
         })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/cancel',
             data: {
               stateToken: 'testStateToken'
@@ -91,7 +91,7 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
           .then(function (test) {
             spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.setNextResponse(res200);
             var $link = test.form.signoutLink();
             expect($link.length).toBe(1);
@@ -99,8 +99,8 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
             return Expect.waitForSpyCall(SharedUtil.redirect, test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
-            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+            expect(Util.numAjaxRequests()).toBe(1);
+            Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
               data: {
                 stateToken: 'testStateToken'
@@ -169,15 +169,15 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
     });
     itp('makes the right auth request when form is submitted', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccess);
         test.form.submit();
-        return Expect.waitForSpyCall($.ajax);
+        return Expect.waitForAjaxRequest();
       })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/answer',
             data: {
               answer: '4444',
@@ -188,15 +188,15 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
     });
     itp('shows unlock page when response is success with unlock recoveryType', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccessUnlock);
         test.form.submit();
         return Expect.waitForAccountUnlocked(test);
       })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/answer',
             data: {
               answer: '4444',
@@ -211,15 +211,15 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
     });
     itp('with OIDC configured, it shows unlock page when response is success with unlock recoveryType', function () {
       return setupOIDC().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccessUnlock);
         test.form.submit();
         return Expect.waitForAccountUnlocked(test);
       })
         .then(function (test) {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/answer',
             data: {
               answer: '4444',
@@ -234,9 +234,9 @@ function (Okta, OktaAuth, Util, RecoveryQuestionForm, Beacon, Expect, Router,
     });
     itp('validates that the answer is not empty before submitting', function () {
       return setup().then(function (test) {
-        $.ajax.calls.reset();
+        Util.resetAjaxRequests();
         test.form.submit();
-        expect($.ajax).not.toHaveBeenCalled();
+        expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.hasErrors()).toBe(true);
       });
     });

--- a/test/unit/spec/RefreshAuthState_spec.js
+++ b/test/unit/spec/RefreshAuthState_spec.js
@@ -1,7 +1,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/Beacon',
   'helpers/dom/Form',
@@ -14,13 +14,13 @@ define([
 function (Q, Okta, OktaAuth, Util, Beacon, FormView, Expect,
   Router, resEnroll, resSecurityImage, $sandbox) {
 
-  var { _, $ } = Okta;
+  var { _ } = Okta;
   var itp = Expect.itp;
 
   function setup (settings) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({ url: baseUrl });
+    var authClient = new OktaAuth({ issuer: baseUrl });
     var router = new Router(_.extend({
       el: $sandbox,
       baseUrl: baseUrl,
@@ -64,8 +64,8 @@ function (Q, Okta, OktaAuth, Util, Beacon, FormView, Expect,
           return Expect.waitForEnrollChoices();
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'a-token-in-cookie'
@@ -81,8 +81,8 @@ function (Q, Okta, OktaAuth, Util, Beacon, FormView, Expect,
           return Expect.waitForEnrollChoices();
         })
         .then(function () {
-          expect($.ajax.calls.count()).toBe(1);
-          Expect.isJsonPost($.ajax.calls.argsFor(0), {
+          expect(Util.numAjaxRequests()).toBe(1);
+          Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
             data: {
               stateToken: 'dummy-token',

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 17], max-statements:[2, 70] */
 define([
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/util/Expect',
   'helpers/dom/Beacon',
@@ -111,7 +111,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
     settings || (settings = {});
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl});
+    var authClient = new OktaAuth({issuer: baseUrl});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
@@ -213,7 +213,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         return setup({
           relayState: '%2Fapp%2FUserHome'
         }).then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setUserName('test@example.com');
           test.form.setPassword('Abcd1234');
           var model = test.router.controller.model;
@@ -223,7 +223,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
       });
       itp('sends relay state as undefined string with registration post if not set', function () {
         return setup().then(function (test) {
-          $.ajax.calls.reset();
+          Util.resetAjaxRequests();
           test.form.setUserName('test@example.com');
           test.form.setPassword('Abcd1234');
           var model = test.router.controller.model;
@@ -594,7 +594,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -624,7 +624,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             expect(test.form.getFieldByName('zip').length).toBe(1);
             expect(test.form.fieldPlaceholder('zip')).toBe('Zip');
           });
@@ -642,7 +642,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -668,7 +668,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -713,7 +713,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             expect(test.form.getFieldByName('zip').length).toBe(1);
             expect(test.form.fieldPlaceholder('zip')).toBe('Zip');
             expect(test.form.getFieldByName('countryCode').length).toBe(1);
@@ -756,7 +756,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -790,7 +790,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         return setup(setting)
           .then(function (test) {
             spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -823,7 +823,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test@example.com');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');
@@ -856,7 +856,7 @@ function (Okta, OktaAuth, Util, Expect, Beacon, RegForm, RegSchema,
         };
         return setup(setting)
           .then(function (test) {
-            $.ajax.calls.reset();
+            Util.resetAjaxRequests();
             test.form.setUserName('test');
             test.form.setPassword('Abcd1234');
             test.form.setFirstname('firstName');

--- a/test/unit/spec/VerifyPIV_spec.js
+++ b/test/unit/spec/VerifyPIV_spec.js
@@ -2,7 +2,7 @@
 define([
   'q',
   'okta',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'helpers/mocks/Util',
   'helpers/dom/PivForm',
   'helpers/dom/PrimaryAuthForm',
@@ -21,10 +21,10 @@ function (Q, Okta, OktaAuth, Util, PivForm, PrimaryAuthForm, Beacon, Expect,
   var { _ } = Okta;
   var itp = Expect.itp;
 
-  function setup (errorResponse, responseTextOnly) {
+  function setup (errorResponse) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl});
+    var authClient = new OktaAuth({issuer: baseUrl});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = new Router(_.extend({
@@ -43,7 +43,7 @@ function (Q, Okta, OktaAuth, Util, PivForm, PrimaryAuthForm, Beacon, Expect,
     Util.registerRouter(router);
     Util.mockRouterNavigate(router);
     spyOn(SharedUtil, 'redirect');
-    setNextResponse(errorResponse ? [errorResponse] : [resGet, resPost], responseTextOnly);
+    setNextResponse(errorResponse ? [errorResponse] : [resGet, resPost]);
     router.verifyPIV();
     return Expect.waitForVerifyPIV({
       router: router,
@@ -148,7 +148,7 @@ function (Q, Okta, OktaAuth, Util, PivForm, PrimaryAuthForm, Beacon, Expect,
         var res = deepClone(resError);
         res.responseType = 'text';
         res.response = '';
-        return setup(res, true).then(function (test) {
+        return setup(res).then(function (test) {
           return Expect.waitForFormError(test.form, test);
         }).then(function (test) {
           expect(test.form.hasErrors()).toBe(true);
@@ -162,7 +162,7 @@ function (Q, Okta, OktaAuth, Util, PivForm, PrimaryAuthForm, Beacon, Expect,
         res.responseType = 'text';
         res.response =
           '{"errorCode":"E0000004","errorSummary":"Authentication failed","errorLink":"E0000004","errorId":"oaeDtg9knyJR7agwMN-70SYgw","errorCauses":[]}';
-        return setup(res, true).then(function (test) {
+        return setup(res).then(function (test) {
           return Expect.waitForFormError(test.form, test);
         }).then(function (test) {
           expect(test.form.hasErrors()).toBe(true);

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -3,7 +3,7 @@
 define([
   'okta',
   'q',
-  '@okta/okta-auth-js/jquery',
+  '@okta/okta-auth-js',
   'util/Util',
   'util/CryptoUtil',
   'helpers/mocks/Util',
@@ -68,7 +68,7 @@ function (Okta,
   function setup (options) {
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+    var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });
@@ -176,7 +176,7 @@ function (Okta,
     mockWebauthn(options);
     var setNextResponse = Util.mockAjax();
     var baseUrl = 'https://foo.com';
-    var authClient = new OktaAuth({url: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
+    var authClient = new OktaAuth({issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR});
     var successSpy = jasmine.createSpy('success');
     var afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     var router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });
@@ -292,8 +292,8 @@ function (Okta,
           },
           signal: jasmine.any(Object)
         });
-        expect($.ajax.calls.count()).toBe(3);
-        Expect.isJsonPost($.ajax.calls.argsFor(2), {
+        expect(Util.numAjaxRequests()).toBe(3);
+        Expect.isJsonPost(Util.getAjaxRequest(2), {
           url: 'https://foo.com/api/v1/authn/factors/webauthn/verify?rememberDevice=false',
           data: {
             clientData: testClientData,
@@ -334,8 +334,8 @@ function (Okta,
           },
           signal: jasmine.any(Object)
         });
-        expect($.ajax.calls.count()).toBe(3);
-        Expect.isJsonPost($.ajax.calls.argsFor(2), {
+        expect(Util.numAjaxRequests()).toBe(3);
+        Expect.isJsonPost(Util.getAjaxRequest(2), {
           url: 'https://foo.com/api/v1/authn/factors/webauthn/verify?rememberDevice=true',
           data: {
             clientData: testClientData,
@@ -348,7 +348,7 @@ function (Okta,
     });
 
     itp('shows an error if navigator.credentials.get fails', function () {
-      Q.stopUnhandledRejectionTracking();
+      Expect.allowUnhandledPromiseRejection();
       return setupFn({
         webauthnSupported: true,
         signStatus: 'fail'
@@ -401,8 +401,8 @@ function (Okta,
           },
           signal: jasmine.any(Object)
         });
-        expect($.ajax.calls.count()).toBe(3);
-        Expect.isJsonPost($.ajax.calls.argsFor(2), {
+        expect(Util.numAjaxRequests()).toBe(3);
+        Expect.isJsonPost(Util.getAjaxRequest(2), {
           url: 'https://foo.com/api/v1/authn/factors/webauthnFactorId/verify?rememberDevice=false',
           data: {
             clientData: testClientData,
@@ -436,8 +436,8 @@ function (Okta,
           },
           signal: jasmine.any(Object)
         });
-        expect($.ajax.calls.count()).toBe(3);
-        Expect.isJsonPost($.ajax.calls.argsFor(2), {
+        expect(Util.numAjaxRequests()).toBe(3);
+        Expect.isJsonPost(Util.getAjaxRequest(2), {
           url: 'https://foo.com/api/v1/authn/factors/webauthnFactorId/verify?rememberDevice=true',
           data: {
             clientData: testClientData,
@@ -450,7 +450,7 @@ function (Okta,
     });
 
     itp('shows an error if navigator.credentials.get fails', function () {
-      Q.stopUnhandledRejectionTracking();
+      Expect.allowUnhandledPromiseRejection();
       return setupWebauthnFactor({
         webauthnSupported: true,
         signStatus: 'fail'

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -66,6 +66,12 @@ module.exports = function (outputFilename) {
           test: /\.json$/,
           loader: 'json-loader'
         },
+        // load external source maps
+        {
+          test: /\.js$/,
+          use: ['source-map-loader'],
+          enforce: 'pre'
+        }
       ]
     },
 

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -20,6 +20,9 @@ let widgetRc = {
       multiOptionalFactorEnroll: true
     },
     stateToken: 'dummy-state-token-wrc',
+    authParams: {
+      pkce: false // PKCE is enabled by default in okta-auth-js@3.0
+    },
     // Host the assets (i.e. jsonp files) locally
     assets: {
       baseUrl: '/'

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,17 +367,15 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
 
-"@okta/okta-auth-js@2.13.2":
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.13.2.tgz#94cc3f9cb621fa8f2f71eecc3cb025ad805bbd0f"
-  integrity sha512-fjPZATU286/cYTMiUY0PxItrukPNa3W3cwhEPCjeHYxb4EXCt8OdmPjaoKfvERALmLEHbNGqweqalTF5Q7x3wg==
+"@okta/okta-auth-js@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.0.0.tgz#8fc9d07e3e2906f6f2506fa92a483789892110fb"
+  integrity sha512-RD9R2JdNYKeg4OD6weRk/tHURVbC88L40ve2qZdbi1UrfdLyh3wlmrz5H/9H80my1t5JACZvUIR9MWnQaEapGA==
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"
     js-cookie "2.2.0"
     node-cache "^4.2.0"
-    q "1.4.1"
-    reqwest "2.0.5"
     tiny-emitter "1.1.0"
     xhr2 "0.1.3"
 
@@ -8544,10 +8542,6 @@ require-main-filename@^2.0.0:
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-
-reqwest@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/reqwest/-/reqwest-2.0.5.tgz#00fb15ac4918c419ca82b43f24c78882e66039a1"
 
 resolve-cwd@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Brings in [changes from AuthjS 3.0](https://github.com/okta/okta-auth-js/blob/master/CHANGELOG.md#300)
- PKCE is true by default
- PKCE will use responseMode=query by default
- jQuery removed from unit tests
- Q removed from AuthJS, replaced with standard promise
- showSignInToGetTokens changed:
  - getAccessToken is now `true` by default
  - `authorizationServerId` option has been removed from To specify a custom authorization server, use `authParams.issuer`. The issuer should be specified as a full URI, not just the server ID.
- minimum node version is 10