### PR TITLE
feat: enhance universal link experience

### DIFF
--- a/playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback.json
+++ b/playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback.json
@@ -2,7 +2,6 @@
   "stateHandle": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5cD",
   "version": "1.0.0",
   "expiresAt": "2020-10-15T17:28:11.000Z",
-
   "intent": "LOGIN",
   "remediation": {
       "type": "array",
@@ -49,6 +48,9 @@
           {
                 "rel": ["create-form"],
                 "name": "launch-authenticator",
+                "relatesTo":[
+                    "authenticatorChallenge"
+                 ],
                 "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
                 "method": "POST",
                 "accepts": "application/ion+json;okta-version=1",
@@ -96,5 +98,12 @@
               "mutable": false
           }
       ]
-  }
+  },
+  "authenticatorChallenge":{
+    "type":"object",
+    "value":{
+       "challengeMethod":"UNIVERSAL_LINK",
+       "href": "https://login.okta.com/auth/okta-verify?challengeRequest=something"
+    }
+ }
 }

--- a/src/util/Enums.js
+++ b/src/util/Enums.js
@@ -71,4 +71,11 @@ export default {
   //App Store Links
   OKTA_VERIFY_APPLE_APP_STORE_URL: 'https://apps.apple.com/us/app/okta-verify/id490179405',
   OKTA_VERIFY_GOOGLE_PLAY_STORE_URL: 'https://play.google.com/store/apps/details?id=com.okta.android.auth',
+
+  // Device Challenge Method
+  LOOPBACK_CHALLENGE: 'LOOPBACK',
+  CUSTOM_URI_CHALLENGE: 'CUSTOM_URI',
+  UNIVERSAL_LINK_CHALLENGE: 'UNIVERSAL_LINK',
+
+  LAUNCH_AUTHENTICATOR_REMEDIATION_NAME: 'launch-authenticator',
 };

--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -10,6 +10,7 @@ import Logger from '../../../util/Logger';
 import DeviceFingerprint from '../../../util/DeviceFingerprint';
 import polling from './shared/polling';
 import Util from '../../../util/Util';
