### PR TITLE
feat: remove requirements from error message if description is shown

### DIFF
--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -82,6 +82,21 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
 
         return FactorUtil.getPasswordComplexityDescription(policy);
       },
+      parseErrorMessage: function(responseJSON) {
+        var policy = this.options.appState.get('policy');
+        if (!!policy && this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+          /*
+            - This is a specific case where don't want to repeat the requirements again in the error message, since this
+              is already shown in the description. The description as bullet-points itself should give an indication
+              of the requirements.
+            - We cannot check for error code this in this case, as the error code is shared between
+              requirements not met message, common password message, etc. So error summary is the only differentiating
+              factor. Replace the password requirements string with empty string in this case.
+          */
+          responseJSON = FactorUtil.removeRequirementsFromError(responseJSON, policy);
+        }
+        return responseJSON;
+      },
       formChildren: function () {
         var children = [];
 
@@ -147,7 +162,6 @@ function (Okta, FormController, Enums, FormType, ValidationUtil, FactorUtil, Uti
           .then(_.bind(this.model.save, this.model));
       });
     }
-
   });
 
 });

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -62,6 +62,21 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, Foot
 
         return FactorUtil.getPasswordComplexityDescription(policy);
       },
+      parseErrorMessage: function(responseJSON) {
+        var policy = this.options.appState.get('policy');
+        if (!!policy && this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+          /*
+            - This is a specific case where don't want to repeat the requirements again in the error message, since this
+              is already shown in the description. The description as bullet-points itself should give an indication
+              of the requirements.
+            - We cannot check for error code this in this case, as the error code is shared between
+              requirements not met message, common password message, etc. So error summary is the only differentiating
+              factor. Replace the password requirements string with empty string in this case.
+          */
+          responseJSON = FactorUtil.removeRequirementsFromError(responseJSON, policy);
+        }
+        return responseJSON;
+      },
       formChildren: function () {
         var children = [];
 

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -346,6 +346,13 @@ function (Okta, TimeUtil) {
     return localizedQuestion.indexOf('L10N_ERROR') < 0 ? localizedQuestion : questionObj.questionText;
   };
 
+  fn.removeRequirementsFromError = function (responseJSON, policy) {
+    var passwordRequirementsAsString = this.getPasswordComplexityDescription(policy);
+    responseJSON.errorCauses[0].errorSummary = responseJSON.errorCauses[0].errorSummary
+        .replace(passwordRequirementsAsString, '').trim();
+    return responseJSON;
+  };
+
   fn.getPasswordComplexityDescriptionForHtmlList = function (policy) {
     var passwordRequirementHtmlI18nKeys = {
       complexity: {

--- a/test/unit/helpers/xhr/PASSWORD_EXPIRED_error_complexity.js
+++ b/test/unit/helpers/xhr/PASSWORD_EXPIRED_error_complexity.js
@@ -7,7 +7,7 @@ define({
     "errorLink": "E0000014",
     "errorId": "oaeRXeoXe24RWqjj0R-pL03ZA",
     "errorCauses": [{
-      "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name."
+      "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."
     }]
   }
 });

--- a/test/unit/helpers/xhr/PASSWORD_RESET_error.js
+++ b/test/unit/helpers/xhr/PASSWORD_RESET_error.js
@@ -7,7 +7,7 @@ define({
     "errorLink": "E0000080",
     "errorId": "oaeZL71b-kLQyae-eG7rzghzQ",
     "errorCauses": [{
-      "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name."
+      "errorSummary": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."
     }]
   }
 });

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -449,7 +449,7 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe(
               'Password requirements were not met. Password requirements: at least 8 characters,' +
-            ' a lowercase letter, an uppercase letter, a number, no parts of your username,' +
+            ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username,' +
             ' does not include your first name, does not include your last name.'
             );
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -464,20 +464,59 @@ function (Okta, OktaAuth, LoginUtil, Util, PasswordExpiredForm, Beacon, Expect, 
                 xhr: {
                   status: 403,
                   responseType: 'json',
-                  responseText: '{"errorCode":"E0000014","errorSummary":"Update of credentials failed","errorLink":"E0000014","errorId":"oaeRXeoXe24RWqjj0R-pL03ZA","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name."}]}',
+                  responseText: '{"errorCode":"E0000014","errorSummary":"Update of credentials failed","errorLink":"E0000014","errorId":"oaeRXeoXe24RWqjj0R-pL03ZA","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."}]}',
                   responseJSON: {
                     errorCode: 'E0000014',
-                    errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name.',
+                    errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.',
                     errorLink: 'E0000014',
                     errorId: 'oaeRXeoXe24RWqjj0R-pL03ZA',
                     errorCauses: [{
-                      errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name.'
+                      errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.'
                     }]
                   }
                 }
               }
             ]);
           });
