### PR TITLE
feat: supports ready and afterRender events in v2

### DIFF
--- a/playground/main.js
+++ b/playground/main.js
@@ -60,6 +60,14 @@ const renderPlaygroundWidget = (options = {}) => {
     }
   );
 
+  signIn.on('ready', () => {
+    console.log('===== playground widget ready event received =====');
+  });
+  signIn.on('afterRender', (opt) => {
+    console.log('===== playground widget afterRender event received =====');
+    console.log(JSON.stringify(opt));
+  });
+
 };
 
 window.renderPlaygroundWidget = renderPlaygroundWidget;

--- a/playground/main.js
+++ b/playground/main.js
@@ -61,9 +61,16 @@ const renderPlaygroundWidget = (options = {}) => {
   );
 
   signIn.on('ready', () => {
+    // handle `ready` event.
+    // use `console.log` in particular so that those logs can be retrived
+    // in testcafe for assertion
     console.log('===== playground widget ready event received =====');
   });
+
   signIn.on('afterRender', (opt) => {
+    // handle `afterRender` event.
+    // use `console.log` in particular so that those logs can be retrived
+    // in testcafe for assertion
     console.log('===== playground widget afterRender event received =====');
     console.log(JSON.stringify(opt));
   });

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -170,6 +170,10 @@ export default Router.extend({
       appState: this.appState
     }, options);
     this.controller = new Controller(controllerOptions);
+
+    // Bubble up all controller events
+    this.listenTo(this.controller, 'all', this.trigger);
+
     this.controller.render();
   },
 

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -12,6 +12,7 @@
 import { _, Controller } from 'okta';
 import ViewFactory from '../view-builder/ViewFactory';
 import IonResponseHelper from '../ion/IonResponseHelper';
