### PR TITLE
feat: lay groundwork for admin consent OKTA-299441

### DIFF
--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 46], max-statements: [2, 40] */
+/* eslint complexity: [2, 47], max-statements: [2, 40] */
 define([
   'okta',
   './OAuth2Util',
@@ -207,6 +207,9 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
       } else {
         router.settings.callGlobalSuccess(Enums.SUCCESS, successData);
       }
+      return;
+    case 'ADMIN_CONSENT_REQUIRED':
+      router.navigate('signin/consent', {trigger: true});
       return;
     case 'CONSENT_REQUIRED':
       if (router.settings.get('features.consent')) {


### PR DESCRIPTION
## Description:
- Handle v1 state tokens in status ADMIN_CONSENT_REQUIRED with same page as CONSENT_REQUIRED
- Temporarily introduced to unblock backend integration tests.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
- @haishengwu-okta 

### Issue:

- [OKTA-299441](https://oktainc.atlassian.net/browse/OKTA-299441)


