### PR TITLE
fix: fix redundant error at enroll security question

### DIFF
--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-security-question-create-question.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-security-question-create-question.json
@@ -49,7 +49,20 @@
                         "name": "answer",
                         "label": "Answer",
                         "required": true,
-                        "secret": true
+                        "secret": true,
+                        "messages": {
+                          "type": "array",
+                          "value": [
+                            {
+                              "class": "ERROR",
+                              "i18n": {
+                                "key": "securityQuestion.answer.tooShort",
+                                "params": []
+                              },
+                              "message": "The security answer must be at least 4 characters"
+                            }
+                          ]
+                        }
                       }
                     ]
                   }

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-security-question.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-security-question.json
@@ -88,7 +88,20 @@
                         "name": "answer",
                         "label": "Answer",
                         "required": true,
-                        "secret": true
+                        "secret": true,
+                        "messages": {
+                          "type": "array",
+                          "value": [
+                            {
+                              "class": "ERROR",
+                              "i18n": {
+                                "key": "securityQuestion.answer.tooShort",
+                                "params": []
+                              },
+                              "message": "The security answer must be at least 4 characters"
+                            }
+                          ]
+                        }
                       }
                     ]
                   }

--- a/src/v2/ion/IonResponseHelper.js
+++ b/src/v2/ion/IonResponseHelper.js
@@ -30,12 +30,43 @@ const convertErrorMessageToErrorSummary = (formName, remediationValues = []) => 
 };
 
 /**
+ * Although time complexity is O(n^2),
+ * the `array` is actually very small (size < 5),
+ * hence performance doesn't matter.
+ */
+const uniqWith = (array, comparator) => {
+  if (!Array.isArray(array)) {
+    return [];
+  }
+  if (!_.isFunction(comparator) || array.length === 1) {
+    return array;
+  }
+
+  const result = [];
+  for (let i = 0; i < array.length; i++) {
+    let seen = false;
+    for (let j = i + 1; j < array.length; j++) {
+      /* eslint max-depth: [2, 3] */
+      if (comparator(array[i], array[j])) {
+        seen = true;
+        break;
+      }
+    }
+    if (!seen) {
+      result.push(array[i]);
+    }
+  }
+
+  return result;
+};
+
+/**
  * returns errors
  * @example
  * errors = [
  *   {property : fieldName1, errorSummary: [errorMessage1]},
- *   {property : fieldName2, errorSummary: [errorMessage1]}
- *   {property : fieldName3, errorSummary: [errorMessage1, errorMessage2]}
+ *   {property : fieldName2, errorSummary: [errorMessage2]}
+ *   {property : fieldName3, errorSummary: [errorMessage31, errorMessage32]}
  * ]
  */
 const getRemediationErrors = (res) => {
@@ -71,7 +102,10 @@ const getRemediationErrors = (res) => {
     }
   });
 
-  return _.flatten(errors);
+  // API may return identical error on same field
+  // thus run through `uniqWith`.
+  // Check unit test for details.
+  return uniqWith(_.flatten(errors), _.isEqual);
 };
 
 /**

--- a/test/unit/spec/v2/ion/IonResponseHelper_spec.js
+++ b/test/unit/spec/v2/ion/IonResponseHelper_spec.js
@@ -257,7 +257,6 @@ describe('v2/ion/IonResponseHelper', function () {
         }
       });
     });
-
     it('has `options` fields messages', () => {
       const resp = {
         remediation: {
@@ -269,12 +268,146 @@ describe('v2/ion/IonResponseHelper', function () {
                   name: 'authenticator',
                   options: [
                     {
-                      label: 'xxx',
+                      label: 'select a question',
                       value: {
                         form: {
                           value: [
                             {
-                              label: 'Question',
+                              label: 'choose a question',
+                              name: 'questionKey',
+                              options: {
+                                foo: 'Foo',
+                                bar: 'Bar'
+                              }
+                            },
+                            {
+                              label: 'Answer',
+                              name: 'answer',
+                              messages: {
+                                value: [
+                                  {
+                                    'class': 'ERROR',
+                                    'i18n': {
+                                      'key': 'answer.is.short',
+                                      'params': []
+                                    },
+                                    'message': 'security question answer is too short'
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      label: 'create your own question',
+                      value: {
+                        form: {
+                          value: [
+                            {
+                              name: 'questionKey',
+                              value: 'custom',
+                            },
+                            {
+                              label: 'create you own question',
+                              name: 'question',
+                            },
+                            {
+                              label: 'Answer',
+                              name: 'answer',
+                              messages: {
+                                value: [
+                                  {
+                                    'class': 'ERROR',
+                                    'i18n': {
+                                      'key': 'answer.is.short',
+                                      'params': []
+                                    },
+                                    'message': 'security question answer is too short'
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+
+                }
+              ]
+            }
+          ]
+        }
+      };
+      expect(IonResponseHelper.convertFormErrors(resp)).toEqual({
+        responseJSON: {
+          errorCauses: [
+            {
+              property: 'authenticator.answer',
+              errorSummary: ['security question answer is too short'],
+            }
+          ],
+          errorSummary: '',
+        }
+      });
+    });
+
+    it('has `options` fields messages with i18n override', () => {
+      const resp = {
+        remediation: {
+          value: [
+            {
+              name: 'test-form',
+              value: [
+                {
+                  name: 'authenticator',
+                  options: [
+                    {
+                      label: 'select a question',
+                      value: {
+                        form: {
+                          value: [
+                            {
+                              label: 'choose a question',
+                              name: 'questionKey',
+                              options: {
+                                foo: 'Foo',
+                                bar: 'Bar'
+                              }
+                            },
+                            {
+                              label: 'Answer',
+                              name: 'answer',
+                              messages: {
+                                value: [
+                                  {
+                                    'class': 'ERROR',
+                                    'i18n': {
+                                      'key': 'answer.too.short',
+                                      'params': []
+                                    },
+                                    'message': 'security question answer is too short'
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      label: 'create your own question',
+                      value: {
+                        form: {
+                          value: [
+                            {
+                              name: 'questionKey',
+                              value: 'custom',
+                            },
+                            {
+                              label: 'create you own question',
                               name: 'question',
                             },
                             {


### PR DESCRIPTION
## Description:

- API send back errors in both `Answer` field hence has to filter the redundancy.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- OKTA-309274


