### PR TITLE
fix: load custom uri from iframe

### DIFF
--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -22,6 +22,13 @@ const Body = BaseForm.extend(Object.assign(
 
     className: 'ion-form device-challenge-poll',
 
+    events: {
+      'click #launch-ov': function (e) {
+        e.preventDefault();
+        this.doCustomURI();
+      }
+    },
+
     initialize () {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.onPollingFail);
@@ -74,11 +81,6 @@ const Body = BaseForm.extend(Object.assign(
           }
         }));
       }
-    },
-
-    postRender () {
-      BaseForm.prototype.postRender.apply(this, arguments);
-      this.$('#launch-ov').on('click', this.doCustomURI.bind(this));
     },
 
     doLoopback (authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
@@ -141,7 +143,10 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     doCustomURI () {
-      this.customURI && Util.redirectWithFormGet(this.customURI);
+      this.ulDom && this.ulDom.remove();
+      this.ulDom = this.add(`
+        <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
+      `).last();
     },
   },
 

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -4,6 +4,7 @@ import BasePageObject from './BasePageObject';
 export default class DeviceChallengePollViewPageObject extends BasePageObject {
   constructor(t) {
     super(t);
+    this.t = t;
     this.body = new Selector('.device-challenge-poll');
     this.footer = new Selector('.auth-footer');
   }
@@ -26,5 +27,9 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
 
   async clickUniversalLink() {
     await this.t.click(Selector('.ul-button'));
+  }
+
+  async clickLaunchOktaVerifyLink() {
+    await this.t.click(this.body.find('#launch-ov'));
   }
 }


### PR DESCRIPTION
## Description:
This is moved from https://github.com/okta/okta-signin-widget/pull/1141 after rebased off master for the coming release.

Form redirect does not open custom URI in MacOS. The problem is fixed by loading the custom URI from iframe, where the iframe's parent can still do polling at the same time.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![siw-iframe-custom-uri](https://user-images.githubusercontent.com/5066836/79283984-4a85b380-7e6e-11ea-8428-5fcd7cd2dc2f.gif)
![Custom URI Scheme](https://user-images.githubusercontent.com/5066836/79394425-4f10a180-7f2c-11ea-95b2-5c8e69b63034.gif)

### Reviewers:
@nikhilvenkatraman-okta @aarongranick-okta 

### Issue:

- [OKTA-289825](https://oktainc.atlassian.net/browse/OKTA-289825)


