### PR TITLE
fix: handles device fingerprint iframe loading errors

### DIFF
--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -82,16 +82,20 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
 
     events: {
       'focusout input[name=username]': function () {
-        if (this.shouldComputeDeviceFingerprint()) {
+        if (this.shouldComputeDeviceFingerprint() && this.model.get('username')) {
           var self = this;
+          this.options.appState.trigger('loading', true);
           DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
             .then(function (fingerprint) {
               self.options.appState.set('deviceFingerprint', fingerprint);
               self.options.appState.set('username', self.model.get('username'));
             })
             .catch(function () {
-            // Keep going even if device fingerprint fails
+              // Keep going even if device fingerprint fails
               self.options.appState.set('username', self.model.get('username'));
+            })
+            .finally(function () {
+              self.options.appState.trigger('loading', false);
             });
         } else {
           this.options.appState.set('username', this.model.get('username'));
@@ -124,6 +128,9 @@ function (Okta, PrimaryAuthForm, CustomButtons, FooterRegistration, PrimaryAuthM
       });
       this.listenTo(this.model, 'error', function () {
         this.state.set('enabled', true);
+      });
+      this.listenTo(this.state, 'togglePrimaryAuthButton', function (buttonState) {
+        this.toggleButtonState(buttonState);
       });
     },
 

--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -34,6 +34,7 @@ define(['q', 'okta'], function (Q, Okta) {
       var deferred = Q.defer();
       var self = this;
       var $iframe;
+      var iFrameTimeout;
 
       function isWindowsPhone (userAgent) {
         return userAgent.match(/windows phone|iemobile|wpdesktop/i);
@@ -54,6 +55,8 @@ define(['q', 'okta'], function (Q, Okta) {
         if (!self.isMessageFromCorrectSource($iframe, event)) {
           return;
         }
+        // deviceFingerprint service is available, clear timeout
+        clearTimeout(iFrameTimeout);
         if (!event || !event.data || event.origin !== oktaDomainUrl) {
           handleError('no data');
           return;
@@ -88,6 +91,11 @@ define(['q', 'okta'], function (Q, Okta) {
         src: oktaDomainUrl + '/auth/services/devicefingerprint'
       });
       element.append($iframe);
+
+      iFrameTimeout = setTimeout(() => {
+        // If the iFrame does not load, throw an error
+        handleError('service not available');
+      }, 2000);
 
       return deferred.promise;
     }

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -62,12 +62,18 @@ define([
             if (!self.settings.get('features.deviceFingerprinting')) {
               return;
             }
+            self.options.appState.trigger('loading', true);
+            self.state.trigger('togglePrimaryAuthButton', true);
             return DeviceFingerprint.generateDeviceFingerprint(self.settings.get('baseUrl'), self.$el)
               .then(function (fingerprint) {
                 self.options.appState.set('deviceFingerprint', fingerprint);
               })
               .catch(function () {
                 // Keep going even if device fingerprint fails
+              })
+              .finally(function () {
+                self.options.appState.trigger('loading', false);
+                self.state.trigger('togglePrimaryAuthButton', false);
               });
           })
           .then(_.bind(this.model.save, this.model));

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -50,6 +50,32 @@ function (Expect, $sandbox, DeviceFingerprint) {
         });
     });
 
+    it('fails if the iframe does not load', function (done) {
+      DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
+        .then(function () {
+          done.fail('Fingerprint promise should have been rejected');
+        })
+        .catch(function (reason) {
+          expect(reason).toBe('service not available');
+          var $iFrame = $sandbox.find('iframe');
+          expect($iFrame).not.toExist();
+          done();
+        });
+    });
+
+    it('clears iframe timeout once the iframe loads', function () {
+      mockIFrameMessages(true);
+      bypassMessageSourceCheck();
+      var originalClearTimeout = window.clearTimeout;
+      window.clearTimeout = jasmine.createSpy('clearTimeout');
+      return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
+        .then(function (fingerprint) {
+          expect(fingerprint).toBe('thisIsTheFingerprint');
+          expect(window.clearTimeout).toHaveBeenCalled();
+          window.clearTimeout = originalClearTimeout;
+        });
+    });
+
     it('fails if there is a problem with communicating with the iframe', function (done) {
       mockIFrameMessages(false);
       bypassMessageSourceCheck();


### PR DESCRIPTION
## Description:

- If iframe does not load for any reason, we now have a timeout to proceed with the flow

Resolves: OKTA-305633





## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added unit tests?
- [ ] Added e2e tests
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
 getImage:
![devicefingerprint-429-getImage](https://user-images.githubusercontent.com/6979296/85076980-1da79280-b176-11ea-97ee-fa56fab00d38.gif)


login:
![devicefingerprint-429-login](https://user-images.githubusercontent.com/6979296/85076997-24360a00-b176-11ea-8f91-0130ee071a77.gif)


### Reviewers:


### Issue:

- [OKTA-OKTA-305633](https://oktainc.atlassian.net/browse/OKTA-OKTA-305633)


