### PR TITLE
feat: support Okta verify in select authenticator

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -769,6 +769,8 @@ oie.verify.webauthn.uv.required.instructions = Biometric verification or a PIN i
 oie.security.question.enroll.title = Set up security question
 oie.security.question.challenge.title = Verify with your Security Question
 
+## ODA/ Okta verify
+oie.app = Okta Verify
 
 ## Select factor/authenticator enrollment
 oie.select.authenticators.enroll.title = Set up Authenticators

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
@@ -42,6 +42,7 @@
                 "relatesTo": "$.authenticatorEnrollments.value[0]"
               },
               {
+
                 "label": "FIDO2 (WebAuthn)",
                 "value": {
                   "form": {
@@ -145,6 +146,30 @@
                   }
                 },
                 "relatesTo": "$.authenticatorEnrollments.value[5]"
+              },
+              {
+                "label": "Okta Verify",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "auttheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "signed_nonce",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[6]"
               }
             ]
           },
@@ -202,6 +227,17 @@
         "type": "security_question",
         "authenticatorId": "aid568g3mXgtID0HHSLH",
         "id": "autwa6eD9o02iBbaaa82"
+      },
+      {
+        "displayName": "Okta Verify Device 1",
+        "type": "app",
+        "id": "aen1mz5J4cuNoaR3l0g4",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [
+           {
+            "type":  "signed_nonce"
+           }
+        ]
       }
     ]
   },

--- a/src/v2/view-builder/utils/FactorUtil.js
+++ b/src/v2/view-builder/utils/FactorUtil.js
@@ -49,6 +49,12 @@ const factorData = {
     description: loc('oie.webauthn.description', 'login'),
     iconClassName: 'mfa-webauthn',
   },
+
+  'app': {
+    label: loc('oie.app', 'login'),
+    description: '',
+    iconClassName: 'mfa-okta-verify',
+  },
 };
 
 const getFactorData = function (factorName) {

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -38,7 +38,7 @@ test.requestHooks(mockChallengePassword)(`should load select authenticator list`
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
-  await t.expect(selectFactorPage.getFactorsCount()).eql(5);
+  await t.expect(selectFactorPage.getFactorsCount()).eql(6);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Password');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-password');
@@ -59,6 +59,10 @@ test.requestHooks(mockChallengePassword)(`should load select authenticator list`
   await t.expect(selectFactorPage.getFactorLabelByIndex(4)).eql('Security Question');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(4)).contains('mfa-okta-security-question');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(4)).eql('Select');
+
+  await t.expect(selectFactorPage.getFactorLabelByIndex(5)).eql('Okta Verify');
+  await t.expect(selectFactorPage.getFactorIconClassByIndex(5)).contains('mfa-okta-verify');
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(5)).eql('Select');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();


### PR DESCRIPTION
 * Added OV support for verify flow.

This is for m1. Eventually if we need to show multiple OV enrollments with additional text we need api support for that. 

    RESOLVES: OKTA-311498

<img width="624" alt="Screen Shot 2020-07-08 at 9 28 42 AM" src="https://user-images.githubusercontent.com/17267130/86946884-de7aba80-c0ff-11ea-8cc0-ee4ecafcbf82.png">



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-311498](https://oktainc.atlassian.net/browse/OKTA-311498)


