### PR TITLE
fix: display 403/generic error messages in idx

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -5,6 +5,7 @@ const idx = {
 
   '/idp/idx/introspect': [
     'identify',
+    // 'error-403-security-access-denied',
     // 'authenticator-enroll-email',
     // 'error-internal-server-error',
     // 'authenticator-enroll-password',

--- a/playground/mocks/data/idp/idx/error-403-security-access-denied.json
+++ b/playground/mocks/data/idp/idx/error-403-security-access-denied.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "You do not have permission to perform the requested action.",
+        "i18n": {
+          "key": "security.access_denied"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -93,10 +93,21 @@ export default Router.extend({
   },
 
   handleIdxResponseFailure (error = {}) {
-    if (error?.details?.stateHandle) {
-      // 1. loosely check whether is IDX error response
-      // see idx for details: https://github.com/okta/okta-idx-js/blob/master/src/index.js
-
+    // 1. loosely check whether is IDX error response
+    // see idx for details: https://github.com/okta/okta-idx-js/blob/master/src/index.js
+    if (error?.details) {
+      // Populate generic error message if there isnt any.
+      if (!error.details.messages ) {
+        error.details.messages = {
+          type: 'array',
+          'value': [
+            {
+              message: loc('oform.error.unexpected', 'login'),
+              class: 'ERROR'
+            }
+          ]
+        };
+      }
       // Need to mimic IdxRespones as idx returns raw response at error case
       this.handleIdxResponseSuccess({
         rawIdxState: error.details,

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -15,4 +15,8 @@ export default class TerminalPageObject extends BasePageObject {
     return this.form.getTerminalContent();
   }
 
+  waitForErrorBox() {
+    return this.form.waitForErrorBox();
+  }
+
 }

--- a/test/testcafe/spec/GenericErrorHandling_spec.js
+++ b/test/testcafe/spec/GenericErrorHandling_spec.js
@@ -1,0 +1,42 @@
+import { RequestMock } from 'testcafe';
+import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
+import xhr403SecurityAccessDenied from '../../../playground/mocks/data/idp/idx/error-403-security-access-denied';
+
+const securityAccessDeniedMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhr403SecurityAccessDenied, 403);
+
+const noMessageResponse = {};
+const noMessagesErrorMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(noMessageResponse, 403);
+
+fixture('GenericErrors');
+
+async function setup(t) {
+  const terminalPage = new TerminalPageObject(t);
+  await terminalPage.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: null,
+    formName: 'terminal',
+  });
+
+  return terminalPage;
+}
+
+test.requestHooks(noMessagesErrorMock)('should be able generic error when request does not have messages', async t => {
+  const terminalPage = await setup(t);
+  await terminalPage.waitForErrorBox();
+  await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('There was an unexpected internal error. Please try again.');
+});
+
+test.requestHooks(securityAccessDeniedMock)('should be able display error when request failed ith 403 with no stateToken', async t => {
+  const terminalPage = await setup(t);
+  await terminalPage.waitForErrorBox();
+  await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('You do not have permission to perform the requested action.');
+});


### PR DESCRIPTION
* When there are 403 errors with proper idx response format and stateToken
is missing we should display the error. Since cases like okta threat insight
doesnt return stateToken.

RESOLVES: OKTA-337505

![Screen Shot 2020-10-20 at 12 47 14 PM](https://user-images.githubusercontent.com/17267130/96636912-cb68b080-12d2-11eb-9981-82e1f4e57c69.png)


**no message generic error**

![Screen Shot 2020-10-23 at 9 56 06 AM](https://user-images.githubusercontent.com/17267130/97032055-0a3a7880-1516-11eb-9923-23b4a424c4ee.png)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-337505](https://oktainc.atlassian.net/browse/OKTA-337505)


