### PR TITLE
fix: discard hash from config.version

### DIFF
--- a/buildtools/commands/generate-language-config.js
+++ b/buildtools/commands/generate-language-config.js
@@ -18,6 +18,11 @@ exports.handler = () => {
   // 1. Add current widget version number
   config.version = packageJson.version;
   console.log('config.version: ' + config.version);
+  const versionParts = config.version.split('-');
+  if (versionParts.length > 1) {
+    console.log('version contains hash. language assets will be served based on version without hash');
+    config.version = versionParts[0];
+  }
 
   // 2. Add list of supported languages
   const re = new RegExp('/[a-z]+_([^.]+).json');


### PR DESCRIPTION
## Description:

Removes sha from version. This is an artifact of the build system and has no connection to our CDN or cachebust strategy

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


