### PR TITLE
feat: add after error in OIE flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "eslint": "^5.9.0",
     "eslint-plugin-local-rules": "^0.1.1",
     "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-testcafe": "^0.2.1",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
     "grunt": "^1.0.3",

--- a/playground/main.js
+++ b/playground/main.js
@@ -67,13 +67,23 @@ const renderPlaygroundWidget = (options = {}) => {
     console.log('===== playground widget ready event received =====');
   });
 
-  signIn.on('afterRender', (opt) => {
+  signIn.on('afterRender', (context) => {
     // handle `afterRender` event.
     // use `console.log` in particular so that those logs can be retrived
     // in testcafe for assertion
     console.log('===== playground widget afterRender event received =====');
-    console.log(JSON.stringify(opt));
+    console.log(JSON.stringify(context));
   });
+
+  signIn.on('afterError', (context, error) => {
+    // handle `afterError` event.
+    // use `console.log` in particular so that those logs can be retrived
+    // in testcafe for assertion
+    console.log('===== playground widget afterError event received =====');
+    console.log(JSON.stringify(context));
+    console.log(JSON.stringify(error));
+  });
+
 
 };
 

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -17,14 +17,12 @@ import { getV1ClassName } from '../ion/ViewClassNamesFactory';
 export default Controller.extend({
   className: 'form-controller',
 
-  initialize: function () {
-    Controller.prototype.initialize.call(this);
-
-    this.listenTo(this.options.appState, 'change:currentFormName', this.render);
-    this.listenTo(this.options.appState, 'invokeAction', this.invokeAction);
-    this.listenTo(this.options.appState, 'switchForm', this.switchForm);
-    this.listenTo(this.options.appState, 'saveForm', this.handleFormSave);
-    this.listenTo(this.options.appState, 'afterError', this.triggerAfterErrorEvent);
+  appStateEvents: {
+    'change:currentFormName': 'handleFormNameChange',
+    'afterError': 'handleAfterError',
+    'invokeAction': 'handleInvokeAction',
+    'saveForm': 'handleSaveForm',
+    'switchForm': 'handleSwitchForm',
   },
 
   preRender () {
@@ -62,7 +60,11 @@ export default Controller.extend({
     this.trigger('afterRender', contextData);
   },
 
-  triggerAfterErrorEvent (error = {}) {
+  handleFormNameChange () {
+    this.render();
+  },
+
+  handleAfterError (error = {}) {
     const contextData = this.createAfterEventContext();
     const errorContextData = {
       xhr: error,
@@ -101,12 +103,12 @@ export default Controller.extend({
     return eventData;
   },
 
-  switchForm (formName) {
+  handleSwitchForm (formName) {
     // trigger formname change to change view
     this.options.appState.set('currentFormName', formName);
   },
 
-  invokeAction (actionPath = '') {
+  handleInvokeAction (actionPath = '') {
     const idx = this.options.appState.get('idx');
     if (idx['neededToProceed'].find(item => item.name === actionPath)) {
       idx.proceed(actionPath, {})
@@ -133,7 +135,7 @@ export default Controller.extend({
     }
   },
 
-  handleFormSave (model) {
+  handleSaveForm (model) {
     const formName = model.get('formName');
 
     const idx = this.options.appState.get('idx');

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -24,6 +24,7 @@ export default Controller.extend({
     this.listenTo(this.options.appState, 'invokeAction', this.invokeAction);
     this.listenTo(this.options.appState, 'switchForm', this.switchForm);
     this.listenTo(this.options.appState, 'saveForm', this.handleFormSave);
+    this.listenTo(this.options.appState, 'afterError', this.triggerAfterErrorEvent);
   },
 
   preRender () {
@@ -57,6 +58,22 @@ export default Controller.extend({
   },
 
   triggerAfterRenderEvent () {
+    const contextData = this.createAfterEventContext();
+    this.trigger('afterRender', contextData);
+  },
+
+  triggerAfterErrorEvent (error = {}) {
+    const contextData = this.createAfterEventContext();
+    const errorContextData = {
+      xhr: error,
+      errorSummary: error.responseJSON && error.responseJSON.errorSummary,
+    };
+    // TODO: need some enhancement after https://github.com/okta/okta-idx-js/pull/27
+    // OKTA-318062
+    this.trigger('afterError', contextData, errorContextData);
+  },
+
+  createAfterEventContext () {
     const formName = this.options.appState.get('currentFormName');
     const authenticatorType = this.options.appState.get('authenticatorType');
     const methodType = this.options.appState.get('authenticatorMethodType');
@@ -81,7 +98,7 @@ export default Controller.extend({
       eventData.methodType = methodType;
     }
 
-    this.trigger('afterRender', eventData);
+    return eventData;
   },
 
   switchForm (formName) {

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -17,6 +17,7 @@ export default Form.extend({
 
   modelEvents: {
     'clearFormError': 'handleClearFormError',
+    'error': 'triggerAfterError',
   },
 
   initialize () {
@@ -37,6 +38,10 @@ export default Form.extend({
     if (this.$('.o-form-error-container').hasClass('o-form-has-errors')) {
       this.clearErrors();
     }
+  },
+
+  triggerAfterError (model, error) {
+    this.options.appState.trigger('afterError', error);
   },
 
   saveForm (model) {

--- a/test/testcafe/.eslintrc.js
+++ b/test/testcafe/.eslintrc.js
@@ -1,22 +1,22 @@
 /* eslint-env node */
 module.exports = {
-  'extends': [
-    'eslint:recommended',
-    'plugin:testcafe/recommended'
-  ],
   'parserOptions': {
     'ecmaVersion': 2017,
     'sourceType': 'module'
   },
-  'plugins': [
-    'testcafe'
-  ],
+  globals: {
+    fixture: false,
+    test: false,
+  },
   'env': {
     'browser': true,
     'es6': true,
   },
   'rules': {
+    'space-before-function-paren': 0, // remove me after clear up root eslintrc.
+    'new-cap': 0, // for testcafe functions like RequestLogger, RequestMock
     'semi': 2,
     'max-len': 0,
+    'max-statements': 0,
   },
 };

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -101,10 +101,10 @@ test
     await t.expect(logger.count(() => true)).eql(1);
 
     const { request: {
-        body: answerRequestBodyString,
-        method: answerRequestMethod,
-        url: answerRequestUrl,
-      }
+      body: answerRequestBodyString,
+      method: answerRequestMethod,
+      url: answerRequestUrl,
+    }
     } = logger.requests[0];
     const answerRequestBody = JSON.parse(answerRequestBodyString);
     await t.expect(answerRequestBody).eql({
@@ -140,16 +140,16 @@ test
     )).eql(1);
 
     const { request: {
-        body: firstRequestBody,
-        method: firstRequestMethod,
-        url: firstRequestUrl,
-      }
+      body: firstRequestBody,
+      method: firstRequestMethod,
+      url: firstRequestUrl,
+    }
     } = logger.requests[0];
     const { request: {
-        body: lastRequestBody,
-        method: lastRequestMethod,
-        url: lastRequestUrl,
-      }
+      body: lastRequestBody,
+      method: lastRequestMethod,
+      url: lastRequestUrl,
+    }
     } = logger.requests[logger.requests.length - 1];
     let jsonBody = JSON.parse(firstRequestBody);
     await t.expect(jsonBody).eql({'stateHandle':'02WTSGqlHUPjoYvorz8T48txBIPe3VUisrQOY4g5N8'});

--- a/test/testcafe/spec/ChallengeFactorEmailOTP_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmailOTP_spec.js
@@ -35,7 +35,7 @@ test
     await t.expect(saveBtnText).contains('Verify');
     await t.expect(pageTitle).contains('Verify with your email');
     await t.expect(challengeFactorPageObject.getFormSubtitle())
-        .contains('A verification code was sent to inca@clouditude.net. Check your email and enter the code below.');
+      .contains('A verification code was sent to inca@clouditude.net. Check your email and enter the code below.');
 
     await t.expect(await challengeFactorPageObject.signoutLinkExists()).ok();
     await t.expect(challengeFactorPageObject.getSignoutLinkText()).eql('Sign Out');

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -38,19 +38,19 @@ async function setup(t) {
 }
 
 test('probing and polling APIs are sent and responded', async t => {
-    const deviceChallengePollPageObject = await setup(t);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
+  const deviceChallengePollPageObject = await setup(t);
+  await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
+  await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+  await t.expect(logger.count(
+    record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|2000/)
-    )).eql(3);
-    await t.expect(logger.count(
-      record => record.response.statusCode === 200 &&
+  )).eql(3);
+  await t.expect(logger.count(
+    record => record.response.statusCode === 200 &&
       record.request.url.match(/challenge/) &&
       record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
-    )).eql(1);
-    await t.expect(logger.contains(record => record.request.url.match(/6511|6512|6513/))).eql(false);
-    await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).eql('Authentication failed');
-    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('none');
-  });
+  )).eql(1);
+  await t.expect(logger.contains(record => record.request.url.match(/6511|6512|6513/))).eql(false);
+  await t.expect(deviceChallengePollPageObject.form.getErrorBoxText()).eql('Authentication failed');
+  await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('none');
+});

--- a/test/testcafe/spec/DeviceSSOExtensionView_spec.js
+++ b/test/testcafe/spec/DeviceSSOExtensionView_spec.js
@@ -52,55 +52,55 @@ fixture('App SSO Extension View');
 const getPageUrl = ClientFunction(() => window.location.href);
 test
   .requestHooks(logger, redirectSSOExtensionMock)('with redirect SSO Extension approach, opens the verify URL', async t => {
-  const ssoExtensionPage = new BasePageObject(t);
-  await ssoExtensionPage.navigateToPage();
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
+    const ssoExtensionPage = new BasePageObject(t);
+    await ssoExtensionPage.navigateToPage();
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
     record.request.url.match(/introspect/)
-  )).eql(1);
-  await t.expect(getPageUrl()).eql(verifyUrl);
-  await t.expect(Selector('h1').innerText).eql('Sign in verified');
-});
+    )).eql(1);
+    await t.expect(getPageUrl()).eql(verifyUrl);
+    await t.expect(Selector('h1').innerText).eql('Sign in verified');
+  });
 
 test
-.requestHooks(logger, credentialSSOExtensionMock)('with credential SSO Extension approach, opens the verify URL', async t => {
-  const ssoExtensionPage = new BasePageObject(t);
-  await ssoExtensionPage.navigateToPage();
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
+  .requestHooks(logger, credentialSSOExtensionMock)('with credential SSO Extension approach, opens the verify URL', async t => {
+    const ssoExtensionPage = new BasePageObject(t);
+    await ssoExtensionPage.navigateToPage();
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
     record.request.url.match(/introspect/)
-  )).eql(1);
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.fillIdentifierField('Test Identifier');
-  await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-});
+    )).eql(1);
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
 
 test
-.requestHooks(logger, uvCredentialSSOExtensionMock)('with credential SSO Extension approach during user verification, opens the verify URL', async t => {
-  const ssoExtensionPage = new BasePageObject(t);
-  await ssoExtensionPage.navigateToPage();
-  await t.expect(logger.count(
-    record => record.response.statusCode === 200 &&
+  .requestHooks(logger, uvCredentialSSOExtensionMock)('with credential SSO Extension approach during user verification, opens the verify URL', async t => {
+    const ssoExtensionPage = new BasePageObject(t);
+    await ssoExtensionPage.navigateToPage();
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
     record.request.url.match(/introspect/)
-  )).eql(1);
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.fillIdentifierField('Test Identifier');
-  await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-});
+    )).eql(1);
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
 
 test
-.requestHooks(credentialSSONotExistLogger, credentialSSONotExistMock)('cancels transaction when the authenticator does not exist', async t => {
-  const ssoExtensionPage = new BasePageObject(t);
-  await ssoExtensionPage.navigateToPage();
-  await t.expect(credentialSSONotExistLogger.count(
-    record => record.response.statusCode === 200 &&
+  .requestHooks(credentialSSONotExistLogger, credentialSSONotExistMock)('cancels transaction when the authenticator does not exist', async t => {
+    const ssoExtensionPage = new BasePageObject(t);
+    await ssoExtensionPage.navigateToPage();
+    await t.expect(credentialSSONotExistLogger.count(
+      record => record.response.statusCode === 200 &&
     record.request.url.match(/introspect/)
-  )).eql(1);
-  await t.expect(credentialSSONotExistLogger.count(
-    record => record.response.statusCode === 200 &&
+    )).eql(1);
+    await t.expect(credentialSSONotExistLogger.count(
+      record => record.response.statusCode === 200 &&
     record.request.url.match(/verify\/cancel/)
-  )).eql(1);
-  const identityPage = new IdentityPageObject(t);
-  await identityPage.fillIdentifierField('Test Identifier');
-  await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
-});
+    )).eql(1);
+    const identityPage = new IdentityPageObject(t);
+    await identityPage.fillIdentifierField('Test Identifier');
+    await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -81,10 +81,10 @@ test
 
     await t.expect(logger.count(() => true)).eql(1);
     const { request: {
-        body: answerRequestBodyString,
-        method: answerRequestMethod,
-        url: answerRequestUrl,
-      }
+      body: answerRequestBodyString,
+      method: answerRequestMethod,
+      url: answerRequestUrl,
+    }
     } = logger.requests[0];
     const answerRequestBody = JSON.parse(answerRequestBodyString);
     await t.expect(answerRequestBody).eql({
@@ -120,16 +120,16 @@ test
     )).eql(1);
 
     const { request: {
-        body: firstRequestBody,
-        method: firstRequestMethod,
-        url: firstRequestUrl,
-      }
+      body: firstRequestBody,
+      method: firstRequestMethod,
+      url: firstRequestUrl,
+    }
     } = logger.requests[0];
     const { request: {
-        body: lastRequestBody,
-        method: lastRequestMethod,
-        url: lastRequestUrl,
-      }
+      body: lastRequestBody,
+      method: lastRequestMethod,
+      url: lastRequestUrl,
+    }
     } = logger.requests[logger.requests.length - 1];
     let jsonBody = JSON.parse(firstRequestBody);
     await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});

--- a/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPasswordView_spec.js
@@ -74,16 +74,16 @@ test('should succeed when fill same value', async t => {
 });
 
 test('should have the correct reqiurements', async t => {
-    const enrollPasswordPage = await setup(t);
-    await t.expect(enrollPasswordPage.getRequirements()).contains('Password requirements:');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('At least 8 characters');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('An uppercase letter');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('A number');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('A symbol');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your first name');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your last name');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
-    await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
-  });
+  const enrollPasswordPage = await setup(t);
+  await t.expect(enrollPasswordPage.getRequirements()).contains('Password requirements:');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('At least 8 characters');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('An uppercase letter');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('A number');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('A symbol');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your first name');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('Does not include your last name');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('At least 2 hour(s) must have elapsed since you last changed your password');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('No parts of your username');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('Your password cannot be any of your last 4 passwords');
+  await t.expect(enrollPasswordPage.getRequirements()).contains('A lowercase letter');
+});

--- a/test/testcafe/spec/IdentifyOktaVerify_spec.js
+++ b/test/testcafe/spec/IdentifyOktaVerify_spec.js
@@ -22,7 +22,7 @@ async function setup(t) {
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: 'primary-auth',
     formName: 'identify',
   });

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -21,7 +21,7 @@ const enrollProfileErrorMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/enroll/new')
   .respond(enrollProfileError, 403);
 
-  const enrollProfileFinishMock = RequestMock()
+const enrollProfileFinishMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identify)
   .onRequestTo('http://localhost:3000/idp/idx/enroll')
@@ -41,7 +41,7 @@ async function verifyRegistrationPageEvent(t) {
   await t.expect(log.length).eql(5);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: 'primary-auth',
     formName: 'identify',
   });
