### PR TITLE
feat: add screen for required sign in with Okta Verify authenticator

### DIFF
--- a/assets/sass/v2/_device-challenge.scss
+++ b/assets/sass/v2/_device-challenge.scss
@@ -10,7 +10,8 @@
         background: url('../img/ui/indicators/loader@1x.gif') no-repeat center;
       }
 
-      div + div {
+      div + div,
+      p + p {
         margin-top: 10px;
       }
     }

--- a/assets/sass/v2/_identify.scss
+++ b/assets/sass/v2/_identify.scss
@@ -2,6 +2,9 @@
 .sign-in-with-idp,
 .custom-buttons {
   .okta-verify-container {
+    .signin-with-ov-description {
+      margin-bottom: 0.83em;
+    }
     .button {
       display: block;
       position: relative;

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -513,7 +513,8 @@ primaryauth.password.tooltip = Password
 primaryauth.submit = Sign In
 primaryauth.newUser.tooltip=This is the first time you are connecting to {0} from this browser
 primaryauth.newUser.tooltip.close=Close
-oktaVerify.button = Sign in with Okta Verify
+oktaVerify.description = To access this resource, your organization requires you to sign in using your device.
+oktaVerify.button = Sign in using Okta Verify on this device
 
 # IDP Discovery
 idpDiscovery.email.placeholder = Email
@@ -678,6 +679,8 @@ signin.with.fastpass = Signing in using Okta FastPass
 customUri.title = Verify account access
 customUri.subtitle = Launching Okta Verify...
 customUri.content = <div class="skinny-content"> If nothing prompts from the browser, <a href="#" id="launch-ov" class="link">click here</a> to launch Okta Verify, or make sure Okta Verify is installed.</div>
+customUri.required.content.p1 = Please click&nbsp;<span class="strong">Open oktaverify.app</span>&nbsp;if you see the system dialog.
+customUri.required.content.p2 = If nothing prompts from the browser,&nbsp;<a href="#" id="launch-ov" class="link">click here</a>&nbsp;to launch Okta Verify, or&nbsp;<a href="{0}" target="_blank" id="download-ov" class="link">download & run Okta Verify</a>.
 universalLink.title = Verify your sign in
 universalLink.content = To continue, you\'ll need to use the <span class="highlight-text">Okta Verify</span> app to confirm your sign in.
 universalLink.userVerification.title = Extra verification needed

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -210,7 +210,26 @@ const windowAuthnLoopbackFailfast = {
   ],
 };
 
-// device probe: Windows/Android authenticator with custom URI
+// device probe: silent probe failed, but probing is still required
+const desktopSmartProbe = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-loopback',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify',
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'identify-with-device-launch-authenticator',
+  ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'smart-probing-required',
+  ],
+  '/idp/idx/enroll': [
+    'enroll-profile-new'
+  ],
+};
+
+// device probe: Windows/Android authenticator with custom URI, probing is not required
 const windowAuthnCustomUri = {
   '/idp/idx/introspect': [
     'identify-with-device-probing-loopback-challenge-not-received',

--- a/playground/mocks/data/idp/idx/identify-with-device-launch-authenticator.json
+++ b/playground/mocks/data/idp/idx/identify-with-device-launch-authenticator.json
@@ -2,7 +2,6 @@
     "stateHandle": "02Su_kH3sC3blG075ZdSW5v0N-oiOpK3HqGmR5TS1w",
     "version": "1.0.0",
     "expiresAt": "2020-12-18T21:48:19.000Z",
-
     "intent": "LOGIN",
     "remediation": {
         "type": "array",
@@ -68,6 +67,7 @@
         "value": {
             "challengeMethod": "CUSTOM_URI",
             "href": "com.verify.okta://open",
+            "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405",
             "cancel": {
                 "rel": [
                     "create-form"

--- a/playground/mocks/data/idp/idx/smart-probing-required.json
+++ b/playground/mocks/data/idp/idx/smart-probing-required.json
@@ -1,0 +1,73 @@
+{
+  "stateHandle": "02MmwXJegtQ1FxZnnbHFdnzSaD-_r2Ae3Nz6M1m91C",
+  "version": "1.0.0",
+  "expiresAt": "2020-10-19T07:13:01.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+      "type": "array",
+      "value": [
+          {
+              "rel": [
+                  "create-form"
+              ],
+              "name": "launch-authenticator",
+              "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+              "method": "POST",
+              "value": [
+                  {
+                      "name": "stateHandle",
+                      "required": true,
+                      "value": "02MmwXJegtQ1FxZnnbHFdnzSaD-_r2Ae3Nz6M1m91C",
+                      "visible": false,
+                      "mutable": false
+                  }
+              ],
+              "accepts": "application/ion+json; okta-version=1.0.0"
+          },
+          {
+              "rel": [
+                  "create-form"
+              ],
+              "name": "select-enroll-profile",
+              "href": "http://localhost:3000/idp/idx/enroll",
+              "method": "POST",
+              "value": [
+                  {
+                      "name": "stateHandle",
+                      "required": true,
+                      "value": "02MmwXJegtQ1FxZnnbHFdnzSaD-_r2Ae3Nz6M1m91C",
+                      "visible": false,
+                      "mutable": false
+                  }
+              ],
+              "accepts": "application/ion+json; okta-version=1.0.0"
+          }
+      ]
+  },
+  "cancel": {
+      "rel": [
+          "create-form"
+      ],
+      "name": "cancel",
+      "href": "http://localhost:3000/idp/idx/cancel",
+      "method": "POST",
+      "value": [
+          {
+              "name": "stateHandle",
+              "required": true,
+              "value": "02MmwXJegtQ1FxZnnbHFdnzSaD-_r2Ae3Nz6M1m91C",
+              "visible": false,
+              "mutable": false
+          }
+      ],
+      "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+      "type": "object",
+      "value": {
+          "name": "office365",
+          "label": "Microsoft Office 365",
+          "id": "0oabq3knA2YMLrgvK0g4"
+      }
+  }
+}

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -10,6 +10,7 @@ import SuccessView from './views/SuccessView';
 // Device (Okta Mobile)
 import DeviceChallengePollView from './views/DeviceChallengePollView';
 import SSOExtensionView from './views/SSOExtensionView';
+import SignInDeviceView from './views/SignInDeviceView';
 
 // registration
 import EnrollProfileView from './views/EnrollProfileView';
@@ -67,6 +68,9 @@ const VIEWS_MAPPING = {
   [RemediationForms.DEVICE_CHALLENGE_POLL]: {
     [DEFAULT]: DeviceChallengePollView,
   },
+  [RemediationForms.LAUNCH_AUTHENTICATOR]: {
+    [DEFAULT]: SignInDeviceView,
+  } ,
   [RemediationForms.DEVICE_APPLE_SSO_EXTENSION]: {
     [DEFAULT]: SSOExtensionView,
   },

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -1,0 +1,51 @@
+import { loc } from 'okta';
+import BaseFooter from '../internals/BaseFooter';
+import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
+import { getForgotPasswordLink } from '../utils/LinksUtil';
+
+export default BaseFooter.extend({
+  links () {
+    let helpLinkHref;
+    if (this.options.settings.get('helpLinks.help')) {
+      helpLinkHref = this.options.settings.get('helpLinks.help');
+    } else {
+      const baseUrl = this.options.settings.get('baseUrl');
+      helpLinkHref = baseUrl + '/help/login';
+    }
+
+    const helpLink = [
+      {
+        'name': 'help',
+        'label': loc('help', 'login'),
+        'href': helpLinkHref,
+      },
+    ];
+
+    const signupLink = [];
+    if (this.options.appState.hasRemediationObject(RemediationForms.SELECT_ENROLL_PROFILE)) {
+      signupLink.push({
+        'type': 'link',
+        'label': loc('signup', 'login'),
+        'name': 'enroll',
+        'actionPath': RemediationForms.SELECT_ENROLL_PROFILE,
+      });
+    }
+
+    const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
+
+    const customHelpLinks = [];
+    if (this.options.settings.get('helpLinks.custom')) {
+      //add custom helpLinks
+      this.options.settings.get('helpLinks.custom').forEach(customHelpLink => {
+        customHelpLink.name = 'custom';
+        customHelpLink.label = customHelpLink.text;
+        customHelpLinks.push(customHelpLink);
+      });
+    }
+
+    return forgotPasswordLink
+      .concat(signupLink)
+      .concat(helpLink)
+      .concat(customHelpLinks);
+  }
+});

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -61,10 +61,22 @@ const Body = BaseForm.extend(Object.assign(
         this.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
         break;
       case 'CUSTOM_URI':
-        this.title = loc('customUri.title', 'login');
-        this.subtitle = loc('customUri.subtitle', 'login');
+        this.title = loc('oktaVerify.button', 'login');
         this.add(View.extend({
-          template: hbs`{{{i18n code="customUri.content" bundle="login"}}}`
+          className: 'skinny-content',
+          template: hbs`
+            <p>
+              {{{i18n code="customUri.required.content.p1" bundle="login"}}}
+            </p>
+            <p>
+              {{{i18n code="customUri.required.content.p2" bundle="login" arguments="downloadOVLink"}}}
+            </p>
+          `,
+          getTemplateData () {
+            return {
+              downloadOVLink: deviceChallenge.downloadHref
+            };
+          },
         }));
         this.customURI = deviceChallenge.href;
         this.doCustomURI();
@@ -167,7 +179,7 @@ const Footer = BaseFooter.extend({
         {
           name: 'sign-in-options',
           type: 'link',
-          label: loc('goback', 'login'),
+          label: loc('oie.go.back', 'login'),
           href: this.settings.get('baseUrl')
         }
       ];

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -2,12 +2,12 @@ import { loc, createCallout } from 'okta';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
-import BaseFooter from '../internals/BaseFooter';
+import IdentifierFooter from '../components/IdentifierFooter';
 import signInWithIdps from './signin/SignInWithIdps';
 import customButtonsView from './signin/CustomButtons';
 import signInWithDeviceOption from './signin/SignInWithDeviceOption';
 import { createIdpButtons, createCustomButtons } from '../internals/FormInputFactory';
-import { getForgotPasswordLink } from '../utils/LinksUtil';
+
 
 const Body = BaseForm.extend({
 
@@ -21,7 +21,7 @@ const Body = BaseForm.extend({
 
     // Launch Device Authenticator
     if (this.options.appState.hasRemediationObject(RemediationForms.LAUNCH_AUTHENTICATOR)) {
-      this.add(signInWithDeviceOption, '.o-form-fieldset-container', false, true);
+      this.add(signInWithDeviceOption, '.o-form-fieldset-container', false, true, { isRequired: false });
     }
 
     // This IdentifierView has been reused for the case when there is no `identify` remediation form
@@ -74,56 +74,9 @@ const Body = BaseForm.extend({
   },
 });
 
-const Footer = BaseFooter.extend({
-  links () {
-    let helpLinkHref;
-    if (this.options.settings.get('helpLinks.help')) {
-      helpLinkHref = this.options.settings.get('helpLinks.help');
-    } else {
-      const baseUrl = this.options.settings.get('baseUrl');
-      helpLinkHref = baseUrl + '/help/login';
-    }
-
-    const helpLink = [
-      {
-        'name': 'help',
-        'label': loc('help', 'login'),
-        'href': helpLinkHref,
-      },
-    ];
-
-    const signupLink = [];
-    if (this.options.appState.hasRemediationObject(RemediationForms.SELECT_ENROLL_PROFILE)) {
-      signupLink.push({
-        'type': 'link',
-        'label': loc('signup', 'login'),
-        'name': 'enroll',
-        'actionPath': RemediationForms.SELECT_ENROLL_PROFILE,
-      });
-    }
-
-    const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
-
-    const customHelpLinks = [];
-    if (this.options.settings.get('helpLinks.custom')) {
-      //add custom helpLinks
-      this.options.settings.get('helpLinks.custom').forEach(customHelpLink => {
-        customHelpLink.name = 'custom';
-        customHelpLink.label = customHelpLink.text;
-        customHelpLinks.push(customHelpLink);
-      });
-    }
-
-    return forgotPasswordLink
-      .concat(signupLink)
-      .concat(helpLink)
-      .concat(customHelpLinks);
-  }
-});
-
 export default BaseView.extend({
   Body,
-  Footer,
+  Footer: IdentifierFooter,
 
   postRender () {
     BaseView.prototype.postRender.apply(this, arguments);

--- a/src/v2/view-builder/views/SignInDeviceView.js
+++ b/src/v2/view-builder/views/SignInDeviceView.js
@@ -1,0 +1,31 @@
+import { loc } from 'okta';
+import BaseView from '../internals/BaseView';
+import BaseForm from '../internals/BaseForm';
+import IdentifierFooter from '../components/IdentifierFooter';
+import SignInWithDeviceOption from './signin/SignInWithDeviceOption';
+
+const Body = BaseForm.extend({
+
+  title () {
+    return loc('primaryauth.title', 'login');
+  },
+
+  noButtonBar: true,
+
+  initialize () {
+    BaseForm.prototype.initialize.apply(this, arguments);
+    this.add(
+      SignInWithDeviceOption,
+      { selector: '.o-form-fieldset-container',
+        bubble: false,
+        prepend: true,
+        options: { isRequired: true }
+      }
+    );
+  },
+});
+
+export default BaseView.extend({
+  Body,
+  Footer: IdentifierFooter,
+});

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -4,8 +4,18 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   className: 'sign-in-with-device-option',
   template: hbs`
-    <div class="okta-verify-container"></div>
-    <div class="separation-line"><span>OR</span></div>
+    <div class="okta-verify-container">
+    {{#if signInWithDeviceIsRequired}}
+      <div class="signin-with-ov-description">
+        {{i18n code="oktaVerify.description" bundle="login"}}
+      </div>
+    {{/if}}
+    </div>
+    {{#unless signInWithDeviceIsRequired}}
+    <div class="separation-line">
+      <span>{{i18n code="authbutton.divider.text" bundle="login"}}</span>
+    </div>
+    {{/unless}}
   `,
   initialize () {
     const appState = this.options.appState;
@@ -13,8 +23,18 @@ export default View.extend({
       className: 'button',
       title: loc('oktaVerify.button', 'login'),
       click () {
-        appState.trigger('invokeAction', 'launch-authenticator');
+        if (this.options.isRequired) {
+          appState.trigger('saveForm', this.model);
+        } else {
+          appState.trigger('invokeAction', 'launch-authenticator');
+        }
       }
     }), '.okta-verify-container');
+  },
+
+  getTemplateData () {
+    return {
+      signInWithDeviceIsRequired: !!this.options.isRequired,
+    };
   }
 });

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -30,6 +30,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('.spinner');
   }
 
+  getDownloadOktaVerifyLink() {
+    return this.body.find('#download-ov').getAttribute('href');
+  }
+
   async clickUniversalLink() {
     await this.t.click(Selector('.ul-button'));
   }

--- a/test/testcafe/framework/page-objects/SignInDevicePageObject.js
+++ b/test/testcafe/framework/page-objects/SignInDevicePageObject.js
@@ -1,0 +1,36 @@
+import { Selector } from 'testcafe';
+import BasePageObject from './BasePageObject';
+
+export default class SignInDeviceViewPageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+    this.t = t;
+    this.beacon = new Selector('.beacon-container');
+    this.body = new Selector('.launch-authenticator');
+    this.footer = new Selector('.auth-footer');
+  }
+
+  getBeaconClass() {
+    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
+  }
+
+  getHeader() {
+    return this.body.find('[data-se="o-form-head"]').innerText;
+  }
+
+  getContentText() {
+    return this.getTextContent('[data-se="o-form-fieldset-container"] .signin-with-ov-description');
+  }
+
+  getOVButtonLabel() {
+    return this.getTextContent('.okta-verify-container [data-se="button"]');
+  }
+
+  getEnrollFooterLinkText() {
+    return this.footer.find('[data-se="enroll"]').innerText;
+  }
+
+  async clickLaunchOktaVerifyButton() {
+    await this.t.click(this.body.find('.okta-verify-container [data-se="button"]'));
+  }
+}

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -134,11 +134,19 @@ test
     deviceChallengeFalllbackPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
-    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
-    await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
-    await t.expect(deviceChallengePollPageObject.getContent())
-      .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Back to Sign In');
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in using Okta Verify on this device');
+    const content = deviceChallengePollPageObject.getContent();
+    await t.expect(content).contains('Please click');
+    await t.expect(content).contains('Open oktaverify.app');
+    await t.expect(content).contains('if you see the system dialog.');
+    await t.expect(content).contains('If nothing prompts from the browser,');
+    await t.expect(content).contains('click here to launch Okta Verify, or download & run Okta Verify.');
+    await t.expect(content).contains('If nothing prompts from the browser,');
+    await t.expect(content).contains('click here');
+    await t.expect(content).contains('to launch Okta Verify, or');
+    await t.expect(content).contains('download & run Okta Verify.');
+    await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Go back');
     await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
   });
 
@@ -168,7 +176,7 @@ test
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify your sign in');
-    await t.expect(deviceChallengePollPageObject.getContent()).eql('To continue, you\'ll need to use the Okta Verify app to confirm your sign in.\nSign in with Okta Verify');
+    await t.expect(deviceChallengePollPageObject.getContent()).eql('To continue, you\'ll need to use the Okta Verify app to confirm your sign in.\nSign in using Okta Verify on this device');
     deviceChallengePollPageObject.clickUniversalLink();
     await t.expect(getPageUrl()).contains(mockHttpCustomUri);
     await t.expect(Selector('h1').innerText).eql('open universal link');

--- a/test/testcafe/spec/IdentifyOktaVerify_spec.js
+++ b/test/testcafe/spec/IdentifyOktaVerify_spec.js
@@ -57,9 +57,9 @@ test('should the correct title', async t => {
 test('should the correct content', async t => {
   const identityPage = await setup(t);
   await t.expect(identityPage.getPageTitle()).eql('Sign In');
-  await t.expect(identityPage.getOktaVerifyButtonText()).eql('Sign in with Okta Verify');
-  await t.expect(identityPage.getSeparationLineText()).eql('OR');
+  await t.expect(identityPage.getOktaVerifyButtonText()).eql('Sign in using Okta Verify on this device');
+  await t.expect(identityPage.getSeparationLineText()).eql('or');
   await identityPage.clickOktaVerifyButton();
   const header = new Selector('h2[data-se="o-form-head"]');
-  await t.expect(header.textContent).eql('Verify account access');
+  await t.expect(header.textContent).eql('Sign in using Okta Verify on this device');
 });

--- a/test/testcafe/spec/SignInDeviceView_spec.js
+++ b/test/testcafe/spec/SignInDeviceView_spec.js
@@ -1,0 +1,37 @@
+import { RequestLogger, RequestMock, Selector } from 'testcafe';
+import SignInDevicePageObject from '../framework/page-objects/SignInDevicePageObject';
+import smartProbingRequired from '../../../playground/mocks/data/idp/idx/smart-probing-required';
+import launchAuthenticatorOption from '../../../playground/mocks/data/idp/idx/identify-with-device-launch-authenticator';
+
+const logger = RequestLogger(/introspect/);
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(smartProbingRequired)
+  .onRequestTo('http://localhost:3000/idp/idx/authenticators/okta-verify/launch')
+  .respond(launchAuthenticatorOption);
+
+fixture('Sign in with Okta Verify is required')
+  .requestHooks(logger, mock);
+
+async function setup(t) {
+  const signInDevicePageObject = new SignInDevicePageObject(t);
+  await signInDevicePageObject.navigateToPage();
+  return signInDevicePageObject;
+}
+
+test('shows the correct content', async t => {
+  const signInDevicePage = await setup(t);
+  await t.expect(signInDevicePage.getHeader()).eql('Sign In');
+  await t.expect(signInDevicePage.getBeaconClass()).contains('undefined-user');
+  await t.expect(signInDevicePage.getContentText()).eql('To access this resource, your organization requires you to sign in using your device.');
+  await t.expect(signInDevicePage.getOVButtonLabel()).eql('Sign in using Okta Verify on this device');
+  await t.expect(signInDevicePage.getEnrollFooterLinkText()).eql('Sign Up');
+});
+
+test('clicking the launch Okta Verify button takes user to the right UI', async t => {
+  const signInDevicePage = await setup(t);
+  await signInDevicePage.clickLaunchOktaVerifyButton();
+  const header = new Selector('h2[data-se="o-form-head"]');
+  await t.expect(header.textContent).eql('Sign in using Okta Verify on this device');
+});


### PR DESCRIPTION
## Description:
- when device probing is required, show I 22 and I 33
- when it is not, show I 23 and I 32
- update custom URI screen to I 34
- note: the Okta Verify icon is not added to the button in this PR, will address it separately

UX: https://www.figma.com/file/VEFAgD40zwFS9kTJkrem3cg4/Okta-Verify-Library-(WIP)?node-id=4099%3A980

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
when device probing is required:
![smart-probe](https://user-images.githubusercontent.com/5066836/96839301-d79d5c80-13fd-11eb-9585-a4a76b856d74.gif)

when device probing is not required:
![smart-probe-not-required](https://user-images.githubusercontent.com/5066836/96839573-3d89e400-13fe-11eb-8224-3c03527aaee0.gif)

### Reviewers:
@stevennguyen-okta @haishengwu-okta @santoshmale-okta 

### Issue:

- [OKTA-338135](https://oktainc.atlassian.net/browse/OKTA-338135)
