### PR TITLE
Fix for terminal view in case of expired email link

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -741,6 +741,7 @@ oie.email.authenticator.description = Verify with a link or code sent to your em
 oie.email.mfa.title = Verify with your email
 oie.email.verify.sentText = An email was sent to
 oie.email.enroll.subtitle = Please check your email and enter the code below.
+oie.email.return.link.expired.title = Verify with your email
 
 ## Webauthn
 oie.authenticator.webauthn.label = Security Key or Biometric Authenticator

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -13,7 +13,7 @@
 import { _, Model } from 'okta';
 import Logger from 'util/Logger';
 import { FORMS_WITHOUT_SIGNOUT, FORMS_WITH_STATIC_BACK_LINK,
-  FORMS_FOR_VERIFICATION } from '../ion/RemediationConstants';
+  FORMS_FOR_VERIFICATION, FORMS } from '../ion/RemediationConstants';
 
 /**
  * Keep track of stateMachine with this special model. Similar to `src/models/AppState.js`
@@ -151,6 +151,12 @@ export default Model.extend({
     return !hideSignOutConfigOverride
       && _.isFunction(idxActions?.cancel)
       && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
+  },
+
+  containsMessageWithI18nKey (key) {
+    const messagesObjs = this.get('messages');
+    return messagesObjs && Array.isArray(messagesObjs.value)
+      && messagesObjs.value.some(messagesObj => messagesObj.i18n?.key === key);
   },
 
   setIonResponse (transformedResponse) {

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -113,9 +113,22 @@ const getSignOutLink = (settings) => {
   }
 };
 
+const getBackToSignInLink = (settings) => {
+  let baseUrl = settings?.get('baseUrl') ? settings.get('baseUrl') : window.location.hostname;
+  return [
+    {
+      'type': 'link',
+      'label': loc('backToSignin', 'login'),
+      'name': 'go-back',
+      'href': baseUrl + '/login/login.htm'
+    },
+  ];
+};
+
 export {
   getSwitchAuthenticatorLink,
   getForgotPasswordLink,
   goBackLink,
-  getSignOutLink
+  getSignOutLink,
+  getBackToSignInLink
 };

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -1,12 +1,24 @@
-import { createCallout } from 'okta';
+import { createCallout, loc } from 'okta';
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
+import BaseFooter from '../internals/BaseFooter';
+import {getBackToSignInLink} from '../utils/LinksUtil';
+
+const RETURN_LINK_EXPIRED_KEY = 'idx.return.link.expired';
 
 const Body = BaseForm.extend({
   noButtonBar: true,
+
   postRender () {
     BaseForm.prototype.postRender.apply(this, arguments);
     this.$el.addClass('terminal-state');
+  },
+
+  title () {
+    if (this.options.appState.containsMessageWithI18nKey(RETURN_LINK_EXPIRED_KEY)) {
+      return loc('oie.email.return.link.expired.title', 'login');
+    }
+    return BaseForm.prototype.title.apply(this, arguments);
   },
 
   showMessages () {
@@ -17,7 +29,7 @@ const Body = BaseForm.extend({
       messagesObjs.value
         .forEach(messagesObj => {
           const msg = messagesObj.message;
-          if (messagesObj.class === 'ERROR') {
+          if (messagesObj.class === 'ERROR' || messagesObj.i18n?.key === RETURN_LINK_EXPIRED_KEY) {
             this.add(createCallout({
               content: msg,
               type: 'error',
@@ -32,6 +44,15 @@ const Body = BaseForm.extend({
 
 });
 
+const Footer = BaseFooter.extend({
+  links: function () {
+    if (this.options.appState.containsMessageWithI18nKey(RETURN_LINK_EXPIRED_KEY)) {
+      return getBackToSignInLink(this.options.settings);
+    }
+  }
+});
+
 export default BaseView.extend({
-  Body
+  Body,
+  Footer
 });

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -191,5 +191,8 @@ test
   .requestHooks(magicLinkExpiredMock)('challenge email factor with expired magic link', async t => {
     await setup(t);
     const terminalPageObject = new TerminalPageObject(t);
-    await t.expect(terminalPageObject.getMessages()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
+    await t.expect(terminalPageObject.getErrorMessages().isError()).eql(true);
+    await t.expect(terminalPageObject.getErrorMessages().getTextContent()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
+    await t.expect(await terminalPageObject.goBackLinkExists()).ok();
+    await t.expect(terminalPageObject.getFormTitle()).eql('Verify with your email');
   });

--- a/test/testcafe/spec/ChallengeFactorEmailMagicLink_spec.js
+++ b/test/testcafe/spec/ChallengeFactorEmailMagicLink_spec.js
@@ -43,6 +43,8 @@ test
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Please return to the original tab.');
+    await t.expect(await terminalPageObject.goBackLinkExists()).notOk();
+    await t.expect(terminalPageObject.getFormTitle()).eql('Authenticate');
   });
 
 test
@@ -50,13 +52,18 @@ test
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Flow continued in a new tab.');
+    await t.expect(await terminalPageObject.goBackLinkExists()).notOk();
+    await t.expect(terminalPageObject.getFormTitle()).eql('Authenticate');
   });
 
 test
   .requestHooks(magicLinkExpiredMock)('challenge email factor with expired magic link', async t => {
     await setup(t);
     const terminalPageObject = await new TerminalPageObject(t);
-    await t.expect(terminalPageObject.getMessages()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
+    await t.expect(terminalPageObject.getErrorMessages().isError()).eql(true);
+    await t.expect(terminalPageObject.getErrorMessages().getTextContent()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
+    await t.expect(await terminalPageObject.goBackLinkExists()).ok();
+    await t.expect(terminalPageObject.getFormTitle()).eql('Verify with your email');
   });
 
 test


### PR DESCRIPTION
## Description:

Show **Back to signin** link for expired email link terminal view

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://oktainc.atlassian.net/secure/attachment/374712/ExpiredEmailLinkBackToSigninDemo.mov

### Reviewers:

@bellatumaneng-okta 
@haishengwu-okta 

### Issue:

- [OKTA-318058](https://oktainc.atlassian.net/browse/OKTA-318058)