@@ -125,17 +125,43 @@ test.requestHooks(enrollProfileErrorMock)('should show email field validation er
   await t.expect(registrationPage.hasEmailError()).eql(true);
   await t.expect(registrationPage.hasEmailErrorMessage()).eql(true);
   await t.expect(registrationPage.getEmailErrorMessage()).contains('\'Email\' must be in the form of an email address');
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(8);
+  await t.expect(log[5]).eql('===== playground widget afterError event received =====');
+  await t.expect(JSON.parse(log[6])).eql({
+    controller: 'registration',
+    formName: 'enroll-profile',
+  });
+  await t.expect(JSON.parse(log[7])).eql({
+    'errorSummary': '',
+    'xhr': {
+      'responseJSON': {
+        'errorSummary': '',
+        'errorCauses': [
+          {
+            'errorSummary': [
+              '\'Email\' must be in the form of an email address',
+              'Provided value for property \'Email\' does not match required pattern'
+            ],
+            'property': 'userProfile.email'
+          }
+        ]
+      }
+    }
+  });
+
 });
 
 
 test.requestHooks(enrollProfileFinishMock)('should show terminal screen after registration', async t => {
   const registrationPage = await setup(t);
 
-    const { log } = await t.getBrowserConsoleMessages();
+  const { log } = await t.getBrowserConsoleMessages();
   await t.expect(log.length).eql(5);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: 'primary-auth',
     formName: 'identify',
   });

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -23,7 +23,7 @@ async function setup(t) {
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: 'primary-auth',
     formName: 'identify',
   });

