### PR TITLE
feat: implement resend push for okta verify on idx

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -377,7 +377,7 @@ const ovPushError = {
     'authenticator-verification-okta-verify-push',
     'authenticator-verification-okta-verify-push',
     'authenticator-verification-okta-verify-push',
-    'error-okta-verify-push',
+    'authenticator-verification-okta-verify-reject-push',
   ],
 };
 

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push.json
@@ -42,7 +42,7 @@
             "type": "object",
             "options": [
               {
-                "label": "Okta Verify",
+                "label": "",
                 "value": {
                   "form": {
                     "value": [
@@ -55,7 +55,7 @@
                       },
                       {
                         "name": "methodType",
-                        "required": true,
+                        "required": false,
                         "mutable": false,
                         "visible": false,
                         "type": "string",
@@ -117,13 +117,11 @@
   "currentAuthenticator":{
     "type":"object",
     "value": {
-      "profile": {
-        "name": "Okta Verify"
-      },
       "type": "app", 
       "id": "auttheidkwh282hv8g3",
+      "displayName": "",
       "methods": [
-        { "methodType": "push" }
+        { "type": "push" }
       ]
     }
   },
@@ -133,16 +131,16 @@
       {
         "type": "app",
         "id": "auteq0lLiL9o1cYoN0g4",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [
           {
-            "value": "signed_nonce"
+            "type": "signed_nonce"
           },
           {
-            "value": "push"
+            "type": "push"
           },
           {
-            "value": "totp"
+            "type": "totp"
           }
         ]
       },
@@ -152,7 +150,7 @@
         "displayName": "Okta Password",
         "methods": [
           {
-            "value": "password"
+            "type": "password"
           }
         ]
       }
@@ -162,32 +160,37 @@
     "type": "array",
     "value": [
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g4",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g3",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
         "displayName": "Okta Password",
         "type": "password",
         "id": "autwa6eD9o02iBbtv0g1",
-        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+        "authenticatorId": "aidwboITrg4b4yAYd0g3",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
       }
     ]
   },

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-reject-push.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-reject-push.json
@@ -8,6 +8,10 @@
     "value": [
       {
         "message": "You have chosen to reject this login.",
+        "i18n": {
+          "key": "api.authn.poll.error.push_rejected",
+          "params": []
+        },
         "class": "ERROR"
       }
     ]
@@ -19,15 +23,38 @@
         "rel":[
           "create-form"
         ],
-        "name":"challenge-poll",
+        "name":"resend-push",
         "relatesTo":[
           "$.currentAuthenticator"
         ],
-        "href":"http://localhost:3000/idp/idx/challenge/poll",
+        "href":"http://localhost:3000/idp/idx/challenge",
         "method":"POST",
         "accepts":"application/vnd.okta.v1+json",
-        "refresh": 4000,
-        "value":[
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "label": "Okta Verify",
+            "value": {
+              "form": {
+                "value": [
+                  {
+                    "name": "id",
+                    "value": "auteq0lLiL9o1cYoN0g4",
+                    "required": true,
+                    "mutable": false
+                  },
+                  {
+                    "name": "methodType",
+                    "value" : "push",
+                    "label" :  "PUSH",
+                    "required": true,
+                    "mutable": false
+                  }
+                ]
+              }
+            }
+          },
           {
             "name": "stateHandle",
             "required": true,
@@ -51,7 +78,7 @@
             "type": "object",
             "options": [
               {
-                "label": "Okta Verify",
+                "label": "",
                 "value": {
                   "form": {
                     "value": [
@@ -64,7 +91,7 @@
                       },
                       {
                         "name": "methodType",
-                        "required": true,
+                        "required": false,
                         "mutable": false,
                         "visible": false,
                         "type": "string",
@@ -126,13 +153,11 @@
   "currentAuthenticator":{
     "type":"object",
     "value": {
-      "profile": {
-        "name": "Okta Verify"
-      },
       "type": "app", 
       "id": "auttheidkwh282hv8g3",
+      "displayName": "",
       "methods": [
-        { "methodType": "push" }
+        { "type": "push" }
       ]
     }
   },
@@ -142,16 +167,16 @@
       {
         "type": "app",
         "id": "auteq0lLiL9o1cYoN0g4",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [
           {
-            "value": "signed_nonce"
+            "type": "signed_nonce"
           },
           {
-            "value": "push" 
+            "type": "push"
           },
           {
-            "value": "totp" 
+            "type": "totp"
           }
         ]
       },
@@ -161,7 +186,7 @@
         "displayName": "Okta Password",
         "methods": [
           {
-            "value": "password"
+            "type": "password"
           }
         ]
       }
@@ -171,32 +196,37 @@
     "type": "array",
     "value": [
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g4",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g3",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
         "displayName": "Okta Password",
         "type": "password",
         "id": "autwa6eD9o02iBbtv0g1",
-        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+        "authenticatorId": "aidwboITrg4b4yAYd0g3",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
       }
     ]
   },

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp.json
@@ -54,7 +54,7 @@
             "type": "object",
             "options": [
               {
-                "label": "Okta Verify",
+                "label": "",
                 "value": {
                   "form": {
                     "value": [
@@ -67,7 +67,7 @@
                       },
                       {
                         "name": "methodType",
-                        "required": true,
+                        "required": false,
                         "mutable": false,
                         "visible": false,
                         "type": "string",
@@ -129,13 +129,11 @@
   "currentAuthenticator":{
     "type":"object",
     "value": {
-      "profile": {
-        "name": "Okta Verify"
-      },
       "type": "app", 
       "id": "auttheidkwh282hv8g3",
+      "displayName": "",
       "methods": [
-        { "methodType": "totp" } 
+        { "type": "totp" }
       ]
     }
   },
@@ -145,16 +143,16 @@
       {
         "type": "app",
         "id": "auteq0lLiL9o1cYoN0g4",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [
           {
-            "value": "signed_nonce"
+            "type": "signed_nonce"
           },
           {
-            "value": "push"
+            "type": "push"
           },
           {
-            "value": "totp"
+            "type": "totp"
           }
         ]
       },
@@ -164,7 +162,7 @@
         "displayName": "Okta Password",
         "methods": [
           {
-            "value": "password"
+            "type": "password"
           }
         ]
       }
@@ -174,32 +172,37 @@
     "type": "array",
     "value": [
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g4",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
-        "displayName": "Okta Verify",
+        "displayName": "",
         "type": "app",
         "id": "aen1mz5J4cuNoaR3l0g3",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
         "displayName": "Okta Password",
         "type": "password",
         "id": "autwa6eD9o02iBbtv0g1",
-        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+        "authenticatorId": "aidwboITrg4b4yAYd0g3",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
       }
     ]
   },

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2.json
@@ -20,7 +20,7 @@
             "type": "object",
             "options": [
               {
-                "label": "Okta Verify",
+                "label": "",
                 "value": {
                   "form": {
                     "value": [
@@ -32,6 +32,9 @@
                       },
                       {
                         "name": "methodType",
+                        "type": "string",
+                        "required": false,
+                        "mutable": false,
                         "options": [
                           {
                             "value": "signed_nonce",
@@ -45,9 +48,7 @@
                             "value": "totp",
                             "label" :  "Enter a code"
                           }
-                        ],
-                        "required": true,
-                        "mutable": false
+                        ]
                       }
                     ]
                   }
@@ -95,16 +96,16 @@
       {
         "type": "app",
         "id": "auteq0lLiL9o1cYoN0g4",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [
           {
-            "value": "signed_nonce"
+            "type": "signed_nonce"
           },
           {
-            "value": "push" 
+            "type": "push"
           },
           {
-            "value": "totp" 
+            "type": "totp"
           }
         ]
       },
@@ -114,7 +115,7 @@
         "displayName": "Okta Password",
         "methods": [
           {
-            "value": "password"
+            "type": "password"
           }
         ]
       }
@@ -124,22 +125,22 @@
     "type": "array",
     "value": [
       {
-        "type": "okta_verify",
+        "type": "app",
         "id": "aentheidkwh282hv8g3",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" }
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
          ]
       },
      {
-        "type": "okta_verify",
+        "type": "app",
         "id": "aentheidkwh2823",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [ 
-           { "methodType": "push" },
-           { "methodType": "totp" } 
+           { "type": "push" },
+           { "type": "totp" }
          ]
       },
       {
@@ -147,7 +148,7 @@
         "id": "auttmbseAWnMPtLe20g3",
         "displayName": "Okta Password",
         "methods": [ 
-          { "methodType": "password" }
+          { "type": "password" }
         ]
       }
     ]

--- a/playground/mocks/data/idp/idx/error-okta-verify-totp.json
+++ b/playground/mocks/data/idp/idx/error-okta-verify-totp.json
@@ -63,7 +63,7 @@
             "type": "object",
             "options": [
               {
-                "label": "Okta Verify",
+                "label": "",
                 "value": {
                   "form": {
                     "value": [
@@ -76,7 +76,7 @@
                       },
                       {
                         "name": "methodType",
-                        "required": true,
+                        "required": false,
                         "mutable": false,
                         "visible": false,
                         "type": "string",
@@ -138,13 +138,11 @@
   "currentAuthenticator":{
     "type":"object",
     "value":{
-      "profile": {
-        "name": "Okta Verify"
-      },
       "type": "app", 
       "id": "auttheidkwh282hv8g3",
+      "displayName": "",
       "methods": [
-        { "methodType": "totp" }
+        { "type": "totp" }
       ]
     }
   },
@@ -154,16 +152,16 @@
       {
         "type": "app",
         "id": "auteq0lLiL9o1cYoN0g4",
-        "displayName": "Okta Verify",
+        "displayName": "",
         "methods": [
           {
-            "value": "signed_nonce"
+            "type": "signed_nonce"
           },
           {
-            "value": "push" 
+            "type": "push"
           },
           {
-            "value": "totp" 
+            "type": "totp"
           }
         ]
       },
@@ -173,7 +171,7 @@
         "displayName": "Okta Password",
         "methods": [
           {
-            "value": "password"
+            "type": "password"
           }
         ]
       }
@@ -188,9 +186,9 @@
         "id": "aen1mz5J4cuNoaR3l0g4",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
@@ -199,16 +197,21 @@
         "id": "aen1mz5J4cuNoaR3l0g3",
         "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [ 
-          { "methodType": "signed_nonce" },
-          { "methodType": "push" },
-          { "methodType": "totp" } 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
         ]
       },
       {
         "displayName": "Okta Password",
         "type": "password",
         "id": "autwa6eD9o02iBbtv0g1",
-        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+        "authenticatorId": "aidwboITrg4b4yAYd0g3",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
       }
     ]
   },

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -20,6 +20,7 @@ const FORMS = {
   AUTHENTICATOR_VERIFICATION_DATA: 'authenticator-verification-data',
   CHALLENGE_AUTHENTICATOR: 'challenge-authenticator',
   CHALLENGE_POLL: 'challenge-poll',
+  RESEND_PUSH: 'resend-push',
 
   SELECT_AUTHENTICATOR_ENROLL: 'select-authenticator-enroll',
   SELECT_AUTHENTICATOR_ENROLL_DATA: 'select-authenticator-enroll-data',
@@ -67,7 +68,9 @@ const FORMS_WITH_STATIC_BACK_LINK = [
 
 const FORMS_FOR_VERIFICATION = [
   FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE,
-  FORMS.CHALLENGE_AUTHENTICATOR
+  FORMS.CHALLENGE_AUTHENTICATOR,
+  FORMS.CHALLENGE_POLL,
+  FORMS.RESEND_PUSH
 ];
 
 export {

--- a/src/v2/ion/ViewClassNamesFactory.js
+++ b/src/v2/ion/ViewClassNamesFactory.js
@@ -21,6 +21,9 @@ const FORMNAME_CLASSNAME_MAPPINGS = {
   [FORMS.CHALLENGE_POLL]: {
     app: 'mfa-verify',
   },
+  [FORMS.RESEND_PUSH]: {
+    app: 'mfa-verify',
+  },
   [FORMS.ENROLL_AUTHENTICATOR]: {
     email: 'enroll-email',
     password: 'enroll-password',

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -31,6 +31,9 @@ const createOVOptions = (options = []) => {
       // create a new methodType object that removes the options array and
       // has a value of the current method
       const newMethodTypeObj = Object.assign(_.omit(methodTypeObj, 'options'), method);
+      // set the methodType field to be required in our UI,
+      // so it is always sent to the backend.
+      newMethodTypeObj.required = true;
       // replace old methodType object with the new one
       value.splice(methodTypeIndex, 1, newMethodTypeObj);
       // return a new ov item for a specific method

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -55,6 +55,7 @@ import SelectEnrollmentChannelOktaVerifyView from './views/ov/SelectEnrollmentCh
 import EnrollementChannelDataOktaVerifyView from './views/ov/EnrollementChannelDataOktaVerifyView';
 import ChallengeOktaVerifyView from './views/ov/ChallengeOktaVerifyView';
 import ChallengeOktaVerifyPushView from './views/ov/ChallengeOktaVerifyPushView';
+import ChallengeOktaVerifyResendPushView from './views/ov/ChallengeOktaVerifyResendPushView';
 
 const DEFAULT = '_';
 
@@ -141,6 +142,9 @@ const VIEWS_MAPPING = {
   },
   [RemediationForms.CHALLENGE_POLL]: {
     app: ChallengeOktaVerifyPushView,
+  },
+  [RemediationForms.RESEND_PUSH]: {
+    [DEFAULT]: ChallengeOktaVerifyResendPushView,
   },
   [RemediationForms.AUTHENTICATOR_VERIFICATION_DATA]: {
     phone: ChallengeAuthenticatorDataPhoneView,

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
@@ -1,0 +1,45 @@
+import { loc, createCallout } from 'okta';
+import BaseForm from '../../internals/BaseForm';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
+
+const Body = BaseForm.extend(Object.assign(
+  {
+    className: 'okta-verify-resend-push',
+
+    title () {
+      return loc('oie.okta_verify.push.title', 'login');
+    },
+
+    save () {
+      return loc('oie.okta_verify.push.send', 'login');
+    },
+
+    showMessages () {
+      // override showMessages to display error in cases like reject push
+      // or timeout. Borrowed this logic from TerminalView.
+      const messagesObjs = this.options.appState.get('messages');
+      if (messagesObjs && Array.isArray(messagesObjs.value)) {
+        this.add('<div class="ion-messages-container"></div>', '.o-form-error-container');
+
+        messagesObjs.value.forEach(messagesObj => {
+          const msg = messagesObj.message;
+          if (messagesObj?.class === 'ERROR') {
+            this.add(createCallout({
+              content: msg,
+              type: 'error',
+            }), '.o-form-error-container');
+          } else {
+            this.add(`<p>${msg}</p>`, '.ion-messages-container');
+          }
+        });
+
+      }
+    },
+  },
+));
+
+export default BaseAuthenticatorView.extend({
+  Body,
+  Footer: AuthenticatorVerifyFooter,
+});

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
@@ -9,7 +9,7 @@ export default BaseAuthenticatorView.extend({
 
     const currentAuthenticator = this.options?.appState?.get('currentAuthenticator');
     const selectedMethod = currentAuthenticator?.methods[0];
-    if (selectedMethod?.methodType === 'totp') {
+    if (selectedMethod?.type === 'totp') {
       this.Body = ChallengeOktaVerifyTotpView;
       this.Footer = AuthenticatorVerifyFooter;
     } else {

--- a/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
@@ -1,6 +1,7 @@
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
 const FORM_INFOBOX_WARNING = '.okta-form-infobox-warning';
+const FORM_INFOBOX_ERROR = '.o-form-error-container .infobox-error';
 
 export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPageObject {
   constructor(t) {
@@ -11,8 +12,20 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
     return this.form.getElement('.send-push');
   }
 
-  getError () {
-    return this.form.getErrorBoxText();
+  getResendPushButton () {
+    return this.form.getElement('.button-primary');
+  }
+
+  clickResendPushButton() {
+    return this.form.clickSaveButton();
+  }
+
+  async waitForErrorBox() {
+    await this.form.el.find(FORM_INFOBOX_ERROR).exists;
+  }
+
+  getErrorBox () {
+    return this.form.getElement(FORM_INFOBOX_ERROR);
   }
 
   getWarningBox () {

--- a/test/testcafe/spec/ChallengeOktaVerifyTotp_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyTotp_spec.js
@@ -46,6 +46,7 @@ test
       controller: 'mfa-verify',
       formName: 'challenge-authenticator',
       authenticatorType: 'app',
+      methodType: 'totp',
     });
 
     const pageTitle = challengeOktaVerifyTOTPPageObject.getPageTitle();


### PR DESCRIPTION
Resolves: OKTA-322821

## Description:

Uses new remediation form `resend-push` to challenge for push

![resendPush](https://user-images.githubusercontent.com/26014318/90345964-f9332f80-dfd9-11ea-9398-4aede3b1479a.gif)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-322821](https://oktainc.atlassian.net/browse/OKTA-322821)


