### PR TITLE
fix: keyboard enter issues on email authenticate 

### DIFF
--- a/src/views/mfa-verify/SendEmailAndVerifyCodeForm.js
+++ b/src/views/mfa-verify/SendEmailAndVerifyCodeForm.js
@@ -42,23 +42,29 @@ define([
     events: Object.assign({}, Okta.Form.prototype.events, {
       submit: function (e) {
         e.preventDefault();
-        this.clearErrors();
-
-        if (this.options.appState.get('isMfaChallenge')) {
-          if (this.isValid()) {
-            this.model.save();
-          }
-        } else {
-          // Send email and switch to verification view
-          this.model.set('answer', '');
-          this.model.save()
-            .then(this.renderChallengView.bind(this));
-        }
+        this.handleSubmit();
       }
     }),
+    
+    handleSubmit () {
+      this.clearErrors();
+      if (this.options.appState.get('isMfaChallenge')) {
+        if (this.isValid()) {
+          this.model.save();
+        }
+      } else {
+        // Send email and switch to verification view
+        this.model.set('answer', '');
+        this.model.save()
+          .then(this.renderChallengView.bind(this));
+      }
+    },
 
     initialize: function () {
       Okta.Form.prototype.initialize.apply(this, arguments);
+
+      //Added thorttle to prevent keyboard enter trigger multipele API calls
+      this.handleSubmit = _.throttle(this.handleSubmit, 100, { leading: false });
 
       // render 'Send Email' page at first place
       this.add(Okta.View.extend({


### PR DESCRIPTION
## Description:
This should fix press "enter" on keyboard  should prevent twice API call trigger

![fix_email](https://user-images.githubusercontent.com/39984255/86972131-697ba500-c140-11ea-9513-e1d639b79170.gif)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


