### PR TITLE
feat: add support for user verification

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -234,6 +234,55 @@ const appleUniversalLink = {
   ],
 };
 
+const userVerificationLoopback = {
+  '/idp/idx/introspect': [
+    'identify-with-user-verification-loopback'
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-user-verification-loopback',
+    'identify-with-user-verification-loopback',
+    'identify-with-user-verification-loopback',
+    'success',
+  ],
+};
+
+// Windows/Android authenticator with custom URI
+const userVerificationCustomUri = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-loopback-challenge-not-received',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-user-verification-custom-uri',
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'identify-with-user-verification-custom-uri',
+  ]
+};
+
+const userVerificationCredentialSSOExtension = {
+  '/idp/idx/introspect': [
+    'identify-with-user-verification-credential-sso-extension'
+  ],
+  '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel': [
+    'identify'
+  ],
+};
+
+const userVerificationUniversalLink = {
+  '/idp/idx/introspect': [
+    'identify-with-user-verification-universal-link'
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'identify-with-user-verification-universal-link',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-user-verification-universal-link',
+    'identify-with-user-verification-universal-link',
+    'identify-with-user-verification-universal-link',
+    'success',
+  ],
+};
+
 module.exports = {
   mocks: idx,
 };

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-credential-sso-extension.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-credential-sso-extension.json
@@ -1,0 +1,142 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "name": "device-apple-sso-extension",
+        "href": "http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/ft2FCeXuk7ov8iehMivYavZFhPxZUpBvB0/verify",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..V4cvSiSPJsgjecpp.-On44MjqUJNcGT91KzoEj4tR4G7hM77PK0QpdTeBbcfuVjXXtGIc0ltkpQPvHyxEYXeC7wnLfIsEs8TFxjWI_0llcXUxkGbjC9ZHYchN7GE1appdcJCL_kjynVQ68V3__QvdsMRje3c_mx6B_ud_f5Dbiq0RwfqB4SBrCI9w8dTJlFP2UfMH3gdVBcFuDrq62F21GqglwJqtycGnMeQj605_ZxdhbVYZPKbgLXE3VLC6lfZsHVkjYdAzuyl8QPaeQpwg51YaewE-y_T41jdWdXaS74AKWEesxZzTF_nJWlG4Dkp4mpgr20SaXD5Kt7mGu3_ydzgVyl8rjh2jMVX7xESyvJG8e8XT-AAb40XLCAOyOKQwzp7s-sbsNG29TZAfP1xdK3QEE4aW4lMYaZBAuBYZBTTji2BhPojfItcKWZJHUm4WeIVaToZYrFDCn7N9ucYP-Cf0b4SAMrzKdRpi93W8xeKJW5p7yxkJEc6jhsFojO4T6Gcdr5_KWbG3if6BXf6A0WD4qs8kjS3XN8K7oyY1LuAc9BLJ1o6HkWulDA0hpMR767xcgZEbgbumE7Mtkmm27MDR4WbaAFhXe7DyBN4Gk34PeFpIHGCIZ97cRnFq3zl7T9yT2BmtwOt40FOk0qt3L-DG6sPGy41REC7sZ4E73n_Qjkqhz-ra-aTmInxnUIxebJu4WeDiPJtC8kvMY8WCQsk_sho1QhHI76yFLWM6P894XO_cfM2i0bPbppqw3eflCydmjTDr6SwPxbUtjb2W3idXVY6vlH4pf_knINALPMJyg9mMdE7bpv1ZB43YPZtBGaWsp7vidM94Q4kjn5DC82jediMAmOfRELKXD51UJa0KBEcr69843qGFGYmt-NZ5SEFtAvp_4t_ebmJoopc35zFPojg1wtsk0yAetDMDVwkAbzYjQdLjOY_adK4Wv0IaCjduuRUmaucqbotuJP0am9qwjgqc1F50bbRIyFBhsExzfltB-fYrC_Ptry_xXbauQhJ2HvSQLN-gc0moEIaCW0Gj9NFLIugZftjJf-38SJnnZy9RSd3DLWrhJyW-OyACsFUH0r3NIsEpDChNuUeAvfqkfjg9pOb0lXKhahgLtAEaiov7q3Mrl6ZU5n8DgwSCLV2C3_DsogjAlPjNhq7EE-5SuujkQ3Lv-Rg5XRfXVfv9JrVtX2Xu0ZljD0kQJYTfSIrKp2FPaJbYgFAbi_9RnJCigYWDGNZGy46s-EWG42orp7z0sK42-K4tKThVTdNb4lSOsSCpuElL2nFqJeXjqBgVinWXzC50TiyUxsuycu8PcTU0M5Jjo01xk6wfLE1DV78TNHBCSwXy-d8IrP8lG73j8Zmxlo-krt4IVzA33WjzNaLh64h26ScP-9N2se1_ncfE9VXo8NGlHfV9Rf3UC28CqdtZJHpr1aMKYNsClT_JBVcM6fUKsa8xycUlF-iCOiRPw1qsf6Pz9ANa9MU4zqly_szOdFpYz9qaAEyl6Hgbf4jN5al0yW63yEhmu235V4AEyoKflGKtXrCZc42vGB3Rd1uaDTxgqfj7aCTnYKYDEKx6QB3yl9KhmWpJIpUfG6MMLnMSCp5KpIVC5CBg.1eu0DsfqywhW4yUGYrgywg",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+   "currentAuthenticatorEnrollment": {
+      "type": "object",
+      "value": {
+          "profile": {
+            "name": "Okta Verify"
+          },
+          "type": "app", 
+          "id": "aen1mz5J4cuNoaR3l0g4"
+      }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri.json
@@ -1,0 +1,170 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "name": "user-verification-poll", 
+        "href": "http://localhost:3000/idp/idx/authenticators/poll",  
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+   "currentAuthenticatorEnrollment": {
+      "type": "object",
+      "value": {
+          "profile": {
+            "name": "Okta Verify"
+          },
+          "type": "app", 
+          "id": "aen1mz5J4cuNoaR3l0g4",
+          "cancel": {
+              "rel": [
+                  "create-form"
+              ],
+              "name": "cancel-polling",
+              "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+              "method": "POST",
+              "accepts": "application/vnd.okta.v1+json",
+              "value": [
+                  {
+                      "name": "stateHandle",
+                      "required": true,
+                      "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+                      "visible": false,
+                      "mutable": false
+                  }
+              ]
+          },
+          "contextualData": {
+              "challenge": {
+                  "type": "object",
+                  "value": {
+                      "challengeMethod": "CUSTOM_URI",
+                      "href": "com-okta-authenticator:/deviceChallenge?challengeRequest=eyJraWQiOiJWbEdrNkZZcVJ3T3I5TlpwcF9KeV9IaldJZFphY3VzV053eEl1VmhIVklJIiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb20iLCJhdWQiOiJva3RhLjYzYzA4MWRiLTFmMTMtNTA4NC04ODJmLWU3OWUxZTVlMmRhNyIsImV4cCI6MTU5MjE2NzEzNCwiaWF0IjoxNTkyMTY2ODM0LCJqdGkiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwibm9uY2UiOiJFQjhLTWUtQmtxTlVjRDVhUDVCeFc3QW5xTGlhUzhHMCIsInRyYW5zYWN0aW9uSWQiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwic2lnbmFscyI6WyJzY3JlZW5Mb2NrIiwicm9vdFByaXZpbGVnZXMiLCJmdWxsRGlza0VuY3J5cHRpb24iLCJpZCIsInBsYXRmb3JtIiwib3NWZXJzaW9uIiwibWFudWZhY3R1cmVyIiwibW9kZWwiLCJkZXZpY2VBdHRlc3RhdGlvbiJdLCJ1c2VyVmVyaWZpY2F0aW9uUmVxdWlyZW1lbnQiOmZhbHNlLCJ2ZXJpZmljYXRpb25VcmkiOiJodHRwczovL2lkeC5va3RhMS5jb20vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dDF1aGZBdWR3Q1NTWUdQMGc0L3RyYW5zYWN0aW9ucy9mdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oL3ZlcmlmeSIsImNhU3ViamVjdE5hbWVzIjpbXSwibWRtQXR0ZXN0YXRpb25Jc3N1ZXJzIjpbXSwia2V5VHlwZSI6InByb29mT2ZQb3NzZXNzaW9uIiwiZmFjdG9yVHlwZSI6ImNyeXB0byIsIm9yZ0lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJ2ZXIiOjB9.M9LovulH2vEzxTYNsCizulfmpxbVjKgjJZ4d3AKS-a3dg6-JZtUA8h_l9TYhnSiUBuaZWM5ebIlO9IOsGJa8VQ6tCD0gCfLVp0tUlB3pgmxRWRiOzAL_Z-rKvdz7zF5DJYVa3GgFM7ed7mE6OFNbKdUQmAAQWzzfZ1Kp8i08eTme57COpr6zYg5-Up_ivmsSPUcHQ0piRzCnDeWY03dPzezOn-9NfhPQgsoL-0JyJOFbw61MrzNnXAmZqD23TX3tDXXgmjWA1exjgf2Qua1ppZAY_lgtuMXipa0auKRP9q9X7cUsg05igEnsM_TIZJxEJATmBON-YG3lzw-FKHikjQ"
+                  } 
+              }
+          }
+      }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-loopback.json
@@ -1,0 +1,177 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "name": "user-verification-poll", 
+        "href": "http://localhost:3000/idp/idx/authenticators/poll",  
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+   "currentAuthenticatorEnrollment": {
+      "type": "object",
+      "value": {
+          "profile": {
+            "name": "Okta Verify"
+          },
+          "type": "app", 
+          "id": "aen1mz5J4cuNoaR3l0g4",
+          "cancel": {
+              "rel": [
+                  "create-form"
+              ],
+              "name": "cancel-polling",
+              "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+              "method": "POST",
+              "accepts": "application/vnd.okta.v1+json",
+              "value": [
+                  {
+                      "name": "stateHandle",
+                      "required": true,
+                      "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+                      "visible": false,
+                      "mutable": false
+                  }
+              ]
+          },
+          "contextualData": {
+              "challenge": {
+                  "type": "object",
+                  "value": {
+                      "challengeMethod": "LOOPBACK",
+                      "challengeRequest": "eyJraWQiOiJWbEdrNkZZcVJ3T3I5TlpwcF9KeV9IaldJZFphY3VzV053eEl1VmhIVklJIiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb20iLCJhdWQiOiJva3RhLjYzYzA4MWRiLTFmMTMtNTA4NC04ODJmLWU3OWUxZTVlMmRhNyIsImV4cCI6MTU5MjE2NzEzNCwiaWF0IjoxNTkyMTY2ODM0LCJqdGkiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwibm9uY2UiOiJFQjhLTWUtQmtxTlVjRDVhUDVCeFc3QW5xTGlhUzhHMCIsInRyYW5zYWN0aW9uSWQiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwic2lnbmFscyI6WyJzY3JlZW5Mb2NrIiwicm9vdFByaXZpbGVnZXMiLCJmdWxsRGlza0VuY3J5cHRpb24iLCJpZCIsInBsYXRmb3JtIiwib3NWZXJzaW9uIiwibWFudWZhY3R1cmVyIiwibW9kZWwiLCJkZXZpY2VBdHRlc3RhdGlvbiJdLCJ1c2VyVmVyaWZpY2F0aW9uUmVxdWlyZW1lbnQiOmZhbHNlLCJ2ZXJpZmljYXRpb25VcmkiOiJodHRwczovL2lkeC5va3RhMS5jb20vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dDF1aGZBdWR3Q1NTWUdQMGc0L3RyYW5zYWN0aW9ucy9mdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oL3ZlcmlmeSIsImNhU3ViamVjdE5hbWVzIjpbXSwibWRtQXR0ZXN0YXRpb25Jc3N1ZXJzIjpbXSwia2V5VHlwZSI6InByb29mT2ZQb3NzZXNzaW9uIiwiZmFjdG9yVHlwZSI6ImNyeXB0byIsIm9yZ0lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJ2ZXIiOjB9.M9LovulH2vEzxTYNsCizulfmpxbVjKgjJZ4d3AKS-a3dg6-JZtUA8h_l9TYhnSiUBuaZWM5ebIlO9IOsGJa8VQ6tCD0gCfLVp0tUlB3pgmxRWRiOzAL_Z-rKvdz7zF5DJYVa3GgFM7ed7mE6OFNbKdUQmAAQWzzfZ1Kp8i08eTme57COpr6zYg5-Up_ivmsSPUcHQ0piRzCnDeWY03dPzezOn-9NfhPQgsoL-0JyJOFbw61MrzNnXAmZqD23TX3tDXXgmjWA1exjgf2Qua1ppZAY_lgtuMXipa0auKRP9q9X7cUsg05igEnsM_TIZJxEJATmBON-YG3lzw-FKHikjQ",
+                      "domain": "http://localhost",
+                      "ports": [
+                        "2000",
+                        "6511",
+                        "6512",
+                        "6513"
+                     ]
+                  } 
+              }
+          }
+      }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-universal-link.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-universal-link.json
@@ -1,0 +1,170 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "name": "user-verification-poll", 
+        "href": "http://localhost:3000/idp/idx/authenticators/poll",  
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+   "currentAuthenticatorEnrollment": {
+      "type": "object",
+      "value": {
+          "profile": {
+            "name": "Okta Verify"
+          },
+          "type": "app", 
+          "id": "aen1mz5J4cuNoaR3l0g4",
+          "cancel": {
+              "rel": [
+                  "create-form"
+              ],
+              "name": "cancel-polling",
+              "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+              "method": "POST",
+              "accepts": "application/vnd.okta.v1+json",
+              "value": [
+                  {
+                      "name": "stateHandle",
+                      "required": true,
+                      "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+                      "visible": false,
+                      "mutable": false
+                  }
+              ]
+          },
+          "contextualData": {
+              "challenge": {
+                  "type": "object",
+                  "value": {
+                      "challengeMethod": "UNIVERSAL_LINK",
+                      "href": "https://login.okta1.com/auth/okta-verify/?challengeRequest=eyJraWQiOiJWbEdrNkZZcVJ3T3I5TlpwcF9KeV9IaldJZFphY3VzV053eEl1VmhIVklJIiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL2lkeC5va3RhMS5jb20iLCJhdWQiOiJva3RhLjYzYzA4MWRiLTFmMTMtNTA4NC04ODJmLWU3OWUxZTVlMmRhNyIsImV4cCI6MTU5MjE2NzEzNCwiaWF0IjoxNTkyMTY2ODM0LCJqdGkiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwibm9uY2UiOiJFQjhLTWUtQmtxTlVjRDVhUDVCeFc3QW5xTGlhUzhHMCIsInRyYW5zYWN0aW9uSWQiOiJmdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oIiwic2lnbmFscyI6WyJzY3JlZW5Mb2NrIiwicm9vdFByaXZpbGVnZXMiLCJmdWxsRGlza0VuY3J5cHRpb24iLCJpZCIsInBsYXRmb3JtIiwib3NWZXJzaW9uIiwibWFudWZhY3R1cmVyIiwibW9kZWwiLCJkZXZpY2VBdHRlc3RhdGlvbiJdLCJ1c2VyVmVyaWZpY2F0aW9uUmVxdWlyZW1lbnQiOmZhbHNlLCJ2ZXJpZmljYXRpb25VcmkiOiJodHRwczovL2lkeC5va3RhMS5jb20vaWRwL2F1dGhlbnRpY2F0b3JzL2F1dDF1aGZBdWR3Q1NTWUdQMGc0L3RyYW5zYWN0aW9ucy9mdGM2aVIyekpMQlZCMnJLU1E1LW41R3llejZZT3BNek9oL3ZlcmlmeSIsImNhU3ViamVjdE5hbWVzIjpbXSwibWRtQXR0ZXN0YXRpb25Jc3N1ZXJzIjpbXSwia2V5VHlwZSI6InByb29mT2ZQb3NzZXNzaW9uIiwiZmFjdG9yVHlwZSI6ImNyeXB0byIsIm9yZ0lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJ2ZXIiOjB9.M9LovulH2vEzxTYNsCizulfmpxbVjKgjJZ4d3AKS-a3dg6-JZtUA8h_l9TYhnSiUBuaZWM5ebIlO9IOsGJa8VQ6tCD0gCfLVp0tUlB3pgmxRWRiOzAL_Z-rKvdz7zF5DJYVa3GgFM7ed7mE6OFNbKdUQmAAQWzzfZ1Kp8i08eTme57COpr6zYg5-Up_ivmsSPUcHQ0piRzCnDeWY03dPzezOn-9NfhPQgsoL-0JyJOFbw61MrzNnXAmZqD23TX3tDXXgmjWA1exjgf2Qua1ppZAY_lgtuMXipa0auKRP9q9X7cUsg05igEnsM_TIZJxEJATmBON-YG3lzw-FKHikjQ"
+                  } 
+              }
+          }
+      }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -34,6 +34,7 @@ const FORMS = {
 
   DEVICE_CHALLENGE_POLL: 'device-challenge-poll',
   DEVICE_APPLE_SSO_EXTENSION: 'device-apple-sso-extension',
+  USER_VERIFICATION_CHALLENGE_POLL: 'user-verification-poll',
   CANCEL_TRANSACTION: 'cancel-transaction',
   LAUNCH_AUTHENTICATOR: 'launch-authenticator',
 };

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -57,6 +57,9 @@ const VIEWS_MAPPING = {
   [RemediationForms.DEVICE_APPLE_SSO_EXTENSION]: {
     [DEFAULT]: SSOExtensionView,
   },
+  [RemediationForms.USER_VERIFICATION_CHALLENGE_POLL]: {
+    [DEFAULT]: DeviceChallengePollView,
+  },
   [RemediationForms.CANCEL_TRANSACTION]: {
     [DEFAULT]: SSOExtensionView,
   },

--- a/test/testcafe/spec/DeviceChallengePollViewUserVerification_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewUserVerification_spec.js
@@ -1,0 +1,170 @@
+import { RequestLogger, RequestMock, ClientFunction, Selector } from 'testcafe';
+import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import identify from '../../../playground/mocks/data/idp/idx/identify';
+import identifyWithUserVerificationLoopback from '../../../playground/mocks/data/idp/idx/identify-with-user-verification-loopback';
+import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received';
+import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri';
+import identifyWithSSOExtensionFallback from '../../../playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback';
+import identifyWithUserVerificationLaunchUniversalLink from '../../../playground/mocks/data/idp/idx/identify-with-user-verification-universal-link';
+
+let failureCount = 0;
+const loopbackSuccessLogger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
+const loopbackSuccesskMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
+  .respond(identifyWithUserVerificationLoopback)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond((req, res) => {
+    res.statusCode = '200';
+    if (failureCount === 2) {
+      res.setBody(identify);
+    } else {
+      res.setBody(identifyWithUserVerificationLoopback);
+    }
+  })
+  .onRequestTo(/2000|6511\/probe/)
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  });
+
+const loopbackFallbackLogger = RequestLogger(/introspect|probe|cancel|launch|poll/);
+const loopbackFallbackMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithUserVerificationLoopback)
+  .onRequestTo(/2000|6511|6512|6513\/probe/)
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
+  .respond(loopbackChallengeNotReceived)
+  .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(identifyWithUserVerificationCustomURI)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithUserVerificationCustomURI);
+
+const identifyWithLaunchAuthenticatorHttpCustomUri = JSON.parse(JSON.stringify(identifyWithUserVerificationCustomURI));
+const mockHttpCustomUri = 'http://localhost:3000/launch-okta-verify';
+// replace custom URI with http URL so that we can mock and verify
+identifyWithLaunchAuthenticatorHttpCustomUri.currentAuthenticatorEnrollment.value.contextualData.challenge.value.href = mockHttpCustomUri;
+
+const customURILogger = RequestLogger(/launch-okta-verify/);
+const customURIMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri)
+  .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(identifyWithUserVerificationCustomURI)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri);
+
+// replace universal link with http URL so that we can mock and verify
+identifyWithUserVerificationLaunchUniversalLink.currentAuthenticatorEnrollment.value.contextualData.challenge.value.href = mockHttpCustomUri;
+const universalLinkMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithSSOExtensionFallback)
+  .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(identifyWithUserVerificationLaunchUniversalLink)
+  .onRequestTo(mockHttpCustomUri)
+  .respond('<html><h1>open universal link</h1></html>')
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithUserVerificationLaunchUniversalLink);
+
+fixture(`Device Challenge Polling View for user verification with the Loopback Server, Custom URI and Universal Link approaches`);
+
+async function setup(t) {
+  const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
+  await deviceChallengePollPage.navigateToPage();
+  return deviceChallengePollPage;
+}
+
+async function setupLoopbackFallback(t) {
+  const deviceChallengeFalllbackPage = new IdentityPageObject(t);
+  await deviceChallengeFalllbackPage.navigateToPage();
+  return deviceChallengeFalllbackPage;
+}
+
+test
+  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)(`in loopback server approach, probing and polling requests are sent and responded`, async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/introspect|6512/)
+    )).eql(3);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/challenge/) &&
+      record.request.body.match(/challengeRequest":"eyJraWQiOiJW/)
+    )).eql(1);
+    failureCount = 2;
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 500 &&
+      record.request.url.match(/2000|6511/)
+    )).eql(2);
+    await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
+
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
+
+test
+  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)(`loopback fails and falls back to custom uri`, async t => {
+    loopbackFallbackLogger.clear();
+    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/introspect/)
+    )).eql(1);
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/2000|6511|6512|6513/)
+    )).eql(4);
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/authenticators\/poll\/cancel/)
+    )).eql(1);
+    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
+    await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
+    await t.expect(deviceChallengePollPageObject.getContent())
+      .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Back to Sign In');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
+  });
+
+const getPageUrl = ClientFunction(() => window.location.href);
+test
+  .requestHooks(customURILogger, customURIMock)(`in custom URI approach, Okta Verify is launched`, async t => {
+    const deviceChallengePollPageObject = await setup(t);
+    await t.expect(customURILogger.count(
+      record => record.request.url.match(/launch-okta-verify/)
+    )).eql(1);
+    await deviceChallengePollPageObject.clickLaunchOktaVerifyLink();
+    await t.expect(customURILogger.count(
+      record => record.request.url.match(/launch-okta-verify/)
+    )).eql(2);
+  });
+
+test
+  .requestHooks(loopbackFallbackLogger, universalLinkMock)(`SSO Extension fails and falls back to universal link`, async t => {
+    loopbackFallbackLogger.clear();
+    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/introspect/)
+    )).eql(1);
+    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify your sign in');
+    await t.expect(deviceChallengePollPageObject.getContent()).eql('To continue, you\'ll need to use the Okta Verify app to confirm your sign in.\nSign in with Okta Verify');
+    deviceChallengePollPageObject.clickUniversalLink();
+    await t.expect(getPageUrl()).contains(mockHttpCustomUri);
+    await t.expect(Selector('h1').innerText).eql('open universal link');
+  });


