### PR TITLE
remove deprecated features for release 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ You can learn more on the [Okta + JavaScript][lang-landing] page in our document
   - [afterError](#aftererror)
   - [afterRender](#afterrender)
   - [pageRendered](#pagerendered)
-  - [passwordRevealed](#passwordrevealed)
 - [Building the Widget](#building-the-widget)
   - [The `.widgetrc.js` config file](#the-widgetrc-config-file)
   - [Build and test commands](#build-and-test-commands)
@@ -1267,18 +1266,6 @@ signIn.on('pageRendered', function (data) {
   console.log(data);
   // { page: 'forgot-password' }
 });
-```
-
-### passwordRevealed
-
-:warning: This event has been *deprecated*, do not use.
-
-Triggered when the show password button is clicked.
-
-```javascript
-signIn.on('passwordRevealed', function () {
-  // Handle the event
-})
 ```
 
 ## Building the Widget

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "4.6.0",
+  "version": "5.0.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -14,7 +14,6 @@ import { $ } from 'okta';
 import PrimaryAuthModel from 'models/PrimaryAuth';
 import BaseLoginController from 'util/BaseLoginController';
 import DeviceFingerprint from 'util/DeviceFingerprint';
-import Logger from 'util/Logger';
 import CustomButtons from 'views/primary-auth/CustomButtons';
 import PrimaryAuthForm from 'views/primary-auth/PrimaryAuthForm';
 import Footer from 'views/shared/Footer';
@@ -107,16 +106,6 @@ export default BaseLoginController.extend({
     },
     'focusout input': function (e) {
       $(e.target.parentElement).removeClass('focused-input');
-    },
-
-    /**
-     * @deprecated
-     * This event was originally added for capturing specific usage metrics
-     * and is now obsolete.
-     */
-    'click .button-show': function () {
-      Logger.deprecate('use "passwordRevealed" event is deprecated');
-      this.trigger('passwordRevealed');
     },
   },
 

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -78,7 +78,6 @@ export default Model.extend({
     'features.trackTypingPattern': ['boolean', false, false],
     'features.redirectByFormSubmit': ['boolean', false, false],
     'features.useDeviceFingerprintForSecurityImage': ['boolean', false, true],
-    'features.hideDefaultTip': ['boolean', false, true],
     'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
     'features.mfaOnlyFlow': ['boolean', false, false],
 

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -111,7 +111,7 @@ export default Form.extend({
       label: loc('primaryauth.username.placeholder', 'login'),
       'label-top': true,
       explain: () => {
-        if (this.settings.get('features.hideDefaultTip') && !this.isCustomized('primaryauth.username.tooltip')) {
+        if (!this.isCustomized('primaryauth.username.tooltip')) {
           return false;
         }
 
@@ -138,7 +138,7 @@ export default Form.extend({
       label: loc('primaryauth.password.placeholder', 'login'),
       'label-top': true,
       explain: () => {
-        if (this.settings.get('features.hideDefaultTip') && !this.isCustomized('primaryauth.password.tooltip')) {
+        if (!this.isCustomized('primaryauth.password.tooltip')) {
           return false;
         }
 

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -731,33 +731,6 @@ Expect.describe('PrimaryAuth', function () {
         expect(test.form.passwordToggleContainer().length).toBe(1);
       });
     });
-    itp('Triggers a passwordRevealed event when show password button is clicked', function () {
-      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function (test) {
-        const eventSpy = jasmine.createSpy('eventSpy');
-
-        test.router.on('passwordRevealed', eventSpy);
-        test.form.setPassword('testpass');
-        test.form.setUsername('testuser');
-        expect(test.form.passwordToggleContainer().length).toBe(1);
-        test.form.passwordToggleShowContainer().click();
-        expect(eventSpy).toHaveBeenCalled();
-      });
-    });
-    itp('Does not trigger a passwordRevealed event when hide password button is clicked', function () {
-      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function (test) {
-        const eventSpy = jasmine.createSpy('eventSpy');
-
-        test.router.on('passwordRevealed', eventSpy);
-        test.form.setPassword('testpass');
-        test.form.setUsername('testuser');
-        expect(test.form.passwordToggleContainer().length).toBe(1);
-        test.form.passwordToggleShowContainer().click();
-        expect(eventSpy).toHaveBeenCalledTimes(1);
-        test.form.passwordToggleHideContainer().click();
-        // Hide password should not have triggered passwordRevealed event, so called times should still be 1
-        expect(eventSpy).toHaveBeenCalledTimes(1);
-      });
-    });
     itp(
       'Toggles icon when the password toggle button with features.showPasswordToggleOnSignInPage is clicked',
       function () {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -360,25 +360,6 @@ Expect.describe('PrimaryAuth', function () {
         expect(explain.length).toBe(0);
       });
     });
-    itp('username field does have explain when label is customized and features.hideDefaultTip is false', function () {
-      const options = {
-        language: 'en',
-        i18n: {
-          en: {
-            'primaryauth.username.placeholder': 'Custom Username Label',
-          },
-        },
-        features: {
-          hideDefaultTip: false,
-        },
-      };
-
-      return setup(options).then(function (test) {
-        const explain = test.form.usernameExplain();
-
-        expect(explain.text()).toEqual('Username');
-      });
-    });
     itp('username field does have explain when is customized', function () {
       const options = {
         language: 'en',
@@ -416,25 +397,6 @@ Expect.describe('PrimaryAuth', function () {
         const explain = test.form.passwordExplain();
 
         expect(explain.length).toBe(0);
-      });
-    });
-    itp('password field does have explain when label is customized and features.hideDefaultTip is false', function () {
-      const options = {
-        language: 'en',
-        i18n: {
-          en: {
-            'primaryauth.password.placeholder': 'Custom Password Explain',
-          },
-        },
-        features: {
-          hideDefaultTip: false,
-        },
-      };
-
-      return setup(options).then(function (test) {
-        const explain = test.form.passwordExplain();
-
-        expect(explain.text()).toEqual('Password');
       });
     });
     itp('password field does have explain when is customized', function () {


### PR DESCRIPTION
## Description:

### Breaking changes:

- "hideDefaultTip" option is removed
- remove `passwordRevealed` event

### refactoring
- convert AMD module syntax to ES6 import.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Reviewers:


### Issue:

- [OKTA-324788](https://oktainc.atlassian.net/browse/OKTA-324788)


