### PR TITLE
fix: changes challenge password title to "Verify with"

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -704,7 +704,7 @@ cert.authentication.title = Certificate authentication
 
 ## Password
 oie.password.authenticator.description = Choose a password for your account
-oie.password.challenge.title = Sign in using your password
+oie.password.challenge.title = Verify with your password
 oie.password.enroll.title = Set up password
 oie.password.passwordLabel = Enter password
 oie.password.confirmPasswordLabel = Re-enter password

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -121,7 +121,7 @@ test.requestHooks(mockChallengePassword)('should navigate to password challenge 
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
-  await t.expect(challengeFactorPage.getPageTitle()).eql('Sign in using your password');
+  await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with your password');
 });
 
 test.requestHooks(requestLogger, mockChallengePassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
@@ -130,12 +130,12 @@ test.requestHooks(requestLogger, mockChallengePassword)('select password challen
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
-  await t.expect(challengeFactorPage.getPageTitle()).eql('Sign in using your password');
+  await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with your password');
   await challengeFactorPage.clickSwitchAuthenticatorButton();
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
   // re-select password
   selectFactorPage.selectFactorByIndex(0);
-  await t.expect(challengeFactorPage.getPageTitle()).eql('Sign in using your password');
+  await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with your password');
 
   await t.expect(requestLogger.count(() => true)).eql(3);
   const req1 = requestLogger.requests[0].request;


### PR DESCRIPTION
## Description:

- other challenge-authenticator views have "Verify with" titles, but password had "Sign in using your". Changing this to be consistent with our verify views

Resolves: OKTA-311939

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added unit tests?
- [x] Added e2e tests
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

| Before | After |
| --- | --- |
|<img width="430" alt="SIW-SignInPassword" src="https://user-images.githubusercontent.com/6979296/88861630-3cf10100-d1b3-11ea-9b7e-e2de6ea8540f.png"> | <img width="428" alt="SIW-VerifyPassword" src="https://user-images.githubusercontent.com/6979296/88861639-40848800-d1b3-11ea-9335-31a7d7269e35.png"> |


### Reviewers:


### Issue:

- [OKTA-311939](https://oktainc.atlassian.net/browse/OKTA-311939)