--- a/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
+++ b/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
@@ -37,7 +37,7 @@ test.requestHooks(mockWithIdentify) ('should render idp buttons with identifier 
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: 'primary-auth',
     formName: 'identify',
   });
@@ -51,18 +51,18 @@ test.requestHooks(mockWithIdentify) ('should render idp buttons with identifier 
 
 test
   .requestHooks(mockWithIdentify)('clicking on idp button does redirect ', async t => {
-  const identityPage = await setup(t);
-  await t.expect(identityPage.identifierFieldExists('.o-form-input .input-fix input')).eql(true);
-  await t.expect(identityPage.getIdpButton('.social-auth-facebook-button').textContent).eql('Sign in with Facebook');
-  await t.expect(identityPage.getIdpButton('.social-auth-google-button').textContent).eql('Sign in with Google');
-  await t.expect(identityPage.getIdpButton('.social-auth-linkedin-button').textContent).eql('Sign in with LinkedIn');
-  await t.expect(identityPage.getIdpButton('.social-auth-microsoft-button').textContent).eql('Sign in with Microsoft');
-  //click on social idp button
-  await identityPage.clickIdpButton('.social-auth-facebook-button');
-  const pageUrl = await identityPage.getPageUrl();
-  await t.expect(pageUrl)
-    .eql('http://localhost:3000/sso/idps/facebook-123?stateToken=eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..aDi6JnIZwCRzk7RN.xQ1R9jj43bV5S17F1juzgTZGd9Gq7VvuE4Hc1V_tMVcTWiVQ1Ntim1tQPZtmnpfOifu-N_quGGDSdgiidb_2xU1m9SbDMJhV-Yp6E07tABwjaRd_ekuRzDFw7Jxknz33LtSwQOTQ-WiH2o6JikLiEz2BQbgoizIc2izbtdod7HJg0HVnMZ9ZlBqyBG1-EISI_xPypq8uzP8n79hP_Zz41RI7VJA35yfTuNLOX_k6B-mfeVKf4HyFsKm62XWQgcPIxhjxBMqmyZow2toNclV3sIqgw7I5tKCLQSmSnKbFxxuT4-G31BdaVOALAe9Z89zlluTYaKAPOr86RMsqaGKnQFaplc_0PiPbreKhVgvSeeJgqX2RwnLgckLLiRo7TRDs2kLhGY2ope0AeA9TSsTVdJzsScftZWKgh9iHpXjS-kGcbRx0etu4iTtbHOu3rDIfIcvvt55mfvA66wzy1CCxHt4WYNnBKHX0fIOW_fa_-RYGYug9YRV5G6nQ6V-CfHoxmEsMhsoFJu0hei34_SJv15w2l3vxxBytrWSWi5qUfm5zGjNlx8e9n1Sf_eAqXCfLhBLK4_14jwtjNbWOZCdg5dwzxQiQWDItBjijEjdQrK0i6tw2Rp-IMJD1-4_ZfFZDmAXgZZtBYc3kdmumgYpKeYUJJgw0ZJWoG-Xr0bbzGGMx46yHzMpDbSTpiWhKGytQPbNja8sf_eeOKx_AAosamDUub9yuZJb0-Nj0xvXZ89J0m_09wa2Z3G-zY01sv9ONkXMFzRVwAb2bHmGle082bq33-7Klk7_ZzzkBROJhgDHQcw5QibGWaqYqscgKv2NQV8ebGJO_BHU46p1T3MQzStxRZ2EZua9qQwsmL8P5yboNDt2YmYnUvaOcGfeAqwgovqNDQ0H4u-D5psFmiU1STLOlN5pSAauKe4VxlLxphiirrmiNOOOW0XTwaQ1vtPz8gFlXsmGB-0zcsySG6A6HJ49eOeEI0J2REy2dlFRxzdKthANM2xFc_AIgas9mcNhSWtmVEtMxv7N0xqGAJbxaJC6U4kDDXdImZVaovz4lgRFkIh3aUXgUMX558u9MBeF6Q7z3piIpT6A4I1ww_eDNM02Vew.inRUXNhsc6Evt7GAb8DPAA');
-});
+    const identityPage = await setup(t);
+    await t.expect(identityPage.identifierFieldExists('.o-form-input .input-fix input')).eql(true);
+    await t.expect(identityPage.getIdpButton('.social-auth-facebook-button').textContent).eql('Sign in with Facebook');
+    await t.expect(identityPage.getIdpButton('.social-auth-google-button').textContent).eql('Sign in with Google');
+    await t.expect(identityPage.getIdpButton('.social-auth-linkedin-button').textContent).eql('Sign in with LinkedIn');
+    await t.expect(identityPage.getIdpButton('.social-auth-microsoft-button').textContent).eql('Sign in with Microsoft');
+    //click on social idp button
+    await identityPage.clickIdpButton('.social-auth-facebook-button');
+    const pageUrl = await identityPage.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/sso/idps/facebook-123?stateToken=eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..aDi6JnIZwCRzk7RN.xQ1R9jj43bV5S17F1juzgTZGd9Gq7VvuE4Hc1V_tMVcTWiVQ1Ntim1tQPZtmnpfOifu-N_quGGDSdgiidb_2xU1m9SbDMJhV-Yp6E07tABwjaRd_ekuRzDFw7Jxknz33LtSwQOTQ-WiH2o6JikLiEz2BQbgoizIc2izbtdod7HJg0HVnMZ9ZlBqyBG1-EISI_xPypq8uzP8n79hP_Zz41RI7VJA35yfTuNLOX_k6B-mfeVKf4HyFsKm62XWQgcPIxhjxBMqmyZow2toNclV3sIqgw7I5tKCLQSmSnKbFxxuT4-G31BdaVOALAe9Z89zlluTYaKAPOr86RMsqaGKnQFaplc_0PiPbreKhVgvSeeJgqX2RwnLgckLLiRo7TRDs2kLhGY2ope0AeA9TSsTVdJzsScftZWKgh9iHpXjS-kGcbRx0etu4iTtbHOu3rDIfIcvvt55mfvA66wzy1CCxHt4WYNnBKHX0fIOW_fa_-RYGYug9YRV5G6nQ6V-CfHoxmEsMhsoFJu0hei34_SJv15w2l3vxxBytrWSWi5qUfm5zGjNlx8e9n1Sf_eAqXCfLhBLK4_14jwtjNbWOZCdg5dwzxQiQWDItBjijEjdQrK0i6tw2Rp-IMJD1-4_ZfFZDmAXgZZtBYc3kdmumgYpKeYUJJgw0ZJWoG-Xr0bbzGGMx46yHzMpDbSTpiWhKGytQPbNja8sf_eeOKx_AAosamDUub9yuZJb0-Nj0xvXZ89J0m_09wa2Z3G-zY01sv9ONkXMFzRVwAb2bHmGle082bq33-7Klk7_ZzzkBROJhgDHQcw5QibGWaqYqscgKv2NQV8ebGJO_BHU46p1T3MQzStxRZ2EZua9qQwsmL8P5yboNDt2YmYnUvaOcGfeAqwgovqNDQ0H4u-D5psFmiU1STLOlN5pSAauKe4VxlLxphiirrmiNOOOW0XTwaQ1vtPz8gFlXsmGB-0zcsySG6A6HJ49eOeEI0J2REy2dlFRxzdKthANM2xFc_AIgas9mcNhSWtmVEtMxv7N0xqGAJbxaJC6U4kDDXdImZVaovz4lgRFkIh3aUXgUMX558u9MBeF6Q7z3piIpT6A4I1ww_eDNM02Vew.inRUXNhsc6Evt7GAb8DPAA');
+  });
 
 
 test.requestHooks(mockWithoutIdentify)('should only render idp buttons with identifier form ', async t => {
@@ -72,7 +72,7 @@ test.requestHooks(mockWithoutIdentify)('should only render idp buttons with iden
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: null,
     formName: 'redirect-idp',
   });
@@ -99,7 +99,7 @@ test.requestHooks(mockOnlyOneIdp)('should auto redirect to 3rd party IdP login p
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+  await t.expect(JSON.parse(log[2])).eql({
     controller: null,
     formName: 'success-redirect',
   });

--- a/test/testcafe/spec/Introspect_spec.js
+++ b/test/testcafe/spec/Introspect_spec.js
@@ -20,10 +20,20 @@ fixture('Introspect');
 async function setup(t) {
   const terminalPageObject = new TerminalPageObject(t);
   await terminalPageObject.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: null,
+    formName: 'terminal',
+  });
+
   return terminalPageObject;
 }
 
