### PR TITLE
Bootstrap device enrollment instructions UI

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -63,7 +63,10 @@ const idx = {
     // 'terminal-return-stale-email',
     // 'terminal-transfered-email',
     // 'unknown-user',
-    // 'terminal-registration'
+    // 'terminal-registration',
+    // 'oda-enrollment-ios',
+    // 'oda-enrollment-android',
+    // 'mdm-enrollment',
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new'

--- a/playground/mocks/data/idp/idx/mdm-enrollment.json
+++ b/playground/mocks/data/idp/idx/mdm-enrollment.json
@@ -1,0 +1,40 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+  "version": "1.0.0",
+  "expiresAt": "2020-06-14T22:15:50.000Z",
+  "intent": "LOGIN",
+  "deviceEnrollment": {
+    "type": "object",
+    "value": {
+      "name": "mdm",
+      "vendor": "Airwatch",
+      "enrollmentLink": "https://sampleEnrollmentlink.com"
+    }
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://idx.okta1.com/idp/idx/cancel",
+      "method": "POST",
+      "accepts": "application/vnd.okta.v1+json",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+              "visible": false,
+              "mutable": false
+          }
+      ]
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "oidc_client",
+          "label": "Native client",
+          "id": "0oa2lpzzzJHJy0E6q0g4"
+      }
+  }
+}

--- a/playground/mocks/data/idp/idx/oda-enrollment-android.json
+++ b/playground/mocks/data/idp/idx/oda-enrollment-android.json
@@ -1,0 +1,40 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+  "version": "1.0.0",
+  "expiresAt": "2020-06-14T22:15:50.000Z",
+  "intent": "LOGIN",
+  "deviceEnrollment": {
+    "type": "object",
+    "value": {
+      "name": "oda",
+      "signInUrl": "https://idx.okta1.com",
+      "appStoreName": "android"
+    }
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://idx.okta1.com/idp/idx/cancel",
+      "method": "POST",
+      "accepts": "application/vnd.okta.v1+json",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+              "visible": false,
+              "mutable": false
+          }
+      ]
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "oidc_client",
+          "label": "Native client",
+          "id": "0oa2lpzzzJHJy0E6q0g4"
+      }
+  }
+}

--- a/playground/mocks/data/idp/idx/oda-enrollment-ios.json
+++ b/playground/mocks/data/idp/idx/oda-enrollment-ios.json
@@ -1,0 +1,40 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+  "version": "1.0.0",
+  "expiresAt": "2020-06-14T22:15:50.000Z",
+  "intent": "LOGIN",
+  "deviceEnrollment": {
+    "type": "object",
+    "value": {
+      "name": "oda",
+      "signInUrl": "https://idx.okta1.com",
+      "platform": "iOS"
+    }
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "https://idx.okta1.com/idp/idx/cancel",
+      "method": "POST",
+      "accepts": "application/vnd.okta.v1+json",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+              "visible": false,
+              "mutable": false
+          }
+      ]
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "oidc_client",
+          "label": "Native client",
+          "id": "0oa2lpzzzJHJy0E6q0g4"
+      }
+  }
+}

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -41,6 +41,7 @@ const FORMS = {
   DEVICE_APPLE_SSO_EXTENSION: 'device-apple-sso-extension',
   CANCEL_TRANSACTION: 'cancel-transaction',
   LAUNCH_AUTHENTICATOR: 'launch-authenticator',
+  DEVICE_ENROLLMENT_TERMINAL: 'device-enrollment',
 
   // 'terminal` is not ION Form name but only coined in widget
   // for rendering a page that user has nothing to remediate.

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -77,6 +77,13 @@ const getRemediationValues = (idx) => {
         // messages generically.
         value: [],
       });
+    } else if (idx.context.deviceEnrollment) {
+      // no remediation or messages for device enrollment state
+      // and the state is meant to be terminal state with different UI than the regular terminal view
+      remediationValues.push({
+        name: RemediationForms.DEVICE_ENROLLMENT_TERMINAL,
+        value: [],
+      });
     }
 
   }
