### PR TITLE
fix: prevent additional polling request in OV enrollment

### DIFF
--- a/src/views/enroll-factors/ManualSetupPushFooter.js
+++ b/src/views/enroll-factors/ManualSetupPushFooter.js
@@ -39,28 +39,17 @@ define(['okta', 'util/RouterUtil'], function (Okta, RouterUtil) {
         e.preventDefault();
         var goToFactor = _.partial(goToFactorActivation, this.options.appState);
         this.options.appState.unset('factorActivationType');
-        if (this.options.appState.get('activatedFactorType') !== 'push') {
-          this.model.doTransaction(function (transaction) {
-            return transaction.prev()
-              .then(function (trans) {
-                var factor = _.findWhere(trans.factors, {
-                  factorType: 'push',
-                  provider: 'OKTA'
-                });
-                return factor.enroll();
+        this.model.doTransaction(function (transaction) {
+          return transaction.prev()
+            .then(function (trans) {
+              var factor = _.findWhere(trans.factors, {
+                factorType: 'push',
+                provider: 'OKTA'
               });
-          })
-            .then(goToFactor);
-        } else {
-          this.model.startTransaction(function (authClient) {
-            return authClient.tx.resume();
-          })
-            .then(function () {
-            // Sets to trigger on a tick after the appState has been set.
-            // This is due to calling the globalSuccessFn in a callback
-              setTimeout(goToFactor);
+              return factor.enroll();
             });
-        }
+        })
+          .then(goToFactor);
       }
     },
     back: function () {

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -740,17 +740,22 @@ function (Okta, OktaAuth, LoginUtil, Util, DeviceTypeForm, BarcodeForm,
           .then(function (test) {
             $.ajax.calls.reset();
             Expect.isVisible(test.manualSetupForm.form());
-            test.setNextResponse(pushEnrollSuccessNewQRRes);
-            Util.mockSDKCookie(test.ac);
+            test.setNextResponse([factorsWithPushRes, pushEnrollSuccessNewQRRes]);
             test.manualSetupForm.gotoScanBarcode();
             return Expect.waitForBarcodePush(test);
           })
           .then(function (test) {
-            expect($.ajax.calls.count()).toBe(1);
+            expect($.ajax.calls.count()).toBe(2);
             Expect.isJsonPost($.ajax.calls.argsFor(0), {
-              url: 'https://foo.com/api/v1/authn',
+              url: 'https://foo.com/api/v1/authn/previous',
+              data: { stateToken: expectedStateToken }
+            });
+            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              url: 'https://foo.com/api/v1/authn/factors',
               data: {
-                stateToken: 'testStateToken'
+                factorType: 'push',
+                provider: 'OKTA',
+                stateToken: expectedStateToken
               }
             });
             Expect.isVisible(test.scanCodeForm.form());


### PR DESCRIPTION
    * When enrolling OV with push the polling is reinitiated again when user
    navigates from 'scan QR code' to 'send link via sms' and back to 'scan QR code'.

    * We are not navigating by invoking trrans.prev rather starting a new one with resume which doesn't cancel the ongoing poll. 


   Fixing this by invoking prev and then calling factor.enroll when user wants to get back to QR code view. 


RESOLVES: OKTA-285071

**OV enroll with push (polling occurs only every 6 seconds) - even when user switches back and forth.**
https://okta.box.com/s/ff2ttflt9zvuca0qmev4xnznb0my9dp3

back to QR code after submitting wrong number sms 
 https://okta.box.com/s/9ol00xxrj993wwpp0srfm28isw52v1g8

**OV enroll without push - just totp (no polling)** 

https://okta.box.com/s/mbtivljm6wce9q2627vvr10z96qjbxxt
