### PR TITLE
fix: remove extra explain from idp discovery login form

### DIFF
--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -12,9 +12,8 @@
 
 define([
   'okta',
-  'util/Util',
   'views/primary-auth/PrimaryAuthForm'
-], function (Okta, Util, PrimaryAuthForm) {
+], function (Okta, PrimaryAuthForm) {
 
   var _ = Okta._;
 
@@ -35,12 +34,6 @@ define([
       var usernameProps = {
         className: 'margin-btm-30',
         label: Okta.loc('primaryauth.username.placeholder', 'login'),
-        'label-top': true,
-        explain: Util.createInputExplain(
-          'primaryauth.username.tooltip',
-          'primaryauth.username.placeholder',
-          'login'),
-        'explain-top': true,
         inputId: 'idp-discovery-username',
         disabled: false
       };

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -37,6 +37,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
   function setup (settings, requests) {
     settings || (settings = {});
     settings['features.idpDiscovery'] = true;
+    settings['language'] = 'en';
 
     // To speed up the test suite, calls to debounce are
     // modified to wait 0 ms.
@@ -382,7 +383,7 @@ function (Q, OktaAuth, WidgetUtil, Okta, Util, AuthContainer, IDPDiscoveryForm, 
           expect(explain.length).toBe(0);
         });
       });
-      itp('username field does have explain when is customized', function () {
+      itp('username field does have explain when it is customized', function () {
         var options = {
           'i18n': {
             'en': {


### PR DESCRIPTION
## Description:

1. it adds unnecessary explain text if username is customized


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-306126](https://oktainc.atlassian.net/browse/OKTA-306126)


