### PR TITLE
fix: fix nullpoint exception at BaseFooter

### DIFF
--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -27,9 +27,12 @@ const Link = View.extend({
   },
 
   className () {
-    const nameToClass = this.options.name.replace(/[ ]/g, '-');
-
-    return `link js-${nameToClass}`;
+    const names = ['link'];
+    if (this.options.name) {
+      const nameToClass = this.options.name.replace(/[ ]/g, '-');
+      names.push(`js-${nameToClass}`);
+    }
+    return names.join(' ');
   },
 
   postRender () {

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -1,4 +1,4 @@
-import { View, _, loc } from 'okta';
+import { View, _, loc, $ } from 'okta';
 import Link from '../components/Link';
 
 /**
@@ -28,6 +28,16 @@ export default View.extend({
 
   initialize () {
     let links = _.resultCtx(this, 'links', this);
+
+    // safe check
+    // 1. avoid none array from override
+    // 2. ignore any none plain object arguments
+    if (!Array.isArray(links)) {
+      links = [];
+    } else {
+      links = links.filter(l => $.isPlainObject(l));
+    }
+
     if (this.options.appState.get('showSignoutLink')) {
       //add cancel/signout link
       links = links.concat([

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -26,6 +26,8 @@ const getSwitchAuthenticatorLink = (appState) => {
       }
     ];
   }
+
+  return [];
 };
 
 const getForgotPasswordLink = (appState) => {

--- a/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
@@ -1,0 +1,129 @@
+import BaseFooter from 'v2/view-builder/internals/BaseFooter';
+import AppState from 'v2/models/AppState';
+import Link from 'v2/view-builder/components/Link';
+
+describe('v2/view-builder/internals/BaseFooter', function () {
+
+  let testContext;
+
+  const renderFooter = (links) => {
+    const FooFooter = BaseFooter.extend({
+      links,
+    });
+    spyOn(FooFooter.prototype, 'add');
+    const fooFooter = new FooFooter({
+      appState: testContext.appState,
+    });
+    fooFooter.render();
+    return fooFooter;
+  };
+
+  beforeEach(() => {
+    testContext = {
+      appState: new AppState(),
+    };
+  });
+
+  it('adds nothing when links function return undefined', function () {
+    const fooFooter = renderFooter(() => {});
+
+    expect(fooFooter.add).not.toHaveBeenCalled();
+  });
+  it('adds nothing when links function return empty array', function () {
+    const fooFooter = renderFooter(() => {return [];});
+
+    expect(fooFooter.add).not.toHaveBeenCalled();
+  });
+  it('adds nothing when empty links array', function () {
+    const fooFooter = renderFooter([]);
+
+    expect(fooFooter.add).not.toHaveBeenCalled();
+  });
+
+  it('adds links from `links` array', () => {
+    const fooFooter = renderFooter(() => [
+      {
+        actionPath: 'bar',
+        label: 'Bar',
+        name: 'bar',
+        type: 'link',
+      },
+      undefined,
+    ]);
+
+    expect(fooFooter.add.calls.count()).toEqual(1);
+    expect(fooFooter.add.calls.argsFor(0)).toEqual([
+      Link,
+      {
+        options: {
+          actionPath: 'bar',
+          label: 'Bar',
+          name: 'bar',
+          type: 'link',
+        }
+      }
+    ]);
+  });
+
+  it('adds signout link when `showSignoutLink` is true', () => {
+    spyOn(AppState.prototype, 'get').and.callFake(name => {
+      return name === 'showSignoutLink';
+    });
+
+    const fooFooter = renderFooter([]);
+
+    expect(fooFooter.add.calls.count()).toEqual(1);
+    expect(fooFooter.add.calls.argsFor(0)).toEqual([
+      Link,
+      {
+        options: {
+          'actionPath': 'cancel',
+          'label': 'Sign Out',
+          'name': 'cancel',
+          'type': 'link'
+        }
+      }
+    ]);
+  });
+
+  it('adds other links and signout link when `showSignoutLink` is true', () => {
+    spyOn(AppState.prototype, 'get').and.callFake(name => {
+      return name === 'showSignoutLink';
+    });
+
+    const fooFooter = renderFooter([
+      {
+        actionPath: 'foo',
+        label: 'Foo',
+        name: 'foo',
+        type: 'link',
+      }
+    ]);
+
+    expect(fooFooter.add.calls.count()).toEqual(2);
+    expect(fooFooter.add.calls.argsFor(0)).toEqual([
+      Link,
+      {
+        options: {
+          actionPath: 'foo',
+          label: 'Foo',
+          name: 'foo',
+          type: 'link',
+        }
+      }
+    ]);
+    expect(fooFooter.add.calls.argsFor(1)).toEqual([
+      Link,
+      {
+        options: {
+          'actionPath': 'cancel',
+          'label': 'Sign Out',
+          'name': 'cancel',
+          'type': 'link'
+        }
+      }
+    ]);
+  });
+
+
+});


### PR DESCRIPTION
## Description:

- when `links` didn't return anything, fallback to empty array to avoid NPE.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- OKTA-308658


