### PR TITLE
fix: provide instructions to user on how to proceed for E0000079

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -47,6 +47,7 @@ error.password.required = Please enter a password
 errors.E0000004 = Unable to sign in
 errors.E0000069 = Your account is locked because of too many authentication attempts.
 errors.E0000047 = You exceeded the maximum number of requests. Try again in a while.
+errors.E0000079 = The operation is not allowed. Please refresh the page to proceed.
 
 # ERROR MESSAGE TRANSLATIONS
 errors.E0000001 = Api validation failed: {0}
@@ -122,7 +123,6 @@ errors.E0000075 = Cannot modify the {0} attribute because it has a field mapping
 errors.E0000076 = Cannot modify the app user because it is mastered by an external app.
 errors.E0000077 = Cannot modify the {0} attribute because it is read-only.
 errors.E0000078 = Cannot modify the {0} attribute because it is immutable.
-errors.E0000079 = This operation is not allowed in the current authentication state.
 errors.E0000081 = Cannot modify the {0} attribute because it is a reserved attribute for this application.
 errors.E0000082 = Each code can only be used once. Please wait for a new code and try again.
 errors.E0000083 = PassCode is valid but exceeded time window.

--- a/test/unit/helpers/xhr/ERROR_OPERATION_NOT_ALLOWED.js
+++ b/test/unit/helpers/xhr/ERROR_OPERATION_NOT_ALLOWED.js
@@ -1,0 +1,15 @@
+define({
+  status: 403,
+  responseType: "json",
+  response: {
+    errorCode: 'E0000079',
+    errorSummary: 'This operation is not allowed in the current authentication state.',
+    errorLink: 'E0000079',
+    errorId: 'oaeAAjMfwlZS0C1N65KG8dG-g',
+    errorCause: [
+      {
+        errorSummary: 'This operation is not allowed in the current authentication state.'
+      }
+    ]
+  }
+});


### PR DESCRIPTION
* When user ends up in 'operation not allowed in current auth state'
We now override the error message to let the user know how to proceed.
ie) Refresh the page.

RESOLVES: OKTA-288059


<img width="470" alt="Screen Shot 2020-04-08 at 11 39 29 AM" src="https://user-images.githubusercontent.com/17267130/78821032-a7283080-798d-11ea-88be-2eca704046f9.png">



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


