### PR TITLE
refactor: update the authenticator object name for verify

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-email.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email.json
@@ -162,7 +162,7 @@
       }
     ]
   },
-  "currentAuthenticator": {
+  "currentAuthenticatorEnrollment": {
     "type": "object",
     "label":"Okta Email",
     "value": {

--- a/playground/mocks/data/idp/idx/authenticator-verification-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-password.json
@@ -162,7 +162,7 @@
       }
     ]
   },
-  "currentAuthenticator": {
+  "currentAuthenticatorEnrollment": {
     "type": "object",
     "label": "Okta Password",
     "value": {

--- a/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
@@ -172,7 +172,7 @@
       }
     ]
   },
-  "currentAuthenticator": {
+  "currentAuthenticatorEnrollment": {
     "type": "object",
     "label": "Security Key or Biometric Authenticator (FIDO2)",
     "value": {

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -34,19 +34,19 @@ export default Model.extend({
       // While we're moving toward `authenticator` platform, but still
       // need to support `factor` for certain period.
       // Could remove `factor` after it's deprecated completely.
-      deps: ['currentAuthenticator', 'enrollmentAuthenticator', 'factor'],
-      fn (currentAuthenticator = {}, enrollmentAuthenticator = {}, factor = {}) {
+      deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment', 'factor'],
+      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}, factor = {}) {
         return currentAuthenticator.profile
-          || enrollmentAuthenticator.profile
+          || currentAuthenticatorEnrollment.profile
           || factor.profile
           || {};
       },
     },
     authenticatorType: {
-      deps: ['currentAuthenticator', 'enrollmentAuthenticator', 'factor'],
-      fn (currentAuthenticator = {}, enrollmentAuthenticator = {}, factor = {}) {
+      deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment', 'factor'],
+      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}, factor = {}) {
         return currentAuthenticator.type
-          || enrollmentAuthenticator.type
+          || currentAuthenticatorEnrollment.type
           || factor.factorType
           || '';
       },

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -128,7 +128,7 @@ describe('v2/ion/responseTransformer', function () {
         authenticatorEnrollments: {
           value: XHRAuthenticatorRequiredEmail.authenticatorEnrollments.value,
         },
-        currentAuthenticator: XHRAuthenticatorRequiredEmail.currentAuthenticator.value,
+        currentAuthenticatorEnrollment: XHRAuthenticatorRequiredEmail.currentAuthenticatorEnrollment.value,
         'user':{
           'id':'00uwb8GLwf1HED5Xs0g3'
         },

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -283,7 +283,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
       const result = _.compose(uiSchemaTransformer, responseTransformer)(idxResp);
       expect(result).toEqual({
         'authenticatorEnrollments': _.pick(XHRAuthenticatorRequiredEmail.authenticatorEnrollments, 'value'),
-        'currentAuthenticator': XHRAuthenticatorRequiredEmail.currentAuthenticator.value,
+        'currentAuthenticatorEnrollment': XHRAuthenticatorRequiredEmail.currentAuthenticatorEnrollment.value,
         'user': {
           'id': '00uwb8GLwf1HED5Xs0g3'
         },


### PR DESCRIPTION
## Description:

- `currentAuthenticator` during enrollment
- `currentAuthenticatorEnrollment` during verify flow.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-304015](https://oktainc.atlassian.net/browse/OKTA-304015)


