### PR TITLE
feat: base password requirements changes

### DIFF
--- a/assets/sass/modules/_password-requirements.scss
+++ b/assets/sass/modules/_password-requirements.scss
@@ -1,0 +1,13 @@
+.password-requirements--header {
+  padding-bottom: 10px;
+}
+
+.password-requirements--list {
+  list-style: initial;
+  padding-left: 20px;
+  padding-bottom: 10px;
+}
+
+.password-requirements--list-item {
+  line-height: 1.5 * $font-size;
+}

--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -51,6 +51,7 @@
   @import 'modules/footer';
   @import 'modules/enroll';
   @import 'modules/registration';
+  @import 'modules/password-requirements';
   @import 'v2/all';
 
   &.can-remove-beacon {

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -556,6 +556,22 @@ password.complexity.no_username = no parts of your username
 password.complexity.no_first_name = does not include your first name
 password.complexity.no_last_name = does not include your last name
 
+# Requirements as HTML list.
+# These are copy of existing strings, but we need them since in a list, the starting letter has to be in CAPS and no period at the end.
+password.complexity.requirements.header = Password requirements:
+password.complexity.length.description = At least {0} characters
+password.complexity.lowercase.description = A lowercase letter
+password.complexity.uppercase.description = An uppercase letter
+password.complexity.number.description = A number
+password.complexity.symbol.description = A symbol
+password.complexity.no_username.description = No parts of your username
+password.complexity.no_first_name.description = Does not include your first name
+password.complexity.no_last_name.description = Does not include your last name
+password.complexity.history.description = Your password cannot be any of your last {0} passwords
+password.complexity.minAgeMinutes.description = At least {0} minute(s) must have elapsed since you last changed your password
+password.complexity.minAgeHours.description = At least {0} hour(s) must have elapsed since you last changed your password
+password.complexity.minAgeDays.description = At least {0} day(s) must have elapsed since you last changed your password
+
 # Password Expired
 password.expired.submit = Change Password
 password.expired.title = Your Okta password has expired

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -19,9 +19,11 @@ define([
   'util/FactorUtil',
   'util/Util',
   'views/expired-password/Footer',
-  'views/shared/TextBox'
+  'views/shared/TextBox',
+  'views/shared/PasswordRequirements'
 ],
-function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Util, Footer, TextBox) {
+function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Util, Footer, TextBox,
+  PasswordRequirements) {
 
   var _ = Okta._;
 
@@ -74,14 +76,22 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
         }
 
         var policy = this.options.appState.get('policy');
-        if (!policy) {
+        if (!policy || this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
           return;
         }
 
         return FactorUtil.getPasswordComplexityDescription(policy);
       },
       formChildren: function () {
-        return [
+        var children = [];
+
+        if (this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+          children.push(FormType.View({
+            View: new PasswordRequirements({ policy: this.options.appState.get('policy') }),
+          }));
+        }
+
+        children = children.concat([
           FormType.Input({
             'label-top': true,
             label: Okta.loc('password.oldPassword.placeholder', 'login'),
@@ -120,7 +130,9 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
             input: TextBox,
             type: 'password'
           })
-        ];
+        ]);
+
+        return children;
       }
     },
     Footer: Footer,

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -18,9 +18,11 @@ define([
   'util/FactorUtil',
   'util/Util',
   'views/shared/FooterSignout',
-  'views/shared/TextBox'
+  'views/shared/TextBox',
+  'views/shared/PasswordRequirements'
 ],
-function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, FooterSignout, TextBox) {
+function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, FooterSignout, TextBox,
+  PasswordRequirements) {
 
   var _ = Okta._;
 
@@ -54,14 +56,22 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, Foot
       },
       subtitle: function () {
         var policy = this.options.appState.get('policy');
-        if (!policy) {
+        if (!policy || this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
           return;
         }
 
         return FactorUtil.getPasswordComplexityDescription(policy);
       },
       formChildren: function () {
-        return [
+        var children = [];
+
+        if (this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+          children.push(FormType.View({
+            View: new PasswordRequirements({ policy: this.options.appState.get('policy') }),
+          }));
+        }
+
+        children = children.concat([
           FormType.Input({
             className: 'margin-btm-5',
             label: Okta.loc('password.newPassword.placeholder', 'login'),
@@ -87,7 +97,8 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, Foot
             input: TextBox,
             type: 'password'
           })
-        ];
+        ]);
+        return children;
       }
     },
 

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -92,6 +92,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
       'features.restrictRedirectToForeground': ['boolean', true, false],
       'features.hideDefaultTip': ['boolean', false, true],
