### PR TITLE
feat: method selector view for Okta verify on OIE

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method.json
@@ -34,15 +34,15 @@
                   "required": true,
                   "options": [
                     {
-                      "label": "Use Okta FastPass",
+                      "label": "FastPass",
                       "value": "signed_nonce"
                     },
                     {
-                      "label": "Get a push notification",
+                      "label": "push notification",
                       "value": "push"
                     },
                     {
-                      "label": "Enter a code",
+                      "label": "totp",
                       "value": "totp"
                     }
                   ]

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method.json
@@ -1,0 +1,235 @@
+{
+  "stateHandle": "02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3",
+  "version": "1.0.0",
+  "expiresAt": "2020-09-02T15:58:07.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "authenticator-verification-data",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "value": [
+          {
+            "name": "authenticator",
+            "label": "",
+            "form": {
+              "value": [
+                {
+                  "name": "id",
+                  "required": true,
+                  "value": "aut13qrZReYpIib7R0g4",
+                  "mutable": false
+                },
+                {
+                  "name": "methodType",
+                  "type": "string",
+                  "required": true,
+                  "options": [
+                    {
+                      "label": "Use Okta FastPass",
+                      "value": "signed_nonce"
+                    },
+                    {
+                      "label": "Get a push notification",
+                      "value": "push"
+                    },
+                    {
+                      "label": "Enter a code",
+                      "value": "totp"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut13qrZReYpIib7R0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "type": "string",
+                        "required": false,
+                        "options": [
+                          {
+                            "label": "Use Okta FastPass",
+                            "value": "signed_nonce"
+                          },
+                          {
+                            "label": "Get a push notification",
+                            "value": "push"
+                          },
+                          {
+                            "label": "Enter a code",
+                            "value": "totp"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "send": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "send",
+        "href": "http://localhost:3000/idp/idx/challenge/send",
+        "method": "POST",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      "type": "app",
+      "id": "aut13qrZReYpIib7R0g4",
+      "displayName": "",
+      "methods": [
+        {
+          "type": "signed_nonce"
+        },
+        {
+          "type": "push"
+        },
+        {
+          "type": "totp"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "id": "aut13qrZReYpIib7R0g4",
+        "displayName": "",
+        "methods": [
+          {
+            "type": "signed_nonce"
+          },
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "id": "pfd3a9cMcr0ZYWJ8t0g4",
+        "displayName": "",
+        "methods": [
+          {
+            "type": "signed_nonce"
+          },
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u2x779KA0h4HgM40g4"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "test",
+      "id": "0oa13qtA9bXl2q7Qu0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2.json
@@ -44,7 +44,7 @@
                             "value": "push",
                             "label":  "Get a push notification"
                           },
-                          { 
+                          {
                             "value": "totp",
                             "label" :  "Enter a code"
                           }
@@ -128,7 +128,7 @@
         "type": "app",
         "id": "aentheidkwh282hv8g3",
         "displayName": "",
-        "methods": [ 
+        "methods": [
           { "type": "signed_nonce" },
           { "type": "push" },
           { "type": "totp" }
@@ -138,7 +138,7 @@
         "type": "app",
         "id": "aentheidkwh2823",
         "displayName": "",
-        "methods": [ 
+        "methods": [
            { "type": "push" },
            { "type": "totp" }
          ]
@@ -147,7 +147,7 @@
         "type": "password",
         "id": "auttmbseAWnMPtLe20g3",
         "displayName": "Okta Password",
-        "methods": [ 
+        "methods": [
           { "type": "password" }
         ]
       }

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -60,6 +60,9 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-authenticate.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
   'select-authenticator-authenticate.authenticator.app.push': 'oie.okta_verify.push.title',
   'select-authenticator-authenticate.authenticator.app.totp': 'oie.okta_verify.totp.title',
+  'authenticator-verification-data.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
+  'authenticator-verification-data.authenticator.app.push': 'oie.okta_verify.push.title',
+  'authenticator-verification-data.authenticator.app.totp': 'oie.okta_verify.totp.title',
 
   'authenticator-enrollment-data.phone.authenticator.phoneNumber': 'mfa.phoneNumber.placeholder',
 

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -60,9 +60,10 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-authenticate.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
   'select-authenticator-authenticate.authenticator.app.push': 'oie.okta_verify.push.title',
   'select-authenticator-authenticate.authenticator.app.totp': 'oie.okta_verify.totp.title',
-  'authenticator-verification-data.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
-  'authenticator-verification-data.authenticator.app.push': 'oie.okta_verify.push.title',
-  'authenticator-verification-data.authenticator.app.totp': 'oie.okta_verify.totp.title',
+
+  'authenticator-verification-data.app.authenticator.methodType.signed_nonce': 'oie.okta_verify.signed_nonce.title',
+  'authenticator-verification-data.app.authenticator.methodType.push': 'oie.okta_verify.push.title',
+  'authenticator-verification-data.app.authenticator.methodType.totp': 'oie.okta_verify.totp.title',
 
   'authenticator-enrollment-data.phone.authenticator.phoneNumber': 'mfa.phoneNumber.placeholder',
 

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -56,6 +56,7 @@ import EnrollementChannelDataOktaVerifyView from './views/ov/EnrollementChannelD
 import ChallengeOktaVerifyView from './views/ov/ChallengeOktaVerifyView';
 import ChallengeOktaVerifyPushView from './views/ov/ChallengeOktaVerifyPushView';
 import ChallengeOktaVerifyResendPushView from './views/ov/ChallengeOktaVerifyResendPushView';
+import ChallengeAuthenticatorDataOktaVerifyView from './views/ov/ChallengeAuthenticatorDataOktaVerifyView';
 
 const DEFAULT = '_';
 
@@ -148,6 +149,7 @@ const VIEWS_MAPPING = {
   },
   [RemediationForms.AUTHENTICATOR_VERIFICATION_DATA]: {
     phone: ChallengeAuthenticatorDataPhoneView,
+    app: ChallengeAuthenticatorDataOktaVerifyView
   },
   [RemediationForms.SUCCESS_REDIRECT]: {
     [DEFAULT]: SuccessView,

--- a/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
@@ -2,7 +2,7 @@ import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
 import { loc } from 'okta';
 
-const Body = BaseForm.extend({
+export const Body = BaseForm.extend({
   title: function () {
     if (this.isPasswordRecoveryFlow())  {
       return loc('password.reset.title.generic', 'login');

--- a/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
@@ -1,0 +1,28 @@
+import { Collection } from 'okta';
+import BaseForm from '../../internals/BaseForm';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import AuthenticatorVerifyOptions from '../../components/AuthenticatorVerifyOptions';
+import { getAuthenticatorDataForVerification } from '../../utils/AuthenticatorUtil';
+import { Body as SelectAuthenticatorVerifyViewBody } from '../SelectAuthenticatorVerifyView';
+
+const Body = SelectAuthenticatorVerifyViewBody.extend({
+  getUISchema () {
+    // Change the UI schema to not display radios here.
+    const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
+    const methodsSchema = uiSchemas.find(schema => schema.name === 'authenticator.methodType');
+    const methodOptions = methodsSchema.options.map((option) => {
+      return Object.assign({}, option, getAuthenticatorDataForVerification({authenticatorType: 'app'}));
+    });
+    return [{
+      View: AuthenticatorVerifyOptions,
+      options: {
+        name: methodsSchema.name,
+        collection: new Collection(methodOptions),
+      }
+    }];
+  },
+});
+
+export default BaseAuthenticatorView.extend({
+  Body
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -1,0 +1,118 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
+
+import xhrSelectMethodOktaVerify from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method';
+import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
+import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
+
+const requestLogger = RequestLogger(/challenge/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+const mockChallengeOVSelectMethod = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrSelectMethodOktaVerify)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .respond(xhrSuccess);
+
+fixture('Select Method screen for Okta verify');
+
+async function setup(t) {
+  const selectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+  await selectAuthenticatorPageObject.navigateToPage();
+  return selectAuthenticatorPageObject;
+}
+
+test.requestHooks(mockChallengeOVSelectMethod)('should load select method list with okta verify options', async t => {
+  const selectAuthenticatorPage = await setup(t);
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
+  //await t.expect(selectAuthenticatorPage.getFactorsCount()).eql(3);
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(0)).eql('Use Okta FastPass');
+  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(0)).eql(false);
+  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
+  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(0)).eql('Select');
+
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(1)).eql('Get a push notification');
+  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(1)).eql(false);
+  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
+  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(2)).eql('Enter a code');
+  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(2)).eql(false);
+  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-verify');
+  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+
+  // signout link at enroll page
+  await t.expect(await selectAuthenticatorPage.signoutLinkExists()).ok();
+  await t.expect(selectAuthenticatorPage.getSignoutLinkText()).eql('Sign Out');
+});
+
+test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when fastpass is selected', async t => {
+  const selectAuthenticatorPage = await setup(t);
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
+  selectAuthenticatorPage.selectFactorByIndex(0);
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  const req2 = requestLogger.requests[0].request;
+  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
+  await t.expect(req2.method).eql('post');
+  await t.expect(JSON.parse(req2.body)).eql({
+    'authenticator':
+    {
+      'id': 'aut13qrZReYpIib7R0g4',
+      'methodType': 'signed_nonce'
+    },
+    'stateHandle': '02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3'
+  });
+});
+
+test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when push is selected', async t => {
+  const selectAuthenticatorPage = await setup(t);
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
+  selectAuthenticatorPage.selectFactorByIndex(1);
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  const req2 = requestLogger.requests[0].request;
+  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
+  await t.expect(req2.method).eql('post');
+  await t.expect(JSON.parse(req2.body)).eql({
+    'authenticator':
+    {
+      'id': 'aut13qrZReYpIib7R0g4',
+      'methodType': 'push'
+    },
+    'stateHandle': '02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3'
+  });
+});
+
+test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when totp is selected', async t => {
+  const selectAuthenticatorPage = await setup(t);
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
+  selectAuthenticatorPage.selectFactorByIndex(2);
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  await t.expect(pageUrl)
+    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  const req2 = requestLogger.requests[0].request;
+  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
+  await t.expect(req2.method).eql('post');
+  await t.expect(JSON.parse(req2.body)).eql({
+    'authenticator':
+    {
+      'id': 'aut13qrZReYpIib7R0g4',
+      'methodType': 'totp'
+    },
+    'stateHandle': '02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3'
+  });
+});


### PR DESCRIPTION
* adds a method selector view for Okta verify in OIE.
This shows up only when OV is the only authenticator select authenticator
remediation is skipped.

RESOLVES: OKTA-326159

![Screen Shot 2020-09-08 at 1 22 00 PM](https://user-images.githubusercontent.com/17267130/92524081-5c2d7600-f1d6-11ea-9caf-5dc77a2c6373.png)




## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-326159](https://oktainc.atlassian.net/browse/OKTA-326159)


