### PR TITLE
updates @okta/okta-auth-js to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "^3.2.3",
+    "@okta/okta-auth-js": "^4.0.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -14,6 +14,8 @@ import { _, loc, Model } from 'okta';
 import CookieUtil from 'util/CookieUtil';
 import Enums from 'util/Enums';
 import BaseLoginModel from './BaseLoginModel';
+import Util from 'util/Util';
+
 export default BaseLoginModel.extend({
   props: function () {
     const cookieUsername = CookieUtil.getCookieUsername();
@@ -171,12 +173,15 @@ export default BaseLoginModel.extend({
 
     // Add the custom header for fingerprint, typing pattern if needed, and then remove it afterwards
     // Since we only need to send it for primary auth
-    if (deviceFingerprintEnabled) {
+    if (deviceFingerprintEnabled && this.appState.get('deviceFingerprint')) { // OKTA-325445
       authClient.options.headers['X-Device-Fingerprint'] = this.appState.get('deviceFingerprint');
     }
-    if (typingPatternEnabled) {
+    if (typingPatternEnabled && this.appState.get('typingPattern')) { // OKTA-325445
       authClient.options.headers['X-Typing-Pattern'] = this.appState.get('typingPattern');
     }
+    // TODO: remove when auth-js is updated: OKTA-325445
+    authClient.options.headers = Util.removeNils(authClient.options.headers);
+
     const self = this;
 
     return func(signInArgs).finally(function () {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -221,4 +221,18 @@ Util.isV1StateToken = function (token) {
   return !!(token && _.isString(token) && token.startsWith('00'));
 };
 
+// TODO: remove when auth-js is updated: OKTA-325445
+Util.removeNils = function removeNils (obj) {
+  var cleaned = {};
+  for (var prop in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, prop)) {
+      var value = obj[prop];
+      if (value !== null && value !== undefined) {
+        cleaned[prop] = value;
+      }
+    }
+  }
+  return cleaned;
+};
+
 export default Util;

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import config from 'config/config.json';
 import OAuth2Util from 'util/OAuth2Util';
 import Util from 'util/Util';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import V1Router from 'LoginRouter';
 import V2Router from 'v2/WidgetRouter';
 
@@ -96,26 +96,6 @@ var OktaSignIn = (function () {
     };
   }
 
-  function createAuthClient (options) {
-    var authParams = _.extend(
-      {
-        transformErrorXHR: Util.transformErrorXHR,
-        headers: {
-          'X-Okta-User-Agent-Extended': 'okta-signin-widget-' + config.version,
-        },
-        clientId: options.clientId,
-        redirectUri: options.redirectUri,
-      },
-      options.authParams
-    );
-
-    if (!authParams.issuer) {
-      authParams.issuer = options.baseUrl + '/oauth2/default';
-    }
-
-    return new OktaAuth(authParams);
-  }
-
   /**
    * Render the sign in widget to an element.
    * @param options - options for the signin widget.
@@ -130,7 +110,16 @@ var OktaSignIn = (function () {
         See: https://developer.okta.com/code/javascript/okta_sign-in_widget#cdn
       `);
 
-    var authClient = createAuthClient(options);
+    var authParams = _.extend({
+      clientId: options.clientId,
+      redirectUri: options.redirectUri
+    }, options.authParams);
+
+    if (!authParams.issuer) {
+      authParams.issuer = options.baseUrl + '/oauth2/default';
+    }
+
+    var authClient = createAuthClient(authParams);
 
     var Router;
     if (options.stateToken && !Util.isV1StateToken(options.stateToken)) {

--- a/src/widget/createAuthClient.js
+++ b/src/widget/createAuthClient.js
@@ -1,0 +1,23 @@
+import { OktaAuth } from '@okta/okta-auth-js';
+import Util from 'util/Util';
+import config from 'config/config.json';
+import _ from 'underscore';
+
+export default function (options) {
+  var authParams = _.extend({
+    transformErrorXHR: Util.transformErrorXHR,
+    headers: {
+      'X-Okta-User-Agent-Extended': 'okta-signin-widget-' + config.version
+    },
+  }, options);
+
+  // Disable token manager auto renew
+  authParams.tokenManager = _.extend({}, authParams.tokenManager, {
+    autoRenew: false
+  });
+
+  // TODO: remove when auth-js is updated: OKTA-325445
+  authParams.headers = Util.removeNils(authParams.headers);
+  
+  return new OktaAuth(authParams);
+}

--- a/test/unit/spec/AdminConsentRequired_spec.js
+++ b/test/unit/spec/AdminConsentRequired_spec.js
@@ -1,5 +1,5 @@
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import LoginRouter from 'LoginRouter';
 import AdminConsentRequiredForm from 'helpers/dom/AdminConsentRequiredForm';
 import Util from 'helpers/mocks/Util';
@@ -21,7 +21,7 @@ function setup (settings, res = resAdminConsentRequired) {
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
   const baseUrl = window.location.origin;
-  const authClient = new OktaAuth({
+  const authClient = createAuthClient({
     issuer: baseUrl,
     transformErrorXHR: LoginUtil.transformErrorXHR,
   });

--- a/test/unit/spec/ConsentRequired_spec.js
+++ b/test/unit/spec/ConsentRequired_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 13], max-len: [2, 160] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import ConsentRequiredForm from 'helpers/dom/ConsentRequiredForm';
 import Util from 'helpers/mocks/Util';
@@ -22,7 +22,7 @@ function setup (settings, res) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = window.location.origin;
   const logoUrl = '/img/logos/default.png';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/EnrollActivateClaimsFactor_spec.js
+++ b/test/unit/spec/EnrollActivateClaimsFactor_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params:[2, 15] */
 import { internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollCustomFactorForm';
@@ -18,7 +18,7 @@ Expect.describe('EnrollActivateCustomFactor', function () {
     const initResponse = getInitialResponse(options);
     const setNextResponse = Util.mockAjax([initResponse]);
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({

--- a/test/unit/spec/EnrollCall_spec.js
+++ b/test/unit/spec/EnrollCall_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: 0 */
 import { _, $ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollCallForm';
@@ -22,7 +22,7 @@ Expect.describe('EnrollCall', function () {
   function setup (resp, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const afterRenderHandler = jasmine.createSpy('afterRenderHandler');
     const router = new Router({
       el: $sandbox,

--- a/test/unit/spec/EnrollChoices_spec.js
+++ b/test/unit/spec/EnrollChoices_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 19] */
 /*global JSON */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import EnrollChoicesForm from 'helpers/dom/EnrollChoicesForm';
@@ -100,8 +100,8 @@ Expect.describe('EnrollChoices', function () {
     }
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({
-      issuer: baseUrl,
+    const authClient = createAuthClient({
+      issuer: baseUrl
     });
     const router = new Router(
       _.extend(

--- a/test/unit/spec/EnrollCustomFactor_spec.js
+++ b/test/unit/spec/EnrollCustomFactor_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params:[2, 16] */
 import { internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollCustomFactorForm';
@@ -21,7 +21,7 @@ Expect.describe('EnrollCustomFactor', function () {
   function setup (factorType) {
     const setNextResponse = Util.mockAjax([responseMfaEnrollAll]);
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({

--- a/test/unit/spec/EnrollDuo_spec.js
+++ b/test/unit/spec/EnrollDuo_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 13], camelcase: 0 */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Duo from 'duo';
 import Beacon from 'helpers/dom/Beacon';
@@ -18,7 +18,7 @@ Expect.describe('EnrollDuo', function () {
   function setup (startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const router = new Router({
       el: $sandbox,
       baseUrl: baseUrl,

--- a/test/unit/spec/EnrollEmail_spec.js
+++ b/test/unit/spec/EnrollEmail_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: 0 */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AuthContainer from 'helpers/dom/AuthContainer';
 import Beacon from 'helpers/dom/Beacon';
@@ -19,7 +19,7 @@ Expect.describe('EnrollEmail', function () {
   function setup (resp) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'http://localhost:3000';
-    const authClient = new OktaAuth({
+    const authClient = createAuthClient({
       issuer: baseUrl,
       transformErrorXHR: LoginUtil.transformErrorXHR,
     });

--- a/test/unit/spec/EnrollHotpController_spec.js
+++ b/test/unit/spec/EnrollHotpController_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 16] */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollHotpForm';
@@ -14,7 +14,7 @@ Expect.describe('EnrollHotp', function () {
   function setup () {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({

--- a/test/unit/spec/EnrollOnPrem_spec.js
+++ b/test/unit/spec/EnrollOnPrem_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 15] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollTokenFactorForm';
@@ -19,7 +19,7 @@ Expect.describe('EnrollOnPrem', function () {
   function setup (response, includeOnPrem, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({
       el: $sandbox,

--- a/test/unit/spec/EnrollPassword_spec.js
+++ b/test/unit/spec/EnrollPassword_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 18] */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollPasswordForm';
@@ -18,7 +18,7 @@ Expect.describe('EnrollPassword', function () {
   function setup (startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const successSpy = jasmine.createSpy('success');
     const router = new Router({

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 19] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollQuestionsForm';
@@ -22,7 +22,7 @@ const itp = Expect.itp;
 function setup (res, startRouter, languagesResponse) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const successSpy = jasmine.createSpy('success');
   const router = new Router({

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: 0 */
 import { _, $ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AuthContainer from 'helpers/dom/AuthContainer';
 import Beacon from 'helpers/dom/Beacon';
@@ -22,7 +22,7 @@ Expect.describe('EnrollSms', function () {
   function setup (resp, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({
       el: $sandbox,

--- a/test/unit/spec/EnrollSymantecVip_spec.js
+++ b/test/unit/spec/EnrollSymantecVip_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 15] */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollTokenFactorForm';
@@ -16,7 +16,7 @@ Expect.describe('EnrollSymantecVip', function () {
   function setup (startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({
       el: $sandbox,

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 24] */
 import { _, loc } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import LinkSentConfirmation from 'helpers/dom/EnrollPushLinkSentForm';
@@ -30,7 +30,7 @@ Expect.describe('EnrollTotp', function () {
   function setup (res, selectedFactor, settings, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router(
       _.extend(
@@ -683,6 +683,7 @@ Expect.describe('EnrollTotp', function () {
         });
     });
     itp('removes the sms activation form on successful activation response', function () {
+      Expect.allowUnhandledPromiseRejection(); // OKTA-324849
       return enrollOktaPushGoCannotScanFn()
         .then(function (test) {
           Util.resetAjaxRequests();

--- a/test/unit/spec/EnrollU2F_spec.js
+++ b/test/unit/spec/EnrollU2F_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 14] */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollU2FForm';
@@ -18,7 +18,7 @@ Expect.describe('EnrollU2F', function () {
   function setup (startRouter, onlyU2F) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router({

--- a/test/unit/spec/EnrollUser_spec.js
+++ b/test/unit/spec/EnrollUser_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 13], max-len: [2, 160] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import EnrollUserForm from 'helpers/dom/EnrollUserForm';
 import Util from 'helpers/mocks/Util';
@@ -22,7 +22,7 @@ function setup (isUnauthenticated) {
   setNextResponse(nextResponse);
   const baseUrl = 'https://example.okta.com';
   const logoUrl = 'https://logo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 16] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollWebauthnForm';
@@ -27,7 +27,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = new Router(

--- a/test/unit/spec/EnrollWindowsHello_spec.js
+++ b/test/unit/spec/EnrollWindowsHello_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params:[2, 16] */
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollWindowsHelloForm';
@@ -18,7 +18,7 @@ Expect.describe('EnrollWindowsHello', function () {
   function setup () {
     const setNextResponse = Util.mockAjax([responseMfaEnrollAll, responseMfaEnrollActivateWindowsHello]);
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const router = new Router({
       el: $sandbox,

--- a/test/unit/spec/EnrollYubikey_spec.js
+++ b/test/unit/spec/EnrollYubikey_spec.js
@@ -1,4 +1,4 @@
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import Form from 'helpers/dom/EnrollTokenFactorForm';
@@ -14,7 +14,7 @@ Expect.describe('EnrollYubikey', function () {
   function setup (startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl });
+    const authClient = createAuthClient({ issuer: baseUrl });
     const router = new Router({
       el: $sandbox,
       baseUrl: baseUrl,

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 18], max-statements: 0 */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AccountRecoveryForm from 'helpers/dom/AccountRecoveryForm';
 import Beacon from 'helpers/dom/Beacon';
@@ -20,7 +20,7 @@ const itp = Expect.itp;
 function setup (settings, startRouter) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params:[2, 28], max-statements:[2, 41], camelcase:0, max-len:[2, 180] */
 import { _, $, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AuthContainer from 'helpers/dom/AuthContainer';
 import Beacon from 'helpers/dom/Beacon';
@@ -42,7 +42,7 @@ function setup (settings, requests) {
 
   const setNextResponse = Util.mockAjax(requests);
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({
+  const authClient = createAuthClient({
     issuer: baseUrl,
     pkce: false,
     transformErrorXHR: WidgetUtil.transformErrorXHR,

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 34], max-statements: 0, max-len: [2, 180], camelcase:0 */
 import { _, $, Backbone, Router, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import LoginRouter from 'LoginRouter';
 import config from 'config/config.json';
 import EnrollCallForm from 'helpers/dom/EnrollCallForm';
@@ -66,7 +66,7 @@ Expect.describe('LoginRouter', function () {
     const setNextResponse = settings.mockAjax === false ? function () {} : Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const usePKCE = settings['authParams.pkce'] || false;
-    const authClient = new OktaAuth({ issuer: baseUrl, pkce: usePKCE, headers: {} });
+    const authClient = createAuthClient({ issuer: baseUrl, pkce: usePKCE, headers: {} });
     const eventSpy = jasmine.createSpy('eventSpy');
     const afterRenderHandler = jasmine.createSpy('afterRenderHandler');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
@@ -316,7 +316,7 @@ Expect.describe('LoginRouter', function () {
   });
   it('throws a ConfigError if issuer is not passed as a widget param', function () {
     const fn = function () {
-      setup({ authClient: new OktaAuth({ issuer: undefined }) });
+      setup({ authClient: createAuthClient({ issuer: undefined }) });
     };
 
     expect(fn).toThrowError(

--- a/test/unit/spec/MfaVerifyEmail_spec.js
+++ b/test/unit/spec/MfaVerifyEmail_spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import MfaVerifyForm from 'helpers/dom/MfaVerifyForm';
@@ -36,7 +36,7 @@ function createRouter (baseUrl, authClient, successSpy, settings) {
 function setupEmail () {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({
+  const authClient = createAuthClient({
     issuer: baseUrl,
     transformErrorXHR: LoginUtil.transformErrorXHR,
   });

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint camelcase: 0 */
 import { _, $, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Duo from 'duo';
 import Beacon from 'helpers/dom/Beacon';
@@ -107,7 +107,7 @@ Expect.describe('MFA Verify', function () {
   function setup (res, selectedFactorProps, settings, languagesResponse, useResForIntrospect) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = createRouter(baseUrl, authClient, successSpy, settings);
@@ -181,7 +181,7 @@ Expect.describe('MFA Verify', function () {
   function setupNoProvider (res, selectedFactorProps, settings) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = createRouter(baseUrl, authClient, successSpy, settings);
@@ -227,7 +227,7 @@ Expect.describe('MFA Verify', function () {
   function setupWindowsHelloOnly () {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const router = createRouter(baseUrl, authClient, successSpy);
 
@@ -436,7 +436,7 @@ Expect.describe('MFA Verify', function () {
 
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = createRouter(baseUrl, authClient, successSpy);
@@ -480,7 +480,7 @@ Expect.describe('MFA Verify', function () {
     //get MFA_CHALLENGE, and routerUtil calls prev, to set state to MFA_REQUIRED
 
     const baseUrl = 'https://foo.com';
-    const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+    const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
     const router = createRouter(baseUrl, authClient, successSpy, options.settings);

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 19] */
 import { _, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import PasswordExpiredForm from 'helpers/dom/PasswordExpiredForm';
@@ -30,7 +30,7 @@ function setup (settings, res, custom) {
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -1,5 +1,5 @@
 import { _, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import PasswordResetForm from 'helpers/dom/PasswordResetForm';
@@ -79,7 +79,7 @@ function setup (settings) {
 
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/PollController_spec.js
+++ b/test/unit/spec/PollController_spec.js
@@ -1,5 +1,5 @@
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import PollingForm from 'helpers/dom/PollingForm';
 import Util from 'helpers/mocks/Util';
@@ -14,7 +14,7 @@ function setup (settings, res) {
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
   const baseUrl = window.location.origin;
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params:[2, 32], max-statements:[2, 45], camelcase:0, max-len:[2, 180] */
 import { _, $, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import PrimaryAuthController from 'PrimaryAuthController';
 import AuthContainer from 'helpers/dom/AuthContainer';
@@ -73,7 +73,7 @@ function setup (settings, requests, refreshState) {
 
   const setNextResponse = Util.mockAjax(requests);
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR, headers: {} });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR, headers: {} });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 16] */
 import { _, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import RecoveryChallengeForm from 'helpers/dom/RecoveryChallengeForm';
@@ -18,7 +18,7 @@ const itp = Expect.itp;
 function setup (settings) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(
     _.extend(

--- a/test/unit/spec/RecoveryLoading_spec.js
+++ b/test/unit/spec/RecoveryLoading_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 15] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import PrimaryAuthFormView from 'helpers/dom/PrimaryAuthForm';
@@ -16,7 +16,7 @@ const itp = Expect.itp;
 function setup (settings, callRecoveryLoading, fail = false) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(
     _.extend(

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 16] */
 import { _, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import RecoveryQuestionForm from 'helpers/dom/RecoveryQuestionForm';
@@ -18,7 +18,7 @@ const itp = Expect.itp;
 function setup (settings, res) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(
     _.extend(

--- a/test/unit/spec/RefreshAuthState_spec.js
+++ b/test/unit/spec/RefreshAuthState_spec.js
@@ -1,5 +1,5 @@
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import FormView from 'helpers/dom/Form';
@@ -13,7 +13,7 @@ const itp = Expect.itp;
 function setup (settings) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const router = new Router(
     _.extend(
       {

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 17], max-statements:[2, 70] */
 import { _, $, Backbone } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import RegForm from 'helpers/dom/RegistrationForm';
@@ -111,7 +111,7 @@ function setup (settings) {
   settings || (settings = {});
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(

--- a/test/unit/spec/UnlockAccount_spec.js
+++ b/test/unit/spec/UnlockAccount_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 16], max-statements: [2, 44] */
 import { _ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AccountRecoveryForm from 'helpers/dom/AccountRecoveryForm';
 import Beacon from 'helpers/dom/Beacon';
@@ -17,7 +17,7 @@ const itp = Expect.itp;
 function setup (settings, startRouter) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = new Router(

--- a/test/unit/spec/VerifyPIV_spec.js
+++ b/test/unit/spec/VerifyPIV_spec.js
@@ -1,6 +1,6 @@
 /* eslint max-params: [2, 18], max-statements: 0 */
 import { _, internal } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import PivForm from 'helpers/dom/PivForm';
@@ -17,7 +17,7 @@ const itp = Expect.itp;
 function setup (errorResponse, pivConfig) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl });
+  const authClient = createAuthClient({ issuer: baseUrl });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const defaultConfig = {

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -1,7 +1,7 @@
 /* eslint max-params: [2, 19] */
 
 import { _, $ } from 'okta';
-import OktaAuth from '@okta/okta-auth-js';
+import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import Beacon from 'helpers/dom/Beacon';
 import MfaVerifyForm from 'helpers/dom/MfaVerifyForm';
@@ -51,7 +51,7 @@ function clickFactorInDropdown (test, factorName) {
 function setup (options) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });
@@ -165,7 +165,7 @@ function setupMultipleWebauthnOnly (options) {
   mockWebauthn(options);
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
-  const authClient = new OktaAuth({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
+  const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
   const router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -9,7 +9,7 @@ var rootDir       = path.resolve(__dirname);
 var RemoveStrictPlugin = require( 'remove-strict-webpack-plugin' );
 var plugins = createPlugins({ isProduction: false });
 var webpack = require('webpack');
-var SDK_VERSION = require('@okta/okta-auth-js').SDK_VERSION;
+var SDK_VERSION = require('@okta/okta-auth-js').SDK_VERSION; // Maintain CommonJS require for Node.js
 
 plugins.unshift(new RemoveStrictPlugin());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,16 +1222,19 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.2.3.tgz#3bae9aa24eeac23b9d86504df346c514b62a6abf"
-  integrity sha512-lPKcITlHhfNhrGhnL8+zzlk86u2tZnXAahUPtiyEwFr+ktTpo8vWhraCR13hw0z46rTRVZ1lCMtedJt/wzMaoQ==
+"@okta/okta-auth-js@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.0.0.tgz#1c9b5518678e29e1e799c59556881bf6d61c01d6"
+  integrity sha512-Iy0iIuZHFJMcxYDuW7ZbQ0TgSPmGZzvNrMoTKAWseW77v0ez1iBLqxU71Ymuzpvr1Cw2SWnUltcs+vZQtpHFug==
   dependencies:
     Base64 "0.3.0"
+    core-js "^3.6.5"
     cross-fetch "^3.0.0"
     js-cookie "2.2.0"
     node-cache "^4.2.0"
+    text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
+    webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
 "@sindresorhus/to-milliseconds@^1.0.0":
@@ -3849,6 +3852,11 @@ core-js@^2.4.0, core-js@^2.5.0:
 core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -12122,6 +12130,11 @@ testcafe@^1.4.0:
     tree-kill "^1.1.0"
     typescript "^3.3.3"
 
+text-encoding@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -12871,6 +12884,11 @@ webauth@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webauth/-/webauth-1.1.0.tgz#64704f6b8026986605bc3ca629952e6e26fdd100"
   integrity sha1-ZHBPa4AmmGYFvDymKZUubib90QA=
+
+webcrypto-shim@^0.1.5:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/webcrypto-shim/-/webcrypto-shim-0.1.6.tgz#b4554d95c0a63637226c9732440dc674bf96f5cb"
+  integrity sha512-0o612s3S5z3IkDSRghIwd3Ul4X8NRmmZDpt6PWGI9gSM+nygVvrfzGjhIh4vwzlOJxYxS0fcFD1wh3yznuVzFg==
 
 webdriver-js-extender@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This is for SIW 5.0.0 release

## Description:
Also updates unit tests from AMD to ES6
tokenmanager.autoRenew is forcibly disabled. This will prevent a background process from being started which will attempt to auto renew tokens. Running this process in the SIW may interfere with background renew processes in other javascript SDKs.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-324596](https://oktainc.atlassian.net/browse/OKTA-324596)


