### PR TITLE
fix: added a prepush hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ packages/@okta/courage-dist/*.html
 /dist
 .yalc
 .env
+.eslintcache
 testenv
 packages/@okta/i18n/src/json/
 packages/@okta/i18n/src/properties/*_in.*

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "build:webpack-e2e-app": "webpack target/e2e/app/app-using-osw-entry.js target/js/app-bundle.js",
     "prestart": "yarn build:dev",
     "prepublishOnly": "yarn build:release",
-    "mock:authenticator": "dyson playground/mocks/authenticator/ 6512"
+    "mock:authenticator": "dyson playground/mocks/authenticator/ 6512",
+    "prepush": "yarn lint:eslint --cache && yarn lint:stylelint --cache"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",


### PR DESCRIPTION
## Description:

- execute lint before pushing to siw repo, which will save running extra Travis builds that eventually fails with lint errors.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-288097](https://oktainc.atlassian.net/browse/OKTA-288097) 