+      });
+      itp('shows an simple error if showPasswordRequirementsAsHtmlList is on and if the server returns a complexity error', function () {
+        return setup({ 'features.showPasswordRequirementsAsHtmlList': true })
+            .then(function (test) {
+              test.setNextResponse(resErrorComplexity);
+              submitNewPass(test, 'oldpassyo', 'badpass', 'badpass');
+              return Expect.waitForFormError(test.form, test);
+            })
+            .then(function (test) {
+              expect(test.form.hasErrors()).toBe(true);
+              expect(test.form.errorMessage()).toBe(
+                  'Password requirements were not met.'
+              );
+              expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+              expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+                {
+                  controller: 'password-expired'
+                },
+                {
+                  name: 'AuthApiError',
+                  message: 'Update of credentials failed',
+                  statusCode: 403,
+                  xhr: {
+                    status: 403,
+                    responseType: 'json',
+                    responseText: '{"errorCode":"E0000014","errorSummary":"Update of credentials failed","errorLink":"E0000014","errorId":"oaeRXeoXe24RWqjj0R-pL03ZA","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."}]}',
+                    responseJSON: {
+                      errorCode: 'E0000014',
+                      errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.',
+                      errorLink: 'E0000014',
+                      errorId: 'oaeRXeoXe24RWqjj0R-pL03ZA',
+                      errorCauses: [{
+                        errorSummary: 'Password requirements were not met.'
+                      }]
+                    }
+                  }
+                }
+              ]);
+            });
       });
       itp('validates that fields are not empty', function () {
         return setup().then(function (test) {

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -738,7 +738,7 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe(
             'Password requirements were not met. Password requirements: at least 8 characters,' +
-          ' a lowercase letter, an uppercase letter, a number, no parts of your username,' +
+          ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username,' +
           ' does not include your first name, does not include your last name.'
           );
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -753,20 +753,63 @@ function (Q, Okta, OktaAuth, LoginUtil, Util, PasswordResetForm, Beacon, Expect,
               xhr: {
                 status: 403,
                 responseType: 'json',
-                responseText: '{"errorCode":"E0000080","errorSummary":"The password does not meet the complexity requirements of the current password policy.","errorLink":"E0000080","errorId":"oaeZL71b-kLQyae-eG7rzghzQ","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name."}]}',
+                responseText: '{"errorCode":"E0000080","errorSummary":"The password does not meet the complexity requirements of the current password policy.","errorLink":"E0000080","errorId":"oaeZL71b-kLQyae-eG7rzghzQ","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."}]}',
                 responseJSON: {
                   errorCode: 'E0000080',
-                  errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name.',
+                  errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.',
                   errorLink: 'E0000080',
                   errorId: 'oaeZL71b-kLQyae-eG7rzghzQ',
                   errorCauses: [{
-                    errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username, does not include your first name, does not include your last name.'
+                    errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.'
                   }]
                 }
               }
             }
           ]);
         });
+    });
+
+    itp('shows an error msg if there is an error submitting', function () {
+      return setup({policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true})
+          .then(function (test) {
+            Q.stopUnhandledRejectionTracking();
+            test.setNextResponse(resError);
+            test.form.setNewPassword('a');
+            test.form.setConfirmPassword('a');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function (test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe(
+                'Password requirements were not met.'
+            );
+            expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+            expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+              {
+                controller: 'password-reset'
+              },
+              {
+                name: 'AuthApiError',
+                message: 'The password does not meet the complexity requirements of the current password policy.',
+                statusCode: 403,
+                xhr: {
+                  status: 403,
+                  responseType: 'json',
+                  responseText: '{"errorCode":"E0000080","errorSummary":"The password does not meet the complexity requirements of the current password policy.","errorLink":"E0000080","errorId":"oaeZL71b-kLQyae-eG7rzghzQ","errorCauses":[{"errorSummary":"Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name."}]}',
+                  responseJSON: {
+                    errorCode: 'E0000080',
+                    errorSummary: 'Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username, does not include your first name, does not include your last name.',
+                    errorLink: 'E0000080',
+                    errorId: 'oaeZL71b-kLQyae-eG7rzghzQ',
+                    errorCauses: [{
+                      errorSummary: 'Password requirements were not met.'
+                    }]
+                  }
+                }
+              }
+            ]);
+          });
     });
   });
 


### PR DESCRIPTION
## Description:

- This is a follow up to showing the password requirements as a HTML list.
- This is a specific case where don't want to repeat the requirements again in the error message, since this is already shown in the description.
- Limiting this to places where the feature is on and if language is Japanese, since the requirements message was misleading for some combinations of the requirements. The description as bullet-points itself should give an indication of the requirements.
- We cannot check for error code this in this case, as the error code is shared between requirements not met message, common password message, etc. So error summary is the only differentiating factor.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

FF on:

<img width="448" alt="Screen Shot 2020-05-27 at 4 05 50 PM" src="https://user-images.githubusercontent.com/24683447/83081445-8c8d4200-a035-11ea-9d33-efed6fdf9ade.png">

FF off:

<img width="417" alt="Screen Shot 2020-05-27 at 4 06 13 PM" src="https://user-images.githubusercontent.com/24683447/83081446-8e570580-a035-11ea-990f-77ee10035967.png">


### Reviewers:


### Issue:

- [OKTA-300832](https://oktainc.atlassian.net/browse/OKTA-300832)


