### PR TITLE
fix: username customization property

### DIFF
--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -11,7 +11,6 @@
  */
 
 import { _, loc } from 'okta';
-import Util from 'util/Util';
 import PrimaryAuthForm from 'views/primary-auth/PrimaryAuthForm';
 export default PrimaryAuthForm.extend({
   className: 'idp-discovery-form',
@@ -29,10 +28,6 @@ export default PrimaryAuthForm.extend({
     const inputs = [];
     const usernameProps = {
       className: 'margin-btm-30',
-      label: loc('primaryauth.username.placeholder', 'login'),
-      'label-top': true,
-      explain: Util.createInputExplain('primaryauth.username.tooltip', 'primaryauth.username.placeholder', 'login'),
-      'explain-top': true,
       inputId: 'idp-discovery-username',
       disabled: false,
     };

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -29,6 +29,7 @@ const OIDC_STATE = 'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 
 function setup (settings, requests) {
   settings || (settings = {});
+  settings['language'] = 'en';
   settings['features.idpDiscovery'] = true;
 
   // To speed up the test suite, calls to debounce are
@@ -405,7 +406,7 @@ Expect.describe('IDPDiscovery', function () {
         expect(explain.length).toBe(0);
       });
     });
-    itp('username field does have explain when is customized', function () {
+    itp('username field does have explain when it is customized', function () {
       const options = {
         i18n: {
           en: {
@@ -416,7 +417,6 @@ Expect.describe('IDPDiscovery', function () {
 
       return setup(options).then(function (test) {
         const explain = test.form.usernameExplain();
-
         expect(explain.text()).toEqual('Custom Username Explain');
       });
     });


### PR DESCRIPTION
## Description:
1. removed extra explain introduced in IDPDiscoveryForm


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2020-09-16 at 11 52 39 AM](https://user-images.githubusercontent.com/38230587/93379830-4130b680-f813-11ea-8e55-3be347941391.png)
![Screen Shot 2020-09-16 at 11 53 03 AM](https://user-images.githubusercontent.com/38230587/93379832-41c94d00-f813-11ea-86a2-1d59d01a099e.png)
![Screen Shot 2020-09-16 at 11 53 12 AM](https://user-images.githubusercontent.com/38230587/93379833-4261e380-f813-11ea-8d5d-aec5a8d9f2fe.png)


### Reviewers:


### Issue:

- [OKTA-306126](https://oktainc.atlassian.net/browse/OKTA-306126)


