### PR TITLE
feat: adds polling state for v1 pipeline

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -649,5 +649,8 @@ consent.required.privacyPolicy = Privacy Policy
 consent.required.consentButton = Allow Access
 consent.required.cancelButton = Don't Allow
 
+# Polling state
+polling.title = There are too many users trying to sign in right now. We will automatically retry in {0} seconds.
+
 ##--JSP page titles
 cert.authentication.title = Certificate authentication

--- a/src/LoginRouter.js
+++ b/src/LoginRouter.js
@@ -64,7 +64,8 @@ define([
   'EnrollUserController',
   'views/shared/SecurityBeacon',
   'views/shared/FactorBeacon',
-  'views/shared/PIVBeacon'
+  'views/shared/PIVBeacon',
+  'PollController',
 ],
 function (BaseLoginRouter,
   IDPDiscoveryController,
@@ -118,7 +119,8 @@ function (BaseLoginRouter,
   EnrollUserController,
   SecurityBeacon,
   FactorBeacon,
-  PIVBeacon) {
+  PIVBeacon,
+  PollController) {
   return BaseLoginRouter.extend({
 
     routes: {
@@ -126,6 +128,7 @@ function (BaseLoginRouter,
       'signin': 'primaryAuth',
       'signin/verify/duo/web': 'verifyDuo',
       'signin/verify/piv': 'verifyPIV',
+      'signin/poll': 'poll',
       'signin/verify/fido/webauthn': 'verifyWebauthn',
       'signin/verify/webauthn': 'verifyWebauthn',
       'signin/verify/fido/u2f': 'verifyU2F',
@@ -218,6 +221,10 @@ function (BaseLoginRouter,
 
     verifyPIV: function () {
       this.render(VerifyPIVController, { Beacon: PIVBeacon });
+    },
+
+    poll: function () {
+      this.render(PollController);
     },
 
     verifyWebauthn: function () {

--- a/src/PollController.js
+++ b/src/PollController.js
@@ -44,7 +44,7 @@ function (Okta, FormController) {
       },
 
       _startPolling: function () {
-        // start polling request
+        // start polling request 
         this.transaction.poll()
           .then((resp) => {
             this.options.appState.set('transaction', resp);
@@ -52,11 +52,11 @@ function (Okta, FormController) {
             let factorPollingIntervalSeconds = Math.floor(factorPollingInterval/1000);
             // start one second countdown for next poll request
             this.countDown  = setInterval(() => {
-              // update title
+              // update title after every second and check if countdown == 1 to poll again
               const title = Okta.loc('polling.title','login', [factorPollingIntervalSeconds]);
               this.$el.find('.okta-form-title').text(title);
               if (factorPollingIntervalSeconds === 1) {
-                // restart poll after countdown hit 1
+                // restart poll after countdown hits 1
                 this._stopPolling();
                 this._startPolling();
               } else {

--- a/src/PollController.js
+++ b/src/PollController.js
@@ -1,0 +1,102 @@
+/*!
+ * Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define([
+  'okta',
+  'util/FormController',
+],
+function (Okta, FormController) {
+  return FormController.extend({
+    className: 'poll',
+    Model: {
+      save: function () {
+        this.trigger('cancelRequest');
+        return this.appState.get('transaction').cancel()
+          .then(() => {
+            this.options.appState.trigger('navigate', '');
+          })
+          .fail(() => {
+            this._stopPolling();
+          });
+      },
+    },
+  
+    Form: {
+      autoSave: true,
+      hasSavingState: false,
+      title: function () {
+        return this.title;
+      },
+      className: 'poll-controller',
+      noCancelButton: true,
+      save: Okta.loc('oform.cancel', 'login'),
+      modelEvents: {
+        'cancelRequest': '_stopPolling'
+      },
+
+      _startPolling: function () {
+        // start polling request
+        this.transaction.poll()
+          .then((resp) => {
+            this.options.appState.set('transaction', resp);
+            const factorPollingInterval = resp.factor.profile.refresh;
+            let factorPollingIntervalSeconds = Math.floor(factorPollingInterval/1000);
+            // start one second countdown for next poll request
+            this.countDown  = setInterval(() => {
+              // update title
+              const title = Okta.loc('polling.title','login', [factorPollingIntervalSeconds]);
+              this.$el.find('.okta-form-title').text(title);
+              if (factorPollingIntervalSeconds === 1) {
+                // restart poll after countdown hit 1
+                this._stopPolling();
+                this._startPolling();
+              } else {
+                // reduce countdown after every second
+                factorPollingIntervalSeconds = factorPollingIntervalSeconds-1;
+              }
+            }, 1000);
+          })
+          .fail(()=> {
+            this._stopPolling();
+          });
+      },
+
+      _stopPolling: function () {
+        // clear polling
+        if (this.countDown) {
+          clearInterval(this.countDown);
+        }
+      },
+
+      initialize: function (options) {
+        this.transaction = options.appState.get('transaction');
+        this.factorPollingInterval = this.transaction.factor.profile.refresh;
+        const factorPollingIntervalSeconds = Math.floor(this.factorPollingInterval/1000);
+        this.title = Okta.loc('polling.title','login', [factorPollingIntervalSeconds]);
+      },
+  
+      postRender: function () {
+        this._startPolling(this.factorPollingInterval);
+      },
+    },
+  
+    back: function () {
+      // Empty function on verify controllers to prevent users
+      // from navigating back during 'verify' using the browser's
+      // back button. The URL will still change, but the view will not
+      // More details in OKTA-135060.
+    },
+  
+  });
+  
+});
+  

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 45], max-statements: [2, 30] */
+/* eslint complexity: [2, 46], max-statements: [2, 40] */
 define([
   'okta',
   './OAuth2Util',
@@ -230,6 +230,12 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
       router.navigate(url, { trigger: true });
       router.appState.clearLastFailedChallengeFactorData();
       return;
+
+    case 'POLL':
+      var pollUrl = 'signin/poll';
+      router.navigate(pollUrl, { trigger: true });
+      return;
+
     case 'MFA_CHALLENGE':
       // Since we normally trap MFA_CHALLENGE, this will only get called on a
       // page refresh or when an error is returned on verification with an IdP.

--- a/test/unit/helpers/dom/PollingForm.js
+++ b/test/unit/helpers/dom/PollingForm.js
@@ -1,0 +1,12 @@
+define(['./Form'], function (Form) {
+
+  return Form.extend({
+    pageTitle: function () {
+      return this.$('.poll-controller .okta-form-title');
+    },
+    cancelButton: function () {
+      return this.$('.poll-controller .o-form-button-bar input');
+    }
+  });
+
+});

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -287,6 +287,7 @@ define([
     VerifyCustomFactor: 'verify-custom-factor',
     EnrollUser: 'enroll-user',
     VerifyPIV: 'piv-cac-card',
+    Poll: 'poll',
   };
 
   _.each(controllerClasses, function (className, controller) {

--- a/test/unit/helpers/xhr/POLLING.js
+++ b/test/unit/helpers/xhr/POLLING.js
@@ -1,0 +1,39 @@
+define({
+  "status": 200,
+  "responseType": "json",
+  "response": {
+    "stateToken":"00_J1qxqyLs-6ZutUUWfbqm-1nqnW6n2o5z2wnBRHs",
+    "type":"SESSION_STEP_UP",
+    "expiresAt":"2020-03-23T17:09:34.000Z",
+    "status":"POLL",
+    "_embedded":{
+       "factor":{
+          "id":"okta-poll",
+          "factorType":"okta-poll",
+          "provider":"OKTA",
+          "profile":{
+             "refresh": 1000
+          }
+       }
+    },
+    "_links":{
+       "next":{
+          "name":"poll",
+          "href":"https://example.okta.com/api/v1/authn/factors/okta-poll/poll",
+          "hints":{
+             "allow":[
+                "POST"
+             ]
+          }
+       },
+       "cancel":{
+          "href":"https://example.okta.com/api/v1/authn/cancel",
+          "hints":{
+             "allow":[
+                "POST"
+             ]
+          }
+       }
+    }
+  }
+});

--- a/test/unit/helpers/xhr/POLLING.js
+++ b/test/unit/helpers/xhr/POLLING.js
@@ -12,7 +12,7 @@ define({
           "factorType":"okta-poll",
           "provider":"OKTA",
           "profile":{
-             "refresh": 1000
+             "refresh": 2000
           }
        }
     },

--- a/test/unit/spec/PollController_spec.js
+++ b/test/unit/spec/PollController_spec.js
@@ -1,0 +1,119 @@
+define([
+  'okta',
+  'q',
+  '@okta/okta-auth-js/jquery',
+  'helpers/mocks/Util',
+  'helpers/dom/PollingForm',
+  'helpers/util/Expect',
+  'LoginRouter',
+  'sandbox',
+  'helpers/xhr/POLLING',
+  'helpers/xhr/CANCEL',
+  'helpers/xhr/SUCCESS'
+],
+function (Okta, Q, OktaAuth, Util, PollingForm, Expect, Router, $sandbox, resPolling, resCancel, resSuccess) {
+
+  var { _, $ } = Okta;
+  var itp = Expect.itp;
+
+  function setup (settings, res) {
+    settings || (settings = {});
+    var successSpy = jasmine.createSpy('successSpy');
+    var setNextResponse = Util.mockAjax();
+    var baseUrl = window.location.origin;
+    var authClient = new OktaAuth({url: baseUrl});
+    var router = new Router(_.extend({
+      el: $sandbox,
+      baseUrl: baseUrl,
+      authClient: authClient,
+      globalSuccessFn: successSpy
+    }, settings));
+    Util.registerRouter(router);
+    Util.mockRouterNavigate(router);
+    Util.mockJqueryCss();
+    setNextResponse(res || [resPolling, resPolling, resPolling]);
+    router.refreshAuthState('polling-token');
+    settings = {
+      router: router,
+      successSpy: successSpy,
+      form: new PollingForm($sandbox),
+      ac: authClient,
+      setNextResponse: setNextResponse
+    };
+    return Expect.waitForPoll(settings);
+  }
+
+  Expect.describe('Polling', function () {
+    describe('PollingForm Content', function () {
+      itp('shows the correct content on load', function () {
+        return setup().then(function (test) {
+          const title = 'There are too many users trying to sign in right now. We will automatically retry in';
+          expect(test.form.pageTitle().text().trim()).toContain(title);
+        });
+      });
+      itp('has the cancel button', function () {
+        return setup().then(function (test) {
+          expect(test.form.cancelButton()).toExist();
+          expect(test.form.cancelButton().attr('value')).toBe('Cancel');
+          expect(test.form.cancelButton().attr('class')).toBe('button button-primary');
+        });
+      });
+      itp('cancel button click cancels the current stateToken and calls the cancel function', function () {
+        return setup({}, [resPolling, resPolling, resPolling, resCancel]).then(function (test) {
+          $.ajax.calls.reset();
+          test.setNextResponse(resCancel);
+          test.form.cancelButton().click();
+          return Expect.wait(function () {
+            return $.ajax.calls.count() > 0;
+          }, test);
+        })
+          .then(function () {
+            expect($.ajax.calls.count()).toBe(1);
+            Expect.isJsonPost($.ajax.calls.argsFor(0), {
+              url: 'https://example.okta.com/api/v1/authn/cancel',
+              data: {
+                stateToken: '00_J1qxqyLs-6ZutUUWfbqm-1nqnW6n2o5z2wnBRHs'
+              }
+            });
+          });
+      });
+    });
+  });
+
+  Expect.describe('Polling', function () {
+    describe('API', function () {
+      itp('starts polling on load', function () {
+        return setup({}, [resPolling, resPolling, resPolling, resSuccess]).then(function (test) {
+          return Expect.wait(function () {
+            return $.ajax.calls.count() > 3;
+          }, test);
+        })
+          .then(function () {
+            // first call is for refresh-auth
+            expect($.ajax).toHaveBeenCalledTimes(4);
+            // 1st poll
+            Expect.isJsonPost($.ajax.calls.argsFor(1), {
+              url: 'https://example.okta.com/api/v1/authn/factors/okta-poll/poll',
+              data: {
+                stateToken: '00_J1qxqyLs-6ZutUUWfbqm-1nqnW6n2o5z2wnBRHs'
+              }
+            });
+            // 2nd poll
+            Expect.isJsonPost($.ajax.calls.argsFor(2), {
+              url: 'https://example.okta.com/api/v1/authn/factors/okta-poll/poll',
+              data: {
+                stateToken: '00_J1qxqyLs-6ZutUUWfbqm-1nqnW6n2o5z2wnBRHs'
+              }
+            });
+            // 3rd poll
+            Expect.isJsonPost($.ajax.calls.argsFor(3), {
+              url: 'https://example.okta.com/api/v1/authn/factors/okta-poll/poll',
+              data: {
+                stateToken: '00_J1qxqyLs-6ZutUUWfbqm-1nqnW6n2o5z2wnBRHs'
+              }
+            });
+          });
+      });
+    });
+  });
+});

--- a/test/unit/spec/PollController_spec.js
+++ b/test/unit/spec/PollController_spec.js
@@ -47,8 +47,8 @@ function (Okta, Q, OktaAuth, Util, PollingForm, Expect, Router, $sandbox, resPol
     describe('PollingForm Content', function () {
       itp('shows the correct content on load', function () {
         return setup().then(function (test) {
-          const title = 'There are too many users trying to sign in right now. We will automatically retry in';
-          expect(test.form.pageTitle().text().trim()).toContain(title);
+          const title = 'There are too many users trying to sign in right now. We will automatically retry in 2 seconds.';
+          expect(test.form.pageTitle().text().trim()).toBe(title);
         });
       });
       itp('has the cancel button', function () {


### PR DESCRIPTION
Resolves: OKTA-282592
- Adds a polling state for V1 pipeline to handle use cases where we hit rate limits for an org this specifically for saml/oidc jit flows on a read_only server.
- When the widget receives this polling response, it will go into this state and poll the server till it gets back a non 429 response.
- It could take multiple attempts to login, where the user has to wait anywhere between 2-5 secs before each polling attempt.

@magizh-okta @petermiller-okta @taylorlaubach-okta @royalchan-okta 

@okta/idx 

Video : 

https://okta.box.com/s/j0tupa05se2g4s1b94f15nqiz53zvdns