### PR TITLE
feat: makes i18n transformer changes for okta verify

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -784,6 +784,7 @@ oie.okta_verify.totp.enterCodeText = Enter code from Okta Verify app
 oie.okta_verify.push.title = Get a push notification
 oie.okta_verify.push.sent = Push notification sent
 oie.okta_verify.push.send = Send push notification
+oie.okta_verify.signed_nonce.title = Use Okta FastPass
 
 ## Select authenticator enrollment
 oie.select.authenticators.enroll.title = Set up Authenticators

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -57,7 +57,9 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-authenticate.authenticator.phone': 'oie.authenticator.phone.label',
   'select-authenticator-authenticate.authenticator.security_key': 'oie.authenticator.webauthn.label',
   'select-authenticator-authenticate.authenticator.security_question': 'oie.authenticator.security.question.label',
-  'select-authenticator-authenticate.authenticator.app': 'oie.authenticator.okta_verify.label',
+  'select-authenticator-authenticate.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
+  'select-authenticator-authenticate.authenticator.app.push': 'oie.okta_verify.push.title',
+  'select-authenticator-authenticate.authenticator.app.totp': 'oie.okta_verify.totp.title',
 
   'authenticator-enrollment-data.phone.authenticator.phoneNumber': 'mfa.phoneNumber.placeholder',
 
@@ -75,6 +77,7 @@ const I18N_OVERRIDE_MAPPINGS = {
   'challenge-authenticator.password.credentials.passcode': 'mfa.challenge.password.placeholder',
   'challenge-authenticator.phone.credentials.passcode': 'mfa.challenge.enterCode.placeholder',
   'challenge-authenticator.security_question.credentials.answer': 'mfa.challenge.answer.placeholder',
+  'challenge-authenticator.app.credentials.totp': 'oie.okta_verify.totp.enterCodeText',
 };
 
 const getI18nKey = (i18nPath) => {
@@ -153,6 +156,11 @@ const updateLabelForUiSchema = (remediation, uiSchema) => {
       let i18nPathOption;
       if (o.authenticatorType) {
         i18nPathOption = `${i18nPath}.${o.authenticatorType}`;
+
+        const methodType = o.value?.methodType;
+        if (o.authenticatorType === 'app' && methodType) {
+          i18nPathOption = `${i18nPathOption}.${methodType}`;
+        }
       } else if (o.value !== undefined) { // value could be string or number or undefined.
         i18nPathOption = `${i18nPath}.${o.value}`;
       }

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -107,7 +107,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorIconClassByIndex(5)).contains('mfa-okta-security-question');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(5)).eql('Select');
 
-  await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Okta Verify');
+  await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Use Okta FastPass');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(6)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(6)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(6)).eql('Select');

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -14,6 +14,9 @@ describe('v2/ion/i18nTransformer', function () {
       'oie.authenticator.phone.label': 'phone authenticator',
       'oie.webauthn': 'webauthn authenticator',
       'oie.authenticator.security.question.label': 'security question authenticator',
+      'oie.okta_verify.signed_nonce.title': 'okta verify fastpass',
+      'oie.okta_verify.push.title': 'okta verify push',
+      'oie.okta_verify.totp.title': 'okta verify totp',
 
       'oie.password.passwordLabel': 'enter password',
       'oie.security.question.questionKey.label': 'choose a question',
@@ -23,6 +26,7 @@ describe('v2/ion/i18nTransformer', function () {
       'mfa.challenge.answer.placeholder': 'answer',
       'mfa.challenge.enterCode.placeholder': 'enter code',
       'mfa.challenge.password.placeholder': 'password',
+      'oie.okta_verify.totp.enterCodeText': 'enter totp code',
 
       'primaryauth.password.placeholder': 'password',
       'primaryauth.username.placeholder': 'username',
@@ -187,6 +191,30 @@ describe('v2/ion/i18nTransformer', function () {
                     'id': 'aid568g3mXgtID0HHSLH'
                   },
                   'authenticatorType': 'security_question'
+                },
+                {
+                  'label': 'Use Okta FastPass',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'signed_nonce'
+                  },
+                  'authenticatorType': 'app'
+                },
+                {
+                  'label': 'Get a push notification',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'push'
+                  },
+                  'authenticatorType': 'app'
+                },
+                {
+                  'label': 'Enter a code',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'totp'
+                  },
+                  'authenticatorType': 'app'
                 }
               ],
               'label-top': true
@@ -245,6 +273,30 @@ describe('v2/ion/i18nTransformer', function () {
                     'id': 'aid568g3mXgtID0HHSLH'
                   },
                   'authenticatorType': 'security_question'
+                },
+                {
+                  'label': 'unit test - okta verify fastpass',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'signed_nonce'
+                  },
+                  'authenticatorType': 'app'
+                },
+                {
+                  'label': 'unit test - okta verify push',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'push'
+                  },
+                  'authenticatorType': 'app'
+                },
+                {
+                  'label': 'unit test - okta verify totp',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'totp'
+                  },
+                  'authenticatorType': 'app'
                 }
               ],
               'label-top': true
@@ -444,6 +496,49 @@ describe('v2/ion/i18nTransformer', function () {
               'required': true,
               'label-top': true,
               'type': 'text'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('converts label for challenge-authenticator - okta verify totp', () => {
+    const resp = {
+      remediations: [
+        {
+          relatesTo: {
+            value: {
+              type: 'app'
+            }
+          },
+          name: 'challenge-authenticator',
+          uiSchema: [
+            {
+              label: 'Enter code from Okta Verify app',
+              'label-top': true,
+              name: 'credentials.totp',
+              type: 'text',
+            }
+          ]
+        }
+      ]
+    };
+    expect(i18nTransformer(resp)).toEqual({
+      remediations: [
+        {
+          relatesTo: {
+            value: {
+              type: 'app'
+            }
+          },
+          name: 'challenge-authenticator',
+          uiSchema: [
+            {
+              label: 'unit test - enter totp code',
+              'label-top': true,
+              name: 'credentials.totp',
+              type: 'text',
             }
           ]
         }


### PR DESCRIPTION
Resolves: OKTA-322767

## Description:

makes i18n transformer changes for okta verify. This will affect m1 for devices as well. The option for OV will now say `Use Okta FastPass`. @stevennguyen-okta checked with PM and said this was fine.

For m1

<img width="413" alt="Screen Shot 2020-08-24 at 2 56 29 PM" src="https://user-images.githubusercontent.com/26014318/91100418-07a4cb00-e61a-11ea-8730-9bae1d6fcf3d.png">

For m2

<img width="423" alt="Screen Shot 2020-08-24 at 2 55 19 PM" src="https://user-images.githubusercontent.com/26014318/91100436-0d021580-e61a-11ea-8627-5487901fdf0f.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-322767](https://oktainc.atlassian.net/browse/OKTA-322767)


