### PR TITLE
Password Requirements in Enrollment

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-password.json
@@ -155,11 +155,30 @@
   },
   "currentAuthenticator": {
     "type": "object",
-    "value": {
-      "displayName": "Okta Password",
-      "type": "password",
-      "id": "autwa6eD9o02iBbtv0g3"
-    }
+    "value":{
+      "type":"password",
+      "id":"aut1kaiLIbyUwwGBS0g4",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":0,
+          "excludeUsername":true
+        },
+        "age":{
+          "minAgeMinutes":0,
+          "historyCount":4
+        }
+      }
+   }
   },
   "user": {
     "type": "object",

--- a/playground/mocks/data/idp/idx/authenticator-expired-password.json
+++ b/playground/mocks/data/idp/idx/authenticator-expired-password.json
@@ -81,7 +81,7 @@
       "id":"00u1d4o00DWrRfc5u0g4"
     }
   },
-  "recoveryFactor":{
+  "recoveryAuthenticator":{
     "type":"object",
     "value":{
       "profile":{

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -48,7 +48,7 @@ const Body = BaseForm.extend({
   getPasswordPolicy () {
     // This will be overridden by password expired and password will expire soon
     // scenarios since the policies could be different for those.
-    return null; 
+    return this.options.appState.get('currentAuthenticator').settings;
   },
 
   getUISchema () {

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
@@ -14,7 +14,7 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   },
 
   getPasswordPolicy () { 
-    return this.options.appState.get('recoveryFactor').settings;
+    return this.options.appState.get('recoveryAuthenticator').settings;
   },
 
 });

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -61,3 +61,14 @@ test(`should succeed when fill same value`, async t => {
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
+
+test(`should have the correct reqiurements`, async t => {
+    const enrollPasswordPage = await setup(t);
+    await t.expect(enrollPasswordPage.getRequirements()).contains('Password requirements:');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('At least 8 characters');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('An uppercase letter');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('A number');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
+    await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
+  });


### PR DESCRIPTION
## Description:
I have also fixed Password Requirements in `Password Expired` remediation to use `recoveryAuthenticator` instead of `recoveryFactor`

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [X] Added e2e tests

- [X] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/62976351/86659914-18807b00-bf9f-11ea-9f2c-02381440d2ce.png)

### Reviewers:
@haishengwu-okta 

### Issue:

- [OKTA-308791](https://oktainc.atlassian.net/browse/OKTA-308791)


