### PR TITLE
fix: clean up warning callout for pre existing messages

### DIFF
--- a/assets/sass/modules/_social.scss
+++ b/assets/sass/modules/_social.scss
@@ -2,8 +2,7 @@
 // TODO: Remove this disable line!!
 /* stylelint-disable */
 @function unicode($str) {
-  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\"")
-}
+  @return unquote("\"")+unquote(str-insert($str, "\\", 1))+unquote("\""); }
 
 $facebook:                 unicode("e005");
 $google:                   unicode("e004");

--- a/assets/sass/v2/_forms.scss
+++ b/assets/sass/v2/_forms.scss
@@ -1,4 +1,9 @@
 .siw-main-view {
+  .infobox-warning {
+    display: block;
+    margin-bottom: 15px;
+  }
+
   .okta-form-subtitle {
     margin: 25px 0 10px;
     text-align: left;

--- a/playground/config/responseConfig.js
+++ b/playground/config/responseConfig.js
@@ -140,5 +140,5 @@ const appleCredentialSsoExtension = {
 };
 
 module.exports = {
-  mocks: authn,
+  mocks: idx,
 };

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -1,4 +1,4 @@
-import { Form, loc } from 'okta' ;
+import { Form, loc, createCallout } from 'okta' ;
 import FormInputFactory from './FormInputFactory';
 
 export default Form.extend({
@@ -15,6 +15,9 @@ export default Form.extend({
     const uiSchemas = this.getUISchema();
     const inputOptions = uiSchemas.map(FormInputFactory.create);
 
+    //should be used before adding any other input components
+    this.addCallouts();
+
     inputOptions.forEach(input => {
       this.addInputOrView(input);
     });
@@ -23,6 +26,8 @@ export default Form.extend({
   },
 
   saveForm (model) {
+    //remove any existing warnings or messages before saving form
+    this.$el.find('.o-form-error-container').empty();
     this.options.appState.trigger('saveForm', model);
   },
 
@@ -43,5 +48,16 @@ export default Form.extend({
       this.addInput(input);
     }
   },
+
+  addCallouts () {
+    const warningMsgs = this.options.appState.get('messages');
+    if (warningMsgs && warningMsgs.value.length) {
+      const messageCallout = createCallout({
+        content: warningMsgs.value[0].message,
+        type: 'warning',
+      });
+      this.add(messageCallout, '.o-form-error-container');
+    }
+  }
 
 });

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -1,4 +1,4 @@
-import { View, createCallout } from 'okta';
+import { View } from 'okta';
 import BaseForm from './BaseForm';
 import BaseModel from './BaseModel';
 import BaseHeader from './BaseHeader';
@@ -15,11 +15,10 @@ export default View.extend({
   className: 'siw-main-view',
 
   template: '<div class="siw-main-header"></div>' +
-      '<div class="siw-callout"></div>' +
       '<div class="siw-main-body"></div>' +
       '<div class="siw-main-footer"></div>',
 
-  initialize (options) {
+  initialize () {
     // Create Model
     const IonModel = this.createModelClass();
     const model = new IonModel ({
@@ -35,11 +34,6 @@ export default View.extend({
       },
     });
     this.add(this.Footer, { selector : '.siw-main-footer' });
-
-    // add callout for messages
-    if (options.messages && options.messages.value.length) {
-      this.showMessageCallout(options.messages.value[0].message, 'warning');
-    }
   },
 
   postRender () {
@@ -51,14 +45,6 @@ export default View.extend({
       return false;
     });
 
-  },
-
-  showMessageCallout (message, type) {
-    const messageCallout = createCallout({
-      content: message,
-      type: type,
-    });
-    this.add(messageCallout, '.siw-callout');
   },
 
   createModelClass () {

--- a/test/testcafe/README.md
+++ b/test/testcafe/README.md
@@ -2,16 +2,44 @@
 
 At root directory of okta-signin-widget
 
-All in once
+Use following commands to run testcafe tests. Make sure playground is not running and consuming the localhost port.
+Also make sure your .widgetrc file points to localhost:3000 instead of rain.
 
-- `yarn test:testcafe-run chrome`
+Run All
 
-Or start playground at one terminal and run the test in another terminal.
+- `yarn test:testcafe chrome`
+
+Run single Fixture
+
+- `yarn test:testcafe chrome -f "Unknown user form"`
+
+Run all similar Fixtures that matches the pattern
+
+- `yarn test:testcafe chrome -F "Unknown.*"`
+
+Run a single test
+
+- `yarn test:testcafe chrome -t "should have editable fields"`
+
+Run all similar tests that matches the pattern
+
+- `yarn test:testcafe chrome -T "should.*"`
+
+### To run testcafe without building playground each time you run test
+
+Start playground at one terminal and run the test in another terminal.
 Useful at development time in order to get quicker feedback.
 
 - `yarn test:testcafe-setup`
-- `yarn testcafe chrome test/testcafe/spec`
 
+- `yarn testcafe chrome test/testcafe/spec`
+- `yarn testcafe chrome test/testcafe/spec -T "should.*`
+
+Note: Above command directly runs testcafe which is different then test:testcafe
+
+Live reload test for faster development
+
+- `yarn testcafe chrome test/testcafe/spec -f "Unknown user form" --live`
 
 ## Guideline for writting test
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -52,6 +52,10 @@ export default class IdentityPageObject extends BasePageObject {
     return this.form.hasTextBoxErrorMessage('identifier');
   }
 
+  hasCallout() {
+    return !this.form.getCallout(CALLOUT_SELECTOR);
+  }
+
   getUnknownUserCalloutContent() {
     return this.form.getCallout(CALLOUT_SELECTOR).textContent;
   }

--- a/test/testcafe/spec/IdentityUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentityUnknownUser_spec.js
@@ -1,5 +1,6 @@
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import unknownUser from '../../../playground/mocks/idp/idx/data/unknown-user';
+import registeredUser from '../../../playground/mocks/idp/idx/data/select-factor-authenticate';
 import identify from '../../../playground/mocks/idp/idx/data/identify';
 import { RequestMock } from 'testcafe';
 
@@ -7,7 +8,9 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identify)
   .onRequestTo('http://localhost:3000/idp/idx')
-  .respond(unknownUser);
+  .respond(unknownUser)
+  .onRequestTo('http://localhost:3000/idp/idx')
+  .respond(registeredUser);
 
 fixture(`Unknown user form`)
   .requestHooks(mock);
@@ -24,4 +27,13 @@ test(`should show messages callout for unknown user`, async t => {
   await identityPage.clickNextButton();
   await t.expect(identityPage.getUnknownUserCalloutContent())
     .eql('There is no account with the email  test@rain.com .  Sign up  for an account');
+});
+
+test(`should remove messages callout for unknown user once successful`, async t => {
+  const identityPage = await setup(t);
+  await identityPage.fillIdentifierField('unknown');
+  await identityPage.clickNextButton();
+  await identityPage.fillIdentifierField('registered');
+  await identityPage.clickNextButton();
+  await t.expect(identityPage.hasCallout()).eql(false);
 });


### PR DESCRIPTION
## Description:
clean up warning callout for pre existing messages

 - removed static div and added callout in baseform instead

### Resolves : 
OKTA-255094

### Video:
![callout](https://user-images.githubusercontent.com/38230587/77806196-3f92ec80-7041-11ea-9447-e1fc1eb44a90.gif)
