### PR TITLE
feat: add support for brandName

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -761,6 +761,7 @@ oie.okta_verify.authenticator.description = Verify with a code or receive a push
 ## Select authenticator enrollment
 oie.select.authenticators.enroll.title = Set up Authenticators
 oie.select.authenticators.enroll.subtitle = Set up authenticators to ensure that only you have access to your account.
+oie.select.authenticators.enroll.subtitle.custom = Set up authenticators for {0} to ensure that only you have access to your account.
 oie.setup.required = Set up required
 oie.setup.optional = Set up optional
 oie.optional.authenticator.button.title = Finish

--- a/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
@@ -8,7 +8,10 @@ const Body = BaseForm.extend({
     return loc('oie.select.authenticators.enroll.title', 'login');
   },
   subtitle: function () {
-    return loc('oie.select.authenticators.enroll.subtitle', 'login');
+    const subtitle = this.options.settings.get('brandName') ?
+      loc('oie.select.authenticators.enroll.subtitle.custom', 'login', [this.options.settings.get('brandName')]):
+      loc('oie.select.authenticators.enroll.subtitle', 'login');
+    return subtitle;
   },
   noButtonBar: true,
 });

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
@@ -6,7 +6,10 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   className: 'password-authenticator',
 
   title () {
-    return loc('password.expired.title.generic', 'login');
+    const title = this.options.settings.get('brandName')?
+      loc('password.expired.title.specific', 'login', [this.options.settings.get('brandName')]):
+      loc('password.expired.title.generic', 'login');
+    return title;
   },
 
   save () {

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
@@ -4,6 +4,11 @@ import EnrollAuthenticatorPasswordView from './EnrollAuthenticatorPasswordView';
 
 const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   className: 'password-authenticator',
+  subtitle () {
+    if (this.options.settings.get('brandName')) {
+      return loc('password.expiring.subtitle.specific', 'login', [this.options.settings.get('brandName')]);
+    }
+  },
   title () {
     const passwordPolicy = this.getPasswordPolicySettings() || {};
     const daysToExpiry = passwordPolicy.daysToExpiry;
@@ -20,19 +25,13 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   save () {
     return loc('password.expired.submit', 'login');
   },
-
   showMessages () {
-    // render messages as text
-    const messagesObjs = this.options.appState.get('messages');
-    if (messagesObjs && messagesObjs.value.length) {
-      let content = messagesObjs.value.map((messagesObj) => {
-        return messagesObj.message;
-      });
-      content = this.options.settings.get('brandName')?
-        [loc('password.expiring.subtitle.specific', 'login', [this.options.settings.get('brandName')])]:
-        content;
-      this.add(`<div class="ion-messages-container">${content.join(' ')}</div>`, '.o-form-error-container');
+    // if brandName is configured and messages is present, render as subtitle with brandName in context
+    if (this.options.settings.get('brandName')) {
+      return null;
     }
+    // else if brandName is not set, render messages object sent from server as text
+    EnrollAuthenticatorPasswordView.prototype.Body.prototype.showMessages.apply(this, arguments);
   },
 });
 

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
@@ -20,6 +20,20 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   save () {
     return loc('password.expired.submit', 'login');
   },
+
+  showMessages () {
+    // render messages as text
+    const messagesObjs = this.options.appState.get('messages');
+    if (messagesObjs && messagesObjs.value.length) {
+      let content = messagesObjs.value.map((messagesObj) => {
+        return messagesObj.message;
+      });
+      content = this.options.settings.get('brandName')?
+        [loc('password.expiring.subtitle.specific', 'login', [this.options.settings.get('brandName')])]:
+        content;
+      this.add(`<div class="ion-messages-container">${content.join(' ')}</div>`, '.o-form-error-container');
+    }
+  },
 });
 
 const Footer = BaseFooter.extend({

--- a/src/v2/view-builder/views/password/ResetAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ResetAuthenticatorPasswordView.js
@@ -6,7 +6,10 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   className: 'password-authenticator',
 
   title () {
-    return loc('password.reset.title.generic', 'login');
+    const title = this.options.settings.get('brandName')?
+      loc('password.reset.title.specific', 'login', [this.options.settings.get('brandName')]):
+      loc('password.reset.title.generic', 'login');
+    return title;
   },
 
   save () {

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -175,5 +175,5 @@ test.requestHooks(mockAuthenticatorPasswordExpiryWarning)(`should show custom br
   await rerenderWidget({
     "brandName": "Spaghetti Inc",
   });
-  await t.expect(passwordExpiryWarningPage.getIonMessages()).eql('When password expires you will be locked out of your Spaghetti Inc account.');
+  await t.expect(passwordExpiryWarningPage.getFormSubtitle()).eql('When password expires you will be locked out of your Spaghetti Inc account.');
 });


### PR DESCRIPTION
Resolves: OKTA-312535

## Description:

**TLDR;** 

If a brandName  is configured via a widget config, then on some of the screens we will adjust the title to show with the brandName in context.

**For example on the Password Reset screen**

without brandName = Reset your password
with brandName = Reset your Spaghett Inc password

IDX widget screens where we need to add support for `brandName` for parity with V1

```
Enroll Choices: 
enroll.choices.description.generic = Your company requires multifactor authentication to add an additional layer of security when signing in to your account
enroll.choices.description.specific = Your company requires multifactor authentication to add an additional layer of security when signing in to your {0} account

Password Reset: 
password.reset.title.generic = Reset your password
password.reset.title.specific = Reset your {0} password

Password Expired: 
password.expired.title.generic = Your password has expired
password.expired.title.specific = Your {0} password has expired

Password Expiring:
password.expiring.subtitle.generic = When password expires you will be locked out of your account.
password.expiring.subtitle.specific = When password expires you will be locked out of your {0} account.

```

**V1 screens that support brandName but don't exist in M1 yet**

```
Windows Hello : (Not built in M1)
factor.windowsHello.signin.description.generic = Sign in using Windows Hello. factor.windowsHello.signin.description.specific = Sign in to {0} using Windows Hello.

Verify Windows Hello: (Not built in M1)
verify.windowsHello.subtitle.signingIn.generic = Signing in...
verify.windowsHello.subtitle.signingIn.specific = Signing in to {0}...

U2F : (Not built in M1)
factor.u2f.description.generic = Use a Universal 2nd Factor (U2F) security key to sign in.
factor.u2f.description.specific = Use a Universal 2nd Factor (U2F) security key to sign in to {0}.

Custom Factor: (Not built in M1)
factor.customFactor.description.generic = Redirect to a third party MFA provider to sign in.
factor.customFactor.description.specific = Redirect to a third party MFA provider to sign in to {0}.

Enroll TOTP: (Not built in M1)
enroll.totp.manualSetupInstructions.generic = To set up manually enter your Account username and then input the following in the Secret Key Field
enroll.totp.manualSetupInstructions.specific = To set up manually enter your {0} Account username and then input the following in the Secret Key Field

Enroll TOTP Shared Secret: (Not built in M1)
enroll.totp.sharedSecretInstructions.generic = Enter your Account username and enter the following in the Secret Key Field
enroll.totp.sharedSecretInstructions.specific = Enter your {0} Account username and enter the following in the Secret Key Field

```


## PR Checklist

- [x] Have you verified the basic functionality for this change?


- [x] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![Screen Shot 2020-07-27 at 4 18 51 PM](https://user-images.githubusercontent.com/23267876/88601397-6ed45d00-d025-11ea-8988-602deffaed5d.png)

![Screen Shot 2020-07-27 at 4 18 57 PM](https://user-images.githubusercontent.com/23267876/88601404-73007a80-d025-11ea-83cd-f2c2ad181e39.png)

![Screen Shot 2020-07-27 at 4 19 02 PM](https://user-images.githubusercontent.com/23267876/88601410-76940180-d025-11ea-8b19-22c1e452135c.png)

![Screen Shot 2020-07-27 at 4 19 09 PM](https://user-images.githubusercontent.com/23267876/88601413-78f65b80-d025-11ea-871a-75299ff34301.png)





### Reviewers:


### Issue:

- [OKTA-312535](https://oktainc.atlassian.net/browse/OKTA-312535)


