### PR TITLE
fix: i18n for WebAuthnView OKTA-295848

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -170,6 +170,7 @@ oform.next = Next
 oform.verify = Verify
 oform.send = Send
 oform.back = Back
+oform.title.authenticate = Authenticate
 
 # REQUIRED COURAGE COMPONENTS
 oform.save = Save

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -8,7 +8,9 @@ export default Form.extend({
   hasSavingState: true,
   autoSave: false,
   noCancelButton: true,
-  title: 'Authenticate',
+  title () {
+    return loc('oform.title.authenticate', 'login');
+  },
   save: loc('oform.next', 'login'),
 
   initialize: function () {

--- a/src/v2/view-builder/views/webauthn/RequiredFactorWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/RequiredFactorWebauthnView.js
@@ -7,7 +7,9 @@ import webauthn from '../../../../util/webauthn';
 
 const Body = BaseForm.extend({
 
-  title: loc('factor.webauthn.biometric', 'login'),
+  title () {
+    return loc('factor.webauthn.biometric', 'login');
+  },
 
   getUISchema () {
     const schema = [];
@@ -121,7 +123,7 @@ const Footer = BaseFooter.extend({
     if (this.options.appState.hasRemediationObject('select-factor')) {
       links.push({
         'type': 'link',
-        'label': 'Switch Factor',
+        'label': loc('mfa.switch', 'login'),
         'name': 'switchFactor',
         'formName': 'select-factor',
       });


### PR DESCRIPTION
## Description:

* Fixes i18n for biometric message for WebAuthnView
* i18n for baseForm default title "Authenticate"
* i18n for WebAuthnView footer message - "Switch Factor"

Resolves OKTA-295840
Resolves OKTA-295848

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [X] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/62976351/81357536-cdbeb180-9088-11ea-9cf7-0aa19dea9d0a.png)


### Reviewers:
@nikhilvenkatraman-okta @ivandenysenko-okta 

### Issue:

- [OKTA-295840](https://oktainc.atlassian.net/browse/OKTA-295840)
- [OKTA-295848](https://oktainc.atlassian.net/browse/OKTA-295848)