@@ -167,6 +174,7 @@ const convertRedirectIdPToSuccessRedirectIffOneIdp = (result) => {
  *  factors: {},
  *  factor: {},
  *  messages: {},
+ *  deviceEnrollment: {},
  * }
  */
 const convert = (settings, idx = {}) => {

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -7,9 +7,10 @@ import IdentifierView from './views/IdentifierView';
 import TerminalView from './views/TerminalView';
 import SuccessView from './views/SuccessView';
 
-// Device (Okta Mobile)
+// Device (Okta Verify)
 import DeviceChallengePollView from './views/DeviceChallengePollView';
 import SSOExtensionView from './views/SSOExtensionView';
+import DeviceEnrollmentTerminalView from './views/DeviceEnrollmentTerminalView';
 
 // registration
 import EnrollProfileView from './views/EnrollProfileView';
@@ -158,6 +159,11 @@ const VIEWS_MAPPING = {
   [RemediationForms.REDIRECT_IDP]: {
     [DEFAULT]: IdentifierView,
   },
+
+  [RemediationForms.DEVICE_ENROLLMENT_TERMINAL]: {
+    [DEFAULT]: DeviceEnrollmentTerminalView,
+  },
+
   [RemediationForms.TERMINAL]: {
     [DEFAULT]: TerminalView,
   },

--- a/src/v2/view-builder/views/DeviceEnrollmentTerminalView.js
+++ b/src/v2/view-builder/views/DeviceEnrollmentTerminalView.js
@@ -1,0 +1,80 @@
+import { createCallout, View } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+import BaseView from '../internals/BaseView';
+import BaseForm from '../internals/BaseForm';
+
+const ODA = 'oda';
+const MDM = 'mdm';
+const IOS = 'ios';
+const ANDROID = 'android';
+
+const Body = BaseForm.extend({
+  noButtonBar: true,
+
+  title () {
+    return this.enrollmentType === ODA ?
+      'Download Okta Verify' : 'Additional setup required';
+  },
+
+  initialize () {
+    BaseForm.prototype.initialize.apply(this, arguments);
+    const deviceEnrollment = this.options.appState.get('deviceEnrollment');
+    this.enrollmentType = (deviceEnrollment.name || '').toLowerCase(); // oda/mdm
+    switch (this.enrollmentType) {
+    case ODA:
+      this.add(View.extend({
+        template: hbs`
+          <div>
+            To sign in using Okta Verify, you will need to set up Okta Verify on this device.
+            Download the Okta Verify app from {{appStoreName}}.
+          </div>
+          <div>
+            In the app, follow the instructions to add an organizational account.
+            When prompted, choose Sign In, then enter the sign-in URL:<br>
+            {{signInUrl}}
+          </div>
+        `,
+        getTemplateData () {
+          const templateData = {
+            signInUrl: deviceEnrollment.signInUrl,
+          };
+          const platform = (deviceEnrollment.platform || '').toLowerCase();
+          if (platform === IOS) {
+            templateData.appStoreName = 'App Store';
+            templateData.appStoreLogoClass = '';
+          }
+          if (platform === ANDROID) {
+            templateData.appStoreName = 'Google Play Store';
+            templateData.appStoreLogoClass = '';
+          }
+
+          return templateData;
+        },
+      }));
+      break;
+    case MDM:
+      this.add(View.extend({
+        template: hbs`
+          <div>
+            To access this app, your device needs to meet your organization's security requirements.
+            Follow the instructions below to continue. 
+          </div>
+          <ol>
+            <li>Tap the Copy Link button below.</li>
+            <li>On this device, open your browser, then paste the copied link into the address bar.</li>
+            <li>Follow the instructions in your browser to set up {{vendor}}, then try accessing this app again.</li>
+          </ol>
+        `,
+        getTemplateData () {
+          return deviceEnrollment;
+        },
+      }));
+      break;
+    }
+  },
+});
+
+export default BaseView.extend({
+  Body,
+  Footer: '', // Sign out link appears in the footer if a cancel object exists in API response
+});


### PR DESCRIPTION
## Description:

While authenticator is required to access the resource but the device does not have OV or OV is not signed in. We want to show these new UIs to instruct enduser on how to proceed base on the API design:

UI: https://oktawiki.atlassian.net/wiki/spaces/eng/pages/1301556200/Design+ODA+MDM+remediation+flow#Remediation-Flow
API: 
https://oktawiki.atlassian.net/wiki/spaces/eng/pages/1301556200/Design+ODA+MDM+remediation+flow#MDM-Remediation-API
https://oktawiki.atlassian.net/wiki/spaces/eng/pages/1301556200/Design+ODA+MDM+remediation+flow#ODA-Remediation-API

The UI is a deadend of the sign in flow, but not exactly like a terminal state. After discussed with IDX team, we decided not to use `messages` object in the IDX API response but to introduce a new object `deviceEnrollment`. 

This PR only focuses on bootstrapping the SIW flow with IDX API, the UI itself needs to be further polished. Please ignore the UI inconsistency with the mock for now.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-336701](https://oktainc.atlassian.net/browse/OKTA-336701)


