### PR TITLE
fix: adds logic to translate duplicate email error on registration

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -198,6 +198,19 @@ export default BaseLoginController.extend({
         noCancelButton: true,
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
+        parseErrorMessage: function (resp) {
+          const hasErrorCauses = resp.errorCauses && resp.errorCauses.length;
+
+          if (hasErrorCauses) {
+            const isDuplicateEmailCause = resp.errorCode === 'E0000001'
+              && resp.errorCauses[0].reason === 'UNIQUE_CONSTRAINT';
+
+            if (isDuplicateEmailCause) {
+              resp.errorCauses[0].errorSummary = loc('registration.error.userName.notUniqueWithinOrg', 'login');
+            }
+          }
+          return resp;
+        },
       });
       const form = new RegistrationControllerForm(self.toJSON());
 

--- a/test/unit/helpers/xhr/ERROR_notUnique.js
+++ b/test/unit/helpers/xhr/ERROR_notUnique.js
@@ -1,0 +1,18 @@
+export default {
+  status: 400,
+  responseType: 'jrd+json',
+  response: {
+    errorCode: 'E0000001',
+    errorSummary: 'Api validation failed: null',
+    errorLink: 'E0000001',
+    errorId: 'oaeXbQp2gytRhijPgA-Rew56g',
+    errorCauses: [
+      {
+        domain: 'registration request',
+        errorSummary: 'A user with this Email already exists',
+        locationType: 'body',
+        reason: 'UNIQUE_CONSTRAINT',
+      },
+    ],
+  },
+};

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -7,6 +7,7 @@ import RegForm from 'helpers/dom/RegistrationForm';
 import Util from 'helpers/mocks/Util';
 import Expect from 'helpers/util/Expect';
 import resSuccess from 'helpers/xhr/SUCCESS';
+import resErrorNotUnique from 'helpers/xhr/ERROR_notUnique';
 import RegSchema from 'models/RegistrationSchema';
 import $sandbox from 'sandbox';
 
@@ -240,6 +241,29 @@ Expect.describe('Registration', function () {
         const postData = model.toJSON();
 
         expect(postData.relayState).toBeUndefined();
+      });
+    });
+    itp('duplicate email address in org error message is localized by widget', function () {
+      return setup({
+        i18n: {
+          en: {
+            'registration.error.userName.notUniqueWithinOrg': 'Custom duplicate account error message',
+          }
+        }
+      }).then(function (test) {
+        Util.resetAjaxRequests();
+        test.form.setUserName('test@example.com');
+        test.form.setPassword('Abcd1234');
+        test.form.setFirstname('firstName');
+        test.form.setLastname('lastName');
+        test.form.setReferrer('referrer');
+        test.setNextResponse(resErrorNotUnique);
+        test.form.submit();
+
+        return Expect.waitForFormErrorBox(test.form, test);
+      }).then(function (test) {
+        expect(test.form.errorBox().length).toBe(1);
+        expect(test.form.errorBox().text().trim()).toBe('Custom duplicate account error message');
       });
     });
   });


### PR DESCRIPTION
## Description:

* Adds error handling logic to handle cases where the user's email address already exists for an organization during registration and localizes it for the widget
* Allows the above error message to be overridden using `i18n` configuration
* Closes #1062.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Using this `.widgetrc.js` config:
```js
module.exports = {
  baseUrl: 'http://dev1.okta1.com:1802',
  logoText: 'Okta',
  features: {
    registration: true,
  },
  i18n: {
    en: {
      'registration.error.userName.notUniqueWithinOrg': 'custom i18n',
    }
  }
};
```
![image](https://user-images.githubusercontent.com/72248639/96928725-03b0f000-1487-11eb-93bb-f0fc91239bac.png)

If no custom i18n key is added for this error (default behavior):
```js
module.exports = {
  baseUrl: 'http://dev1.okta1.com:1802',
  logoText: 'Okta',
  features: {
    registration: true,
  },
};
```
![image](https://user-images.githubusercontent.com/72248639/96928937-4a064f00-1487-11eb-8d84-7ad7c4446913.png)

### Reviewers:


### Issue:

- [OKTA-280970](https://oktainc.atlassian.net/browse/OKTA-280970)


