### PR TITLE
feat: adds password complexity rules when password is expiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,8 @@ features: {
 
 - **features.showPasswordToggleOnSignInPage** - End users can now toggle visibility of their password on the Okta Sign-In page, allowing end users to check their password before they click Sign In. This helps prevent account lock outs caused by end users exceeding your org's permitted number of failed sign-in attempts. Note that passwords are visible for 30 seconds and then hidden automatically. Defaults to `false`.
 
+- **features.alwaysDisplayPasswordRules** - Display password complexity rules when the user's password is expiring soon in addition to when the password has expired.  Defaults to `false`.
+
 ## Events
 
 Events published by the widget. Subscribe to these events using [on](#onevent-callback-context).

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -68,7 +68,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
       },
       subtitle: function () {
         if (this.options.appState.get('isPwdExpiringSoon') && 
-            !this.settings.get('features.alwaysDisplayPasswordRules')) {
+          !this.settings.get('features.alwaysDisplayPasswordRules')) {
           return this.settings.get('brandName') ?
             Okta.loc('password.expiring.subtitle.specific', 'login', [this.settings.get('brandName')]) :
             Okta.loc('password.expiring.subtitle.generic', 'login');

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -67,7 +67,7 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
         }
       },
       subtitle: function () {
-        if (this.options.appState.get('isPwdExpiringSoon')) {
+        if (this.options.appState.get('isPwdExpiringSoon') && !this.settings.get('features.alwaysDisplayPasswordRules')) {
           return this.settings.get('brandName') ?
             Okta.loc('password.expiring.subtitle.specific', 'login', [this.settings.get('brandName')]) :
             Okta.loc('password.expiring.subtitle.generic', 'login');

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -67,7 +67,8 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
         }
       },
       subtitle: function () {
-        if (this.options.appState.get('isPwdExpiringSoon') && !this.settings.get('features.alwaysDisplayPasswordRules')) {
+        if (this.options.appState.get('isPwdExpiringSoon') && 
+            !this.settings.get('features.alwaysDisplayPasswordRules')) {
           return this.settings.get('brandName') ?
             Okta.loc('password.expiring.subtitle.specific', 'login', [this.settings.get('brandName')]) :
             Okta.loc('password.expiring.subtitle.generic', 'login');

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -92,6 +92,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
       'features.restrictRedirectToForeground': ['boolean', true, false],
       'features.hideDefaultTip': ['boolean', false, true],
+      'features.alwaysDisplayPasswordRules': ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -71,6 +71,12 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
     return setup(settings, resPassWarn);
   }
 
+  function setupWarnExcludeAttributes (excludeAttributesArray, settings) {
+    var policyComplexity = resPassWarn.response._embedded.policy.complexity;
+    policyComplexity.excludeAttributes = excludeAttributesArray;
+    return setup(settings, resPassWarn);
+  }
+
   function setupCustomExpiredPassword (settings, res) {
     return setup(settings, res || resCustomPassExpired, true);
   }
@@ -524,6 +530,12 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
       itp('has the correct subtitle if config has a brandName', function () {
         return setupWarn(4, { brandName: 'Spaghetti Inc.' }).then(function (test) {
           expect(test.form.subtitleText()).toBe('When password expires you will be locked out of your Spaghetti Inc. account.');
+        });
+      });
+      itp('has a valid subtitle if alwaysDisplayPasswordRules is True', function () {
+        return setupWarnExcludeAttributes([], { features: {alwaysDisplayPasswordRules: true} }).then(function (test) {
+          expect(test.form.subtitleText()).toEqual('Password requirements: at least 8 characters,' +
+            ' a lowercase letter, an uppercase letter, a number.');
         });
       });
       itp('has a sign out link', function () {


### PR DESCRIPTION
## Description:

Currently, the password complexity rule are only shown when a user's password has expired.  No rules are displayed during a "password is expiring soon" warning.  The feature flag `alwayDisplayPasswordRules` (defaults to "false") replaces the password warning subtitle with the complexity rules.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?




