### PR TITLE
chore: bundle dependencies, remove externals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,6 +1323,26 @@ We use Yarn as our node package manager. To install Yarn, check out their [insta
 | `yarn test:testcafe <browser>`  | Run testcafe tests on selected browser (example: `yarn test:testcafe chrome`)                                                               |
 | `yarn lint`          | Run eslint and scss linting tests                                                                                                                      |
 
+### Local development workflow using `yarn link`
+
+When developing locally, you may want to test local changes to the widget in another project, which is also local. To use `yarn link` locally, follow these steps:
+
+In `okta-signin-widget` directory:
+
+```bash
+yarn build:release
+yarn link
+yarn build:webpack-dev --output-path ./dist/js --output-filename okta-sign-in.entry.js --watch
+```
+
+This will watch for changes in signin widget source code and automatically rebuild to the dist directory.
+
+In your other local project directory:
+
+```bash
+yarn link @okta/okta-signin-widget
+```
+
 ## Browser support
 
 Need to know if the Sign-In Widget supports your browser requirements?  Please see [Platforms, Browser, and OS Support](https://help.okta.com/en/prod/Content/Topics/Miscellaneous/Platforms_Browser_OS_Support.htm).

--- a/webpack.release.config.js
+++ b/webpack.release.config.js
@@ -19,27 +19,9 @@ var plugins = require('./buildtools/webpack/plugins');
 var useRuntime = require('./buildtools/webpack/runtime');
 var usePolyfill = require('./buildtools/webpack/polyfill');
 
-// 1. entryConfig (node module main entry. minified, no polyfill, external dependencies)
+// 1. entryConfig (node module main entry. minified, no polyfill)
 var entryConfig = config('okta-sign-in.entry.js');
 entryConfig.output.filename = 'okta-sign-in.entry.js';
-entryConfig.externals = {
-  // TODO: remove handlebars external OKTA-320626
-  'handlebars/runtime': {
-    'commonjs': 'handlebars/dist/handlebars.runtime',
-    'commonjs2': 'handlebars/dist/handlebars.runtime',
-    'amd': 'handlebars.runtime',
-    'root': 'handlebars'
-  },
-  'handlebars': {
-    'commonjs': 'handlebars/dist/handlebars.runtime',
-    'commonjs2': 'handlebars/dist/handlebars.runtime',
-    'amd': 'handlebars.runtime',
-    'root': 'handlebars'
-  },
-  'q': true,
-  'u2f-api-polyfill': true,
-  'underscore': true
-};
 entryConfig.plugins = plugins({ isProduction: true, analyzerFile: 'okta-sign-in.entry.analyzer' });
 useRuntime(entryConfig);
 


### PR DESCRIPTION
OKTA-320626

## Description:

Removes webpack "externals" for node module. This will bundle all required dependencies and will not require any additional modules to be installed alongside it. This will avoid errors when external modules are installed with incompatible versions or customizations.

This also enables `yarn link` to work locally.

Although "externals" is not a documented feature, this is considered a breaking change and should be included with the 5.0.0 release

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-320626](https://oktainc.atlassian.net/browse/OKTA-320626)


