### PR TITLE
fix: signup text break issue for small ios screen -OKTA-327188

### DIFF
--- a/assets/sass/modules/_registration.scss
+++ b/assets/sass/modules/_registration.scss
@@ -3,7 +3,6 @@
 
   .content-container {
     padding: 30px 0;
-    text-align: center;
     -moz-transition: padding-top 0.4s;
     -webkit-transition: padding-top 0.4s;
     transition: padding-top 0.4s;

--- a/assets/sass/modules/_registration.scss
+++ b/assets/sass/modules/_registration.scss
@@ -11,6 +11,11 @@
     margin-top: 5px;
   }
 
+  .registration-label,
+  .registration-link {
+    display: inline-block;
+  }
+
   .registration-link {
     margin-left: 10px;
     color: $primary-button-bg-color;

--- a/assets/sass/modules/_registration.scss
+++ b/assets/sass/modules/_registration.scss
@@ -15,8 +15,11 @@
     display: inline-block;
   }
 
+  .registration-label {
+    margin-right: 10px;
+  }
+
   .registration-link {
-    margin-left: 10px;
     color: $primary-button-bg-color;
   }
 

--- a/assets/sass/modules/_registration.scss
+++ b/assets/sass/modules/_registration.scss
@@ -2,7 +2,8 @@
   margin-top: 30px;
 
   .content-container {
-    padding: 30px 42px;
+    padding: 30px 0;
+    text-align: center;
     -moz-transition: padding-top 0.4s;
     -webkit-transition: padding-top 0.4s;
     transition: padding-top 0.4s;


### PR DESCRIPTION
## Description:

Remove the left and right padding and center the text to fix the signup text break issue for smaller screen sizes.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Screen size: iPhone 5s/e

<img width="325" alt="Screen Shot 2020-09-16 at 11 51 54 AM" src="https://user-images.githubusercontent.com/60160041/93362696-493d2600-f814-11ea-8281-bfbcf67ec377.png">


### Reviewers:


### Issue:

- [OKTA-327188](https://oktainc.atlassian.net/browse/OKTA-327188)