+      'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function
@@ -267,7 +268,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       configuredSocialIdps: {
         deps: ['idps'],
         fn: function (idps) {
-          return _.map(idps, function (idp) { 
+          return _.map(idps, function (idp) {
             var type = idp.type && idp.type.toLowerCase();
             if ( !( type && _.contains(supportedIdps, type) ) ) {
               type = 'general-idp';

--- a/src/views/shared/PasswordRequirements.js
+++ b/src/views/shared/PasswordRequirements.js
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+define([
+  'okta',
+  'util/FactorUtil',
+],
+function (Okta, FactorUtil) {
+  return Okta.View.extend({
+    template: `{{#if requirements}}
+      <div class="password-requirements--header">
+        {{i18n code="password.complexity.requirements.header" bundle="login"}}
+      </div>
+      <ul class="password-requirements--list">
+          {{#each requirements}}<li class="password-requirements--list-item">{{this}}</li>{{/each}}
+      </ul>
+    {{/if}}`,
+
+    attributes: {
+      'data-se': 'password-requirements-html'
+    },
+
+    allRequirements: [],
+
+    initialize: function (options) {
+      var policy = options.policy;
+      if (!policy) {
+        return;
+      }
+
+      this.allRequirements = FactorUtil.getPasswordComplexityDescriptionForHtmlList(policy);
+    },
+
+    getTemplateData: function () {
+      return {
+        requirements: this.allRequirements
+      };
+    }
+  });
+});

--- a/test/unit/helpers/dom/PasswordExpiredForm.js
+++ b/test/unit/helpers/dom/PasswordExpiredForm.js
@@ -5,6 +5,17 @@ define(['./Form'], function (Form) {
   var CONFIRM_PASS_FIELD = 'confirmPassword';
 
   return Form.extend({
+    passwordRequirementsHtmlList: function () {
+      return this.el('password-requirements-html');
+    },
+
+    passwordRequirementsHtmlHeader: function () {
+      return this.passwordRequirementsHtmlList().find('.password-requirements--header');
+    },
+
+    passwordRequirementsHtmlListItems: function () {
+      return this.passwordRequirementsHtmlList().find('.password-requirements--list-item');
+    },
 
     oldPassField: function () {
       return this.input(OLD_PASS_FIELD);

--- a/test/unit/helpers/dom/PasswordResetForm.js
+++ b/test/unit/helpers/dom/PasswordResetForm.js
@@ -4,6 +4,17 @@ define(['./Form'], function (Form) {
   var CONFIRM_PASSWORD_FIELD = 'confirmPassword';
 
   return Form.extend({
+    passwordRequirementsHtmlList: function () {
+      return this.el('password-requirements-html');
+    },
+
+    passwordRequirementsHtmlHeader: function () {
+      return this.passwordRequirementsHtmlList().find('.password-requirements--header');
+    },
+
+    passwordRequirementsHtmlListItems: function () {
+      return this.passwordRequirementsHtmlList().find('.password-requirements--list-item');
+    },
 
     newPasswordField: function () {
       return this.input(NEW_PASSWORD_FIELD);

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -327,6 +327,232 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
       });
     });
 
+    Expect.describe('Password description in HTML', function () {
+      itp('does not have subtitle', function () {
+        return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function (test) {
+          expect(test.form.subtitle().length).toEqual(0);
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "minLength" defined', function () {
+        return setup({
+          policyComplexity: 'minLength',
+          'features.showPasswordRequirementsAsHtmlList': true
+        }).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "minLowerCase" defined', function () {
+        return setup({
+          policyComplexity: 'minLowerCase',
+          'features.showPasswordRequirementsAsHtmlList': true
+        }).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A lowercase letter');
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "minUpperCase" defined', function () {
+        return setup({policyComplexity: 'minUpperCase', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('An uppercase letter');
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "minNumber" defined', function () {
+        return setup({policyComplexity: 'minNumber', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A number');
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "minSymbol" defined', function () {
+        return setup({policyComplexity: 'minSymbol', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A symbol');
+        });
+      });
+
+      itp('has a valid subtitle if only password complexity "excludeUsername" defined', function () {
+        return setup({policyComplexity: 'excludeUsername', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
+        });
+      });
+
+      itp('has a valid subtitle if only excludeAttributes["firstName","lastName"] is defined', function () {
+        return setup({policyComplexity: 'excludeAttributes', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your first name');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('Does not include your last name');
+        });
+      });
+
+      itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function () {
+        return setup({
+          policyComplexity: 'excludeAttributes',
+          excludeAttributes: ['firstName'],
+          'features.showPasswordRequirementsAsHtmlList': true
+        }).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your first name');
+        });
+      });
+
+      itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function () {
+        return setup({
+          policyComplexity: 'excludeAttributes',
+          excludeAttributes: ['lastName'],
+          'features.showPasswordRequirementsAsHtmlList': true
+        }).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your last name');
+        });
+      });
+
+      itp('has a valid subtitle if only excludeAttributes[] is defined', function () {
+        return setup({
+          policyComplexity: 'all',
+          excludeAttributes: [],
+          'features.showPasswordRequirementsAsHtmlList': true
+        }).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(6);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('A lowercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(2).text()).toEqual('An uppercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(3).text()).toEqual('A number');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(4).text()).toEqual('A symbol');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(5).text()).toEqual('No parts of your username');
+        });
+      });
+
+      itp('has a valid subtitle if only password age "historyCount" defined', function () {
+        return setup({policyAge: 'historyCount', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text())
+            .toEqual('Your password cannot be any of your last 7 passwords');
+        });
+      });
+
+      itp('has a valid subtitle in minutes if only password age "minAgeMinutes" defined', function () {
+        return setup({policyAge: 'minAgeMinutes', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text())
+            .toEqual('At least 30 minute(s) must have elapsed since you last changed your password');
+        });
+      });
+
+      itp('has a valid subtitle in hours if only password age "minAgeMinutesinHours" defined', function () {
+        return setup({policyAge: 'minAgeMinutesinHours', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text())
+            .toEqual('At least 2 hour(s) must have elapsed since you last changed your password');
+        });
+      });
+
+      itp('has a valid subtitle in days if only password age "minAgeMinutesinDays" defined', function () {
+        return setup({policyAge: 'minAgeMinutesinDays', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text())
+            .toEqual('At least 2 day(s) must have elapsed since you last changed your password');
+        });
+      });
+
+      itp('has a valid subtitle if password complexity "excludeUsername" and password age "historyCount" defined',
+        function () {
+          return setup({
+            policyComplexity: 'excludeUsername',
+            policyAge: 'historyCount',
+            'features.showPasswordRequirementsAsHtmlList': true
+          }).then(function (test) {
+            expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+            expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
+            expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(1).text())
+              .toEqual('Your password cannot be any of your last 7 passwords');
+          });
+        }
+      );
+
+      itp('has a valid subtitle if password complexity is defined with all options', function () {
+        return setup({policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(8);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('A lowercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(2).text()).toEqual('An uppercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(3).text()).toEqual('A number');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(4).text()).toEqual('A symbol');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(5).text()).toEqual('No parts of your username');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(6).text()).toEqual('Does not include your first name');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
+        });
+      });
+
+      itp('has a valid subtitle in minutes if password age is defined with all options', function () {
+        return setup({policyAge: 'all', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Your password cannot be any of your last 7 passwords');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('At least 30 minute(s) must have elapsed since you last changed your password');
+        });
+      });
+
+      itp('has a valid subtitle if password complexity is defined with all options and password age "historyCount" defined',
+        function () {
+          return setup({
+            policyComplexity: 'all',
+            policyAge: 'historyCount',
+            'features.showPasswordRequirementsAsHtmlList': true
+          }).then(function (test) {
+            expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+            expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(9);
+            expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('A lowercase letter');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(2).text()).toEqual('An uppercase letter');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(3).text()).toEqual('A number');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(4).text()).toEqual('A symbol');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(5).text()).toEqual('No parts of your username');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(6).text()).toEqual('Does not include your first name');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
+            expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual('Your password cannot be any of your last 7 passwords');
+          });
+        });
+
+      itp('has a valid subtitle if password age and complexity are defined with all options', function () {
+        return setup({policyComplexity: 'all', policyAge: 'all', 'features.showPasswordRequirementsAsHtmlList': true}).then(function (test) {
+          expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
+          expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(10);
+          expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(1).text()).toEqual('A lowercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(2).text()).toEqual('An uppercase letter');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(3).text()).toEqual('A number');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(4).text()).toEqual('A symbol');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(5).text()).toEqual('No parts of your username');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(6).text()).toEqual('Does not include your first name');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(7).text()).toEqual('Does not include your last name');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(8).text()).toEqual('Your password cannot be any of your last 7 passwords');
+          expect(test.form.passwordRequirementsHtmlListItems().eq(9).text()).toEqual('At least 30 minute(s) must have elapsed since you last changed your password');
+        });
+      });
+    });
+
     itp('has a password field to enter the new password', function () {
       return setup().then(function (test) {
         Expect.isPasswordField(test.form.newPasswordField());


### PR DESCRIPTION
## Description:

- Adds new feature to change password requirements to HTML
- Adds new View which shows password requirements as HTML

OKTA-297986

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

<img width="453" alt="Screen Shot 2020-05-13 at 4 35 01 PM" src="https://user-images.githubusercontent.com/24683447/81877382-bf194400-9539-11ea-80a1-dbf1bafef007.png">


<img width="448" alt="Screen Shot 2020-05-13 at 4 36 21 PM" src="https://user-images.githubusercontent.com/24683447/81877368-b58fdc00-9539-11ea-904f-7aa465a4a450.png">

### Reviewers:


### Issue:

- [OKTA-297986](https://oktainc.atlassian.net/browse/OKTA-297986)


