### PR TITLE
feat: update uv device challenge remediation to CHALLENGE_POLL

### DIFF
--- a/playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri.json
@@ -13,7 +13,7 @@
         "relatesTo": [
           "$.currentAuthenticatorEnrollment"
         ],
-        "name": "challenge-authenticator", 
+        "name": "challenge-poll",
         "href": "http://localhost:3000/idp/idx/authenticators/poll",  
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-loopback.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-loopback.json
@@ -13,7 +13,7 @@
         "relatesTo": [
           "$.currentAuthenticatorEnrollment"
         ],
-        "name": "challenge-authenticator", 
+        "name": "challenge-poll",
         "href": "http://localhost:3000/idp/idx/authenticators/poll",  
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",

--- a/playground/mocks/data/idp/idx/identify-with-user-verification-universal-link.json
+++ b/playground/mocks/data/idp/idx/identify-with-user-verification-universal-link.json
@@ -13,7 +13,7 @@
         "relatesTo": [
           "$.currentAuthenticatorEnrollment"
         ],
-        "name": "challenge-authenticator", 
+        "name": "challenge-poll",
         "href": "http://localhost:3000/idp/idx/authenticators/poll",  
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -54,7 +54,7 @@ import EnrollPollOktaVerifyView from './views/ov/EnrollPollOktaVerifyView';
 import SelectEnrollmentChannelOktaVerifyView from './views/ov/SelectEnrollmentChannelOktaVerifyView';
 import EnrollementChannelDataOktaVerifyView from './views/ov/EnrollementChannelDataOktaVerifyView';
 import ChallengeOktaVerifyView from './views/ov/ChallengeOktaVerifyView';
-import ChallengeOktaVerifyPushView from './views/ov/ChallengeOktaVerifyPushView';
+import ChallengeOktaVerifyTotpView from './views/ov/ChallengeOktaVerifyTotpView';
 import ChallengeOktaVerifyResendPushView from './views/ov/ChallengeOktaVerifyResendPushView';
 import ChallengeAuthenticatorDataOktaVerifyView from './views/ov/ChallengeAuthenticatorDataOktaVerifyView';
 
@@ -139,10 +139,10 @@ const VIEWS_MAPPING = {
     'security_key': ChallengeWebauthnView,
     'security_question': ChallengeAuthenticatorSecurityQuestion,
     phone: ChallengeAuthenticatorPhoneView,
-    app: ChallengeOktaVerifyView,
+    app: ChallengeOktaVerifyTotpView,
   },
   [RemediationForms.CHALLENGE_POLL]: {
-    app: ChallengeOktaVerifyPushView,
+    app: ChallengeOktaVerifyView,
   },
   [RemediationForms.RESEND]: {
     app: ChallengeOktaVerifyResendPushView,

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
@@ -1,8 +1,6 @@
 import { _, loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import BaseForm from '../../internals/BaseForm';
-import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
-import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import polling from '../shared/polling';
 import { WARNING_TIMEOUT } from '../../utils/Constants';
 
@@ -77,7 +75,4 @@ const Body = BaseForm.extend(Object.assign(
   polling,
 ));
 
-export default BaseAuthenticatorView.extend({
-  Body,
-  Footer: AuthenticatorVerifyFooter,
-});
+export default Body;

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
@@ -1,5 +1,7 @@
 import { loc } from 'okta';
 import BaseForm from '../../internals/BaseForm';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 
 const Body = BaseForm.extend(Object.assign(
   {
@@ -15,4 +17,7 @@ const Body = BaseForm.extend(Object.assign(
   },
 ));
 
-export default Body;
+export default BaseAuthenticatorView.extend({
+  Body,
+  Footer: AuthenticatorVerifyFooter,
+});

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
@@ -1,6 +1,6 @@
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
-import ChallengeOktaVerifyTotpView from './ChallengeOktaVerifyTotpView';
+import ChallengeOktaVerifyPushView from './ChallengeOktaVerifyPushView';
 import ChallengeOktaVerifyFastPassView from './ChallengeOktaVerifyFastPassView';
 
 export default BaseAuthenticatorView.extend({
@@ -9,8 +9,8 @@ export default BaseAuthenticatorView.extend({
 
     const currentAuthenticator = this.options?.appState?.get('currentAuthenticator');
     const selectedMethod = currentAuthenticator?.methods[0];
-    if (selectedMethod?.type === 'totp') {
-      this.Body = ChallengeOktaVerifyTotpView;
+    if (selectedMethod?.type === 'push') {
+      this.Body = ChallengeOktaVerifyPushView;
       this.Footer = AuthenticatorVerifyFooter;
     } else {
       this.Body = ChallengeOktaVerifyFastPassView;


### PR DESCRIPTION
* updated remediation form name for device challenge poll to CHALLENGE_POLL
to be inline with what the action does.
* totp challenge has challenge-authenticator and push/fastpass has
challenge-poll.

Resolves: OKTA-322766




## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-322766](https://oktainc.atlassian.net/browse/OKTA-322766)


