### PR TITLE
fix: remove .only in the test OKTA-310501

### DIFF
--- a/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
@@ -138,7 +138,7 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionErrorM
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
 });
 
-test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionCreateQuestionErrorMock).only(`enroll custom security question error`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionCreateQuestionErrorMock)(`enroll custom security question error`, async t => {
   const enrollSecurityQuestionPage = await setup(t);
 
   const radioOptionLabel = await enrollSecurityQuestionPage.clickCreateYouOwnQuestion();


### PR DESCRIPTION
## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


