### PR TITLE
feat: adds go back link during authenticator enrollment

### DIFF
--- a/src/v2/view-builder/components/AuthenticatorEnrollFooter.js
+++ b/src/v2/view-builder/components/AuthenticatorEnrollFooter.js
@@ -1,0 +1,8 @@
+import BaseFooter from '../internals/BaseFooter';
+import { goBackLink } from '../utils/LinksUtil';
+
+export default BaseFooter.extend({
+  links () {
+    return goBackLink(this.options.appState);
+  }
+});

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -56,7 +56,7 @@ const getForgotPasswordLink = (appState) => {
 
 const goBackLink = (appState) => {
 
-  if (appState.hasRemediationObject(RemediationForms.ENROLL_AUTHENTICATOR)) {
+  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
     return [
       {
         'type': 'link',

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -54,7 +54,24 @@ const getForgotPasswordLink = (appState) => {
   }
 };
 
+const goBackLink = (appState) => {
+
+  if (appState.hasRemediationObject(RemediationForms.ENROLL_AUTHENTICATOR)) {
+    return [
+      {
+        'type': 'link',
+        'label':  loc('oie.go.back', 'login'),
+        'name': 'go-back',
+        'formName': RemediationForms.SELECT_AUTHENTICATOR_ENROLL,
+      }
+    ];
+  }
+
+  return [];
+};
+
 export {
   getSwitchAuthenticatorLink,
   getForgotPasswordLink,
+  goBackLink,
 };

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -3,6 +3,7 @@ import BaseView from '../../internals/BaseView';
 import BaseForm from '../../internals/BaseForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { getPasswordComplexityDescriptionForHtmlList } from '../../utils/FactorUtil';
+import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 
 const Body = BaseForm.extend({
   title () {
@@ -67,6 +68,7 @@ const Body = BaseForm.extend({
 export default BaseAuthenticatorView.extend({
 
   Body,
+  Footer: AuthenticatorEnrollFooter,
 
   createModelClass () {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
@@ -3,6 +3,7 @@ import BaseView from '../../internals/BaseView';
 import BaseForm from '../../internals/BaseForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import CountryUtil from '../../../../util/CountryUtil';
+import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 
 const Body = BaseForm.extend({
 
@@ -119,6 +120,7 @@ const Body = BaseForm.extend({
 export default BaseAuthenticatorView.extend({
 
   Body,
+  Footer: AuthenticatorEnrollFooter,
 
   createModelClass () {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);

--- a/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
+++ b/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
@@ -1,6 +1,7 @@
 import { loc } from 'okta';
 import BaseForm from '../../internals/BaseForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 
 const Body = BaseForm.extend({
   title () {
@@ -13,4 +14,5 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
+  Footer: AuthenticatorEnrollFooter,
 });

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -4,6 +4,7 @@ import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import webauthn from '../../../../util/webauthn';
 import CryptoUtil from '../../../../util/CryptoUtil';
 import EnrollWebauthnInfoView from './EnrollWebauthnInfoView';
+import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 
 function getExcludeCredentials (authenticatorEnrollments = []) {
   const credentials = [];
@@ -99,6 +100,7 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
+  Footer: AuthenticatorEnrollFooter,
   postRender () {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
     this.$el.find('.o-form-button-bar [type="submit"]').remove();

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -2,6 +2,7 @@ import BaseFormObject from './components/BaseFormObject';
 import { Selector } from 'testcafe';
 
 const SIGNOUT_LINK = '.auth-footer .js-cancel';
+const GO_BACK_LINK = '.auth-footer .js-go-back';
 
 export default class BasePageObject {
   constructor(t) {
@@ -37,5 +38,14 @@ export default class BasePageObject {
 
   getSignoutLinkText() {
     return Selector(SIGNOUT_LINK).textContent;
+  }
+
+  async goBackLinkExists() {
+    const elCount = await Selector(GO_BACK_LINK).count;
+    return elCount === 1;
+  }
+
+  getGoBackLinkText() {
+    return Selector(GO_BACK_LINK).textContent;
   }
 }

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -28,6 +28,10 @@ test(`should have both password and confirmPassword fields and both are required
   await t.expect(enrollPasswordPage.passwordFieldExists()).eql(true);
   await t.expect(enrollPasswordPage.confirmPasswordFieldExists()).eql(true);
 
+  // assert go back link shows up
+  await t.expect(await enrollPasswordPage.goBackLinkExists()).ok();
+  await t.expect(enrollPasswordPage.getGoBackLinkText()).eql('Go back');
+
   // fields are required
   await enrollPasswordPage.clickNextButton();
   await enrollPasswordPage.waitForErrorBox();

--- a/test/testcafe/spec/EnrollAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhone_spec.js
@@ -38,6 +38,10 @@ test.requestHooks(mock)(`default sms mode`, async t => {
   await t.expect(enrollPhonePage.extensionIsHidden()).eql(true);
 
   await t.expect(await enrollPhonePage.signoutLinkExists()).notOk();
+
+  // assert go back link shows up
+  await t.expect(await enrollPhonePage.goBackLinkExists()).ok();
+  await t.expect(enrollPhonePage.getGoBackLinkText()).eql('Go back');
 });
 
 test.requestHooks(mock)(`voice mode click and extension will get shown`, async t => {

--- a/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
@@ -52,6 +52,9 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(
   await t.expect(enrollSecurityQuestionPage.isCreateMyOwnSecurityQuestionTextBoxVisible()).notOk();
   // no signout link at enroll page
   await t.expect(await enrollSecurityQuestionPage.signoutLinkExists()).notOk();
+  // assert go back link shows up
+  await t.expect(await enrollSecurityQuestionPage.goBackLinkExists()).ok();
+  await t.expect(enrollSecurityQuestionPage.getGoBackLinkText()).eql('Go back');
 
   // select security question and type answer
   await enrollSecurityQuestionPage.selectSecurityQuestion(1);

--- a/test/testcafe/spec/EnrollWebauthnAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollWebauthnAuthenticator_spec.js
@@ -28,4 +28,8 @@ test(`should have webauthn not supported error if browser doesnt support`, async
 
   // no signout link at enroll page
   await t.expect(await enrollWebauthnPage.signoutLinkExists()).notOk();
+
+  // assert go back link shows up
+  await t.expect(await enrollWebauthnPage.goBackLinkExists()).ok();
+  await t.expect(enrollWebauthnPage.getGoBackLinkText()).eql('Go back');
 });

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -17,12 +17,14 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
           value: currentAuthenticator
         },
       };
+      const appState = new AppState({
+        currentAuthenticator,
+        authenticatorEnrollments
+      });
+      spyOn(appState,'hasRemediationObject').and.callFake((formName) => formName === 'select-authenticator-enroll');
       this.view = new EnrollWebauthnView({
         el: $sandbox,
-        appState: new AppState({
-          currentAuthenticator,
-          authenticatorEnrollments
-        }),
+        appState,
         currentViewState,
       });
       this.view.render();


### PR DESCRIPTION
Resolves: OKTA-310203

## Description:

Added go back link for enroll views of password, security question and webauthn

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![goBackV2](https://user-images.githubusercontent.com/26014318/86392184-e219c780-bc4f-11ea-8913-6c2e7e9f8014.gif)

![goBackV2Phone](https://user-images.githubusercontent.com/26014318/86396315-8ef74300-bc56-11ea-8982-144571f42c0d.gif)


### Reviewers:


### Issue:

- [OKTA-310203](https://oktainc.atlassian.net/browse/OKTA-310203)