-test.requestHooks(introspectRequestLogger, introspectMock)('should have password field and forgot password link', async t => {
+test.requestHooks(introspectRequestLogger, introspectMock)('shall display error in terminal page', async t => {
   const terminalPageObject = await setup(t);
 
   const errors = terminalPageObject.getErrorMessages();

--- a/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorPasswordView_spec.js
@@ -27,10 +27,10 @@ async function setup(t) {
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
-      controller: 'password-expired',
-      formName: 'reenroll-authenticator',
-      authenticatorType: 'password'
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'password-expired',
+    formName: 'reenroll-authenticator',
+    authenticatorType: 'password'
   });
 
   return expiredPasswordPage;

--- a/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
+++ b/test/testcafe/spec/ReEnrollAuthenticatorWarningPasswordView_spec.js
@@ -41,10 +41,10 @@ async function setup(t) {
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
-      controller: null,
-      formName: 'reenroll-authenticator-warning',
-      authenticatorType: 'password'
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: null,
+    formName: 'reenroll-authenticator-warning',
+    authenticatorType: 'password'
   });
 
   return passwordExpiryWarningPage;

--- a/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
+++ b/test/testcafe/spec/ResetAuthenticatorPasswordView_spec.js
@@ -27,10 +27,10 @@ async function setup(t) {
   await t.expect(log.length).eql(3);
   await t.expect(log[0]).eql('===== playground widget ready event received =====');
   await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
-      controller: 'forgot-password',
-      formName: 'reset-authenticator',
-      authenticatorType: 'password'
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: 'forgot-password',
+    formName: 'reset-authenticator',
+    authenticatorType: 'password'
   });
 
   return resetPasswordPage;

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -23,12 +23,12 @@ const mockOptionalAuthenticatorEnrollment = RequestMock()
   .respond(success);
 
 const requestLogger = RequestLogger(
-    /idx\/introspect|\/credential\/enroll/,
-    {
-      logRequestBody: true,
-      stringifyRequestBody: true,
-    }
-  );
+  /idx\/introspect|\/credential\/enroll/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
 
 fixture('Select Authenticator for enrollment Form');
 

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -13,23 +13,23 @@ const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentifyWithPassword);
 
