### PR TITLE
fix: clear errors before submitting empty totp

### DIFF
--- a/src/views/mfa-verify/InlineTOTPForm.js
+++ b/src/views/mfa-verify/InlineTOTPForm.js
@@ -27,6 +27,7 @@ define(['okta', 'views/shared/TextBox'], function (Okta, TextBox) {
       className: 'button inline-totp-verify margin-top-30',
       title: Okta.loc('mfa.challenge.verify', 'login'),
       click: function () {
+        form.clearErrors();
         if (!form.isValid()) {
           return;
         }

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -171,8 +171,12 @@ define(['okta', './Dom'], function (Okta, Dom) {
       this.submitButton().click();
     },
 
+    getErrors: function () {
+      return this.$('.okta-form-infobox-error');
+    },
+
     hasErrors: function () {
-      return this.$('.okta-form-infobox-error').length > 0;
+      return this.getErrors().length > 0;
     },
 
     errorBox: function () {


### PR DESCRIPTION
* On click of verify we now call clearErrors to clear any\
previous error messages.

RESOLVES: OKTA-287962
![siw-error](https://user-images.githubusercontent.com/17267130/82930125-ba8d5c00-9f39-11ea-85ba-eece9c90dd8d.gif)
![siw-error2](https://user-images.githubusercontent.com/17267130/82930127-bbbe8900-9f39-11ea-8e86-9b29229e0847.gif)



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


