### PR TITLE
fix: update device trust flow page title with FastPass branding

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -639,6 +639,7 @@ deviceTrust.universalLink.fallback.getOktaMobile.title = Get Okta Mobile
 deviceTrust.universalLink.fallback.getOktaMobile.subtitle = Go to the {0}AppStore{1}, {0}search{1} for {0}Okta Mobile{1} and tap on {0}GET{1} Okta Mobile. Once installed, sign in to Okta Mobile and follow the instructions to secure your device.
 
 # Device Challenge Probing and Polling
+signin.with.fastpass = Signing in using Okta FastPass
 
 # Consent Required
 consent.required.text = <b>{0}</b> would like to:

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -46,7 +46,7 @@ const Body = BaseForm.extend(Object.assign(
       );
       switch (deviceChallenge.challengeMethod) {
       case 'LOOPBACK':
-        this.title = loc('signin', 'login');
+        this.title = loc('signin.with.fastpass', 'login');
         this.add('<div class="spinner"></div>');
         this.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
         break;

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -39,7 +39,7 @@ async function setup(t) {
 
 test(`probing and polling APIs are sent and responded`, async t => {
     const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
     await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -61,7 +61,7 @@ async function setupLoopbackFallback(t) {
 test
   .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)(`in loopback server approach, probing and polling requests are sent and responded`, async t => {
     const deviceChallengePollPageObject = await setupLoopbackSuccess(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign In');
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|6512/)
@@ -87,7 +87,7 @@ test
   .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)(`loopback fails and falls back to custom uri`, async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
-    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Signing in using Okta FastPass');
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)


### PR DESCRIPTION
OKTA-283791

This is a work for FastPass BETA feature for Oktane.

<img width="466" alt="Screen Shot 2020-03-17 at 3 26 44 PM" src="https://user-images.githubusercontent.com/5066836/76908795-d48a2e80-6866-11ea-8613-3c59be880fa3.png">
