### PR TITLE
chore: removes restrictRedirectToForeground option

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -88,7 +88,6 @@ define([
       'features.trackTypingPattern': ['boolean', false, false],
       'features.redirectByFormSubmit': ['boolean', false, false],
       'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
-      'features.restrictRedirectToForeground': ['boolean', true, false],
       'features.hideDefaultTip': ['boolean', false, true],
       'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
 

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -198,8 +198,7 @@ function (Okta, OAuth2Util, Util, Enums, BrowserFeatures, Errors, ErrorCodes) {
       }
       
       // Check if we need to wait for redirect based on host.
-      if (router.settings.get('features.restrictRedirectToForeground') &&
-          fn.isHostBackgroundChromeTab()) {
+      if (fn.isHostBackgroundChromeTab()) {
         document.addEventListener('visibilitychange', function checkVisibilityAndCallSuccess () {
           if (fn.isDocumentVisible()) {
             document.removeEventListener('visibilitychange', checkVisibilityAndCallSuccess);

--- a/test/unit/spec/EnrollPassword_spec.js
+++ b/test/unit/spec/EnrollPassword_spec.js
@@ -22,7 +22,7 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
 
   Expect.describe('EnrollPassword', function () {
 
-    function setup (startRouter, restrictRedirectToForeground) {
+    function setup (startRouter) {
       var setNextResponse = Util.mockAjax();
       var baseUrl = 'https://foo.com';
       var authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -33,7 +33,6 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
         baseUrl: baseUrl,
         authClient: authClient,
         'features.router': startRouter,
-        'features.restrictRedirectToForeground': restrictRedirectToForeground,
         globalSuccessFn: successSpy,
       });
       router.on('afterError', afterErrorHandler);
@@ -103,37 +102,9 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Log
           Util.stopRouter();
         });
     });
-    itp('calls enroll with the right arguments when save is clicked', function () {
-      return setup().then(function (test) {
-        Util.resetAjaxRequests();
-        test.form.setPassword('somepassword');
-        test.form.setConfirmPassword('somepassword');
-        test.setNextResponse(resSuccess);
-        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callThrough();
-        test.form.submit();
-        return Expect.waitForSpyCall(test.successSpy, test);
-      })
-        .then(function () {
-          // restrictRedirectToForeground Flag is not enabled
-          expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
-          expect(Util.numAjaxRequests()).toBe(1);
-          Expect.isJsonPost(Util.getAjaxRequest(0), {
-            url: 'https://foo.com/api/v1/authn/factors',
-            data: {
-              factorType: 'password',
-              provider: 'OKTA',
-              profile: {
-                password: 'somepassword'
-              },
-              stateToken: '01testStateToken'
-            }
-          });
-        });
-    });
 
-    itp(`calls enroll with the right arguments when save is clicked in android chrome
-      in restrictRedirectToForeground flow`, function () {
-      return setup(false, true).then(function (test) {
+    itp('calls enroll with the right arguments when save is clicked', function () {
+      return setup(false).then(function (test) {
         Util.resetAjaxRequests();
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -186,42 +186,11 @@ function (Q, Okta, OktaAuth, Util, Form, Beacon, Expect, Router, RouterUtil, Bro
     });
     itp('calls enroll with the right arguments when save is clicked', function () {
       return setup(allFactors).then(function (test) {
-        Util.resetAjaxRequests();
-        test.form.selectQuestion('favorite_security_question');
-        test.form.setAnswer('No question! Hah!');
-        test.setNextResponse(resSuccess);
-        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callThrough();
-        test.form.submit();
-        return Expect.waitForAjaxRequest();
-      })
-        .then(function () {
-          // restrictRedirectToForeground Flag is not enabled
-          expect(RouterUtil.isHostBackgroundChromeTab).not.toHaveBeenCalled();
-          expect(Util.numAjaxRequests()).toBe(1);
-          Expect.isJsonPost(Util.getAjaxRequest(0), {
-            url: 'https://foo.com/api/v1/authn/factors',
-            data: {
-              factorType: 'question',
-              provider: 'OKTA',
-              profile: {
-                question: 'favorite_security_question',
-                answer: 'No question! Hah!'
-              },
-              stateToken: expectedStateToken
-            }
-          });
-        });
-    });
-
-    itp('calls enroll with the right arguments when save is clicked in restrictRedirectToForeground flow', function () {
-      return setup(allFactors).then(function (test) {
         test.successSpy.calls.reset();
         Util.resetAjaxRequests();
         test.form.selectQuestion('favorite_security_question');
         test.form.setAnswer('No question! Hah!');
         test.setNextResponse(resSuccess);
-        // Set flag
-        test.router.settings.set('features.restrictRedirectToForeground', true);
         spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
           return true;
         });


### PR DESCRIPTION
The behavior is always on, with no option.

OKTA-322516

See related PR in okta-core: https://github.com/okta/okta-core/pull/44531

## Description:



## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-322516](https://oktainc.atlassian.net/browse/OKTA-322516)


