### PR TITLE
feat: add subschema checks to reset password controller

### DIFF
--- a/assets/sass/modules/_password-reset.scss
+++ b/assets/sass/modules/_password-reset.scss
@@ -1,0 +1,34 @@
+.password-reset .subschema {
+
+    margin-bottom: 15px;
+  
+    p {
+      padding: 5px 20px;
+      position: relative;
+  
+      &.default-schema {
+        display: none;
+      }
+  
+      span {
+        position: absolute;
+        left: -2px;
+      }
+    }
+  
+    .subschema-unsatisfied {
+      color: $medium-text-color;
+    }
+  
+    .subschema-satisfied {
+      color: $light-text-color;
+    }
+  
+    .subschema-error {
+      color: $error-text-color;
+  
+      span.error-16-small {
+        display: block;
+      }
+    }
+  }

--- a/assets/sass/okta-sign-in.scss
+++ b/assets/sass/okta-sign-in.scss
@@ -52,6 +52,7 @@
   @import 'modules/enroll';
   @import 'modules/registration';
   @import 'modules/password-requirements';
+  @import 'modules/password-reset';
   @import 'v2/all';
 
   &.can-remove-beacon {

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -17,35 +17,194 @@ define([
   'util/ValidationUtil',
   'util/FactorUtil',
   'util/Util',
-  'views/shared/FooterSignout',
+  'views/shared/FooterWithBackLink',
   'views/shared/TextBox',
   'views/shared/PasswordRequirements'
 ],
-function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, FooterSignout, TextBox,
+function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, FooterWithBackLink, TextBox,
   PasswordRequirements) {
 
   var _ = Okta._;
 
+  var getParts = function (username) {
+    var usernameArr = username.split('');
+    var minPartsLength = 3;
+    var userNameParts = [];
+    var delimiters = [',', '.', '-', '_', '#', '@'];
+    var userNamePart = '';
+
+    _.each(usernameArr, function (part){
+      if(delimiters.indexOf(part) === -1) {
+        userNamePart += part;
+      } else{
+        if (userNamePart.length >= minPartsLength) {
+          userNameParts.push(_.clone(userNamePart));
+        }
+        userNamePart = '';
+      }
+    });
+    if (userNamePart.length >= minPartsLength) {
+      userNameParts.push(_.clone(userNamePart));
+    }
+    return userNameParts.filter(Boolean);
+  };
+
+  var passwordContainsFormField = function (formField, password) {
+    if(!formField) {
+      return false;
+    }
+    formField = formField.toLowerCase();
+    password = password.toLowerCase();
+    var formFieldArr = getParts(formField);
+    //check if each formField part contains password
+    for (var i=0; i < formFieldArr.length; i++){
+      var formFieldPart = formFieldArr[i];
+      if (password.indexOf(formFieldPart) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  var createSubSchemas = function(policy, profile) {
+    var subSchemas = []
+    if (policy.complexity.minLength) {
+      subSchemas.push({
+        "description": "At least " + policy.complexity.minLength + " character(s)",
+        "minLength": policy.complexity.minLength
+      });
+    }
+    if (policy.complexity.minNumber === 1) {
+      subSchemas.push({
+        "description": "At least 1 number(s)",
+        "format": "[0-9]+"
+      })
+    }
+    if (policy.complexity.minLowerCase === 1) {
+      subSchemas.push({
+        "description": "At least 1 lowercase letter(s)",
+        "format": "[a-z]+"
+      });
+    }
+    if (policy.complexity.minUpperCase === 1) {
+      subSchemas.push({
+        "description": "At least 1 uppercase letter(s)",
+        "format": "[A-Z]+"
+      });
+    }
+    if (policy.complexity.minSymbol === 1) {
+      subSchemas.push({
+        "description": "At least 1 symbol(s)",
+        "format": "[-!#$%&’()*+,\-.\\\:;<=>?@\[\]^_`{|}~]+"
+      });
+    }
+    if (policy.complexity.excludeUsername) {
+      var attr = "login"
+      var formFieldArr = getParts(profile[attr]);
+      subSchemas.push({
+        "description": "Does not contain part of username",
+        "format": attr
+      });
+    }
+    if (policy.complexity.excludeAttributes && policy.complexity.excludeAttributes.length > 0) {
+      policy.complexity.excludeAttributes.map(function(attr, index) {
+        var formFieldArr = getParts(profile[attr]);
+        if (profile[attr]) {
+          subSchemas.push({
+            "description": "Does not contain part of '" + profile[attr] + "'",
+            "format": attr
+          })
+        }
+      });
+    }
+   return subSchemas;
+  }
+
+  var checkSubSchema = function (subSchema, value, profile) {
+    var minLength = subSchema['minLength'];
+    var maxLength = subSchema['maxLength'];
+    var regex = subSchema['format'];
+
+    if (_.isNumber(minLength)) {
+      if (value.length < minLength) {
+        return false;
+      }
+    }
+
+    if (_.isNumber(maxLength)) {
+      if (value.length > maxLength) {
+        return false;
+      }
+    }
+    var password = value;
+    if (_.isString(regex)) {
+      // call passwordContainsFormField if regex is userName, firstName, lastName
+      if (regex === 'login' || regex === 'firstName' || regex === 'lastName') {
+        var fieldName = regex;
+        var fieldValue = profile[fieldName];
+        return !passwordContainsFormField(fieldValue, password);
+      } else {
+        if (!new RegExp(regex).test(value)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  };
+
+
+  var checkSubSchemas = function (fieldName, model, subSchemas, showError, profile) {
+    var value = model.get(fieldName);
+    if (!_.isString(value)) {
+      return;
+    }
+
+    subSchemas.map(function (subSchema, index) {
+      var ele = Okta.$('#subschemas-' + fieldName + ' .subschema-' + index);
+      //hide password complexity if no password
+      if (value) {
+        ele.children('p').removeClass('default-schema');
+      } else {
+        ele.children('p').addClass('default-schema');
+      }
+      ele.removeClass('subschema-satisfied subschema-unsatisfied subschema-error');
+      if (checkSubSchema(subSchema, value, profile)) {
+        ele.addClass('subschema-satisfied');
+        ele.find('p span').removeClass('error error-16-small');
+        ele.find('p span').addClass('confirm-16');
+      } else {
+        if (showError) {
+          ele.find('p span').removeClass('confirm-16');
+          ele.find('p span').addClass('error error-16-small');
+          ele.addClass('subschema-error subschema-unsatisfied');
+        }
+      }
+    });
+  };
+
   return FormController.extend({
     className: 'password-reset',
-    Model: {
-      props: {
-        newPassword: ['string', true],
-        confirmPassword: ['string', true]
-      },
-      validate: function () {
-        return ValidationUtil.validatePasswordMatch(this);
-      },
-      save: function () {
-        this.trigger('save');
-        var self = this;
-        return this.doTransaction(function (transaction) {
-          return transaction
-            .resetPassword({
-              newPassword: self.get('newPassword')
-            });
-        });
-      }
+    Model: function () {
+      return {
+        props: {
+          newPassword: ['string', true],
+          confirmPassword: ['string', !this.options.settings.get('features.hideConfirmPasswordOnResetPage') || false]
+        },
+        validate: function () {
+          return (this.options.settings.get('features.hideConfirmPasswordOnResetPage') ? "" : ValidationUtil.validatePasswordMatch(this));
+        },
+        save: function () {
+          this.trigger('save');
+          var self = this;
+          return this.doTransaction(function (transaction) {
+            return transaction
+              .resetPassword({
+                newPassword: self.get('newPassword')
+              });
+          });
+        }
+      };
     },
     Form: {
       save: _.partial(Okta.loc, 'password.reset', 'login'),
@@ -56,48 +215,120 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, Foot
       },
       subtitle: function () {
         var policy = this.options.appState.get('policy');
-        if (!policy || this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+        if (!policy || this.settings.get('features.showPasswordRequirementsAsHtmlList') || this.settings.get('features.showPasswordSubschemaOnResetPage')) {
           return;
         }
 
         return FactorUtil.getPasswordComplexityDescription(policy);
       },
       formChildren: function () {
-        var children = [];
-
-        if (this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
+        var children = []
+        var hideConfirmPasswordField = this.settings.get('features.hideConfirmPasswordOnResetPage') || false;
+        if (this.settings.get('features.showPasswordRequirementsAsHtmlList') && !this.settings.get('features.showPasswordSubschemaOnResetPage')) {
           children.push(FormType.View({
             View: new PasswordRequirements({ policy: this.options.appState.get('policy') }),
           }));
         }
+    
+        if (!hideConfirmPasswordField) {
+          children = children.concat([
+            FormType.Input({
+              className: 'margin-btm-5',
+              label: Okta.loc('password.newPassword.placeholder', 'login'),
+              'label-top': true,
+              explain: Util.createInputExplain(
+                'password.newPassword.tooltip',
+                'password.newPassword.placeholder',
+                'login'),
+              'explain-top': true,
+              name: 'newPassword',
+              input: TextBox,
+              type: 'password'
+            }),
+            FormType.Input({
+              label: Okta.loc('password.confirmPassword.placeholder', 'login'),
+              'label-top': true,
+              explain: Util.createInputExplain(
+                'password.confirmPassword.tooltip',
+                'password.confirmPassword.placeholder',
+                'login'),
+              'explain-top': true,
+              name: 'confirmPassword',
+              input: TextBox,
+              type: 'password'
+            })
+          ]);
+        }
+        else {
+          var policy = this.options.appState.get('policy');
+          var user = this.options.appState.get('user');
+          var subSchemas = createSubSchemas(policy, user.profile)
 
-        children = children.concat([
-          FormType.Input({
-            className: 'margin-btm-5',
-            label: Okta.loc('password.newPassword.placeholder', 'login'),
-            'label-top': true,
-            explain: Util.createInputExplain(
-              'password.newPassword.tooltip',
-              'password.newPassword.placeholder',
-              'login'),
-            'explain-top': true,
-            name: 'newPassword',
-            input: TextBox,
-            type: 'password'
-          }),
-          FormType.Input({
-            label: Okta.loc('password.confirmPassword.placeholder', 'login'),
-            'label-top': true,
-            explain: Util.createInputExplain(
-              'password.confirmPassword.tooltip',
-              'password.confirmPassword.placeholder',
-              'login'),
-            'explain-top': true,
-            name: 'confirmPassword',
-            input: TextBox,
-            type: 'password'
-          })
-        ]);
+          children.push(
+            FormType.Input({
+              className: 'margin-btm-5',
+              label: Okta.loc('password.newPassword.placeholder', 'login'),
+              'label-top': true,
+              explain: Util.createInputExplain(
+                'password.newPassword.tooltip',
+                'password.newPassword.placeholder',
+                'login'),
+              'explain-top': true,
+              name: 'newPassword',
+              type: 'password',
+              params: { showPasswordToggle: this.settings.get('features.showPasswordToggleOnResetPage') },
+              events: {
+                'input': function () {
+                  checkSubSchemas('newPassword', this.model, subSchemas, true, user.profile);
+                },
+                'focusout': function () {
+                  checkSubSchemas('newPassword', this.model, subSchemas, true, user.profile);
+                }
+              }
+            })
+          );
+          if (this.settings.get('features.showPasswordSubschemaOnResetPage')) {
+            
+            children.push(
+              FormType.View({
+                View: Okta.View.extend({
+                  className: 'subschema',
+                  id: 'subschemas-newPassword',
+                  subSchemas: subSchemas,
+                  children: function () {
+                    return this.subSchemas.map(function (subSchema, index) {
+                      var description = subSchema['description'];
+                      // TODO API should send translated strings instead of i18n code inside description
+                      // or send param with i18n code
+                      var message = description;
+                      return Okta.View.extend({
+                        index: index,
+                        message: description,
+                        class: function () {
+                          return ;
+                        },
+                        className: function () {
+                          return 'subschema-unsatisfied subschema-' + this.index;
+                        },
+                        template: '\
+                          <p class="default-schema">\
+                            <span class="icon icon-16"/>\
+                            {{message}}\
+                          </p>\
+                        ',
+                        getTemplateData: function () {
+                          return {
+                            message: this.message
+                          };
+                        }
+                      })
+                    })
+                  }
+                }),
+              })
+            );
+          }
+        }
         return children;
       }
     },
@@ -113,7 +344,12 @@ function (Okta, FormController, FormType, ValidationUtil, FactorUtil, Util, Foot
       });
 
       if (!this.settings.get('features.hideBackToSignInForReset')) {
-        this.addFooter(FooterSignout);
+        this.addFooter(FooterWithBackLink);
+      }
+    },
+    events: {
+      'click .button-show': function () {
+        this.trigger('passwordRevealed');
       }
     }
 

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -93,6 +93,9 @@ function (Okta, Q, Errors, BrowserFeatures, Util, Logger, config) {
       'features.restrictRedirectToForeground': ['boolean', true, false],
       'features.hideDefaultTip': ['boolean', false, true],
       'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
+      'features.hideConfirmPasswordOnResetPage': ['boolean', false, false],
+      'features.showPasswordToggleOnResetPage': ['boolean', false, false],
+      'features.showPasswordSubschemaOnResetPage': ['boolean', false, false],
 
       // I18N
       'language': ['any', false], // Can be a string or a function


### PR DESCRIPTION
## Description:

To match the functionality in the self-service registration form on the reset password page, this adds the same subschema checks on the entered password. It adds 3 new settings to toggle the functionality on and off:

- features.hideConfirmPasswordOnResetPage - hides the Confirm password input field and disables the validation on the New Password/Confirm Password fields
- features.showPasswordToggleOnResetPage - adds the toggle password button to the New Password input field so that you can show/hide the password as it's entered
- features.showPasswordSubschemaOnResetPage - adds the subschema section to the page and hides the other functionality for displaying the password requirements

It reads the policy from the returned json object and builds regular expressions for checking them. It also uses the profile to check the username, firstName and lastName. There might be better ways of doing this....

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![password-reset-subschema](https://user-images.githubusercontent.com/47122114/84204318-e0227580-aaa2-11ea-9fbb-b690677004ed.JPG)


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


