### PR TITLE
chore: add migration notes for widgetrc to widgetrc.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,16 +20,8 @@ module.exports = function (grunt) {
       SASS                  = 'target/sass',
       I18N_SRC              = 'packages/@okta/i18n/src',
       SEARCH_OUT_FILE       = 'build2/OSW-search-checkstyle-result.xml',
-      WIDGET_RC             = '.widgetrc',
       // Note: 3000 is necessary to test against certain browsers in SauceLabs
       DEFAULT_SERVER_PORT   = 3000;
-
-  // .widgetrc is a json file that can be used by a dev to override
-  // things like the widget options in the test server, the server port, etc
-  var widgetRc = {};
-  if (grunt.file.isFile(WIDGET_RC)) {
-    widgetRc = grunt.file.readJSON(WIDGET_RC);
-  }
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -282,9 +274,7 @@ module.exports = function (grunt) {
 
     connect: {
       options: {
-        port: (function () {
-          return widgetRc.serverPort || DEFAULT_SERVER_PORT;
-        }()),
+        port: DEFAULT_SERVER_PORT,
         base: {
           path: 'target',
           options: {

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,32 +4,13 @@ This library uses semantic versioning and follows Okta's [library version policy
 
 ## Migrating `.widgetrc` to `.widgtrc.js`
 
-The rule of thumb is to create a javascript file that `module.exports` the `widgetOptions` in your `.widgetrc` file.
+The existing `.widgetrc` file used to configure the Widget has been **removed**. Simply rename the existing file to `.widgetrc.js` export the contents:
 
-For example, a `.wigetrc` looks like
 
-```json
-{
-  widgetOptions: {
-    baseUrl: 'http://localhost:3000',
-    logo: '/img/logo_widgico.png',
-    logoText: 'Windico',
-    features: {
-      router: true,
-      rememberMe: true,
-    },
-    // Host the assets (i.e. json files) locally
-    assets: {
-      baseUrl: '/'
-    }
-  }
-}
-```
-
-shall be migrated to a `.widgtrc.js` like
-
-```
-module.exports = {
+```diff
+- {
+-  widgetOptions: {
++ module.exports = {
     baseUrl: 'http://localhost:3000',
     logo: '/img/logo_widgico.png',
     logoText: 'Windico',
@@ -42,6 +23,7 @@ module.exports = {
       baseUrl: '/'
     }
   };
+- }
 ```
 
 ## Migrating from 3.x to 4.x

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2,6 +2,48 @@
 
 This library uses semantic versioning and follows Okta's [library version policy](https://developer.okta.com/code/library-versions/). In short, we don't make breaking changes unless the major version changes!
 
+## Migrating `.widgetrc` to `.widgtrc.js`
+
+The rule of thumb is to create a javascript file that `module.exports` the `widgetOptions` in your `.widgetrc` file.
+
+For example, a `.wigetrc` looks like
+
+```json
+{
+  widgetOptions: {
+    baseUrl: 'http://localhost:3000',
+    logo: '/img/logo_widgico.png',
+    logoText: 'Windico',
+    features: {
+      router: true,
+      rememberMe: true,
+    },
+    // Host the assets (i.e. json files) locally
+    assets: {
+      baseUrl: '/'
+    }
+  }
+}
+```
+
+shall be migrated to a `.widgtrc.js` like
+
+```
+module.exports = {
+    baseUrl: 'http://localhost:3000',
+    logo: '/img/logo_widgico.png',
+    logoText: 'Windico',
+    features: {
+      router: true,
+      rememberMe: true,
+    },
+    // Host the assets (i.e. json files) locally
+    assets: {
+      baseUrl: '/'
+    }
+  };
+```
+
 ## Migrating from 3.x to 4.x
 
 ### HTTPS is enforced by default

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ To use the CDN, include links to the JS and CSS files in your HTML:
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/4.1.1/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/4.4.3/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/4.1.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/4.4.3/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 The standard JS asset served from our CDN includes polyfills via [`babel-polyfill`](https://babeljs.io/docs/en/babel-polyfill/) to ensure compatibility with older browsers. This may cause conflicts if your app already includes polyfills. For this case, we provide an alternate JS asset which does not include any polyfills.
 
 ```html
 <!-- Latest CDN production Javascript without polyfills -->
-<script src="https://global.oktacdn.com/okta-signin-widget/4.1.1/js/okta-sign-in.no-polyfill.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/4.4.3/js/okta-sign-in.no-polyfill.min.js" type="text/javascript"></script>
 ```
 
 ### Using the npm module

--- a/playground/README.md
+++ b/playground/README.md
@@ -11,7 +11,7 @@ The configuration consists of
 
 ## Mock server
 
-While starting the playground application, the `baseUrl` in `..widgetrc.js` can be used to point to any Okta tenant. Similarly it can also be set to point to the mock server, which runs at <http://localhost:3000>
+While starting the playground application, the `baseUrl` in `.widgetrc.js` can be used to point to any Okta tenant. Similarly it can also be set to point to the mock server, which runs at <http://localhost:3000>
 
 Here is the directory structure of `mocks` folder
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -7,11 +7,11 @@ In a nutshell, the playground application demonstrates a customer hosted sign-in
 The configuration consists of
 
 - [widgetrc](https://github.com/okta/okta-signin-widget#the-widgetrc-config-file)
-- `./main.js`: initializes the sign-in widget using settings from widgetrc along with a simple success handler.
+- `./main.js`: initializes the sign-in widget using settings from `.widgetrc.js` along with a simple success handler.
 
 ## Mock server
 
-While starting the playground application, the `baseUrl` in `.widgetrc` can be used to point to any Okta tenant. Similarly it can also be set to point to the mock server, which runs at <http://localhost:3000>
+While starting the playground application, the `baseUrl` in `..widgetrc.js` can be used to point to any Okta tenant. Similarly it can also be set to point to the mock server, which runs at <http://localhost:3000>
 
 Here is the directory structure of `mocks` folder
 

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -1,4 +1,5 @@
 /* global module __dirname */
+/* eslint no-console:0 */
 
 const path = require('path');
 const fs = require('fs');
@@ -8,6 +9,14 @@ const TARGET = path.resolve(__dirname, 'target');
 const PLAYGROUND = path.resolve(__dirname, 'playground');
 const DEFAULT_SERVER_PORT = 3000;
 const WIDGET_RC_FILE = '.widgetrc.js';
+
+if (!fs.existsSync(WIDGET_RC_FILE) && fs.existsSync('.widgetrc')) {
+  console.log('============================================');
+  console.log('Please migrate the .widgetrc to .widgetrc.js.');
+  console.log('Check details at https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md');
+  console.log('============================================');
+  process.exit(1);
+}
 
 if (!fs.existsSync(WIDGET_RC_FILE)) {
   // create default WIDGET_RC if it doesn't exist to simplifed the build process

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -8,19 +8,20 @@ const dyson = require('dyson');
 const TARGET = path.resolve(__dirname, 'target');
 const PLAYGROUND = path.resolve(__dirname, 'playground');
 const DEFAULT_SERVER_PORT = 3000;
-const WIDGET_RC_FILE = '.widgetrc.js';
+const WIDGET_RC_JS = '.widgetrc.js';
+const WIDGET_RC = '.widgetrc';
 
-if (!fs.existsSync(WIDGET_RC_FILE) && fs.existsSync('.widgetrc')) {
-  console.log('============================================');
-  console.log('Please migrate the .widgetrc to .widgetrc.js.');
-  console.log('Check details at https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md');
-  console.log('============================================');
+if (!fs.existsSync(WIDGET_RC_JS) && fs.existsSync(WIDGET_RC)) {
+  console.error('============================================');
+  console.error(`Please migrate the ${WIDGET_RC} to ${WIDGET_RC_JS}.`);
+  console.error('For more information, please see https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md');
+  console.error('============================================');
   process.exit(1);
 }
 
-if (!fs.existsSync(WIDGET_RC_FILE)) {
+if (!fs.existsSync(WIDGET_RC_JS)) {
   // create default WIDGET_RC if it doesn't exist to simplifed the build process
-  fs.copyFileSync('.widgetrc.sample.js', WIDGET_RC_FILE);
+  fs.copyFileSync('.widgetrc.sample.js', WIDGET_RC_JS);
 }
 
 module.exports = {


### PR DESCRIPTION
## Description:

```

Loading from cache: https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository.json
Loading from cache: https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/npmrepository.json

Done.


Execution Time (2020-09-17 17:21:05 UTC-7)
loading tasks          496ms  ▇▇▇ 3%
exec:clean             532ms  ▇▇▇ 3%
propertiesToJSON:main  256ms  ▇▇ 1%
copy:app-to-target     523ms  ▇▇▇ 3%
exec:generate-config   486ms  ▇▇▇ 3%
postcss:build          652ms  ▇▇▇▇ 3%
exec:build-dev         13.1s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 70%
exec:retirejs           2.6s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 14%
Total 18.8s

$ webpack-dev-server --config webpack.playground.config.js --no-open
============================================
Please migrate the .widgetrc to .widgetrc.js.
For more information, please see https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md
============================================
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