+import { getV1ClassName } from '../ion/ViewClassNamesFactory';
 
 export default Controller.extend({
   className: 'form-controller',
@@ -52,6 +53,35 @@ export default Controller.extend({
       return;
     }
 
+    this.triggerAfterRenderEvent();
+  },
+
+  triggerAfterRenderEvent () {
+    const formName = this.options.appState.get('currentFormName');
+    const authenticatorType = this.options.appState.get('authenticatorType');
+    const methodType = this.options.appState.get('authenticatorMethodType');
+    const isPasswordRecoveryFlow = this.options.appState.get('isPasswordRecoveryFlow');
+
+    const v1ControllerClassName = getV1ClassName(
+      formName,
+      authenticatorType,
+      methodType,
+      isPasswordRecoveryFlow,
+    );
+
+    const eventData = {
+      controller: v1ControllerClassName,
+      formName,
+    };
+
+    if (authenticatorType) {
+      eventData.authenticatorType = authenticatorType;
+    }
+    if (methodType && authenticatorType !== methodType) {
+      eventData.methodType = methodType;
+    }
+
+    this.trigger('afterRender', eventData);
   },
 
   switchForm (formName) {

--- a/src/v2/ion/ViewClassNamesFactory.js
+++ b/src/v2/ion/ViewClassNamesFactory.js
@@ -14,7 +14,8 @@ const FORMNAME_CLASSNAME_MAPPINGS = {
     password: 'mfa-verify-password',
     sms: 'mfa-verify-passcode',
     voice: 'mfa-verify-passcode',
-    'security_question': 'mfa-verify-question'
+    'security_question': 'mfa-verify-question',
+    'security_key': 'mfa-verify-webauthn',
   },
   [FORMS.ENROLL_AUTHENTICATOR]: {
     email: 'enroll-email',
@@ -22,6 +23,7 @@ const FORMNAME_CLASSNAME_MAPPINGS = {
     sms: 'enroll-sms',
     voice: 'enroll-call',
     'security_question': 'enroll-question',
+    'security_key': 'enroll-webauthn',
   },
 
   [FORMS.SELECT_AUTHENTICATOR_ENROLL]: {

--- a/src/v2/ion/ViewClassNamesFactory.js
+++ b/src/v2/ion/ViewClassNamesFactory.js
@@ -1,79 +1,94 @@
 /* eslint complexity: [2, 25] */
-import {FORMS} from './RemediationConstants';
+import { FORMS } from './RemediationConstants';
 
 const FORMNAME_CLASSNAME_MAPPINGS = {
   [FORMS.IDENTIFY]: {
-    [FORMS.IDENTIFY]: ['primary-auth'],
-    'password': ['primary-auth']
+    [FORMS.IDENTIFY]: 'primary-auth',
+    'password': 'primary-auth'
   },
   [FORMS.ENROLL_PROFILE]: {
-    [FORMS.ENROLL_PROFILE]: ['registration'],
+    [FORMS.ENROLL_PROFILE]: 'registration',
   },
   [FORMS.CHALLENGE_AUTHENTICATOR]: {
-    email: ['mfa-verify-passcode'],
-    password: ['mfa-verify-password'],
-    sms: ['mfa-verify-passcode'],
-    voice: ['mfa-verify-passcode'],
-    'security_question': ['mfa-verify-question']
+    email: 'mfa-verify-passcode',
+    password: 'mfa-verify-password',
+    sms: 'mfa-verify-passcode',
+    voice: 'mfa-verify-passcode',
+    'security_question': 'mfa-verify-question'
   },
   [FORMS.ENROLL_AUTHENTICATOR]: {
-    email: ['enroll-email'],
-    password: ['enroll-password'],
-    sms: ['enroll-sms'],
-    voice: ['enroll-call'],
-    'security_question': ['enroll-question'],
+    email: 'enroll-email',
+    password: 'enroll-password',
+    sms: 'enroll-sms',
+    voice: 'enroll-call',
+    'security_question': 'enroll-question',
   },
 
   [FORMS.SELECT_AUTHENTICATOR_ENROLL]: {
-    'select-authenticator-enroll': ['enroll-choices']
+    'select-authenticator-enroll': 'enroll-choices'
   },
   [FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE]: {
-    'password': ['forgot-password']
+    'password': 'forgot-password'
   },
   [FORMS.REENROLL_AUTHENTICATOR]: {
-    'password':['password-expired']
+    'password': 'password-expired'
   },
 
   [FORMS.RESET_AUTHENTICATOR]: {
-    'password':['forgot-password']
+    'password': 'forgot-password'
   },
 };
 
-const getV1ClassName = (formName, type, isPasswordRecoveryFlow) => {
-  if (isPasswordRecoveryFlow && formName === 'identify') {
-    // if password reset flow from identifier page with recoveryAuthenticator add forgot-password class
-    return ['forgot-password'];
+const getV1ClassName = (formName, authenticatorType, methodType, isPasswordRecoveryFlow) => {
+  // if password reset flow from identifier page with recoveryAuthenticator add forgot-password class
+  if (isPasswordRecoveryFlow && formName === FORMS.IDENTIFY) {
+    return 'forgot-password';
   } else {
-    return FORMNAME_CLASSNAME_MAPPINGS[formName][type];
+    let type = formName;
+    if (authenticatorType === 'phone') {
+      // Both sms and call have same type phone
+      // currentAuthenticatorEnrollment is during verify and currentAuthenticator during enroll flows
+      type = `${methodType}`;
+    }
+    else if (authenticatorType) {
+      type = `${authenticatorType}`;
+    }
+
+    if (FORMNAME_CLASSNAME_MAPPINGS[formName] && FORMNAME_CLASSNAME_MAPPINGS[formName][type]) {
+      return FORMNAME_CLASSNAME_MAPPINGS[formName][type];
+    } else {
+      return null;
+    }
   }
 };
 
-const getClassNameMapping = (formName, authenticatorType, methodType) => {
-  let type = formName;
+const getClassNameMapping = (formName, authenticatorType, methodType, isPasswordRecoveryFlow) => {
+
+  // 1. Generates V2 class name
+  // If we have a type which is authenticatorType/methodType use that to generate a V2 className
+  // Otherwise just use formName
   let v2ClassName = formName;
-  let classNames = [];
-
-  if (authenticatorType === 'phone') {
-    /**
-      Both sms and call have same type phone
-      currentAuthenticatorEnrollment is during verify and currentAuthenticator during enroll flows
-    **/
-    type = `${methodType}`;
+  if (authenticatorType) {
+    v2ClassName = v2ClassName + '--' + authenticatorType;
   }
-  else if (authenticatorType) {
-    type = `${authenticatorType}`;
+  if (methodType && methodType !== authenticatorType) {
+    v2ClassName = v2ClassName + '--' + methodType;
   }
 
-  if (type !== formName) {
-    // If we have a type which is authenticatorType/methodType use that to generate a V2 className
-    v2ClassName = formName + '--' + type;
+
+  // 2. do a lookup for any V1 classNames and concat
+  let v1ClassName = getV1ClassName(
+    formName,
+    authenticatorType,
+    methodType,
+    isPasswordRecoveryFlow,
+  );
+  const result = [v2ClassName];
+  if (v1ClassName) {
+    result.push(v1ClassName);
   }
-  classNames.push(v2ClassName);
-  //do a lookup for any V1 classNames and concat
-  if (FORMNAME_CLASSNAME_MAPPINGS[formName] && FORMNAME_CLASSNAME_MAPPINGS[formName][type]) {
-    classNames = classNames.concat(getV1ClassName(formName, type));
-  }
-  return classNames;
+
+  return result;
 };
 
 export {

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -15,13 +15,21 @@ export default View.extend({
   Footer: BaseFooter,
 
   className () {
-    let classNames = ['siw-main-view'];
     const appState = this.options.appState;
 
     const formName = appState.get('currentFormName');
     const authenticatorType = appState.get('authenticatorType');
     const methodType = appState.get('authenticatorMethodType');
-    classNames = classNames.concat(getClassNameMapping(formName, authenticatorType, methodType));
+    const isPasswordRecoveryFlow = appState.get('isPasswordRecoveryFlow');
+
+    const additionalClassNames = getClassNameMapping(
+      formName,
+      authenticatorType,
+      methodType,
+      isPasswordRecoveryFlow,
+    );
+
+    const classNames = ['siw-main-view'].concat(additionalClassNames);
     return classNames.join(' ');
   },
 

--- a/test/testcafe/.eslintrc.js
+++ b/test/testcafe/.eslintrc.js
@@ -11,13 +11,12 @@ module.exports = {
   'plugins': [
     'testcafe'
   ],
-  "env": {
-    "browser": true,
-    "es6": true,
+  'env': {
+    'browser': true,
+    'es6': true,
   },
   'rules': {
     'semi': 2,
     'max-len': 0,
   },
-  'root': true
 };

--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -1,21 +1,18 @@
 import BasePageObject from './BasePageObject';
 
-const SMS_RADIO_SELECTOR = 'input[value="sms"]';
-const VOICE_RADIO_SELECTOR = 'input[value="voice"]';
 const PHONE_NUMBER_SELECTOR = '.phone-authenticator-enroll__phone';
 const PHONE_NUMBER_EXTENSION_SELECTOR = '.phone-authenticator-enroll__phone-ext';
 const phoneFieldName = 'authenticator\\.phoneNumber';
 const RESEND_VIEW_SELECTOR = '.phone-authenticator-enroll--warning';
+
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
   constructor (t) {
     super (t);
   }
 
-  clickRadio (type = "voice") {
-    return ( type === "voice" )
-      ? this.form.clickElement(VOICE_RADIO_SELECTOR)
-      : this.form.clickElement(SMS_RADIO_SELECTOR);
+  clickRadio (methodType = 'voice') {
+    return this.form.selectRadioButtonOptionByValue('authenticator\\.methodType', methodType);
   }
 
   extensionIsHidden () {

--- a/test/testcafe/framework/page-objects/EnrollSecurityQuestionPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollSecurityQuestionPageObject.js
@@ -10,11 +10,11 @@ export default class EnrollSecurityQuestionPageObject extends BasePageObject {
   }
 
   clickChooseSecurityQuestion() {
-    return this.form.selectRadioButtonOption("sub_schema_local_credentials", 0);
+    return this.form.selectRadioButtonOption('sub_schema_local_credentials', 0);
   }
 
   clickCreateYouOwnQuestion() {
-    return this.form.selectRadioButtonOption("sub_schema_local_credentials", 1);
+    return this.form.selectRadioButtonOption('sub_schema_local_credentials', 1);
   }
 
   selectSecurityQuestion(index) {

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -6,7 +6,7 @@ const factorLabelSelector = `${factorListRowSelector} .authenticator-label`;
 const factorDescriptionSelector = `${factorListRowSelector} .authenticator-description .authenticator-description--text`;
 const factorIconSelector = `${factorListRowSelector} .authenticator-icon-container .authenticator-icon`;
 const factorSelectButtonSelector = `${factorListRowSelector} .authenticator-button .button`;
-const skipOptionalEnrollmentSelector = `.authenticator-list .skip-all`;
+const skipOptionalEnrollmentSelector = '.authenticator-list .skip-all';
 const CUSTOM_SIGN_OUT_LINK_SELECTOR = '.auth-footer .js-cancel';
 
 export default class SelectFactorPageObject extends BasePageObject {

--- a/test/testcafe/framework/page-objects/SelectFactorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectFactorPageObject.js
@@ -5,7 +5,7 @@ const factorLabelSelector = `${factorListRowSelector} .enroll-factor-label`;
 const factorDescriptionSelector = '.factor-description';
 const factorIconSelector = `${factorListRowSelector} .enroll-factor-icon-container .factor-icon`;
 const factorSelectButtonSelector = `${factorListRowSelector} .enroll-factor-button .button`;
-const skipOptionalEnrollmentSelector = `.enroll-factor-list .skip-all`;
+const skipOptionalEnrollmentSelector = '.enroll-factor-list .skip-all';
 
 export default class SelectFactorPageObject extends BasePageObject {
   constructor(t) {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -60,6 +60,9 @@ export default class BaseFormObject {
     return this.el.find(selector).innerText;
   }
 
+  // =====================================
+  // Checkbox
+  // =====================================
   getTextBoxValue(name) {
     return this.el.find(`input[name="${name}"]`).value;
   }
@@ -148,10 +151,26 @@ export default class BaseFormObject {
     await this.t.click(option);
   }
 
+
+  // =====================================
+  // radio button
+  // =====================================
+
   async selectRadioButtonOption(fieldName, index) {
     const radioOption = await this.findFormFieldInput(fieldName)
       .find('.radio-label')
       .nth(index);
+    const radioTextContent = await radioOption.textContent;
+    const radioOptionLabel = radioTextContent.trim();
+    await this.t.click(radioOption);
+
+    return radioOptionLabel;
+  }
+
+  async selectRadioButtonOptionByValue(fieldName, value) {
+    const radioOption = await this.findFormFieldInput(fieldName)
+      .find(`input[value="${value}"] + .radio-label`);
+
     const radioTextContent = await radioOption.textContent;
     const radioOptionLabel = radioTextContent.trim();
     await this.t.click(radioOption);

--- a/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
@@ -32,15 +32,26 @@ const recoveryRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Challenge Authenticator Password`);
+fixture('Challenge Authenticator Password');
 
 async function setup(t) {
   const challengePasswordPage = new ChallengePasswordPageObject(t);
   await challengePasswordPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'mfa-verify-password',
+    formName: 'challenge-authenticator',
+    authenticatorType: 'password',
+  });
+
   return challengePasswordPage;
 }
 
-test.requestHooks(mockChallengeAuthenticatorPassword)(`challenge password authenticator`, async t => {
+test.requestHooks(mockChallengeAuthenticatorPassword)('challenge password authenticator', async t => {
   const challengePasswordPage = await setup(t);
   // assert switch authenticator link
   await challengePasswordPage.switchAuthenticatorExists();
@@ -62,7 +73,7 @@ test.requestHooks(mockChallengeAuthenticatorPassword)(`challenge password authen
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
-test.requestHooks(mockInvalidPassword)(`challege password authenticator with invalid password`, async t => {
+test.requestHooks(mockInvalidPassword)('challege password authenticator with invalid password', async t => {
   const challengePasswordPage = await setup(t);
   await challengePasswordPage.switchAuthenticatorExists();
   await challengePasswordPage.verifyFactor('credentials.passcode', 'test');
@@ -71,7 +82,7 @@ test.requestHooks(mockInvalidPassword)(`challege password authenticator with inv
   await t.expect(challengePasswordPage.getPasswordFieldErrorMessage()).contains('The passcode is absent or invalid');
 });
 
-test.requestHooks(recoveryRequestLogger, mockCannotForgotPassword)(`can not recover password`, async t => {
+test.requestHooks(recoveryRequestLogger, mockCannotForgotPassword)('can not recover password', async t => {
   const challengePasswordPage = await setup(t);
   await challengePasswordPage.forgotPasswordLink.exists();
   await challengePasswordPage.forgotPasswordLink.click();

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -44,17 +44,29 @@ const invalidCodeMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidCode, 403);
 
-fixture(`Challenge Phone Form`);
+fixture('Challenge Phone Form');
 
 async function setup(t) {
   const challengePhonePageObject = new ChallengePhonePageObject(t);
-  challengePhonePageObject.navigateToPage();
+  await challengePhonePageObject.navigateToPage();
   return challengePhonePageObject;
 }
 
 test
-  .requestHooks(smsPrimaryMock)(`SMS primary mode - has the right labels`, async t => {
+  .requestHooks(smsPrimaryMock)('SMS primary mode - has the right labels', async t => {
     const challengePhonePageObject = await setup(t);
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(3);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: null,
+      formName: 'authenticator-verification-data',
+      authenticatorType: 'phone',
+      methodType: 'sms',
+    });
+
     const pageTitle = challengePhonePageObject.getPageTitle();
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
     const primaryButtonText = challengePhonePageObject.getSaveButtonLabel();
@@ -70,7 +82,7 @@ test
   });
 
 test
-  .requestHooks(logger, smsPrimaryMock)(`SMS primary mode - Secondary button click`, async t => {
+  .requestHooks(logger, smsPrimaryMock)('SMS primary mode - Secondary button click', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickSecondaryLink();
     await t.expect(logger.count(() => true)).eql(1);
@@ -81,15 +93,27 @@ test
         id: 'autxl8PPhwHUpOpW60g3',
         methodType: 'voice',
       },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg'
     });
     await t.expect(method).eql('post');
     await t.expect(url).eql('http://localhost:3000/idp/idx/challenge');
   });
 
 test
-  .requestHooks(voicePrimaryMock)(`Voice primary mode - has the right labels`, async t => {
+  .requestHooks(voicePrimaryMock)('Voice primary mode - has the right labels', async t => {
     const challengePhonePageObject = await setup(t);
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(3);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: null,
+      formName: 'authenticator-verification-data',
+      authenticatorType: 'phone',
+      methodType: 'voice',
+    });
+
     const pageTitle = challengePhonePageObject.getPageTitle();
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
     const primaryButtonText = challengePhonePageObject.getSaveButtonLabel();
@@ -102,7 +126,7 @@ test
   });
 
 test
-  .requestHooks(voiceOnlyMock)(`Only one option - has only one primary button`, async t => {
+  .requestHooks(voiceOnlyMock)('Only one option - has only one primary button', async t => {
     const challengePhonePageObject = await setup(t);
     const pageTitle = challengePhonePageObject.getPageTitle();
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
@@ -115,7 +139,7 @@ test
   });
 
 test
-  .requestHooks(logger, voicePrimaryMock)(`Voice primary mode - Secondary button click`, async t => {
+  .requestHooks(logger, voicePrimaryMock)('Voice primary mode - Secondary button click', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickSecondaryLink();
     await t.expect(logger.count(() => true)).eql(1);
@@ -126,16 +150,35 @@ test
         id: 'autxl8PPhwHUpOpW60g3',
         methodType: 'sms',
       },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg'
     });
     await t.expect(method).eql('post');
     await t.expect(url).eql('http://localhost:3000/idp/idx/challenge');
   });
 
 test
-  .requestHooks(smsPrimaryMock)(`SMS mode - Enter code screen has the right labels`, async t => {
+  .requestHooks(smsPrimaryMock)('SMS mode - Enter code screen has the right labels', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(5);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: null,
+      formName: 'authenticator-verification-data',
+      authenticatorType: 'phone',
+      methodType: 'sms',
+    });
+    await t.expect(log[3]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[4])).eql({
+      controller: 'mfa-verify-passcode',
+      formName: 'challenge-authenticator',
+      authenticatorType: 'phone',
+      methodType: 'sms',
+    });
+
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
     await t.expect(challengePhonePageObject.getSaveButtonLabel()).eql('Verify');
     await t.expect(pageSubtitle).contains('A code was sent to');
@@ -143,9 +186,28 @@ test
   });
 
 test
-  .requestHooks(voicePrimaryMock)(`Voice mode - Enter code screen has the right labels`, async t => {
+  .requestHooks(voicePrimaryMock)('Voice mode - Enter code screen has the right labels', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(5);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: null,
+      formName: 'authenticator-verification-data',
+      authenticatorType: 'phone',
+      methodType: 'voice',
+    });
+    await t.expect(log[3]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[4])).eql({
+      controller: 'mfa-verify-passcode',
+      formName: 'challenge-authenticator',
+      authenticatorType: 'phone',
+      methodType: 'voice',
+    });
+
     const pageSubtitle = challengePhonePageObject.getFormSubtitle();
     await t.expect(challengePhonePageObject.getSaveButtonLabel()).eql('Verify');
     await t.expect(pageSubtitle).contains('Calling');
@@ -153,7 +215,7 @@ test
   });
 
 test
-  .requestHooks(logger, smsPrimaryMock)(`SMS flow`, async t => {
+  .requestHooks(logger, smsPrimaryMock)('SMS flow', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
 
@@ -173,20 +235,20 @@ test
         id: 'autxl8PPhwHUpOpW60g3',
         methodType: 'sms',
       },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg'
     });
     await t.expect(methodTypeRequest.request.method).eql('post');
     await t.expect(methodTypeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge');
     await t.expect(challengeCodeRequestBody).eql({
       credentials: { passcode: '1234' },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g'
     });
     await t.expect(challengeCodeRequest.request.method).eql('post');
     await t.expect(challengeCodeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
 
 test
-  .requestHooks(logger, voicePrimaryMock)(`Voice flow`, async t => {
+  .requestHooks(logger, voicePrimaryMock)('Voice flow', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
 
@@ -206,20 +268,20 @@ test
         id: 'autxl8PPhwHUpOpW60g3',
         methodType: 'voice',
       },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg'
     });
     await t.expect(methodTypeRequest.request.method).eql('post');
     await t.expect(methodTypeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge');
     await t.expect(challengeCodeRequestBody).eql({
       credentials: { passcode: '1234' },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g'
     });
     await t.expect(challengeCodeRequest.request.method).eql('post');
     await t.expect(challengeCodeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
 
 test
-  .requestHooks(invalidCodeMock)(`Entering invalid passcode results in an error`, async t => {
+  .requestHooks(invalidCodeMock)('Entering invalid passcode results in an error', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.verifyFactor('credentials.passcode', 'abcd');
     await challengePhonePageObject.clickNextButton();

--- a/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
@@ -20,15 +20,26 @@ const answerRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Challenge Security Question Form`);
+fixture('Challenge Security Question Form');
 
 async function setup(t) {
   const challengeFactorPage = new ChallengeSecurityQuestionPageObject(t);
   await challengeFactorPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'mfa-verify-question',
+    formName: 'challenge-authenticator',
+    authenticatorType: 'security_question',
+  });
+
   return challengeFactorPage;
 }
 
-test.requestHooks(answerRequestLogger, authenticatorRequiredSecurityQuestionMock)(`verify security question`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorRequiredSecurityQuestionMock)('verify security question', async t => {
   const challengeFactorPageObject = await setup(t);
 
   await t.expect(await challengeFactorPageObject.getAnswerLabel()).eql('Where did you go for your favorite vacation?');

--- a/test/testcafe/spec/ChallengeFactorEmailMagicLink_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmailMagicLink_spec.js
@@ -30,7 +30,7 @@ const magicLinkEmailSentMock = RequestMock()
 
 const logger = RequestLogger(/poll|resend/);
 
-fixture(`Challenge Email Magic Link Form Content`);
+fixture('Challenge Email Magic Link Form Content');
 
 async function setup(t) {
   const challengeFactorPageObject = new ChallengeFactorPageObject(t);
@@ -39,28 +39,28 @@ async function setup(t) {
 }
 
 test
-  .requestHooks(magicLinkReturnTabMock)(`challenge email factor with magic link`, async t => {
+  .requestHooks(magicLinkReturnTabMock)('challenge email factor with magic link', async t => {
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Please return to the original tab.');
   });
 
 test
-  .requestHooks(magicLinkTransfer)(`show the correct content when transferred email`, async t => {
+  .requestHooks(magicLinkTransfer)('show the correct content when transferred email', async t => {
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Flow continued in a new tab.');
   });
 
 test
-  .requestHooks(magicLinkExpiredMock)(`challenge email factor with expired magic link`, async t => {
+  .requestHooks(magicLinkExpiredMock)('challenge email factor with expired magic link', async t => {
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
   });
 
 test
-  .requestHooks(logger, magicLinkEmailSentMock)(`challenge email factor with magic link sent renders and has resend link`, async t => {
+  .requestHooks(logger, magicLinkEmailSentMock)('challenge email factor with magic link sent renders and has resend link', async t => {
     const challengeFactorPageObject = await setup(t);
     await t.expect(challengeFactorPageObject.resendEmailView().hasClass('hide')).ok();
 

--- a/test/testcafe/spec/ChallengeFactorEmailOTP_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmailOTP_spec.js
@@ -19,7 +19,7 @@ const inValidOTPmock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidOTP, 403);
 
-fixture(`Challenge Email Form`);
+fixture('Challenge Email Form');
 
 async function setup(t) {
   const challengeFactorPageObject = new ChallengeFactorPageObject(t);
@@ -28,7 +28,7 @@ async function setup(t) {
 }
 
 test
-  .requestHooks(validOTPmock)(`challenge email factor with valid OTP form has right labels`, async t => {
+  .requestHooks(validOTPmock)('challenge email factor with valid OTP form has right labels', async t => {
     const challengeFactorPageObject = await setup(t);
     const pageTitle = challengeFactorPageObject.getPageTitle();
     const saveBtnText = challengeFactorPageObject.getSaveButtonLabel();
@@ -42,7 +42,7 @@ test
   });
 
 test
-  .requestHooks(inValidOTPmock)(`challenge email factor with invalid OTP`, async t => {
+  .requestHooks(inValidOTPmock)('challenge email factor with invalid OTP', async t => {
     const challengeFactorPageObject = await setup(t);
     await challengeFactorPageObject.verifyFactor('credentials.passcode', 'xyz');
     await challengeFactorPageObject.clickNextButton();
@@ -51,7 +51,7 @@ test
   });
 
 test
-  .requestHooks(validOTPmock)(`challenge email factor with valid OTP`, async t => {
+  .requestHooks(validOTPmock)('challenge email factor with valid OTP', async t => {
     const challengeFactorPageObject = await setup(t);
     await challengeFactorPageObject.verifyFactor('credentials.passcode', '1234');
     await challengeFactorPageObject.clickNextButton();

--- a/test/testcafe/spec/ChallengeFactorPassword_spec.js
+++ b/test/testcafe/spec/ChallengeFactorPassword_spec.js
@@ -10,14 +10,14 @@ const factorRequiredPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(success);
 
-fixture(`Challenge Factor Password`);
+fixture('Challenge Factor Password');
 
 async function setup(t) {
   const challengePasswordPage = new ChallengePasswordPageObject(t);
   await challengePasswordPage.navigateToPage();
   return challengePasswordPage;
 }
-test.requestHooks(factorRequiredPasswordMock)(`challenge password factor`, async t => {
+test.requestHooks(factorRequiredPasswordMock)('challenge password factor', async t => {
   const challengeFactorPageObject = await setup(t);
   await challengeFactorPageObject.switchFactorExists();
   await challengeFactorPageObject.forgotPasswordLink.exists();

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -28,7 +28,7 @@ const mock = RequestMock()
     'access-control-allow-methods': 'POST, OPTIONS'
   });
 
-fixture(`Device Challenge Polling View with Polling Failure`)
+fixture('Device Challenge Polling View with Polling Failure')
   .requestHooks(logger, mock);
 
 async function setup(t) {
@@ -37,7 +37,7 @@ async function setup(t) {
   return deviceChallengePollPage;
 }
 
-test(`probing and polling APIs are sent and responded`, async t => {
+test('probing and polling APIs are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
     await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -74,7 +74,7 @@ const universalLinkMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identifyWithLaunchUniversalLink);
 
-fixture(`Device Challenge Polling View with the Loopback Server, Custom URI and Universal Link approaches`);
+fixture('Device Challenge Polling View with the Loopback Server, Custom URI and Universal Link approaches');
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -89,7 +89,7 @@ async function setupLoopbackFallback(t) {
 }
 
 test
-  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)(`in loopback server approach, probing and polling requests are sent and responded`, async t => {
+  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
@@ -115,7 +115,7 @@ test
   });
 
 test
-  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)(`loopback fails and falls back to custom uri`, async t => {
+  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)('loopback fails and falls back to custom uri', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
     await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
@@ -144,7 +144,7 @@ test
 
 const getPageUrl = ClientFunction(() => window.location.href);
 test
-  .requestHooks(customURILogger, customURIMock)(`in custom URI approach, Okta Verify is launched`, async t => {
+  .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify is launched', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(customURILogger.count(
       record => record.request.url.match(/launch-okta-verify/)
@@ -156,7 +156,7 @@ test
   });
 
 test
-  .requestHooks(loopbackFallbackLogger, universalLinkMock)(`SSO Extension fails and falls back to universal link`, async t => {
+  .requestHooks(loopbackFallbackLogger, universalLinkMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
     await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');

--- a/test/testcafe/spec/DeviceSSOExtensionView_spec.js
+++ b/test/testcafe/spec/DeviceSSOExtensionView_spec.js
@@ -8,7 +8,7 @@ import identifyUserVerificationWithCredentialSSOExtension from '../../../playgro
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 
 const logger = RequestLogger(/introspect/);
-const verifyUrl = `http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/123/verify?\
+const verifyUrl = 'http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/123/verify?\
 challengeRequest=eyJraWQiOiJCa2Y3LTVqa2d6eE1NYjBtS0pEX3hpaUxzZFNmLXZ6cks0MmFkcmcyWXEwIiwiYWxnIjoiUlMy\
 NTYifQ.eyJpc3MiOiJodHRwczovL2R0ZGVtby53aWRlcm9jay5jb20iLCJhdWQiOiJva3RhLjYzYzA4MWRiLTFmMTMtNTA4NC04OD\
 JmLWU3OWUxZTVlMmRhNyIsImV4cCI6MTU3ODYxODEzMiwiaWF0IjoxNTc4NjE3ODMyLCJqdGkiOiJ0cmFuc2FjdGlvbklkIiwibm9\
@@ -20,7 +20,7 @@ jYVN1YmplY3ROYW1lcyI6W10sImtleVR5cGUiOiJwcm9vZk9mUG9zc2Vzc2lvbiIsImZhY3RvclR5cGU
 OjB9.aCsWAQHdU3MG6w7ZQl1csuw2UFb1yvH3es97McC6lFswAphkz6bIHNcagob2dhTwWMJ7_RbpZHqXcaZJ7skKZxYHEfdC9Uwr\
 RzdHpy_4Oeq477n4NGsJLvJNKDi_FOEulqAtCMnjh20vEJI6e4uNIxoSSCfxRCzp-0tdRIJ_7dGM-IsyFjefcnbDyFZT7s4l1tbeO\
 7KYXmWXzP00bA8jmcGLb7i9bFwhjw9OBCgdNcqxKXMLmWQA0JZritRDR6u0ZcEjykca-eUCJtG5ISQOONs_lUBGL3Ezz6QsfWtW16\
-E9QJAVEwf06gULnbw5n6wpiAiDqa4HlkKP6K5-v1Y0XQ`;
+E9QJAVEwf06gULnbw5n6wpiAiDqa4HlkKP6K5-v1Y0XQ';
 
 const redirectSSOExtensionMock = RequestMock()
   .onRequestTo(/idp\/idx\/introspect/)
@@ -47,11 +47,11 @@ const uvCredentialSSOExtensionMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/ft2FCeXuk7ov8iehMivYavZFhPxZUpBvB0/verify')
   .respond(identify);
 
-fixture(`App SSO Extension View`);
+fixture('App SSO Extension View');
 
 const getPageUrl = ClientFunction(() => window.location.href);
 test
-  .requestHooks(logger, redirectSSOExtensionMock)(`with redirect SSO Extension approach, opens the verify URL`, async t => {
+  .requestHooks(logger, redirectSSOExtensionMock)('with redirect SSO Extension approach, opens the verify URL', async t => {
   const ssoExtensionPage = new BasePageObject(t);
   await ssoExtensionPage.navigateToPage();
   await t.expect(logger.count(
@@ -63,7 +63,7 @@ test
 });
 
 test
-.requestHooks(logger, credentialSSOExtensionMock)(`with credential SSO Extension approach, opens the verify URL`, async t => {
+.requestHooks(logger, credentialSSOExtensionMock)('with credential SSO Extension approach, opens the verify URL', async t => {
   const ssoExtensionPage = new BasePageObject(t);
   await ssoExtensionPage.navigateToPage();
   await t.expect(logger.count(
@@ -76,7 +76,7 @@ test
 });
 
 test
-.requestHooks(logger, uvCredentialSSOExtensionMock)(`with credential SSO Extension approach during user verification, opens the verify URL`, async t => {
+.requestHooks(logger, uvCredentialSSOExtensionMock)('with credential SSO Extension approach during user verification, opens the verify URL', async t => {
   const ssoExtensionPage = new BasePageObject(t);
   await ssoExtensionPage.navigateToPage();
   await t.expect(logger.count(
@@ -89,7 +89,7 @@ test
 });
 
 test
-.requestHooks(credentialSSONotExistLogger, credentialSSONotExistMock)(`cancels transaction when the authenticator does not exist`, async t => {
+.requestHooks(credentialSSONotExistLogger, credentialSSONotExistMock)('cancels transaction when the authenticator does not exist', async t => {
   const ssoExtensionPage = new BasePageObject(t);
   await ssoExtensionPage.navigateToPage();
   await t.expect(credentialSSONotExistLogger.count(

--- a/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDataPhoneView_spec.js
@@ -17,15 +17,26 @@ const voiceOnlyOptionMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge')
   .respond(xhrSuccess);
 
-fixture(`Authenticator Enroll Data Phone`);
+fixture('Authenticator Enroll Data Phone');
 
 async function setup(t) {
   const enrollPhonePage = new EnrollPhonePageObject(t);
   await enrollPhonePage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: null,
+    formName: 'authenticator-enrollment-data',
+    authenticatorType: 'phone',
+  });
+
   return enrollPhonePage;
 }
 
-test.requestHooks(mock)(`default sms mode`, async t => {
+test.requestHooks(mock)('default sms mode', async t => {
   const enrollPhonePage = await setup(t);
 
   // Check title
@@ -44,7 +55,7 @@ test.requestHooks(mock)(`default sms mode`, async t => {
   await t.expect(enrollPhonePage.getSwitchAuthenticatorLinkText()).eql('Sign in using something else');
 });
 
-test.requestHooks(mock)(`voice mode click and extension will get shown`, async t => {
+test.requestHooks(mock)('voice mode click and extension will get shown', async t => {
   const enrollPhonePage = await setup(t);
 
   // Switch to Voice
@@ -64,7 +75,7 @@ test.requestHooks(mock)(`voice mode click and extension will get shown`, async t
   await t.expect(enrollPhonePage.phoneNumberFieldIsSmall()).eql(true);
 });
 
-test.requestHooks(mock)(`phone number is required`, async t => {
+test.requestHooks(mock)('phone number is required', async t => {
   const enrollPhonePage = await setup(t);
   // fields are required
   await t.expect(enrollPhonePage.hasPhoneNumberError()).eql(false);
@@ -73,25 +84,25 @@ test.requestHooks(mock)(`phone number is required`, async t => {
   await t.expect(enrollPhonePage.hasPhoneNumberError()).eql(true);
 });
 
-test.requestHooks(mock)(`should succeed when values are filled in sms mode`, async t => {
+test.requestHooks(mock)('should succeed when values are filled in sms mode', async t => {
   const enrollPhonePage = await setup(t);
-  const successPage = new SuccessPageObject(t);
 
   await enrollPhonePage.fillPhoneNumber('4156669999');
   await enrollPhonePage.clickSaveButton();
 
+  const successPage = new SuccessPageObject(t);
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
-test.requestHooks(mock)(`should succeed when values are filled in voice mode`, async t => {
+test.requestHooks(mock)('should succeed when values are filled in voice mode', async t => {
   const enrollPhonePage = await setup(t);
-  const successPage = new SuccessPageObject(t);
   await enrollPhonePage.clickRadio();
   await enrollPhonePage.fillPhoneNumber('4156669999');
   await enrollPhonePage.clickSaveButton();
 
+  const successPage = new SuccessPageObject(t);
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
@@ -99,7 +110,7 @@ test.requestHooks(mock)(`should succeed when values are filled in voice mode`, a
 
 
 /* Voice only option mocks */
-test.requestHooks(voiceOnlyOptionMock)(`default is voice mode`, async t => {
+test.requestHooks(voiceOnlyOptionMock)('default is voice mode', async t => {
   const enrollPhonePage = await setup(t);
 
   // Check title
@@ -114,12 +125,12 @@ test.requestHooks(voiceOnlyOptionMock)(`default is voice mode`, async t => {
   await t.expect(enrollPhonePage.phoneNumberFieldIsSmall()).eql(true);
 });
 
-test.requestHooks(voiceOnlyOptionMock)(`should succeed when values are filled when in voice only mode`, async t => {
+test.requestHooks(voiceOnlyOptionMock)('should succeed when values are filled when in voice only mode', async t => {
   const enrollPhonePage = await setup(t);
-  const successPage = new SuccessPageObject(t);
   await enrollPhonePage.fillPhoneNumber('4156669999');
   await enrollPhonePage.clickSaveButton();
 
+  const successPage = new SuccessPageObject(t);
   const pageUrl = await successPage.getPageUrl();
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -30,16 +30,27 @@ const invalidOTPMock = RequestMock()
   .respond(invalidOTP, 403);
 
 
-fixture(`Enroll Email Authenticator`);
+fixture('Enroll Email Authenticator');
 
 async function setup(t) {
   const enrollEmailPageObject = new EnrollEmailPageObject(t);
-  enrollEmailPageObject.navigateToPage();
+  await enrollEmailPageObject.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'enroll-email',
+    formName: 'enroll-authenticator',
+    authenticatorType: 'email',
+  });
+
   return enrollEmailPageObject;
 }
 
 test
-  .requestHooks(invalidOTPMock)(`enroll with invalid OTP`, async t => {
+  .requestHooks(invalidOTPMock)('enroll with invalid OTP', async t => {
     const enrollEmailPageObject = await setup(t);
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
@@ -52,7 +63,7 @@ test
   });
 
 test
-  .requestHooks(logger, validOTPmock)(`enroll with valid OTP`, async t => {
+  .requestHooks(logger, validOTPmock)('enroll with valid OTP', async t => {
     const enrollEmailPageObject = await setup(t);
 
     await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
@@ -87,7 +98,7 @@ test
   });
 
 test
-  .requestHooks(logger, validOTPmock)(`resend after 30 seconds`, async t => {
+  .requestHooks(logger, validOTPmock)('resend after 30 seconds', async t => {
     const enrollEmailPageObject = await setup(t);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
     await t.wait(31000);
@@ -121,12 +132,12 @@ test
       }
     } = logger.requests[logger.requests.length - 1];
     let jsonBody = JSON.parse(firstRequestBody);
-    await t.expect(jsonBody).eql({"stateHandle":"eyJ6aXAiOiJER"});
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
     await t.expect(firstRequestMethod).eql('post');
     await t.expect(firstRequestUrl).eql('http://localhost:3000/idp/idx/challenge/poll');
 
     jsonBody = JSON.parse(lastRequestBody);
-    await t.expect(jsonBody).eql({"stateHandle":"eyJ6aXAiOiJER"});
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
     await t.expect(lastRequestMethod).eql('post');
     await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
   });

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -10,16 +10,27 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture(`Authenticator Enroll Password`)
+fixture('Authenticator Enroll Password')
   .requestHooks(mock);
 
 async function setup(t) {
   const enrollPasswordPage = new FactorEnrollPasswordPageObject(t);
   await enrollPasswordPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'enroll-password',
+    formName: 'enroll-authenticator',
+    authenticatorType: 'password',
+  });
+
   return enrollPasswordPage;
 }
 
-test(`should have both password and confirmPassword fields and both are required`, async t => {
+test('should have both password and confirmPassword fields and both are required', async t => {
   const enrollPasswordPage = await setup(t);
 
   // Check title
@@ -49,7 +60,7 @@ test(`should have both password and confirmPassword fields and both are required
   await t.expect(await enrollPasswordPage.signoutLinkExists()).notOk();
 });
 
-test(`should succeed when fill same value`, async t => {
+test('should succeed when fill same value', async t => {
   const enrollPasswordPage = await setup(t);
   const successPage = new SuccessPageObject(t);
 
@@ -62,7 +73,7 @@ test(`should succeed when fill same value`, async t => {
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
-test(`should have the correct reqiurements`, async t => {
+test('should have the correct reqiurements', async t => {
     const enrollPasswordPage = await setup(t);
     await t.expect(enrollPasswordPage.getRequirements()).contains('Password requirements:');
     await t.expect(enrollPasswordPage.getRequirements()).contains('At least 8 characters');

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -35,7 +35,7 @@ const logger = RequestLogger(/challenge|challenge\/resend|challenge\/answer/,
   }
 );
 
-fixture(`Authenticator Enroll Phone`);
+fixture('Authenticator Enroll Phone');
 
 async function setup(t) {
   const enrollPhonePage = new EnrollPhonePageObject(t);
@@ -44,8 +44,20 @@ async function setup(t) {
 }
 
 test
-  .requestHooks(smsMock)(`SMS mode - has the right labels`, async t => {
+  .requestHooks(smsMock)('SMS mode - has the right labels', async t => {
     const enrollPhonePageObject = await setup(t);
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(3);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: 'enroll-sms',
+      formName: 'enroll-authenticator',
+      authenticatorType: 'phone',
+      methodType: 'sms',
+    });
+
     const pageTitle = enrollPhonePageObject.getFormTitle();
     const pageSubtitle = enrollPhonePageObject.getFormSubtitle();
     await t.expect(pageTitle).contains('Set up phone authentication');
@@ -57,8 +69,20 @@ test
   });
 
 test
-  .requestHooks(voiceMock)(`Voice mode - has the right labels`, async t => {
+  .requestHooks(voiceMock)('Voice mode - has the right labels', async t => {
     const enrollPhonePageObject = await setup(t);
+
+    const { log } = await t.getBrowserConsoleMessages();
+    await t.expect(log.length).eql(3);
+    await t.expect(log[0]).eql('===== playground widget ready event received =====');
+    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: 'enroll-call',
+      formName: 'enroll-authenticator',
+      authenticatorType: 'phone',
+      methodType: 'voice',
+    });
+
     const pageTitle = enrollPhonePageObject.getFormTitle();
     const pageSubtitle = enrollPhonePageObject.getFormSubtitle();
     await t.expect(pageTitle).contains('Set up phone authentication');
@@ -70,7 +94,7 @@ test
   });
 
 test
-  .requestHooks(logger, smsMock)(`SMS flow`, async t => {
+  .requestHooks(logger, smsMock)('SMS flow', async t => {
     const enrollPhonePageObject = await setup(t);
     await enrollPhonePageObject.clickNextButton();
 
@@ -86,14 +110,14 @@ test
     const codeRequestBody = JSON.parse(codeRequest.request.body);
     await t.expect(codeRequestBody).eql({
       credentials: { passcode: '1234' },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTlubUtEZFVmdFR3d2MwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..7iJKcaUK4F3II_Hk.uCorA7x6QGy7cErZZfETAg5DVXgVtZ1SABqjPurfVpVpahblVhWOsAlsYZYPznj3vYBa1EpHgFIUiVYwm3NAO4wSY6wcsWxEd54E_pZ86MzM2y3PQEMbesvk5t60Muxg4PDlSaFe0wd_ObT_9344fT0Fdbg1FISdLbXDqwuHCXEh13_1U34vwhlgKzmlQnmxDbEqNpYzircDxvptTF35eBeN13s7zRTj3wnTS3gQ6e67cy7ytvVMExqIfsGaAyaauLHsSWkdJBQEWYhTy9sofT3Eue4FrfAFSZdyPNdbSLUbwpPxlhK-JoN0d4WTr98em_0WRHKc_TB7C59UYdzWieuknlMm-CjpEVI1I-FsRLrcHS6HrA-2--UbDhxZLWxk1o3m8M_9YwzUv4BypXcNg2X-Mtfs_pq7mgHm9dtukaVd57UT60_VbGlGOH_Jn6GJh8J0Cc2bVa8XSZPRZxiwKuY56HbB_33jxIwcQG6ty7bu2id42618euDbQ6PBo-cqVRT7NvUPo-0tcZAw5WhvpdyJIvC1rm6EPxh1YuGFP8n3uT1ix6gRliuIWMhGrJdGSfw6PBQZaFoUyIWm-J7BZaonJeKBkbmhGHi-WrWGNyHI1JI1P7XOmntY-gV7o5jhSQObLQZfApHjdIoXIYcTaPe6FfVjiyn-DG4Wr6BsK-O7nkyE5hXOZqRVXiOuOnHevJL76RUUOFC1ewSHzB2Oln0jSrEkaXDCkIXnzHS8KfhdqRetWN_O3Nbspne87h3VYA1Zod_xpBtcLW2R7WXpkoBQzUKfo3jeCulob66US1gJYwScpoQxFEf44cTBLmSQsP8Vjli05d29p5H9v2QMsTxqO5bZPpQIBBamduGg-wqUZDOLDLRUwun6LaFUPULZaAyViOftaiLP14kUApPz8DavytQqwor8UVaGm761vs5w7TnGSAdhFJeq19SAZfwX4YQ-Wc2kFhjfUUKJxZnJ0Qq8Sj1R1jADdmGEAuuMYo_lBgu5DsyhSzSQQpXDHnt_aNf-6m9s89C9fsSy-S53HH-wIqjDPD40Fmll2_MZ0QxVGEZs9l4RlAJmWgl4w2LElfzQ_m6UGU2n96lJ7MHDfw-7pHzsvyUZTDXz23E0Ak07S_Fh2myycXnfmVAUhkR-V-nNzrdq2XEUeJmUiG-TosWoRKD1SLoBd_uzLbeqofzXdshMBFD0gJ_9g7ZbB_S-3BWXrZtkwTaaNuBzljNR3rKvIcYbn6-M5Ki3ubIRZPem7t3O7Y1MxobKX98fk7kem8dQyc0f7OeMyOPgB667BvRzIyZUPq8IHBhMlVsvGlTw3xs2z9ROwi0f37k1et3-lrY7FuvePioHNouZhzrNY_iif_znKQcps7r2VmIznmgAvnE2X8gzDFUtx7AbJfJm6juQi276Hd97PS6nC4oIUB-Of8uqhzs3Jqday52ZUITuNyAR4jQWb3TANYAez2WOx0f9cgjSE6wxo17J7L9JIS52b6D6m8huq6Gxb_tRwGr1ewIWhLcB2zKjTOy54pZm8ZjQdJU3vIpQdTiSUd11SI_PCsEgMWL_KZDcn05GkrDC786ADGZd7NlETefjcy-0ulUkiWuXYIaLYUXD_ypNbPUNr-Oqs8wa8UvSFJsm-Y1b4n7kY5w5MZbns-doxWUyai44Sh6GdKRDtLQlgMFZHwiRKZA94COFsZ0KzqpaiDutwirgT59cu0JcOliFse5pjQtTlo9rOhcGClK9YJgoRp-mcUM7aCAXliSXcrvcHLrtW947lDxiHCvWWqmDKKtI1VLtw3_lK33x01ky8NjnbxvO2KNheVMgmFB0lwKWQsxkM1AL0V4pk4x2KPDhD2Vd.h1OCkg8gSKMvb3zAKGVm4Q`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTlubUtEZFVmdFR3d2MwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..7iJKcaUK4F3II_Hk.uCorA7x6QGy7cErZZfETAg5DVXgVtZ1SABqjPurfVpVpahblVhWOsAlsYZYPznj3vYBa1EpHgFIUiVYwm3NAO4wSY6wcsWxEd54E_pZ86MzM2y3PQEMbesvk5t60Muxg4PDlSaFe0wd_ObT_9344fT0Fdbg1FISdLbXDqwuHCXEh13_1U34vwhlgKzmlQnmxDbEqNpYzircDxvptTF35eBeN13s7zRTj3wnTS3gQ6e67cy7ytvVMExqIfsGaAyaauLHsSWkdJBQEWYhTy9sofT3Eue4FrfAFSZdyPNdbSLUbwpPxlhK-JoN0d4WTr98em_0WRHKc_TB7C59UYdzWieuknlMm-CjpEVI1I-FsRLrcHS6HrA-2--UbDhxZLWxk1o3m8M_9YwzUv4BypXcNg2X-Mtfs_pq7mgHm9dtukaVd57UT60_VbGlGOH_Jn6GJh8J0Cc2bVa8XSZPRZxiwKuY56HbB_33jxIwcQG6ty7bu2id42618euDbQ6PBo-cqVRT7NvUPo-0tcZAw5WhvpdyJIvC1rm6EPxh1YuGFP8n3uT1ix6gRliuIWMhGrJdGSfw6PBQZaFoUyIWm-J7BZaonJeKBkbmhGHi-WrWGNyHI1JI1P7XOmntY-gV7o5jhSQObLQZfApHjdIoXIYcTaPe6FfVjiyn-DG4Wr6BsK-O7nkyE5hXOZqRVXiOuOnHevJL76RUUOFC1ewSHzB2Oln0jSrEkaXDCkIXnzHS8KfhdqRetWN_O3Nbspne87h3VYA1Zod_xpBtcLW2R7WXpkoBQzUKfo3jeCulob66US1gJYwScpoQxFEf44cTBLmSQsP8Vjli05d29p5H9v2QMsTxqO5bZPpQIBBamduGg-wqUZDOLDLRUwun6LaFUPULZaAyViOftaiLP14kUApPz8DavytQqwor8UVaGm761vs5w7TnGSAdhFJeq19SAZfwX4YQ-Wc2kFhjfUUKJxZnJ0Qq8Sj1R1jADdmGEAuuMYo_lBgu5DsyhSzSQQpXDHnt_aNf-6m9s89C9fsSy-S53HH-wIqjDPD40Fmll2_MZ0QxVGEZs9l4RlAJmWgl4w2LElfzQ_m6UGU2n96lJ7MHDfw-7pHzsvyUZTDXz23E0Ak07S_Fh2myycXnfmVAUhkR-V-nNzrdq2XEUeJmUiG-TosWoRKD1SLoBd_uzLbeqofzXdshMBFD0gJ_9g7ZbB_S-3BWXrZtkwTaaNuBzljNR3rKvIcYbn6-M5Ki3ubIRZPem7t3O7Y1MxobKX98fk7kem8dQyc0f7OeMyOPgB667BvRzIyZUPq8IHBhMlVsvGlTw3xs2z9ROwi0f37k1et3-lrY7FuvePioHNouZhzrNY_iif_znKQcps7r2VmIznmgAvnE2X8gzDFUtx7AbJfJm6juQi276Hd97PS6nC4oIUB-Of8uqhzs3Jqday52ZUITuNyAR4jQWb3TANYAez2WOx0f9cgjSE6wxo17J7L9JIS52b6D6m8huq6Gxb_tRwGr1ewIWhLcB2zKjTOy54pZm8ZjQdJU3vIpQdTiSUd11SI_PCsEgMWL_KZDcn05GkrDC786ADGZd7NlETefjcy-0ulUkiWuXYIaLYUXD_ypNbPUNr-Oqs8wa8UvSFJsm-Y1b4n7kY5w5MZbns-doxWUyai44Sh6GdKRDtLQlgMFZHwiRKZA94COFsZ0KzqpaiDutwirgT59cu0JcOliFse5pjQtTlo9rOhcGClK9YJgoRp-mcUM7aCAXliSXcrvcHLrtW947lDxiHCvWWqmDKKtI1VLtw3_lK33x01ky8NjnbxvO2KNheVMgmFB0lwKWQsxkM1AL0V4pk4x2KPDhD2Vd.h1OCkg8gSKMvb3zAKGVm4Q'
     });
     await t.expect(codeRequest.request.method).eql('post');
     await t.expect(codeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
 
 test
-  .requestHooks(logger, voiceMock)(`Voice flow`, async t => {
+  .requestHooks(logger, voiceMock)('Voice flow', async t => {
     const enrollPhonePageObject = await setup(t);
     await enrollPhonePageObject.clickNextButton();
 
@@ -109,14 +133,14 @@ test
     const codeRequestBody = JSON.parse(codeRequest.request.body);
     await t.expect(codeRequestBody).eql({
       credentials: { passcode: '1234' },
-      stateHandle: `eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTlubUtEZFVmdFR3d2MwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..7iJKcaUK4F3II_Hk.uCorA7x6QGy7cErZZfETAg5DVXgVtZ1SABqjPurfVpVpahblVhWOsAlsYZYPznj3vYBa1EpHgFIUiVYwm3NAO4wSY6wcsWxEd54E_pZ86MzM2y3PQEMbesvk5t60Muxg4PDlSaFe0wd_ObT_9344fT0Fdbg1FISdLbXDqwuHCXEh13_1U34vwhlgKzmlQnmxDbEqNpYzircDxvptTF35eBeN13s7zRTj3wnTS3gQ6e67cy7ytvVMExqIfsGaAyaauLHsSWkdJBQEWYhTy9sofT3Eue4FrfAFSZdyPNdbSLUbwpPxlhK-JoN0d4WTr98em_0WRHKc_TB7C59UYdzWieuknlMm-CjpEVI1I-FsRLrcHS6HrA-2--UbDhxZLWxk1o3m8M_9YwzUv4BypXcNg2X-Mtfs_pq7mgHm9dtukaVd57UT60_VbGlGOH_Jn6GJh8J0Cc2bVa8XSZPRZxiwKuY56HbB_33jxIwcQG6ty7bu2id42618euDbQ6PBo-cqVRT7NvUPo-0tcZAw5WhvpdyJIvC1rm6EPxh1YuGFP8n3uT1ix6gRliuIWMhGrJdGSfw6PBQZaFoUyIWm-J7BZaonJeKBkbmhGHi-WrWGNyHI1JI1P7XOmntY-gV7o5jhSQObLQZfApHjdIoXIYcTaPe6FfVjiyn-DG4Wr6BsK-O7nkyE5hXOZqRVXiOuOnHevJL76RUUOFC1ewSHzB2Oln0jSrEkaXDCkIXnzHS8KfhdqRetWN_O3Nbspne87h3VYA1Zod_xpBtcLW2R7WXpkoBQzUKfo3jeCulob66US1gJYwScpoQxFEf44cTBLmSQsP8Vjli05d29p5H9v2QMsTxqO5bZPpQIBBamduGg-wqUZDOLDLRUwun6LaFUPULZaAyViOftaiLP14kUApPz8DavytQqwor8UVaGm761vs5w7TnGSAdhFJeq19SAZfwX4YQ-Wc2kFhjfUUKJxZnJ0Qq8Sj1R1jADdmGEAuuMYo_lBgu5DsyhSzSQQpXDHnt_aNf-6m9s89C9fsSy-S53HH-wIqjDPD40Fmll2_MZ0QxVGEZs9l4RlAJmWgl4w2LElfzQ_m6UGU2n96lJ7MHDfw-7pHzsvyUZTDXz23E0Ak07S_Fh2myycXnfmVAUhkR-V-nNzrdq2XEUeJmUiG-TosWoRKD1SLoBd_uzLbeqofzXdshMBFD0gJ_9g7ZbB_S-3BWXrZtkwTaaNuBzljNR3rKvIcYbn6-M5Ki3ubIRZPem7t3O7Y1MxobKX98fk7kem8dQyc0f7OeMyOPgB667BvRzIyZUPq8IHBhMlVsvGlTw3xs2z9ROwi0f37k1et3-lrY7FuvePioHNouZhzrNY_iif_znKQcps7r2VmIznmgAvnE2X8gzDFUtx7AbJfJm6juQi276Hd97PS6nC4oIUB-Of8uqhzs3Jqday52ZUITuNyAR4jQWb3TANYAez2WOx0f9cgjSE6wxo17J7L9JIS52b6D6m8huq6Gxb_tRwGr1ewIWhLcB2zKjTOy54pZm8ZjQdJU3vIpQdTiSUd11SI_PCsEgMWL_KZDcn05GkrDC786ADGZd7NlETefjcy-0ulUkiWuXYIaLYUXD_ypNbPUNr-Oqs8wa8UvSFJsm-Y1b4n7kY5w5MZbns-doxWUyai44Sh6GdKRDtLQlgMFZHwiRKZA94COFsZ0KzqpaiDutwirgT59cu0JcOliFse5pjQtTlo9rOhcGClK9YJgoRp-mcUM7aCAXliSXcrvcHLrtW947lDxiHCvWWqmDKKtI1VLtw3_lK33x01ky8NjnbxvO2KNheVMgmFB0lwKWQsxkM1AL0V4pk4x2KPDhD2Vd.h1OCkg8gSKMvb3zAKGVm4Q`
+      stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTlubUtEZFVmdFR3d2MwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..7iJKcaUK4F3II_Hk.uCorA7x6QGy7cErZZfETAg5DVXgVtZ1SABqjPurfVpVpahblVhWOsAlsYZYPznj3vYBa1EpHgFIUiVYwm3NAO4wSY6wcsWxEd54E_pZ86MzM2y3PQEMbesvk5t60Muxg4PDlSaFe0wd_ObT_9344fT0Fdbg1FISdLbXDqwuHCXEh13_1U34vwhlgKzmlQnmxDbEqNpYzircDxvptTF35eBeN13s7zRTj3wnTS3gQ6e67cy7ytvVMExqIfsGaAyaauLHsSWkdJBQEWYhTy9sofT3Eue4FrfAFSZdyPNdbSLUbwpPxlhK-JoN0d4WTr98em_0WRHKc_TB7C59UYdzWieuknlMm-CjpEVI1I-FsRLrcHS6HrA-2--UbDhxZLWxk1o3m8M_9YwzUv4BypXcNg2X-Mtfs_pq7mgHm9dtukaVd57UT60_VbGlGOH_Jn6GJh8J0Cc2bVa8XSZPRZxiwKuY56HbB_33jxIwcQG6ty7bu2id42618euDbQ6PBo-cqVRT7NvUPo-0tcZAw5WhvpdyJIvC1rm6EPxh1YuGFP8n3uT1ix6gRliuIWMhGrJdGSfw6PBQZaFoUyIWm-J7BZaonJeKBkbmhGHi-WrWGNyHI1JI1P7XOmntY-gV7o5jhSQObLQZfApHjdIoXIYcTaPe6FfVjiyn-DG4Wr6BsK-O7nkyE5hXOZqRVXiOuOnHevJL76RUUOFC1ewSHzB2Oln0jSrEkaXDCkIXnzHS8KfhdqRetWN_O3Nbspne87h3VYA1Zod_xpBtcLW2R7WXpkoBQzUKfo3jeCulob66US1gJYwScpoQxFEf44cTBLmSQsP8Vjli05d29p5H9v2QMsTxqO5bZPpQIBBamduGg-wqUZDOLDLRUwun6LaFUPULZaAyViOftaiLP14kUApPz8DavytQqwor8UVaGm761vs5w7TnGSAdhFJeq19SAZfwX4YQ-Wc2kFhjfUUKJxZnJ0Qq8Sj1R1jADdmGEAuuMYo_lBgu5DsyhSzSQQpXDHnt_aNf-6m9s89C9fsSy-S53HH-wIqjDPD40Fmll2_MZ0QxVGEZs9l4RlAJmWgl4w2LElfzQ_m6UGU2n96lJ7MHDfw-7pHzsvyUZTDXz23E0Ak07S_Fh2myycXnfmVAUhkR-V-nNzrdq2XEUeJmUiG-TosWoRKD1SLoBd_uzLbeqofzXdshMBFD0gJ_9g7ZbB_S-3BWXrZtkwTaaNuBzljNR3rKvIcYbn6-M5Ki3ubIRZPem7t3O7Y1MxobKX98fk7kem8dQyc0f7OeMyOPgB667BvRzIyZUPq8IHBhMlVsvGlTw3xs2z9ROwi0f37k1et3-lrY7FuvePioHNouZhzrNY_iif_znKQcps7r2VmIznmgAvnE2X8gzDFUtx7AbJfJm6juQi276Hd97PS6nC4oIUB-Of8uqhzs3Jqday52ZUITuNyAR4jQWb3TANYAez2WOx0f9cgjSE6wxo17J7L9JIS52b6D6m8huq6Gxb_tRwGr1ewIWhLcB2zKjTOy54pZm8ZjQdJU3vIpQdTiSUd11SI_PCsEgMWL_KZDcn05GkrDC786ADGZd7NlETefjcy-0ulUkiWuXYIaLYUXD_ypNbPUNr-Oqs8wa8UvSFJsm-Y1b4n7kY5w5MZbns-doxWUyai44Sh6GdKRDtLQlgMFZHwiRKZA94COFsZ0KzqpaiDutwirgT59cu0JcOliFse5pjQtTlo9rOhcGClK9YJgoRp-mcUM7aCAXliSXcrvcHLrtW947lDxiHCvWWqmDKKtI1VLtw3_lK33x01ky8NjnbxvO2KNheVMgmFB0lwKWQsxkM1AL0V4pk4x2KPDhD2Vd.h1OCkg8gSKMvb3zAKGVm4Q'
     });
     await t.expect(codeRequest.request.method).eql('post');
     await t.expect(codeRequest.request.url).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
 
 test
-  .requestHooks(invalidCodeMock)(`Entering invalid passcode results in an error`, async t => {
+  .requestHooks(invalidCodeMock)('Entering invalid passcode results in an error', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.verifyFactor('credentials.passcode', 'abcd');
     await challengePhonePageObject.clickNextButton();
@@ -125,7 +149,7 @@ test
   });
 
 test
-  .requestHooks(smsMock)(`Callout appears after 30 seconds in sms mode`, async t => {
+  .requestHooks(smsMock)('Callout appears after 30 seconds in sms mode', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
     await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();
@@ -136,7 +160,7 @@ test
   });
 
 test
-  .requestHooks(voiceMock)(`Callout appears after 30 seconds in voice mode`, async t => {
+  .requestHooks(voiceMock)('Callout appears after 30 seconds in voice mode', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
     await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();

--- a/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorSecurityQuestion_spec.js
@@ -34,15 +34,26 @@ const answerRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Enroll Security Question Form`);
+fixture('Enroll Security Question Form');
 
 async function setup(t) {
   const enrollSecurityQuestionPage = new EnrollSecurityQuestionPageObject(t);
   await enrollSecurityQuestionPage.navigateToPage();
+
+      const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'enroll-question',
+    formName: 'enroll-authenticator',
+    authenticatorType: 'security_question',
+  });
+
   return enrollSecurityQuestionPage;
 }
 
-test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(`enroll security question`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)('enroll security question', async t => {
   const enrollSecurityQuestionPage = await setup(t);
 
   const radioOptionLabel = await enrollSecurityQuestionPage.clickChooseSecurityQuestion();
@@ -80,7 +91,7 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
 });
 
-test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(`enroll custom security question`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)('enroll custom security question', async t => {
   const enrollSecurityQuestionPage = await setup(t);
 
   const radioOptionLabel = await enrollSecurityQuestionPage.clickCreateYouOwnQuestion();
@@ -110,7 +121,7 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionMock)(
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
 });
 
-test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionErrorMock)(`enroll security question error`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionErrorMock)('enroll security question error', async t => {
   const enrollSecurityQuestionPage = await setup(t);
 
   const radioOptionLabel = await enrollSecurityQuestionPage.clickChooseSecurityQuestion();
@@ -138,7 +149,7 @@ test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionErrorM
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
 });
 
-test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionCreateQuestionErrorMock)(`enroll custom security question error`, async t => {
+test.requestHooks(answerRequestLogger, authenticatorEnrollSecurityQuestionCreateQuestionErrorMock)('enroll custom security question error', async t => {
   const enrollSecurityQuestionPage = await setup(t);
 
   const radioOptionLabel = await enrollSecurityQuestionPage.clickCreateYouOwnQuestion();

--- a/test/testcafe/spec/EnrollAuthenticatorWebAuthn_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorWebAuthn_spec.js
@@ -9,18 +9,29 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture(`Enroll Webauthn Authenticator`)
+fixture('Enroll Webauthn Authenticator')
   .requestHooks(mock);
 
 async function setup(t) {
   const enrollWebauthnPage = new EnrollWebauthnPageObject(t);
   await enrollWebauthnPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'enroll-webauthn',
+    formName: 'enroll-authenticator',
+    authenticatorType: 'security_key',
+  });
+
   return enrollWebauthnPage;
 }
 
 // This is the only test we can perfrom in testcafe as webauthn api is not available in the version of chrome/chromeheadless
 // that testcafe loads.
-test(`should have webauthn not supported error if browser doesnt support`, async t => {
+test('should have webauthn not supported error if browser doesnt support', async t => {
   const enrollWebauthnPage = await setup(t);
   await t.expect(enrollWebauthnPage.getFormTitle()).eql('Set up security key or biometric authenticator');
   await t.expect(enrollWebauthnPage.hasEnrollInstruction()).eql(false);

--- a/test/testcafe/spec/EnrollFactorPassword_spec.js
+++ b/test/testcafe/spec/EnrollFactorPassword_spec.js
@@ -10,7 +10,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture(`Factor Enroll Password`)
+fixture('Factor Enroll Password')
   .requestHooks(mock);
 
 async function setup(t) {
@@ -19,7 +19,7 @@ async function setup(t) {
   return enrollPasswordPage;
 }
 
-test(`should have both password and confirmPassword fields and both are required`, async t => {
+test('should have both password and confirmPassword fields and both are required', async t => {
   const enrollPasswordPage = await setup(t);
 
   // Check title
@@ -46,7 +46,7 @@ test(`should have both password and confirmPassword fields and both are required
   await t.expect(await enrollPasswordPage.signoutLinkExists()).notOk();
 });
 
-test(`should succeed when fill same value`, async t => {
+test('should succeed when fill same value', async t => {
   const enrollPasswordPage = await setup(t);
   const successPage = new SuccessPageObject(t);
 

--- a/test/testcafe/spec/IdentifyOktaVerify_spec.js
+++ b/test/testcafe/spec/IdentifyOktaVerify_spec.js
@@ -11,16 +11,26 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
   .respond(launchAuthenticatorOption);
 
-fixture(`Identify + Okta Verify`)
+fixture('Identify + Okta Verify')
   .requestHooks(logger, mock);
 
 async function setup(t) {
   const deviceChallengePollPage = new IdentityPageObject(t);
   await deviceChallengePollPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+
   return deviceChallengePollPage;
 }
 
-test(`should have editable fields`, async t => {
+test('should have editable fields', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
@@ -28,7 +38,7 @@ test(`should have editable fields`, async t => {
   await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
 });
 
-test(`should show errors if required fields are empty`, async t => {
+test('should show errors if required fields are empty', async t => {
   const identityPage = await setup(t);
 
   await identityPage.clickNextButton();
@@ -38,13 +48,13 @@ test(`should show errors if required fields are empty`, async t => {
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
 });
 
-test(`should the correct title`, async t => {
+test('should the correct title', async t => {
   const identityPage = await setup(t);
   const pageTitle = identityPage.getPageTitle();
   await t.expect(pageTitle).eql('Sign In');
 });
 
-test(`should the correct content`, async t => {
+test('should the correct content', async t => {
   const identityPage = await setup(t);
   await t.expect(identityPage.getPageTitle()).eql('Sign In');
   await t.expect(identityPage.getOktaVerifyButtonText()).eql('Sign in with Okta Verify');

--- a/test/testcafe/spec/IdentifyOktaVerify_spec.js
+++ b/test/testcafe/spec/IdentifyOktaVerify_spec.js
@@ -11,7 +11,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
   .respond(launchAuthenticatorOption);
 
-fixture(`Identify View with Okta Verify option`)
+fixture(`Identify + Okta Verify`)
   .requestHooks(logger, mock);
 
 async function setup(t) {

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -28,7 +28,7 @@ const enrollProfileErrorMock = RequestMock()
   .respond(enrollProfileFinish);
 
 
-fixture(`Registration`);
+fixture('Registration');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -36,17 +36,36 @@ async function setup(t) {
   await identityPage.clickSignUpLink();
   return new RegistrationPageObject(t);
 }
+async function verifyRegistrationPageEvent(t) {
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(5);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+
+  await t.expect(log[3]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[4])).eql({
+    controller: 'registration',
+    formName: 'enroll-profile',
+  });
+
+}
 
 /* i18n tests */
-test.requestHooks(mock)(`should have the right labels for the fields`, async t => {
+test.requestHooks(mock)('should have the right labels for the fields', async t => {
   const registrationPage = await setup(t);
+  await verifyRegistrationPageEvent(t);
   await t.expect(registrationPage.getHaveAccountLabel()).eql('Already have an account ?');
   await t.expect(await registrationPage.signoutLinkExists()).notOk();
 
 });
 
-test.requestHooks(mock)(`should have editable fields`, async t => {
+test.requestHooks(mock)('should have editable fields', async t => {
   const registrationPage = await setup(t);
+  await verifyRegistrationPageEvent(t);
 
   await registrationPage.fillFirstNameField('Test First Name');
   await registrationPage.fillLastNameField('Test Last Name');
@@ -57,8 +76,9 @@ test.requestHooks(mock)(`should have editable fields`, async t => {
   await t.expect(registrationPage.getEmail()).eql('test@email.com');
 });
 
-test.requestHooks(mock)(`should show errors if required fields are empty`, async t => {
+test.requestHooks(mock)('should show errors if required fields are empty', async t => {
   const registrationPage = await setup(t);
+  await verifyRegistrationPageEvent(t);
 
   await registrationPage.clickRegisterButton();
   await registrationPage.waitForErrorBox();
@@ -71,8 +91,9 @@ test.requestHooks(mock)(`should show errors if required fields are empty`, async
 
 });
 
-test.requestHooks(mock)(`should show errors after empty required fields are focused out`, async t => {
+test.requestHooks(mock)('should show errors after empty required fields are focused out', async t => {
   const registrationPage = await setup(t);
+  await verifyRegistrationPageEvent(t);
 
   await registrationPage.fillFirstNameField('');
   await registrationPage.fillLastNameField('');
@@ -89,8 +110,9 @@ test.requestHooks(mock)(`should show errors after empty required fields are focu
   await t.expect(registrationPage.hasEmailErrorMessage()).eql(true);
 });
 
-test.requestHooks(enrollProfileErrorMock)(`should show email field validation errors`, async t => {
+test.requestHooks(enrollProfileErrorMock)('should show email field validation errors', async t => {
   const registrationPage = await setup(t);
+  await verifyRegistrationPageEvent(t);
 
   await registrationPage.fillFirstNameField('abc');
   await registrationPage.fillLastNameField('xyz');
@@ -106,7 +128,23 @@ test.requestHooks(enrollProfileErrorMock)(`should show email field validation er
 });
 
 
-test.requestHooks(enrollProfileFinishMock)(`should show terminal screen after registration`, async t => {
+test.requestHooks(enrollProfileFinishMock)('should show terminal screen after registration', async t => {
   const registrationPage = await setup(t);
+
+    const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(5);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+
+  await t.expect(log[3]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[4])).eql({
+    controller: null,
+    formName: 'terminal',
+  });
+
   await t.expect(registrationPage.getTerminalContent()).eql('An activation email has been sent to john@gmail.com. Follow instructions in the email to finish creating your account');
 });

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -26,9 +26,9 @@ const enrollProfileErrorMock = RequestMock()
   .respond(identify)
   .onRequestTo('http://localhost:3000/idp/idx/enroll')
   .respond(enrollProfileFinish);
-  
 
-fixture(`Registration Form`);
+
+fixture(`Registration`);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -12,16 +12,26 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(registeredUser);
 
-fixture(`Identify but Unknown User`)
+fixture('Identify but Unknown User')
   .requestHooks(mock);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+
   return identityPage;
 }
 
-test(`should show messages callout for unknown user`, async t => {
+test('should show messages callout for unknown user', async t => {
   const identityPage = await setup(t);
   await identityPage.fillIdentifierField('unknown');
   await identityPage.clickNextButton();
@@ -29,7 +39,7 @@ test(`should show messages callout for unknown user`, async t => {
     .eql('There is no account with the email  test@rain.com .  Sign up  for an account');
 });
 
-test(`should remove messages callout for unknown user once successful`, async t => {
+test('should remove messages callout for unknown user once successful', async t => {
   const identityPage = await setup(t);
   await identityPage.fillIdentifierField('unknown');
   await identityPage.clickNextButton();

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -12,7 +12,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(registeredUser);
 
-fixture(`Unknown user form`)
+fixture(`Identify but Unknown User`)
   .requestHooks(mock);
 
 async function setup(t) {

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -1,0 +1,60 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
+import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
+
+const identifyWithPasswordMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentifyWithPassword)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrErrorIdentify, 403);
+
+const identifyRequestLogger = RequestLogger(
+  /idx\/identify/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+fixture(`Identify + Password`);
+
+async function setup(t) {
+  const identityPage = new IdentityPageObject(t);
+  await identityPage.navigateToPage();
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+    authenticatorType: 'password',
+  });
+
+  return identityPage;
+}
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)(`should have password field and forgot password link`, async t => {
+  const identityPage = await setup(t);
+
+  await identityPage.fillIdentifierField('Test Identifier');
+  await identityPage.fillPasswordField('random password 123');
+  await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
+  await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
+
+  await identityPage.clickNextButton();
+
+  await t.expect(identifyRequestLogger.count(() => true)).eql(1);
+  const req = identifyRequestLogger.requests[0].request;
+  const reqBody = JSON.parse(req.body);
+  await t.expect(reqBody).eql({
+    identifier: 'Test Identifier',
+    credentials: {
+      passcode: 'random password 123',
+    },
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
+  });
+  await t.expect(req.method).eql('post');
+  await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
+});

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -17,7 +17,7 @@ const identifyRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Identify + Password`);
+fixture('Identify + Password');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -35,7 +35,7 @@ async function setup(t) {
   return identityPage;
 }
 
-test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)(`should have password field and forgot password link`, async t => {
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password field and forgot password link', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');

--- a/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
+++ b/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
@@ -23,7 +23,7 @@ const mockOnlyOneIdp = RequestMock()
     res.setBody('<html><h1>A external IdP login page for testcafe testing</h1></html>');
   });
 
-fixture(`Identify With IDPs Form`);
+fixture(`Identify + IDPs`);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -1,7 +1,9 @@
 import { RequestMock, RequestLogger } from 'testcafe';
+import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
 import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
+import xhrAuthenticatorVerifySelect from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator';
 
 const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -15,6 +17,12 @@ const identifyLockedUserMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(xhrErrorIdentify, 403);
 
+const identifyThenSelectAuthenticatorMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrAuthenticatorVerifySelect);
+
 const identifyRequestLogger = RequestLogger(
   /idx\/identify/,
   {
@@ -23,7 +31,7 @@ const identifyRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Identify`);
+fixture('Identify');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -41,7 +49,7 @@ async function setup(t) {
   return identityPage;
 }
 
-test.requestHooks(identifyRequestLogger, identifyMock)(`should be able to submit identifier with rememberMe`, async t => {
+test.requestHooks(identifyRequestLogger, identifyMock)('should be able to submit identifier with rememberMe', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
@@ -52,7 +60,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)(`should be able to submit
   const reqBody = JSON.parse(req.body);
   await t.expect(reqBody).eql({
     identifier: 'Test Identifier',
-    stateHandle: "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
@@ -67,13 +75,13 @@ test.requestHooks(identifyRequestLogger, identifyMock)(`should be able to submit
   await t.expect(reqBody2).eql({
     identifier: 'another foobar',
     rememberMe: true,
-    stateHandle: "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
 });
 
-test.requestHooks(identifyMock)(`should show errors if required fields are empty`, async t => {
+test.requestHooks(identifyMock)('should show errors if required fields are empty', async t => {
   const identityPage = await setup(t);
 
   await identityPage.clickNextButton();
@@ -83,7 +91,7 @@ test.requestHooks(identifyMock)(`should show errors if required fields are empty
   await t.expect(identityPage.hasIdentifierErrorMessage()).eql(true);
 });
 
-test.requestHooks(identifyMock)(`should have correct display texts`, async t => {
+test.requestHooks(identifyMock)('should have correct display texts', async t => {
   // i18n values can be tested here.
   const identityPage = await setup(t);
 
@@ -106,7 +114,7 @@ test.requestHooks(identifyMock)(`should have correct display texts`, async t => 
   await t.expect(await identityPage.hasForgotPasswordLinkText()).notOk();
 });
 
-test.requestHooks(identifyLockedUserMock)(`should show global error for invalid user`, async t => {
+test.requestHooks(identifyLockedUserMock)('should show global error for invalid user', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
@@ -116,4 +124,31 @@ test.requestHooks(identifyLockedUserMock)(`should show global error for invalid 
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action.');
+});
+
+test.requestHooks(identifyThenSelectAuthenticatorMock)('navigate to other screen will not trigger "ready" event again', async t => {
+  const identityPage = await setup(t);
+
+  await identityPage.fillIdentifierField('Test Identifier');
+
+  await identityPage.clickNextButton();
+
+  const selectAuthenticatorPage = new SelectFactorPageObject();
+
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+
+  const { log } = await t.getBrowserConsoleMessages();
+
+  await t.expect(log.length).eql(5);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+  await t.expect(log[3]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[4])).eql({
+    controller: null,
+    formName: 'select-authenticator-authenticate'
+  });
 });

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -1,18 +1,11 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
-import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
 import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
 
 const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify)
-  .onRequestTo('http://localhost:3000/idp/idx/identify')
-  .respond(xhrErrorIdentify, 403);
-
-const identifyWithPasswordMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(xhrIdentifyWithPassword)
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(xhrErrorIdentify, 403);
 
@@ -30,11 +23,21 @@ const identifyRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Identify Form`);
+fixture(`Identify`);
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'primary-auth',
+    formName: 'identify',
+  });
+
   return identityPage;
 }
 
@@ -49,7 +52,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)(`should be able to submit
   const reqBody = JSON.parse(req.body);
   await t.expect(reqBody).eql({
     identifier: 'Test Identifier',
-    stateHandle:"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
+    stateHandle: "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
@@ -64,7 +67,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)(`should be able to submit
   await t.expect(reqBody2).eql({
     identifier: 'another foobar',
     rememberMe: true,
-    stateHandle:"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
+    stateHandle: "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw",
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
@@ -105,6 +108,7 @@ test.requestHooks(identifyMock)(`should have correct display texts`, async t => 
 
 test.requestHooks(identifyLockedUserMock)(`should show global error for invalid user`, async t => {
   const identityPage = await setup(t);
+
   await identityPage.fillIdentifierField('Test Identifier');
 
   await identityPage.clickNextButton();
@@ -112,28 +116,4 @@ test.requestHooks(identifyLockedUserMock)(`should show global error for invalid 
   await identityPage.waitForErrorBox();
 
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action.');
-});
-
-test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)(`should have password field and forgot password link`, async t => {
-  const identityPage = await setup(t);
-
-  await identityPage.fillIdentifierField('Test Identifier');
-  await identityPage.fillPasswordField('random password 123');
-  await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
-  await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
-
-  await identityPage.clickNextButton();
-
-  await t.expect(identifyRequestLogger.count(() => true)).eql(1);
-  const req = identifyRequestLogger.requests[0].request;
-  const reqBody = JSON.parse(req.body);
-  await t.expect(reqBody).eql({
-    identifier: 'Test Identifier',
-    credentials: {
-      passcode: 'random password 123',
-    },
-    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
-  });
-  await t.expect(req.method).eql('post');
-  await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
 });

--- a/test/testcafe/spec/Introspect_spec.js
+++ b/test/testcafe/spec/Introspect_spec.js
@@ -15,7 +15,7 @@ const introspectRequestLogger = RequestLogger(
   }
 );
 
-fixture(`Introspect`);
+fixture('Introspect');
 
 async function setup(t) {
   const terminalPageObject = new TerminalPageObject(t);
@@ -23,7 +23,7 @@ async function setup(t) {
   return terminalPageObject;
 }
 
-test.requestHooks(introspectRequestLogger, introspectMock)(`should have password field and forgot password link`, async t => {
+test.requestHooks(introspectRequestLogger, introspectMock)('should have password field and forgot password link', async t => {
   const terminalPageObject = await setup(t);
 
   const errors = terminalPageObject.getErrorMessages();

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -17,16 +17,27 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture(`Authenticator Expired Password`);
+fixture('Authenticator Expired Password');
 
 async function setup(t) {
   const expiredPasswordPage = new FactorEnrollPasswordPageObject(t);
   await expiredPasswordPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: 'password-expired',
+      formName: 'reenroll-authenticator',
+      authenticatorType: 'password'
+  });
+
   return expiredPasswordPage;
 }
 
 test
-  .requestHooks(logger, mock)(`Should have the correct labels`, async t => {
+  .requestHooks(logger, mock)('Should have the correct labels', async t => {
     const expiredPasswordPage = await setup(t);
     await t.expect(expiredPasswordPage.getFormTitle()).eql('Your password has expired');
     await t.expect(expiredPasswordPage.getSaveButtonLabel()).eql('Change Password');
@@ -41,7 +52,7 @@ test
   });
 
 test
-  .requestHooks(logger, mock)(`should have both password and confirmPassword fields and both are required`, async t => {
+  .requestHooks(logger, mock)('should have both password and confirmPassword fields and both are required', async t => {
     const expiredPasswordPage = await setup(t);
     await t.expect(expiredPasswordPage.passwordFieldExists()).eql(true);
     await t.expect(expiredPasswordPage.confirmPasswordFieldExists()).eql(true);
@@ -64,7 +75,7 @@ test
   });
 
 test
-  .requestHooks(logger, mock)(`should succeed when passwords match and should send password in payload`, async t => {
+  .requestHooks(logger, mock)('should succeed when passwords match and should send password in payload', async t => {
     const expiredPasswordPage = await setup(t);
     const successPage = new SuccessPageObject(t);
 
@@ -82,9 +93,9 @@ test
     const requestBody = JSON.parse(body);
 
     await t.expect(requestBody).eql({
-      "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
-      "credentials": {
-        "passcode": "abcdabcd"
+      'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
+      'credentials': {
+        'passcode': 'abcdabcd'
       },
     });
   });

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -31,11 +31,22 @@ const mockExpireSoon = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorExpiryWarningPasswordExpireSoon);
 
-fixture(`Password Authenticator Expiry Warning`);
+fixture('Password Authenticator Expiry Warning');
 
 async function setup(t) {
   const passwordExpiryWarningPage = new FactorEnrollPasswordPageObject(t);
   await passwordExpiryWarningPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: null,
+      formName: 'reenroll-authenticator-warning',
+      authenticatorType: 'password'
+  });
+
   return passwordExpiryWarningPage;
 }
 
@@ -45,7 +56,7 @@ async function setup(t) {
   [ 'Your password is expiring soon', mockExpireSoon ],
 ].forEach(([ formTitle, mock ]) => {
   test
-    .requestHooks(logger, mock)(`Should have the correct labels - expire in days`, async t => {
+    .requestHooks(logger, mock)('Should have the correct labels - expire in days', async t => {
       const passwordExpiryWarningPage = await setup(t);
       await t.expect(passwordExpiryWarningPage.getFormTitle()).eql(formTitle);
       await t.expect(passwordExpiryWarningPage.getSaveButtonLabel()).eql('Change Password');
@@ -63,7 +74,7 @@ async function setup(t) {
 });
 
 test
-  .requestHooks(logger, mockExpireInDays)(`should have both password and confirmPassword fields and both are required`, async t => {
+  .requestHooks(logger, mockExpireInDays)('should have both password and confirmPassword fields and both are required', async t => {
     const passwordExpiryWarningPage = await setup(t);
     await t.expect(passwordExpiryWarningPage.passwordFieldExists()).eql(true);
     await t.expect(passwordExpiryWarningPage.confirmPasswordFieldExists()).eql(true);
@@ -87,7 +98,7 @@ test
   });
 
 test
-  .requestHooks(logger, mockExpireInDays)(`should succeed when passwords match and should send password in payload`, async t => {
+  .requestHooks(logger, mockExpireInDays)('should succeed when passwords match and should send password in payload', async t => {
     const passwordExpiryWarningPage = await setup(t);
     const successPage = new SuccessPageObject(t);
 

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -17,16 +17,27 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
-fixture(`Authenticator Reset Password`);
+fixture('Authenticator Reset Password');
 
 async function setup(t) {
   const resetPasswordPage = new FactorEnrollPasswordPageObject(t);
   await resetPasswordPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+    await t.expect(JSON.parse(log[2])).eql({
+      controller: 'forgot-password',
+      formName: 'reset-authenticator',
+      authenticatorType: 'password'
+  });
+
   return resetPasswordPage;
 }
 
 test
-  .requestHooks(logger, mock)(`Should have the correct labels`, async t => {
+  .requestHooks(logger, mock)('Should have the correct labels', async t => {
     const resetPasswordPage = await setup(t);
     await t.expect(resetPasswordPage.getFormTitle()).eql('Reset your password');
     await t.expect(resetPasswordPage.getSaveButtonLabel()).eql('Reset Password');
@@ -41,7 +52,7 @@ test
   });
 
 test
-  .requestHooks(logger, mock)(`should have both password and confirmPassword fields and both are required`, async t => {
+  .requestHooks(logger, mock)('should have both password and confirmPassword fields and both are required', async t => {
     const resetPasswordPage = await setup(t);
     await t.expect(resetPasswordPage.passwordFieldExists()).eql(true);
     await t.expect(resetPasswordPage.confirmPasswordFieldExists()).eql(true);
@@ -64,7 +75,7 @@ test
   });
 
 test
-  .requestHooks(logger, mock)(`should succeed when passwords match and should send password in payload`, async t => {
+  .requestHooks(logger, mock)('should succeed when passwords match and should send password in payload', async t => {
     const resetPasswordPage = await setup(t);
     const successPage = new SuccessPageObject(t);
 
@@ -82,9 +93,9 @@ test
     const requestBody = JSON.parse(body);
 
     await t.expect(requestBody).eql({
-      "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
-      "credentials": {
-        "passcode": "abcdabcd"
+      'stateHandle': '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
+      'credentials': {
+        'passcode': 'abcdabcd'
       },
     });
   });

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -30,7 +30,7 @@ const requestLogger = RequestLogger(
     }
   );
 
-fixture(`Select Authenticator for enrollment Form`);
+fixture('Select Authenticator for enrollment Form');
 
 async function setup(t) {
   const selectFactorPageObject = new SelectFactorPageObject(t);
@@ -38,7 +38,7 @@ async function setup(t) {
   return selectFactorPageObject;
 }
 
-test.requestHooks(mockEnrollAuthenticatorPassword)(`should load select authenticator list`, async t => {
+test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authenticator list', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up Authenticators');
   await t.expect(selectFactorPage.getFormSubtitle()).eql(
@@ -70,7 +70,7 @@ test.requestHooks(mockEnrollAuthenticatorPassword)(`should load select authentic
 
 });
 
-test.requestHooks(mockEnrollAuthenticatorPassword)(`should navigate to password enrollment page`, async t => {
+test.requestHooks(mockEnrollAuthenticatorPassword)('should navigate to password enrollment page', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up Authenticators');
 
@@ -80,7 +80,7 @@ test.requestHooks(mockEnrollAuthenticatorPassword)(`should navigate to password 
   await t.expect(enrollPasswordPage.confirmPasswordFieldExists()).eql(true);
 });
 
-test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)(`select password challenge page and hit switch authenticator and re-select password`, async t => {
+test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up Authenticators');
 
@@ -110,7 +110,7 @@ test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)(`select passwo
   await t.expect(req3.body).eql('{"authenticator":{"id":"autwa6eD9o02iBbtv0g3"},"stateHandle":"02CqFbzJ_zMGCqXut-1CNXfafiTkh9wGlbFqi9Xupt"}');
 });
 
-test.requestHooks(mockOptionalAuthenticatorEnrollment)(`should skip optional enrollment and go to success`, async t => {
+test.requestHooks(mockOptionalAuthenticatorEnrollment)('should skip optional enrollment and go to success', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up Authenticators');
 

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -39,7 +39,7 @@ const mockSelectAuthenticatorForRecovery = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrSelectAuthenticatorsRecovery);
 
-fixture(`Select Authenticator for verification Form`);
+fixture('Select Authenticator for verification Form');
 
 async function setup(t) {
   const selectFactorPageObject = new SelectFactorPageObject(t);
@@ -47,7 +47,7 @@ async function setup(t) {
   return selectFactorPageObject;
 }
 
-test.requestHooks(mockChallengePassword)(`should load select authenticator list`, async t => {
+test.requestHooks(mockChallengePassword)('should load select authenticator list', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
@@ -96,7 +96,7 @@ test.requestHooks(mockChallengePassword)(`should load select authenticator list`
 
 });
 
-test.requestHooks(mockSelectAuthenticatorForRecovery)(`should load select authenticator list for recovery password`, async t => {
+test.requestHooks(mockSelectAuthenticatorForRecovery)('should load select authenticator list for recovery password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Reset your password');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following authenticators to reset your password.');
@@ -115,7 +115,7 @@ test.requestHooks(mockSelectAuthenticatorForRecovery)(`should load select authen
   await t.expect(selectFactorPage.getSignoutLinkText()).eql('Sign Out');
 });
 
-test.requestHooks(mockChallengePassword)(`should navigate to password challenge page`, async t => {
+test.requestHooks(mockChallengePassword)('should navigate to password challenge page', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
@@ -124,7 +124,7 @@ test.requestHooks(mockChallengePassword)(`should navigate to password challenge 
   await t.expect(challengeFactorPage.getPageTitle()).eql('Sign in using your password');
 });
 
-test.requestHooks(requestLogger, mockChallengePassword)(`select password challenge page and hit switch authenticator and re-select password`, async t => {
+test.requestHooks(requestLogger, mockChallengePassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
@@ -153,7 +153,7 @@ test.requestHooks(requestLogger, mockChallengePassword)(`select password challen
 
 });
 
-test.requestHooks(mockChallengeWebauthn)(`should navigate to webauthn challenge page`, async t => {
+test.requestHooks(mockChallengeWebauthn)('should navigate to webauthn challenge page', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
@@ -162,7 +162,7 @@ test.requestHooks(mockChallengeWebauthn)(`should navigate to webauthn challenge 
   await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with Security Key or Biometric Authenticator');
 });
 
-test.requestHooks(mockChallengeEmail)(`should navigate to email challenge page`, async t => {
+test.requestHooks(mockChallengeEmail)('should navigate to email challenge page', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 

--- a/test/testcafe/spec/SelectFactorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectFactorForEnroll_spec.js
@@ -6,7 +6,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(factorEnrollOptions);
 
-fixture(`Select Factor to enroll Form`)
+fixture('Select Factor to enroll Form')
   .requestHooks(mock);
 
 async function setup(t) {
@@ -15,10 +15,10 @@ async function setup(t) {
   return selectFactorPageObject;
 }
 
-test(`should load select factor list with right text`, async t => {
+test('should load select factor list with right text', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Setup');
-  await t.expect(selectFactorPage.getFormSubtitle()).eql(`Your company requires multifactor authentication to add an additional layer of security when signing in to your Okta account`);
+  await t.expect(selectFactorPage.getFormSubtitle()).eql('Your company requires multifactor authentication to add an additional layer of security when signing in to your Okta account');
   await t.expect(selectFactorPage.hasPasswordSelectButton()).eql(true);
   await t.expect(selectFactorPage.hasPasswordIcon()).eql(true);
   await t.expect(selectFactorPage.hasEmailIcon()).eql(true);

--- a/test/testcafe/spec/SelectFactorForRecovery_spec.js
+++ b/test/testcafe/spec/SelectFactorForRecovery_spec.js
@@ -6,7 +6,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(selectFactorForPasswordRecovery);
 
-fixture(`Select Factor Form`)
+fixture('Select Factor Form')
   .requestHooks(mock);
 
 async function setup(t) {
@@ -15,7 +15,7 @@ async function setup(t) {
   return selectFactorPageObject;
 }
 
-test(`should load select factor list with right title and description`, async t => {
+test('should load select factor list with right title and description', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Reset your password');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following factors to reset your password.');

--- a/test/testcafe/spec/SelectFactorForVerification_spec.js
+++ b/test/testcafe/spec/SelectFactorForVerification_spec.js
@@ -13,7 +13,7 @@ const selectFactorsMock = RequestMock()
   .respond(xhrFactorRequiredEmail);
 
 
-fixture(`Select Factor for verification Form`);
+fixture('Select Factor for verification Form');
 
 async function setup(t) {
   const selectFactorPageObject = new SelectFactorPageObject(t);
@@ -21,7 +21,7 @@ async function setup(t) {
   return selectFactorPageObject;
 }
 
-test.requestHooks(selectFactorsMock)(`should load select factor list`, async t => {
+test.requestHooks(selectFactorsMock)('should load select factor list', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Select an authentication factor');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following factors.');

--- a/test/testcafe/spec/Success_spec.js
+++ b/test/testcafe/spec/Success_spec.js
@@ -10,7 +10,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(success);
 
-fixture(`Success Form`)
+fixture('Success Form')
   .requestHooks(mock);
 
 async function setup(t) {
@@ -19,7 +19,7 @@ async function setup(t) {
   return identityPage;
 }
 
-test(`should navigate to redirect link google.com after success`, async t => {
+test('should navigate to redirect link google.com after success', async t => {
   const identityPage = await setup(t);
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.clickNextButton();

--- a/test/testcafe/spec/UserVerificationDeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/UserVerificationDeviceChallengePollView_spec.js
@@ -74,7 +74,7 @@ const universalLinkMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identifyWithUserVerificationLaunchUniversalLink);
 
-fixture(`Device Challenge Polling View for user verification with the Loopback Server, Custom URI and Universal Link approaches`);
+fixture('Device Challenge Polling View for user verification with the Loopback Server, Custom URI and Universal Link approaches');
 
 async function setup(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
@@ -89,7 +89,7 @@ async function setupLoopbackFallback(t) {
 }
 
 test
-  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)(`in loopback server approach, probing and polling requests are sent and responded`, async t => {
+  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
@@ -115,7 +115,7 @@ test
   });
 
 test
-  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)(`loopback fails and falls back to custom uri`, async t => {
+  .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)('loopback fails and falls back to custom uri', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
     await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
@@ -143,7 +143,7 @@ test
 
 const getPageUrl = ClientFunction(() => window.location.href);
 test
-  .requestHooks(customURILogger, customURIMock)(`in custom URI approach, Okta Verify is launched`, async t => {
+  .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify is launched', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(customURILogger.count(
       record => record.request.url.match(/launch-okta-verify/)
@@ -155,7 +155,7 @@ test
   });
 
 test
-  .requestHooks(loopbackFallbackLogger, universalLinkMock)(`SSO Extension fails and falls back to universal link`, async t => {
+  .requestHooks(loopbackFallbackLogger, universalLinkMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
     await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -38,7 +38,7 @@ const rerenderWidget = ClientFunction((settings) => {
   window.renderPlaygroundWidget(settings);
 });
 
-fixture(`Custom widget attributes`);
+fixture('Custom widget attributes');
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage();
@@ -67,22 +67,22 @@ async function setupPasswordExpired(t) {
 test.requestHooks(identifyMock)(`should show custom footer links`, async t => {
   const identityPage = await setup(t);
   await rerenderWidget({
-    "helpLinks": {
-      "help": "https://google.com",
-      "forgotPassword": "https://okta.okta.com/signin/forgot-password",
-      "custom": [
+    'helpLinks': {
+      'help': 'https://google.com',
+      'forgotPassword': 'https://okta.okta.com/signin/forgot-password',
+      'custom': [
         {
-          "text": "What is Okta?",
-          "href": "https://acme.com/what-is-okta"
+          'text': 'What is Okta?',
+          'href': 'https://acme.com/what-is-okta'
         },
         {
-          "text": "Acme Portal",
-          "href": "https://acme.com",
-          "target": "_blank"
+          'text': 'Acme Portal',
+          'href': 'https://acme.com',
+          'target': '_blank'
         }
       ]
     },
-    "signOutLink": "https://okta.okta.com/",
+    'signOutLink': 'https://okta.okta.com/',
   });
   await t.expect(identityPage.getCustomForgotPasswordLink()).eql('https://okta.okta.com/signin/forgot-password');
   await t.expect(identityPage.getCustomHelpLink()).eql('https://google.com');
@@ -92,34 +92,34 @@ test.requestHooks(identifyMock)(`should show custom footer links`, async t => {
   await t.expect(identityPage.getCustomHelpLinksLabel(1)).eql('Acme Portal');
 });
 
-test.requestHooks(xhrSelectAuthenticatorMock)(`should show custom signout link`, async t => {
+test.requestHooks(xhrSelectAuthenticatorMock)('should show custom signout link', async t => {
   // setup selectAuthenticatorPageObject to see the signout link
   const selectAuthenticatorPageObject = await setupSelectAuthenticator(t);
   await rerenderWidget({
-    "helpLinks": {
-      "help": "https://google.com",
-      "forgotPassword": "https://okta.okta.com/signin/forgot-password",
-      "custom": [
+    'helpLinks': {
+      'help': 'https://google.com',
+      'forgotPassword': 'https://okta.okta.com/signin/forgot-password',
+      'custom': [
         {
-          "text": "What is Okta?",
-          "href": "https://acme.com/what-is-okta"
+          'text': 'What is Okta?',
+          'href': 'https://acme.com/what-is-okta'
         },
         {
-          "text": "Acme Portal",
-          "href": "https://acme.com",
-          "target": "_blank"
+          'text': 'Acme Portal',
+          'href': 'https://acme.com',
+          'target': '_blank'
         }
       ]
     },
-    "signOutLink": "https://okta.okta.com/",
+    'signOutLink': 'https://okta.okta.com/',
   });
   await t.expect(selectAuthenticatorPageObject.getCustomSignOutLink()).eql('https://okta.okta.com/');
 });
 
-test.requestHooks(identifyMock)(`should show custom buttons links`, async t => {
+test.requestHooks(identifyMock)('should show custom buttons links', async t => {
   const identityPage = await setup(t);
   await rerenderWidget({
-    "customButtons" : [{
+    'customButtons' : [{
       'title': 'Custom Button 1',
       'className': 'btn-customAuth-1',
       'click': function () {

--- a/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
+++ b/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
@@ -1,117 +1,153 @@
 import { getClassNameMapping, getV1ClassName } from 'v2/ion/ViewClassNamesFactory';
 
-describe('Adds the right classname', function () {
+describe('v1/ion/ViewClassNamesFactory', function () {
 
-  it('for identify form with password', function () {
-    const result = getClassNameMapping('identify', 'password', null);
-    expect(result).toEqual(['identify--password', 'primary-auth']);
+  describe('getClassNameMapping for v2 flow plus getV1ClassName', function () {
+
+    it('for identify form with password', function () {
+      const v2Class = getClassNameMapping('identify', 'password', null, false);
+      expect(v2Class).toEqual(['identify--password', 'primary-auth']);
+
+      const v1Class = getV1ClassName('identify', 'password', null, false);
+      expect(v1Class).toEqual('primary-auth');
+    });
+
+    it('for identify form', function () {
+      const v2Class = getClassNameMapping('identify', null, null);
+      expect(v2Class).toEqual(['identify', 'primary-auth']);
+
+      const v1Class = getV1ClassName('identify', null, null);
+      expect(v1Class).toEqual('primary-auth');
+    });
+
+    it('for select-authenticator-authenticate form', function () {
+      const v2Class = getClassNameMapping('select-authenticator-authenticate', null, null);
+      expect(v2Class).toEqual(['select-authenticator-authenticate']);
+
+      const v1Class = getV1ClassName('select-authenticator-authenticate', null, null);
+      expect(v1Class).toEqual(null);
+    });
+
+    it('for select-authenticator-authenticate form with password', function () {
+      const v2Class = getClassNameMapping('select-authenticator-authenticate', 'password', null);
+      expect(v2Class).toEqual(['select-authenticator-authenticate--password', 'forgot-password']);
+
+      const v1Class = getV1ClassName('select-authenticator-authenticate', 'password', null);
+      expect(v1Class).toEqual('forgot-password');
+    });
+
+    it('for select-authenticator-enroll form', function () {
+      const v2Class = getClassNameMapping('select-authenticator-enroll', null, null);
+      expect(v2Class).toEqual(['select-authenticator-enroll', 'enroll-choices']);
+
+      const v1Class = getV1ClassName('select-authenticator-enroll', null, null);
+      expect(v1Class).toEqual('enroll-choices');
+    });
+
+    it('for challenge-authenticator form with email', function () {
+      const v2Class = getClassNameMapping('challenge-authenticator', 'email', null);
+      expect(v2Class).toEqual(['challenge-authenticator--email', 'mfa-verify-passcode']);
+
+      const v1Class = getV1ClassName('challenge-authenticator', 'email', null);
+      expect(v1Class).toEqual('mfa-verify-passcode');
+    });
+
+    it('for challenge-authenticator form with security_question', function () {
+      const v2Class = getClassNameMapping('challenge-authenticator', 'security_question', null);
+      expect(v2Class).toEqual(['challenge-authenticator--security_question', 'mfa-verify-question']);
+
+      const v1Class = getV1ClassName('challenge-authenticator', 'security_question', null);
+      expect(v1Class).toEqual('mfa-verify-question');
+    });
+
+    it('for enroll-authenticator form with security_question', function () {
+      const v2Class = getClassNameMapping('enroll-authenticator', 'security_question', null);
+      expect(v2Class).toEqual(['enroll-authenticator--security_question', 'enroll-question']);
+
+      const v1Class = getV1ClassName('enroll-authenticator', 'security_question', null);
+      expect(v1Class).toEqual('enroll-question');
+    });
+
+    it('for enroll-authenticator form with email', function () {
+      const v2Class = getClassNameMapping('enroll-authenticator', 'email', null);
+      expect(v2Class).toEqual(['enroll-authenticator--email', 'enroll-email']);
+
+      const v1Class = getV1ClassName('enroll-authenticator', 'email', null);
+      expect(v1Class).toEqual('enroll-email');
+    });
+
+    it('for enroll-authenticator form with password', function () {
+      const v2Class = getClassNameMapping('enroll-authenticator', 'password', null);
+      expect(v2Class).toEqual(['enroll-authenticator--password', 'enroll-password']);
+
+      const v1Class = getV1ClassName('enroll-authenticator', 'password', null);
+      expect(v1Class).toEqual('enroll-password');
+    });
+
+    it('for enroll-authenticator form with sms', function () {
+      const v2Class = getClassNameMapping('enroll-authenticator', 'phone', 'sms', null);
+      expect(v2Class).toEqual(['enroll-authenticator--phone--sms', 'enroll-sms']);
+
+      const v1Class = getV1ClassName('enroll-authenticator', 'phone', 'sms', null);
+      expect(v1Class).toEqual('enroll-sms');
+    });
+
+    it('for enroll-authenticator form with voice', function () {
+      const v2Class = getClassNameMapping('enroll-authenticator', 'phone', 'voice', null);
+      expect(v2Class).toEqual(['enroll-authenticator--phone--voice', 'enroll-call']);
+
+      const v1Class = getV1ClassName('enroll-authenticator', 'phone', 'voice', null);
+      expect(v1Class).toEqual('enroll-call');
+    });
+
+    it('for reenroll-authenticator form with voice', function () {
+      const v2Class = getClassNameMapping('reenroll-authenticator', 'password', null);
+      expect(v2Class).toEqual(['reenroll-authenticator--password', 'password-expired']);
+
+      const v1Class = getV1ClassName('reenroll-authenticator', 'password', null);
+      expect(v1Class).toEqual('password-expired');
+    });
+
+    it('for reset-authenticator form with voice', function () {
+      const v2Class = getClassNameMapping('reset-authenticator', 'password', null);
+      expect(v2Class).toEqual(['reset-authenticator--password', 'forgot-password']);
+
+      const v1Class = getV1ClassName('reset-authenticator', 'password', null);
+      expect(v1Class).toEqual('forgot-password');
+    });
+
+    it('for success form', function () {
+      const v2Class = getClassNameMapping('success-redirect', null, null);
+      expect(v2Class).toEqual(['success-redirect']);
+
+      const v1Class = getV1ClassName('success-redirect', null, null);
+      expect(v1Class).toEqual(null);
+    });
+
+    it('for terminal form', function () {
+      const v2Class = getClassNameMapping('terminal', null, null);
+      expect(v2Class).toEqual(['terminal']);
+
+      const v1Class = getV1ClassName('terminal', null, null);
+      expect(v1Class).toEqual(null);
+    });
+
+    it('for authenticator-verification-data form wih email method sms', function () {
+      const v2Class = getClassNameMapping('authenticator-verification-data', 'phone', 'sms');
+      expect(v2Class).toEqual(['authenticator-verification-data--phone--sms']);
+
+      const v1Class = getV1ClassName('authenticator-verification-data', null, null);
+      expect(v1Class).toEqual(null);
+    });
+
+    it('for authenticator-verification-data form wih email method voice', function () {
+      const v2Class = getClassNameMapping('authenticator-verification-data', 'phone', 'voice');
+      expect(v2Class).toEqual(['authenticator-verification-data--phone--voice']);
+
+      const v1Class = getV1ClassName('authenticator-verification-data', null, null);
+      expect(v1Class).toEqual(null);
+    });
+
   });
 
-  it('for identify form', function () {
-    const result = getClassNameMapping('identify', null , null);
-    expect(result).toEqual(['identify', 'primary-auth']);
-  });
-
-  it('for select-authenticator-authenticate form', function () {
-    const result = getClassNameMapping('select-authenticator-authenticate', null , null);
-    expect(result).toEqual(['select-authenticator-authenticate']);
-  });
-  it('for select-authenticator-authenticate form with password ', function () {
-    const result = getClassNameMapping('select-authenticator-authenticate', 'password' , null);
-    expect(result).toEqual(['select-authenticator-authenticate--password', 'forgot-password']);
-  });
-
-  it('for select-authenticator-enroll form', function () {
-    const result = getClassNameMapping('select-authenticator-enroll', null , null);
-    expect(result).toEqual(['select-authenticator-enroll', 'enroll-choices']);
-  });
-
-  it('for challenge-authenticator form with email ', function () {
-    const result = getClassNameMapping('challenge-authenticator', 'email' , null);
-    expect(result).toEqual(['challenge-authenticator--email', 'mfa-verify-passcode']);
-  });
-
-  it('for challenge-authenticator form with security_question ', function () {
-    const result = getClassNameMapping('challenge-authenticator', 'security_question' , null);
-    expect(result).toEqual(['challenge-authenticator--security_question', 'mfa-verify-question']);
-  });
-
-  it('for enroll-authenticator form with security_question ', function () {
-    const result = getClassNameMapping('enroll-authenticator', 'security_question' , null);
-    expect(result).toEqual(['enroll-authenticator--security_question', 'enroll-question']);
-  });
-
-  it('for enroll-authenticator form with email ', function () {
-    const result = getClassNameMapping('enroll-authenticator', 'email' , null);
-    expect(result).toEqual(['enroll-authenticator--email', 'enroll-email']);
-  });
-
-  it('for enroll-authenticator form with password ', function () {
-    const result = getClassNameMapping('enroll-authenticator', 'password' , null);
-    expect(result).toEqual(['enroll-authenticator--password', 'enroll-password']);
-  });
-
-  it('for enroll-authenticator form with sms ', function () {
-    const result = getClassNameMapping('enroll-authenticator', 'sms' , null);
-    expect(result).toEqual(['enroll-authenticator--sms', 'enroll-sms']);
-  });
-
-  it('for enroll-authenticator form with voice ', function () {
-    const result = getClassNameMapping('enroll-authenticator', 'voice' , null);
-    expect(result).toEqual(['enroll-authenticator--voice', 'enroll-call']);
-  });
-
-
-  it('for reenroll-authenticator form with voice ', function () {
-    const result = getClassNameMapping('reenroll-authenticator', 'password' , null);
-    expect(result).toEqual(['reenroll-authenticator--password', 'password-expired']);
-  });
-
-  it('for reset-authenticator form with voice ', function () {
-    const result = getClassNameMapping('reset-authenticator', 'password' , null);
-    expect(result).toEqual(['reset-authenticator--password', 'forgot-password']);
-  });
-
-  it('for success form', function () {
-    const result = getClassNameMapping('success-redirect', null , null);
-    expect(result).toEqual(['success-redirect']);
-  });
-
-  it('for terminal form ', function () {
-    const result = getClassNameMapping('terminal', null , null);
-    expect(result).toEqual(['terminal']);
-  });
-
-  it('for authenticator-verification-data form wih email method sms', function () {
-    const result = getClassNameMapping('authenticator-verification-data', 'phone' , 'sms');
-    expect(result).toEqual(['authenticator-verification-data--sms']);
-  });
-
-  it('for authenticator-verification-data form wih email method voice', function () {
-    const result = getClassNameMapping('authenticator-verification-data', 'phone' , 'voice');
-    expect(result).toEqual(['authenticator-verification-data--voice']);
-  });
-
-});
-
-describe('getV1ClassName returns the right V1 classname', function () {
-  it('for identify with recovery', function () {
-    const result = getV1ClassName('identify', null, true);
-    expect(result).toEqual(['forgot-password']);
-  });
-
-  it('for identify without recovery with password', function () {
-    const result = getV1ClassName('identify', 'password', false);
-    expect(result).toEqual(['primary-auth']);
-  });
-  
-  it('for identify without recovery without password', function () {
-    const result = getV1ClassName('identify', 'identify', false);
-    expect(result).toEqual(['primary-auth']);
-  });
-
-  it('for enroll-profile without recovery', function () {
-    const result = getV1ClassName('enroll-profile', 'enroll-profile', false);
-    expect(result).toEqual(['registration']);
-  });
 });


### PR DESCRIPTION

## Description:

- trigger afterRender event
- refactor getV1Class method to serve afterRender event properly
- add testcafe test for identify page to verify event

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- OKTA-314251


