### PR TITLE
chore: remove features.consent flag

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -71,7 +71,6 @@ export default Model.extend({
     'features.hideBackToSignInForReset': ['boolean', false, false],
     'features.customExpiredPassword': ['boolean', true, false],
     'features.registration': ['boolean', false, false],
-    'features.consent': ['boolean', false, false],
     'features.idpDiscovery': ['boolean', false, false],
     'features.passwordlessAuth': ['boolean', false, false],
     'features.showPasswordToggleOnSignInPage': ['boolean', false, false],

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -210,9 +210,7 @@ fn.handleResponseStatus = function (router, res) {
     router.navigate('signin/admin-consent', { trigger: true });
     return;
   case 'CONSENT_REQUIRED':
-    if (router.settings.get('features.consent')) {
-      router.navigate('signin/consent', { trigger: true });
-    }
+    router.navigate('signin/consent', { trigger: true });
     return;
     // We want the same view for FACTOR_REQUIRED & FACTOR_CHALLENGE
     // In the new idx pipeline FACTOR_CHALLENGE API response does not contain a prev link

--- a/test/unit/spec/ConsentRequired_spec.js
+++ b/test/unit/spec/ConsentRequired_spec.js
@@ -28,7 +28,6 @@ function setup (settings, res) {
       {
         el: $sandbox,
         baseUrl: baseUrl,
-        features: { consent: true },
         logo: logoUrl,
         authClient: authClient,
         globalSuccessFn: successSpy,

--- a/test/unit/spec/EnrollUser_spec.js
+++ b/test/unit/spec/EnrollUser_spec.js
@@ -28,7 +28,6 @@ function setup (isUnauthenticated) {
       {
         el: $sandbox,
         baseUrl: baseUrl,
-        features: { consent: true },
         logo: logoUrl,
         authClient: authClient,
         globalSuccessFn: successSpy,


### PR DESCRIPTION

## Description:

- the flag isn't quite useful as the state is driven by server side


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- https://oktainc.atlassian.net/browse/OKTA-326426

