### PR TITLE
feat: cancel transaction when Apple SSO Extension is not installed

### DIFF
--- a/playground/config/responseConfig.js
+++ b/playground/config/responseConfig.js
@@ -131,11 +131,8 @@ const appleCredentialSsoExtension = {
   '/idp/idx/introspect': [
     'identify-with-apple-credential-sso-extension',
   ],
-  '/idp/idx/authenticators/sso_extension/transactions/123/verify': [
+  '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel': [
     'identify'
-  ],
-  '/idp/idx': [
-    'error-email-verify',
   ],
 };
 

--- a/playground/mocks/idp/idx/cancel-sso-extension.js
+++ b/playground/mocks/idp/idx/cancel-sso-extension.js
@@ -1,0 +1,5 @@
+const templateHelper = require('../../../config/templateHelper');
+
+module.exports = templateHelper({
+  path: '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel',
+});

--- a/playground/mocks/idp/idx/data/identify-with-no-sso-extension.json
+++ b/playground/mocks/idp/idx/data/identify-with-no-sso-extension.json
@@ -1,0 +1,61 @@
+{
+  "stateHandle": "02IAickZV0j0TL0JaJJUxe4GnX7YHTeZY9pCYe-pBZ",
+  "version": "1.0.0",
+  "expiresAt": "2020-15T17:28:11.000Z",
+  "step": "IDENTIFY",
+  "intent": "LOGIN",
+  "remediation": {
+      "type": "array",
+      "value": [
+          {
+                "rel": ["create-form"],
+                "name": "cancel-transaction",
+                "href": "http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/456/verify/cancel",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "value": [
+                    {
+                       "name": "stateHandle",
+                       "value": "02IAickZV0j0TL0JaJJUxe4GnX7YHTeZY9pCYe-pBZ",
+                       "required": true,
+                       "visible": false
+                    }      
+                ]      
+          }
+      ]
+  },
+  "cancel": {
+      "rel": ["create-form"],
+      "name": "cancel",
+      "href": "http://localhost:3000/idp/idx/cancel",
+      "method": "POST",
+      "accepts": "application/ion+json;okta-version=1",
+      "produces": "application/ion+json;okta-version=1",
+      "value": [
+          {
+              "name": "stateHandle",
+              "value": "02IAickZV0j0TL0JaJJUxe4GnX7YHTeZY9pCYe-pBZ",
+              "required": true,
+              "visible": false
+          }
+      ]
+  },
+  "context": {
+      "rel": ["create-form"],
+      "name": "context",
+      "href": "http://localhost:3000/idp/idx/context",
+      "method": "POST",
+      "accepts": "application/ion+json;okta-version=1",
+      "produces": "application/ion+json;okta-version=1",
+      "value": [
+          {
+              "name": "stateHandle",
+              "value": "02IAickZV0j0TL0JaJJUxe4GnX7YHTeZY9pCYe-pBZ",
+              "required": true,
+              "visible": false,
+              "mutable": false
+          }
+      ]
+  }
+}

--- a/playground/mocks/idp/idx/post-sso-extension.js
+++ b/playground/mocks/idp/idx/post-sso-extension.js
@@ -1,5 +1,5 @@
 const templateHelper = require('../../../config/templateHelper');
-const identify = require('./data/identify');
+const cancelTransaction = require('./data/identify-with-no-sso-extension');
 
 module.exports = templateHelper({
   path: '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify',
@@ -9,6 +9,6 @@ module.exports = templateHelper({
     res.append('WWW-Authenticate', 'Oktadevicejwt realm="Okta Device"');
     next();
   },
-  template: identify, // TODO: find a way to improve this, now the mock config is not always on responseConfig
+  template: cancelTransaction, // TODO: find a way to improve this, now the mock config is not always on responseConfig
 });
 

--- a/scripts/update-se-drivers.sh
+++ b/scripts/update-se-drivers.sh
@@ -95,6 +95,9 @@ function setChromeDriverVersion() {
             80)
                 CHROME_DRIVER_VER=80.0.3987.16
             ;;
+            81)
+                CHROME_DRIVER_VER=81.0.4044.69
+            ;;
             *)
                 CHROME_DRIVER_VER=${DEFAULT_CHROME_DRIVER_VER}
             ;;

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -36,6 +36,9 @@ const VIEWS_MAPPING = {
   'device-apple-sso-extension': {
     [DEFAULT]: SSOExtensionView,
   },
+  'cancel-transaction': {
+    [DEFAULT]: SSOExtensionView,
+  },
   'select-factor': { //DEPRECATED: temporary backwards compatibility
     authenticate: SelectFactorAuthenticateView,
     enroll: SelectFactorEnrollView


### PR DESCRIPTION
## Description:

Add support to cancel transaction when Apple SSO Extension is not installed.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![siw-cancel-transaction](https://user-images.githubusercontent.com/5066836/78695270-bdad8980-78b2-11ea-8785-f39019d6d7f0.gif)


### Reviewers:
@aarongranick-okta @nikhilvenkatraman-okta 

### Issue:

- [OKTA-288101](https://oktainc.atlassian.net/browse/OKTA-288101)