### PR DESCRIPTION
## Description:
Supports loopback server, custom URI, universal link and credential SSO extension approach for user verification. 
The API format is different from device probing step. The UX mock is the same https://oktawiki.atlassian.net/wiki/spaces/UX/pages/1170385761/Okta+Verify+M1.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
loopback
![uv-loopback](https://user-images.githubusercontent.com/5066836/87482095-923ee700-c5e5-11ea-9bab-f0187a9eef72.gif)

custom URI
![uv-customURI](https://user-images.githubusercontent.com/5066836/87482161-b0a4e280-c5e5-11ea-835a-6ab2fe93de9f.gif)

universal link
![uv-ul](https://user-images.githubusercontent.com/5066836/87482211-c914fd00-c5e5-11ea-945a-65a8d54bc685.gif)

credential SSO extension
<img width="1293" alt="Screen Shot 2020-07-14 at 2 48 24 PM" src="https://user-images.githubusercontent.com/5066836/87482354-17c29700-c5e6-11ea-93d1-6ba909df0cb7.png">

### Reviewers:
@nbories-okta @stevennguyen-okta @nikhilvenkatraman-okta @magizh-okta 

### Issue:

- [OKTA-309152](https://oktainc.atlassian.net/browse/OKTA-309152)
- [OKTA-310954](https://oktainc.atlassian.net/browse/OKTA-310954)
- [OKTA-312545](https://oktainc.atlassian.net/browse/OKTA-312545)
