### PR TITLE
fix: allow i18nKey to be passed to the custom button title for i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,9 +783,26 @@ customButtons: [{
     window.location.href = 'http://www.example.com';
   }
 }]
+
+// An example that adds a custom button with a localized title underneath the login form on the primary auth page
+i18n: {
+  en: {
+    'customButton.title': 'Custom Button Title',
+  },
+},
+customButtons: [{
+  i18nKey: 'customButton.title',
+  className: 'btn-customAuth',
+  click: function() {
+    // clicking on the button navigates to another page
+    window.location.href = 'http://www.example.com';
+  }
+}]
 ```
 
-- **customButtons.title** - String that is set as the button text
+- **customButtons.title** - String that is set as the button text (set only one of `title` OR `i18nKey`)
+
+- **customButtons.i18nKey** - Custom translation key for button text specified in `i18n` config option (set only one of `title` OR `i18nKey`)
 
 - **customButtons.className** - Optional class that can be added to the button
 

--- a/src/views/primary-auth/CustomButtons.js
+++ b/src/views/primary-auth/CustomButtons.js
@@ -110,7 +110,9 @@ export default View.extend({
         'data-se': options.dataAttr,
       },
       className: options.className + ' default-custom-button',
-      title: options.title,
+      title: function () {
+        return options.title || loc(options.i18nKey);
+      },
       click: options.click,
     });
   },

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -1617,6 +1617,43 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(true);
       });
     });
+    itp('displays custom button translation', function () {
+      const settings = {
+        i18n: {
+          en: {
+            'customButton.title': 'Custom Translated Title',
+          },
+        },
+        customButtons: [
+          {
+            i18nKey: 'customButton.title',
+          },
+        ],
+      };
+
+      return setup(settings).then(function (test) {
+        expect(test.form.additionalAuthButton().text()).toEqual('Custom Translated Title');
+      });
+    });
+    itp('ignores custom button translation if title is passed', function () {
+      const settings = {
+        i18n: {
+          en: {
+            'customButton.title': 'Custom Translated Title',
+          },
+        },
+        customButtons: [
+          {
+            i18nKey: 'customButton.title',
+            title: 'Title Overrides i18n'
+          },
+        ],
+      };
+
+      return setup(settings).then(function (test) {
+        expect(test.form.additionalAuthButton().text()).toEqual('Title Overrides i18n');
+      });
+    });
     itp('displays generic idp buttons', function () {
       return setupWith({ genericIdp: true }).then(function (test) {
         expect(test.form.authDivider()).toHaveLength(1);

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -3083,6 +3083,43 @@ Expect.describe('Additional Auth Button', function () {
       expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(true);
     });
   });
+  itp('displays custom button translation', function () {
+    const settings = {
+      i18n: {
+        en: {
+          'customButton.title': 'Custom Translated Title',
+        },
+      },
+      customButtons: [
+        {
+          i18nKey: 'customButton.title',
+        },
+      ],
+    };
+
+    return setup(settings).then(function (test) {
+      expect(test.form.additionalAuthButton().text()).toEqual('Custom Translated Title');
+    });
+  });
+  itp('ignores custom button translation if title is passed', function () {
+    const settings = {
+      i18n: {
+        en: {
+          'customButton.title': 'Custom Translated Title',
+        },
+      },
+      customButtons: [
+        {
+          i18nKey: 'customButton.title',
+          title: 'Title Overrides i18n'
+        },
+      ],
+    };
+
+    return setup(settings).then(function (test) {
+      expect(test.form.additionalAuthButton().text()).toEqual('Title Overrides i18n');
+    });
+  });
   itp('displays social auth and custom buttons', function () {
     const settings = {
       customButtons: [


### PR DESCRIPTION
## Description:

* Allows for configuring each `customButtons` button with an additional option, `i18nKey` instead of `title`
* The custom `i18nKey` can be set using the `i18n` config option to pass translations for each button
* If both a `title` and `i18nKey` are specified, `title` is used


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Using a minimal configuration:
```js
module.exports = {
  baseUrl: 'https://dev1.okta1.com',
  i18n: {
    en: {
      'my.custom.i18n.key': 'hello world',
    },
  },
  customButtons: [{
    i18nKey: 'my.custom.i18n.key',
  }],
};
```

![image](https://user-images.githubusercontent.com/72248639/96165137-39cffc00-0eea-11eb-9d91-3b25f3b6329d.png)


### Reviewers:


### Issue:

- [OKTA-329120](https://oktainc.atlassian.net/browse/OKTA-329120)