+import Enums from '../../../util/Enums';
 import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
 
 const request = (opts) => {
@@ -54,14 +55,14 @@ const Body = BaseForm.extend(Object.assign(
     doChallenge () {
       const deviceChallenge = this.deviceChallengePollRemediation.relatesTo.value;
       switch (deviceChallenge.challengeMethod) {
-      case 'LOOPBACK':
+      case Enums.LOOPBACK_CHALLENGE:
         this.title = loc('signin.with.fastpass', 'login');
         this.add(View.extend({
           template: hbs`<div class="spinner"></div>`
         }));
         this.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
         break;
-      case 'CUSTOM_URI':
+      case Enums.CUSTOM_URI_CHALLENGE:
         this.title = loc('oktaVerify.button', 'login');
         this.add(View.extend({
           className: 'skinny-content',
@@ -82,7 +83,7 @@ const Body = BaseForm.extend(Object.assign(
         this.customURI = deviceChallenge.href;
         this.doCustomURI();
         break;
-      case 'UNIVERSAL_LINK':
+      case Enums.UNIVERSAL_LINK_CHALLENGE:
         this.title = loc('universalLink.title', 'login');
         this.add(View.extend({
           template: hbs`{{{i18n code="universalLink.content" bundle="login"}}}`

--- a/src/v2/view-builder/views/UserVerificationDeviceChallengePollView.js
+++ b/src/v2/view-builder/views/UserVerificationDeviceChallengePollView.js
@@ -7,6 +7,7 @@ import Logger from '../../../util/Logger';
 import DeviceFingerprint from '../../../util/DeviceFingerprint';
 import polling from './shared/polling';
 import Util from '../../../util/Util';
+import Enums from '../../../util/Enums';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({
@@ -50,14 +51,14 @@ const Body = BaseForm.extend(Object.assign(
     doChallenge () {
       const deviceChallenge = this.deviceChallengePollRemediation.relatesTo.value.contextualData.challenge.value;
       switch (deviceChallenge.challengeMethod) {
-      case 'LOOPBACK':
+      case Enums.LOOPBACK_CHALLENGE:
         this.title = loc('signin.with.fastpass', 'login');
         this.add(View.extend({
           template: hbs`<div class="spinner"></div>`
         }));
         this.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
         break;
-      case 'CUSTOM_URI':
+      case Enums.CUSTOM_URI_CHALLENGE:
         this.title = loc('customUri.title', 'login');
         this.subtitle = loc('customUri.subtitle', 'login');
         this.add(View.extend({
@@ -66,7 +67,7 @@ const Body = BaseForm.extend(Object.assign(
         this.customURI = deviceChallenge.href;
         this.doCustomURI();
         break;
-      case 'UNIVERSAL_LINK':
+      case Enums.UNIVERSAL_LINK_CHALLENGE:
         this.title = loc('universalLink.userVerification.title', 'login');
         this.add(View.extend({
           template: hbs`{{i18n code="universalLink.userVerification.content.p1" bundle="login"}}`

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -1,5 +1,7 @@
 import { View, createButton, loc } from 'okta';
 import hbs from 'handlebars-inline-precompile';
+import Util from '../../../../util/Util';
+import Enums from '../../../../util/Enums';
 
 export default View.extend({
   className: 'sign-in-with-device-option',
@@ -19,14 +21,21 @@ export default View.extend({
   `,
   initialize () {
     const appState = this.options.appState;
+    const deviceChallengePollRemediation = this.options.appState.get('remediations')
+      .find(remediation => remediation.name === Enums.LAUNCH_AUTHENTICATOR_REMEDIATION_NAME);
+    const deviceChallengeRelatesTo = deviceChallengePollRemediation.relatesTo || {};
+    const deviceChallenge = deviceChallengeRelatesTo.value || {};
     this.add(createButton({
       className: 'button',
       title: loc('oktaVerify.button', 'login'),
       click () {
+        if (deviceChallenge.challengeMethod && deviceChallenge.challengeMethod === Enums.UNIVERSAL_LINK_CHALLENGE) {
+          Util.redirect(deviceChallenge.href);
+        }
         if (this.options.isRequired) {
           appState.trigger('saveForm', this.model);
         } else {
-          appState.trigger('invokeAction', 'launch-authenticator');
+          appState.trigger('invokeAction', Enums.LAUNCH_AUTHENTICATOR_REMEDIATION_NAME);
         }
       }
     }), '.okta-verify-container');

--- a/test/testcafe/spec/UserVerificationDeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/UserVerificationDeviceChallengePollView_spec.js
@@ -62,17 +62,29 @@ const customURIMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identifyWithLaunchAuthenticatorHttpCustomUri);
 
+const identifyWithSSOExtensionFallbackWithoutLink = JSON.parse(JSON.stringify(identifyWithSSOExtensionFallback));
+// remove the universal link so that Util.redirect does not open a link and the rest of the flow can be verified
+delete identifyWithSSOExtensionFallbackWithoutLink.authenticatorChallenge.value.href;
 // replace universal link with http URL so that we can mock and verify
 identifyWithUserVerificationLaunchUniversalLink.currentAuthenticatorEnrollment.value.contextualData.challenge.value.href = mockHttpCustomUri;
-const universalLinkMock = RequestMock()
+const universalLinkWithoutLaunchMock = RequestMock()
   .onRequestTo(/idp\/idx\/introspect/)
-  .respond(identifyWithSSOExtensionFallback)
+  .respond(identifyWithSSOExtensionFallbackWithoutLink)
   .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
   .respond(identifyWithUserVerificationLaunchUniversalLink)
   .onRequestTo(mockHttpCustomUri)
   .respond('<html><h1>open universal link</h1></html>')
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identifyWithUserVerificationLaunchUniversalLink);
+
+const identifyWithSSOExtensionFallbackTarget = JSON.parse(JSON.stringify(identifyWithSSOExtensionFallback));
+// replace universal link with http URL so that we can mock and verify
+identifyWithSSOExtensionFallbackTarget.authenticatorChallenge.value.href = mockHttpCustomUri;
+const universalLinkMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(identifyWithSSOExtensionFallbackTarget)
+  .onRequestTo(mockHttpCustomUri)
+  .respond('<html><h1>open universal link</h1></html>');
 
 fixture('Device Challenge Polling View for user verification with the Loopback Server, Custom URI and Universal Link approaches');
 
@@ -155,7 +167,7 @@ test
   });
 
 test
-  .requestHooks(loopbackFallbackLogger, universalLinkMock)('SSO Extension fails and falls back to universal link', async t => {
+  .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
     const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
     await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
@@ -172,6 +184,20 @@ test
       'To continue, confirm your screen lock in Okta Verify.\n' +
       'Confirm screen lock');
     deviceChallengePollPageObject.clickUniversalLink();
+    await t.expect(getPageUrl()).contains(mockHttpCustomUri);
+    await t.expect(Selector('h1').innerText).eql('open universal link');
+  });
+
+test
+  .requestHooks(loopbackFallbackLogger, universalLinkMock)('clicking the launch Okta Verify button opens the universal link', async t => {
+    loopbackFallbackLogger.clear();
+    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/introspect/)
+    )).eql(1);
+    deviceChallengeFalllbackPage.clickOktaVerifyButton();
     await t.expect(getPageUrl()).contains(mockHttpCustomUri);
     await t.expect(Selector('h1').innerText).eql('open universal link');
   });


### PR DESCRIPTION
## Description:
Remove double tapping needed to launch universal link. The SIW change is based off IDX API change. Please see detail from: https://oktawiki.atlassian.net/wiki/spaces/~988051222/pages/1007784504/Design+to+Remove+Universal+Link+Extra+Button+Click+for+IOS#Proposed-change-for-BOTH-universal-link-and-custom-uri:

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@haishengwu-okta @pradeepdewda-okta @aarongranick-okta 

### Issue:

- [OKTA-335169](https://oktainc.atlassian.net/browse/OKTA-335169)


