### PR TITLE
feat: order ov methods in select authenticator ui

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-without-signed-nonce.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-without-signed-nonce.json
@@ -37,10 +37,6 @@
                         "mutable": true,
                         "options": [
                           {
-                            "value": "signed_nonce",
-                            "label":  "Use Okta FastPass"
-                          },
-                          {
                             "value": "push",
                             "label":  "Get a push notification"
                           },

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -22,8 +22,10 @@ const createOVOptions = (options = []) => {
   const ovItem = options.find((option) => option.relatesTo.type === 'app');
   const methodTypeObj = ovItem?.value?.form?.value?.find(v => v.name === 'methodType');
   const methodOptions = methodTypeObj?.options;
+  let signedNonceOption;
   if (methodOptions) {
-    const ovOptions = methodOptions.map((method) => {
+    const ovOptions = [];
+    methodOptions.forEach((method) => {
       // get value object from the ov item
       const value = [...ovItem.value.form.value];
       // get index of the methodType object within the value object
@@ -38,7 +40,7 @@ const createOVOptions = (options = []) => {
       // replace old methodType object with the new one
       value.splice(methodTypeIndex, 1, newMethodTypeObj);
       // return a new ov item for a specific method
-      return Object.assign({}, ovItem, {
+      const newItem = Object.assign({}, ovItem, {
         label: method.label,
         value: {
           form: {
@@ -46,9 +48,19 @@ const createOVOptions = (options = []) => {
           }
         }
       });
+      if (method.value === 'signed_nonce') {
+        signedNonceOption = newItem;
+      } else {
+        ovOptions.push(newItem);
+      }
     });
     const ovIndex = options.findIndex((option) => option.relatesTo.type === 'app');
     options.splice(ovIndex, 1, ...ovOptions);
+
+    // ReArrange fastpass in options based on deviceKnown
+    if (signedNonceOption) {
+      ovItem.relatesTo.deviceKnown ? options.unshift(signedNonceOption) : options.push(signedNonceOption);
+    }
   }
 };
 

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -301,7 +301,7 @@ test.requestHooks(requestLogger, mockChallengeOVTotp)('should navigate to okta v
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
-  selectFactorPage.selectFactorByIndex(2);
+  selectFactorPage.selectFactorByIndex(1);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Enter a code');
 
@@ -326,7 +326,7 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
-  selectFactorPage.selectFactorByIndex(1);
+  selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Get a push notification');
 
@@ -350,8 +350,7 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
 test.requestHooks(requestLogger, mockChallengeOVFastPass)('should navigate to okta verify fast pass page', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-
-  selectFactorPage.selectFactorByIndex(0);
+  selectFactorPage.selectFactorByIndex(3);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Signing in using Okta FastPass');
 


### PR DESCRIPTION
* order ov methods in select authenticator ui in idx.
* if device we are logging is known fastpass option is at the top
* if device is not known but signed_nonce is in the remediation we put
fastpass at the last option.
* if remediation doesnt not have signed_nonce method for ov do not display
ov.

RESOLVES: OKTA-337028

**if device we are logging is known fastpass option is at the top**

![Screen Shot 2020-10-14 at 11 15 05 AM](https://user-images.githubusercontent.com/17267130/96053179-e4d1ae80-0e33-11eb-80b2-f0bd5150dc8b.png)

**if device is not known but signed_nonce is in the remediation we put fastpass at the last option** 

![Screen Shot 2020-10-14 at 11 24 12 AM](https://user-images.githubusercontent.com/17267130/96053181-e602db80-0e33-11eb-9b48-0142fa52538f.png)


**if remediation doesnt not have signed_nonce method for ov do not display ov**
![Screen Shot 2020-10-14 at 11 28 31 AM](https://user-images.githubusercontent.com/17267130/96053184-e69b7200-0e33-11eb-9ed9-bd223f8b5320.png)



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-337028](https://oktainc.atlassian.net/browse/OKTA-337028)


