### PR TITLE
feat: adds css classnames to body for parity with v1

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -4,6 +4,7 @@ const idx = {
   // ===== IDX
 
   '/idp/idx/introspect': [
+    'identify',
     // 'error-internal-server-error',
     // 'authenticator-enroll-password',
     // 'authenticator-enroll-phone',
@@ -12,14 +13,14 @@ const idx = {
     // 'authenticator-enroll-data-phone-voice',
     // 'error-internal-server-error',
     // 'authenticator-enroll-security-question',
-    'authenticator-enroll-select-authenticator',
+    // 'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',
     // 'authenticator-verification-data-phone-sms-then-voice',
     // 'authenticator-verification-data-phone-voice-only',
     // 'authenticator-verification-data-phone-voice-then-sms',
     // 'authenticator-verification-email',
-    'authenticator-verification-password',
+    // 'authenticator-verification-password',
     // 'authenticator-verification-phone-sms',
     // 'authenticator-verification-phone-voice',
     // 'authenticator-verification-security-question',

--- a/src/v2/ion/ViewClassNamesFactory.js
+++ b/src/v2/ion/ViewClassNamesFactory.js
@@ -1,0 +1,83 @@
+/* eslint complexity: [2, 25] */
+import {FORMS} from './RemediationConstants';
+
+const FORMNAME_CLASSNAME_MAPPINGS = {
+  [FORMS.IDENTIFY]: {
+    [FORMS.IDENTIFY]: ['primary-auth'],
+    'password': ['primary-auth']
+  },
+  [FORMS.ENROLL_PROFILE]: {
+    [FORMS.ENROLL_PROFILE]: ['registration'],
+  },
+  [FORMS.CHALLENGE_AUTHENTICATOR]: {
+    email: ['mfa-verify-passcode'],
+    password: ['mfa-verify-password'],
+    sms: ['mfa-verify-passcode'],
+    voice: ['mfa-verify-passcode'],
+    'security_question': ['mfa-verify-question']
+  },
+  [FORMS.ENROLL_AUTHENTICATOR]: {
+    email: ['enroll-email'],
+    password: ['enroll-password'],
+    sms: ['enroll-sms'],
+    voice: ['enroll-call'],
+    'security_question': ['enroll-question'],
+  },
+
+  [FORMS.SELECT_AUTHENTICATOR_ENROLL]: {
+    'select-authenticator-enroll': ['enroll-choices']
+  },
+  [FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE]: {
+    'password': ['forgot-password']
+  },
+  [FORMS.REENROLL_AUTHENTICATOR]: {
+    'password':['password-expired']
+  },
+
+  [FORMS.RESET_AUTHENTICATOR]: {
+    'password':['forgot-password']
+  },
+};
+
+const getV1ClassName = (formName, type, isPasswordRecoveryFlow) => {
+  if (isPasswordRecoveryFlow && formName === 'identify') {
+    // if password reset flow from identifier page with recoveryAuthenticator add forgot-password class
+    return ['forgot-password'];
+  } else {
+    return FORMNAME_CLASSNAME_MAPPINGS[formName][type];
+  }
+};
+
+const getClassNameMapping = (formName, authenticatorType, methodType) => {
+  let type = formName;
+  let v2ClassName = formName;
+  let classNames = [];
+
+  if (authenticatorType === 'phone') {
+    /**
+      Both sms and call have same type phone
+      currentAuthenticatorEnrollment is during verify and currentAuthenticator during enroll flows
+    **/
+    type = `${methodType}`;
+  }
+  else if (authenticatorType) {
+    type = `${authenticatorType}`;
+  }
+
+  if (type !== formName) {
+    // If we have a type which is authenticatorType/methodType use that to generate a V2 className
+    v2ClassName = formName + '--' + type;
+  }
+  classNames.push(v2ClassName);
+  //do a lookup for any V1 classNames and concat
+  if (FORMNAME_CLASSNAME_MAPPINGS[formName] && FORMNAME_CLASSNAME_MAPPINGS[formName][type]) {
+    classNames = classNames.concat(getV1ClassName(formName, type));
+  }
+  return classNames;
+};
+
+export {
+  getClassNameMapping,
+  getV1ClassName
+};
+

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -52,6 +52,14 @@ export default Model.extend({
           || '';
       },
     },
+    authenticatorMethodType: {
+      deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment',],
+      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
+        return currentAuthenticator.methods && currentAuthenticator.methods[0].type
+          || currentAuthenticatorEnrollment.methods && currentAuthenticatorEnrollment.methods[0].type
+          || '';
+      },
+    },
     showSignoutLink: {
       deps: ['idx', 'currentFormName'],
       fn: function (idx = {}, currentFormName) {
@@ -60,6 +68,12 @@ export default Model.extend({
           && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
       },
     },
+    isPasswordRecovery: {
+      deps: ['recoveryAuthenticator'],
+      fn: function (recoveryAuthenticator = {}) {
+        return recoveryAuthenticator && recoveryAuthenticator.type === 'password';
+      }
+    }
   },
 
   hasRemediationObject (formName) {
@@ -148,6 +162,8 @@ export default Model.extend({
 
     // clear appState before setting new values
     this.clear({silent: true});
+    // clear cache for derived props.
+    this.trigger('cache:clear');
 
     // set new app state properties
     this.set(transformedResponse);

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -4,6 +4,7 @@ import BaseModel from './BaseModel';
 import BaseHeader from './BaseHeader';
 import BaseFooter from './BaseFooter';
 import hbs from 'handlebars-inline-precompile';
+import {getClassNameMapping} from '../../ion/ViewClassNamesFactory';
 
 export default View.extend({
 
@@ -13,7 +14,16 @@ export default View.extend({
 
   Footer: BaseFooter,
 
-  className: 'siw-main-view',
+  className () {
+    let classNames = ['siw-main-view'];
+    const appState = this.options.appState;
+
+    const formName = appState.get('currentFormName');
+    const authenticatorType = appState.get('authenticatorType');
+    const methodType = appState.get('authenticatorMethodType');
+    classNames = classNames.concat(getClassNameMapping(formName, authenticatorType, methodType));
+    return classNames.join(' ');
+  },
 
   template: hbs`
     <div class="siw-main-header"></div>

--- a/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
@@ -16,8 +16,7 @@ const Body = BaseForm.extend({
     return loc('oie.select.authenticators.verify.subtitle', 'login');
   },
   isPasswordRecoveryFlow () {
-    const recoveryAuthenticator = this.options.appState.get('recoveryAuthenticator');
-    return recoveryAuthenticator && recoveryAuthenticator.type === 'password';
+    return this.options.appState.get('isPasswordRecovery');
   },
   noButtonBar: true,
 });

--- a/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
+++ b/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
@@ -1,0 +1,117 @@
+import { getClassNameMapping, getV1ClassName } from 'v2/ion/ViewClassNamesFactory';
+
+describe('Adds the right classname', function () {
+
+  it('for identify form with password', function () {
+    const result = getClassNameMapping('identify', 'password', null);
+    expect(result).toEqual(['identify--password', 'primary-auth']);
+  });
+
+  it('for identify form', function () {
+    const result = getClassNameMapping('identify', null , null);
+    expect(result).toEqual(['identify', 'primary-auth']);
+  });
+
+  it('for select-authenticator-authenticate form', function () {
+    const result = getClassNameMapping('select-authenticator-authenticate', null , null);
+    expect(result).toEqual(['select-authenticator-authenticate']);
+  });
+  it('for select-authenticator-authenticate form with password ', function () {
+    const result = getClassNameMapping('select-authenticator-authenticate', 'password' , null);
+    expect(result).toEqual(['select-authenticator-authenticate--password', 'forgot-password']);
+  });
+
+  it('for select-authenticator-enroll form', function () {
+    const result = getClassNameMapping('select-authenticator-enroll', null , null);
+    expect(result).toEqual(['select-authenticator-enroll', 'enroll-choices']);
+  });
+
+  it('for challenge-authenticator form with email ', function () {
+    const result = getClassNameMapping('challenge-authenticator', 'email' , null);
+    expect(result).toEqual(['challenge-authenticator--email', 'mfa-verify-passcode']);
+  });
+
+  it('for challenge-authenticator form with security_question ', function () {
+    const result = getClassNameMapping('challenge-authenticator', 'security_question' , null);
+    expect(result).toEqual(['challenge-authenticator--security_question', 'mfa-verify-question']);
+  });
+
+  it('for enroll-authenticator form with security_question ', function () {
+    const result = getClassNameMapping('enroll-authenticator', 'security_question' , null);
+    expect(result).toEqual(['enroll-authenticator--security_question', 'enroll-question']);
+  });
+
+  it('for enroll-authenticator form with email ', function () {
+    const result = getClassNameMapping('enroll-authenticator', 'email' , null);
+    expect(result).toEqual(['enroll-authenticator--email', 'enroll-email']);
+  });
+
+  it('for enroll-authenticator form with password ', function () {
+    const result = getClassNameMapping('enroll-authenticator', 'password' , null);
+    expect(result).toEqual(['enroll-authenticator--password', 'enroll-password']);
+  });
+
+  it('for enroll-authenticator form with sms ', function () {
+    const result = getClassNameMapping('enroll-authenticator', 'sms' , null);
+    expect(result).toEqual(['enroll-authenticator--sms', 'enroll-sms']);
+  });
+
+  it('for enroll-authenticator form with voice ', function () {
+    const result = getClassNameMapping('enroll-authenticator', 'voice' , null);
+    expect(result).toEqual(['enroll-authenticator--voice', 'enroll-call']);
+  });
+
+
+  it('for reenroll-authenticator form with voice ', function () {
+    const result = getClassNameMapping('reenroll-authenticator', 'password' , null);
+    expect(result).toEqual(['reenroll-authenticator--password', 'password-expired']);
+  });
+
+  it('for reset-authenticator form with voice ', function () {
+    const result = getClassNameMapping('reset-authenticator', 'password' , null);
+    expect(result).toEqual(['reset-authenticator--password', 'forgot-password']);
+  });
+
+  it('for success form', function () {
+    const result = getClassNameMapping('success-redirect', null , null);
+    expect(result).toEqual(['success-redirect']);
+  });
+
+  it('for terminal form ', function () {
+    const result = getClassNameMapping('terminal', null , null);
+    expect(result).toEqual(['terminal']);
+  });
+
+  it('for authenticator-verification-data form wih email method sms', function () {
+    const result = getClassNameMapping('authenticator-verification-data', 'phone' , 'sms');
+    expect(result).toEqual(['authenticator-verification-data--sms']);
+  });
+
+  it('for authenticator-verification-data form wih email method voice', function () {
+    const result = getClassNameMapping('authenticator-verification-data', 'phone' , 'voice');
+    expect(result).toEqual(['authenticator-verification-data--voice']);
+  });
+
+});
+
+describe('getV1ClassName returns the right V1 classname', function () {
+  it('for identify with recovery', function () {
+    const result = getV1ClassName('identify', null, true);
+    expect(result).toEqual(['forgot-password']);
+  });
+
+  it('for identify without recovery with password', function () {
+    const result = getV1ClassName('identify', 'password', false);
+    expect(result).toEqual(['primary-auth']);
+  });
+  
+  it('for identify without recovery without password', function () {
+    const result = getV1ClassName('identify', 'identify', false);
+    expect(result).toEqual(['primary-auth']);
+  });
+
+  it('for enroll-profile without recovery', function () {
+    const result = getV1ClassName('enroll-profile', 'enroll-profile', false);
+    expect(result).toEqual(['registration']);
+  });
+});


### PR DESCRIPTION
Resolves: OKTA-312533

## Description:

- adds css classnames to body for parity with v1

- Class names to be added for parity with V1
https://github.com/okta/okta-signin-widget/blob/master/assets/sass/okta-theme.scss#L910

``` 
    .primary-auth

    .password-expired
    .password-reset
    .password-reset-email-sent
    .forgot-password

    .recovery-challenge
    .recovery-loading
    .recovery-question

    .enroll-choices

    .enroll-sms
    .enroll-call
    .enroll-question

    .mfa-verify
    .mfa-verify-question
    .mfa-verify-passcode  used for email, call, sms in V1
    .mfa-verify-password

```

- adds css classnames for M1 based on form-name + authenticator 

## PR Checklist

- [x] Have you verified the basic functionality for this change?



### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-312533](https://oktainc.atlassian.net/browse/OKTA-312533)


