### PR TITLE
test: adding support for ie + edge in saucelabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ env:
   - TEST_SUITE=lint
   - TEST_SUITE=test
   - TEST_SUITE=test:e2e
+  - TEST_SUITE=test:e2e:windows
   - TEST_SUITE=test:testcafe-ci
   - TEST_SUITE=commitlint-travis
+
   global:
   - SAUCE_BROWSER_NAME="chrome"
   - SAUCE_BROWSER_VERSION=""

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "start:angular": "PORT=4200 yarn --cwd test/e2e/angular-app start & wait-on http-get://localhost:4200",
     "pretest:e2e": "yarn install:react && yarn install:angular",
     "test:e2e": "yarn build:release && yarn start:react && yarn start:angular && grunt test-e2e",
+    "test:e2e:windows": "export SAUCE_PLATFORM_NAME=windows && yarn test:e2e",
     "test:testcafe-setup": "mkdir -p test-reports/testcafe && yarn start --no-open",
     "test:testcafe-run": "wait-on http-get://localhost:3000 && testcafe -c 2 chrome:headless test/testcafe/spec/",
     "test:testcafe-ci": "run-p -r test:testcafe-setup \"test:testcafe-run\" -- 2>/dev/null",

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -16,7 +16,12 @@ require('./env').config();
 var config = {
   framework: 'jasmine2',
   specs: ['specs/*.js'],
-  restartBrowserBetweenTests: false
+  restartBrowserBetweenTests: false,
+  onPrepare: function () {
+    return browser.getProcessedConfig().then(data => {
+      global.browserName = data.capabilities.browserName;
+    });
+  }
 };
 
 // Travis sauceLabs tests
@@ -25,8 +30,6 @@ if (process.env.TRAVIS) {
     // Mobile emulators on sauce labs
     config.sauceUser = process.env.SAUCE_USERNAME;
     config.sauceKey = process.env.SAUCE_ACCESS_KEY;
-    // Default port for Appium
-    config.port = 4723;
   } else {
     // Desktop browser
     config.capabilities = {
@@ -39,12 +42,34 @@ if (process.env.TRAVIS) {
 
   if (process.env.SAUCE_PLATFORM_NAME === 'iOS') {
     var appiumiOS = require('./appium/ios-conf.js');
+    config.port = 4723;
     config.multiCapabilities = appiumiOS.iosCapabilities;
   }
 
   else if (process.env.SAUCE_PLATFORM_NAME === 'android') {
     var appiumAndroid = require('./appium/android-conf.js');
+    config.port = 4723;
     config.multiCapabilities = appiumAndroid.androidCapabilities;
+  }
+
+  if (process.env.SAUCE_PLATFORM_NAME === 'windows') {
+    config.multiCapabilities =
+    [{
+      'browserName': 'internet explorer',
+      'browserVersion': 'latest',
+      'platformName': 'Windows 10',
+      'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+      'build': process.env.TRAVIS_BUILD_NUMBER
+    },
+    {
+      'browserName': 'MicrosoftEdge',
+      'browserVersion': 'latest',
+      'platformName': 'Windows 10',
+      'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+      'build': process.env.TRAVIS_BUILD_NUMBER
+    }];
+    config.exclude = ['specs/angular_spec.js', 'specs/dev_spec.js',
+      'specs/npm_spec.js', 'specs/OIDC_spec.js', 'specs/react_spec.js'];
   }
 }
 // Local tests, required:

--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -72,6 +72,12 @@ describe('Basic flows', function () {
   });
 
   it('has the style from config.colors', function () {
+    /*global browserName*/
+    // In IE, primaryButton.getCssValue('background') is empty. Expectation on line 97 fails
+    if (browserName === 'internet explorer') {
+      return;
+    }
+
     // Create new widget with colors.brand
     browser.executeScript('oktaSignIn.remove()');
     function createWidget () {


### PR DESCRIPTION
resolves okta-298610

## Description:

* Use saucelabs to add tests for IE and Edge

* There have been bugs introduced in trex due to widget not loading on IE/Edge

* Adding these tests will catch them before they’re deployed to staging

* Only runs the basic_spec.js test for now. Some tests fail on IE. This will at least give us confidence that widget loads on IE/Edge

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-302703](https://oktainc.atlassian.net/browse/OKTA-302703)


