### PR TITLE
Reduce Windows Loopback probe timeout to 100 ms

### DIFF
--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -98,10 +98,10 @@ const Body = BaseForm.extend(Object.assign(
       const checkPort = () => {
         return request({
           url: getAuthenticatorUrl('probe'),
-          // in loopback server, SSL handshake sometimes takes more than 1000 ms and thus needs additional timeout
+          // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: DeviceFingerprint.isAndroid() ? 3000 : 1000
+          timeout: DeviceFingerprint.isAndroid() ? 3000 : 100
         });
       };
 

--- a/src/v2/view-builder/views/UserVerificationDeviceChallengePollView.js
+++ b/src/v2/view-builder/views/UserVerificationDeviceChallengePollView.js
@@ -98,10 +98,10 @@ const Body = BaseForm.extend(Object.assign(
       const checkPort = () => {
         return request({
           url: getAuthenticatorUrl('probe'),
-          // in loopback server, SSL handshake sometimes takes more than 1000 ms and thus needs additional timeout
+          // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: DeviceFingerprint.isAndroid() ? 3000 : 1000
+          timeout: DeviceFingerprint.isAndroid() ? 3000 : 100
         });
       };
 


### PR DESCRIPTION
## Description:

fix: shorten the Windows loopback timeout to 100ms for better user experience

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@nikhilvenkatraman-okta @sshen-okta 

### Issue:

- [OKTA-328762](https://oktainc.atlassian.net/browse/OKTA-328762)