-  const xhrSelectAuthenticatorMock = RequestMock()
+const xhrSelectAuthenticatorMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrSelectAuthenticator);
 
-  const mockEnrollAuthenticator = RequestMock()
+const mockEnrollAuthenticator = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrSelectAuthenticatorEnroll);
 
-  const mockAuthenticatorResetPassword =  RequestMock()
+const mockAuthenticatorResetPassword =  RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorResetPassword);
 
-  const mockAuthenticatorPasswordExpired =  RequestMock()
+const mockAuthenticatorPasswordExpired =  RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorExpiredPassword);
 
-  const mockAuthenticatorPasswordExpiryWarning =  RequestMock()
+const mockAuthenticatorPasswordExpiryWarning =  RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrAuthenticatorExpiryWarningPassword);
 
@@ -64,7 +64,7 @@ async function setupPasswordExpired(t) {
 }
 
 
-test.requestHooks(identifyMock)(`should show custom footer links`, async t => {
+test.requestHooks(identifyMock)('should show custom footer links', async t => {
   const identityPage = await setup(t);
   await rerenderWidget({
     'helpLinks': {
@@ -143,37 +143,37 @@ test.requestHooks(identifyMock)('should show custom buttons links', async t => {
     .eql('http://www.example.com/');
 });
 
-test.requestHooks(mockEnrollAuthenticator)(`should show custom brandName title on select authenticator enroll page`, async t => {
+test.requestHooks(mockEnrollAuthenticator)('should show custom brandName title on select authenticator enroll page', async t => {
   const selectAuthenticatorPageObject = await setupSelectAuthenticator(t);
   await rerenderWidget({
-    "brandName": "Spaghetti Inc",
+    'brandName': 'Spaghetti Inc',
   });
   await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql(
     'Set up authenticators for Spaghetti Inc to ensure that only you have access to your account.');
 });
 
-test.requestHooks(mockAuthenticatorResetPassword)(`should show custom brandName title on reset password page`, async t => {
+test.requestHooks(mockAuthenticatorResetPassword)('should show custom brandName title on reset password page', async t => {
   const resetPasswordPage = await setupResetPassword(t);
 
   await rerenderWidget({
-    "brandName": "Spaghetti Inc",
+    'brandName': 'Spaghetti Inc',
   });
   await t.expect(resetPasswordPage.getFormTitle()).eql('Reset your Spaghetti Inc password');
 });
 
-test.requestHooks(mockAuthenticatorPasswordExpired)(`should show custom brandName title on password expired page`, async t => {
+test.requestHooks(mockAuthenticatorPasswordExpired)('should show custom brandName title on password expired page', async t => {
   const passwordExpiredPage = await setupPasswordExpired(t);
   await rerenderWidget({
-    "brandName": "Spaghetti Inc",
+    'brandName': 'Spaghetti Inc',
   });
   await t.expect(passwordExpiredPage.getFormTitle()).eql(
     'Your Spaghetti Inc password has expired');
 });
 
-test.requestHooks(mockAuthenticatorPasswordExpiryWarning)(`should show custom brandName title on password expiring soon page`, async t => {
+test.requestHooks(mockAuthenticatorPasswordExpiryWarning)('should show custom brandName title on password expiring soon page', async t => {
   const passwordExpiryWarningPage = await setupPasswordExpired(t);
   await rerenderWidget({
-    "brandName": "Spaghetti Inc",
+    'brandName': 'Spaghetti Inc',
   });
   await t.expect(passwordExpiryWarningPage.getFormSubtitle()).eql('When password expires you will be locked out of your Spaghetti Inc account.');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4905,10 +4905,6 @@ eslint-plugin-no-only-tests@^2.4.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
   integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
 
-eslint-plugin-testcafe@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testcafe/-/eslint-plugin-testcafe-0.2.1.tgz#4089f646dadb69b1376a01d7e608184907e6036b"
-
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Description:

- remove `eslint-plugin-testcafe` which seems too old to be useful
- add `afterError` event 
- fix eslint config in `testcafe` folder.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- ~Added e2e tests~

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![after-error](https://user-images.githubusercontent.com/13139863/88814542-17420880-d16f-11ea-91ef-4b4d8743819a.gif)


### Reviewers:


### Issue:

- OKTA-312536


