### PR TITLE
fix: change default assets directory to existing endpoint - GH-1038

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -36,7 +36,7 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       UnsupportedBrowserError = Errors.UnsupportedBrowserError;
 
   var assetBaseUrlTpl = Okta.tpl(
-    'https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/{{version}}'
+    'https://global.oktacdn.com/okta-signin-widget/{{version}}'
   );
 
   return Okta.Model.extend({

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1622,7 +1622,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
 
       var expectDefaultCdn = _.partial(
         expectBundles,
-        'https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/9.9.99'
+        'https://global.oktacdn.com/okta-signin-widget/9.9.99'
       );
 
       itp('loads properties from the cdn if no baseUrl and path overrides are supplied', function () {
@@ -1633,7 +1633,7 @@ function (Okta, Q, Logger, Errors, BrowserFeatures, WidgetUtil, Bundles, config,
           }
         })
           .then(function () {
-            expectDefaultPaths('https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/9.9.99');
+            expectDefaultPaths('https://global.oktacdn.com/okta-signin-widget/9.9.99');
           });
       });
       itp('loads properties from the given baseUrl', function () {


### PR DESCRIPTION
## Description:
Change the assetsBaseUrl to use `https://global.oktacdn.com/okta-signin-widget/{{version}}` rather than `https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/{{version}}` where the assets don't seem to exist (anymore).

This PR closes GH-1038.


## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [X] Added unit tests?

- [X] Added e2e tests

- [X] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:

* @haishengwu-okta
* @anipendakur-okta 
* @magizh-okta


### Issue:

- GH-1038


