### PR TITLE
chore: fix/update retirejs OKTA-228855

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -1,7 +1,7 @@
 [
   {
     "component": "jquery",
-    "version": "1.12.1",
-    "justification": "This CVE (CVE-2019-11358) deals with pollution of prototype. The CVE is a blocker and should be solved with the release of SIW 3.0"
+    "version": "1.12.4",
+    "justification": "This CVE (CVE-2019-11358) deals with pollution of prototype. We are mitigating this by using a patched version of jQuery (packages/@okta/courage-dist/jquery.js) The patch begins at line 213"
   }
 ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -388,9 +388,9 @@ module.exports = function (grunt) {
     }
     grunt.task.run([
       'exec:clean',
-      'exec:retirejs',
       `assets:${target}`,
       ...buildTasks,
+      'exec:retirejs',
       ...postBuildTasks,
     ]);
   });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf target && rimraf dist && rimraf build2",
     "generate-phone-codes": "node buildtools generate-phone-codes",
     "generate-config": "node buildtools generate-language-config",
-    "retirejs": "retire --jspath src --package",
+    "retirejs": "retire --jspath target/js --package",
     "lint:eslint": "eslint .",
     "lint:eslint:report": "eslint -f checkstyle -o build2/OSW-eslint-checkstyle-result.xml .",
     "lint:stylelint": "stylelint assets/sass/",


### PR DESCRIPTION
## Description:

Changes the path for `retirejs` from `src` to `target`. We are using webpack config to include specific versions of certain modules. Scanning the `target` folder will inspect the built webpack bundles for security vulnerabilities.

Also update the .requirejsignore.json to ignore the patched version of jQuery from courage we are using.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Reviewers:
@nikhilvenkatraman-okta 
@haishengwu-okta 
@swiftone  


### Issue:

- [OKTA-228855](https://oktainc.atlassian.net/browse/OKTA-228855)


