### PR TITLE
feat: does not display phone number or email when not in the response

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -742,7 +742,8 @@ oie.phone.alternate.title = your phone
 ## Email
 oie.email.authenticator.description = Verify with a link or code sent to your email
 oie.email.mfa.title = Verify with your email
-oie.email.verify.sentText = An email was sent to
+oie.email.verify.sentText = Check <$1>{0}</$1> for a verification message. Click the verification button in your email or enter the code below to continue.
+oie.email.verify.alternate.sentText = Check your email for a verification message. Click the verification button in your email or enter the code below to continue.
 oie.email.enroll.subtitle = Please check your email and enter the code below.
 oie.email.return.link.expired.title = Verify with your email
 

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -422,6 +422,32 @@ const ovPushError = {
   ],
 };
 
+// no phone number available for verification
+const phoneVerificationNoPhoneNumber = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-no-number'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-data-phone-sms-then-voice-no-number',
+    'authenticator-verification-phone-sms-no-number',
+    'authenticator-verification-data-phone-voice-then-sms-no-number',
+    'authenticator-verification-phone-voice-no-number',
+  ],
+};
+
+// no email available for verification
+const emailVerificationNoEmail = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-no-number',
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-email-no-email',
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-verification-email-no-email',
+  ],
+};
+
 module.exports = {
   mocks: idx,
 };

--- a/playground/mocks/data/idp/idx/authenticator-verification-data-phone-sms-then-voice-no-number.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-data-phone-sms-then-voice-no-number.json
@@ -1,0 +1,324 @@
+{
+  "stateHandle":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4BQNyMFP1RQojM0f.dIMxajkel5Sin9G9c8XjGYwcDH6q6rK2dWcZlDovCDQa3SmShn6Z_XgtuW8UpDtdBZYjLTTBcBmM6z_vdx7hhxZiDeAO6G-WRAs56bP-66O4l8aHok4zemRGRw1LLwviSF6LaqZ0ROL4l-wouvUd1nA2qBUABM-JYI6yBlUNy3biAGsUimKkohqhzYtKI99RBcXKHIeKhleVkKeLIBDUib64K1lAUaxXk-aIHuAp5_iAmdAvLXq3JBnBSduQTcrVtZuBwmcnCuDJD8vidINt1WSaayxguLSB4LbdY1CPoY1Le58c1-RWOMUeQwVMtWbdKDF2Lj-bLnPma62HFCtJuRmbzeUdFHUg9qwQ5wuaCy57dMKoymnVclkktcZ_ECC6DL2TrSpiJSMEBmzI-vYb91jxs5-Kov5IJSfMdCypqCBn49Zkthc-Fa3iLq7smqFMVZP2MH346YwCDtT8JJ6AhILFRzR3s-l9or8jlRkKtsqQ58yIPZiKGjGwTAP0RUSVQJDmOEhBo94uOH75YC8e5se8Iu8jm0BF8SHNeZwEvPSApGb6Bz_zKLC4p8YVq_9GWV-OLX1PByv4Af-Njkctcp8I-EW-b175SNKR4B66K_zd5x5CmH_yr3dsOp3mv6RgjKHToesUxjKXwToeFJnuP1HpcL133OdIbYQtk3T1CeEl-U37jBpTqm95ovu7qYTIuo4SKN7-z6MybO-T3ZBGfVav7y5FNpNIepNAWUFPaqR2flY9wJGtYT113NvTkLt3TuGLhomjGHWMYw-41lfifFldAcj3cc6nvu7GHSruz8Xf3qGOHA-v1wUaRXonFYfyWHvDtx5tXb7T8z29_U84w4gvyjN6GmCDld_EGhljRp9Lj9lgVqbR59QTdW_q9n5hTzAndgFaFqxqvJcx8A-8sbfD16vd0CAdFMMP2IGu5uSonwXYhoCtXAZ2Q-Y3gQ_hf6umqBXml9EZrkIFS4dx0JBldwlH-7hUn8bOweNEKYbiR-J8n2PpIFlZCxtbtjvf6S0ge2ijplynoHTd887z23dsefl3jiijEOThaNaz7CveLf5uLhg7-dsOK2bHPZvB43d40N1d7ZRm_ASeHF0DpLi6VKwNI-Hj5K8GHFsEiiGjWjjGyJxuXpzv2B0kDT3VElPbDZ8c9Tl2lnXhqPQuET6eVitgx-8DPyvBhM_Wpbkt4h3EGHbAAQBcKkZ8UvPy1_EPbGwDjX7_Uqw_EiQ3aR74C7Nzu6URdTI_RTFDMxZ-IC9woGXHeN8UESpHbOKskyd-Tr3KbDasvMgCYmgcSh574Xx7__kj-o311zQRu8sVbQCGFSmaaRkvqEXN1LcOo-atXD76gRe-_PARMcVEk3xjI1u-4cJbJDNQb7ji57NULeMY8Wbe7iEeLcAKgyHN3e3q0vOYXQpWOzatVWKnI1s2nS54tREp0HQ.-9f3flqUepYMc0GXwlQ7nA",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-16T21:30:21.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"authenticator-verification-data",
+        "href":"http://localhost:3000/idp/idx/challenge",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"authenticator",
+            "type":"object",
+            "label":"Phone Number",
+            "form":{
+              "value":[
+                {
+                  "name":"id",
+                  "required":true,
+                  "value":"autxl8PPhwHUpOpW60g3",
+                  "mutable":false
+                },
+                {
+                  "name":"methodType",
+                  "required":true,
+                  "options":[
+                    {
+                      "label":"SMS",
+                      "value":"sms"
+                    },
+                    {
+                      "label":"VOICE",
+                      "value":"voice"
+                    }
+                  ]
+                }
+              ]
+            },
+            "relatesTo":"$.authenticatorEnrollments.value[0]"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "relatesTo": ["$.currentAuthenticatorEnrollment"]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment":{
+    "type":"object",
+    "value":{
+      "resend":{
+        "rel":[
+          "create-form"
+        ],
+        "name":"resend",
+        "href":"http://localhost:3000/idp/idx/challenge/resend",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      "profile": {},
+      "type":"phone",
+      "id":"pae133clYVnptmCwD0g4",
+      "displayName":"autxl8PPhwHUpOpW60g3",
+      "methods":[
+        {
+          "type":"sms"
+        },
+        {
+          "type":"voice"
+        }
+      ]
+    }
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "autwa6eD9o02iBbsta82"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u13370Y5HfTVTn10g4"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "accepts":"application/vnd.okta.v1+json",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4BQNyMFP1RQojM0f.dIMxajkel5Sin9G9c8XjGYwcDH6q6rK2dWcZlDovCDQa3SmShn6Z_XgtuW8UpDtdBZYjLTTBcBmM6z_vdx7hhxZiDeAO6G-WRAs56bP-66O4l8aHok4zemRGRw1LLwviSF6LaqZ0ROL4l-wouvUd1nA2qBUABM-JYI6yBlUNy3biAGsUimKkohqhzYtKI99RBcXKHIeKhleVkKeLIBDUib64K1lAUaxXk-aIHuAp5_iAmdAvLXq3JBnBSduQTcrVtZuBwmcnCuDJD8vidINt1WSaayxguLSB4LbdY1CPoY1Le58c1-RWOMUeQwVMtWbdKDF2Lj-bLnPma62HFCtJuRmbzeUdFHUg9qwQ5wuaCy57dMKoymnVclkktcZ_ECC6DL2TrSpiJSMEBmzI-vYb91jxs5-Kov5IJSfMdCypqCBn49Zkthc-Fa3iLq7smqFMVZP2MH346YwCDtT8JJ6AhILFRzR3s-l9or8jlRkKtsqQ58yIPZiKGjGwTAP0RUSVQJDmOEhBo94uOH75YC8e5se8Iu8jm0BF8SHNeZwEvPSApGb6Bz_zKLC4p8YVq_9GWV-OLX1PByv4Af-Njkctcp8I-EW-b175SNKR4B66K_zd5x5CmH_yr3dsOp3mv6RgjKHToesUxjKXwToeFJnuP1HpcL133OdIbYQtk3T1CeEl-U37jBpTqm95ovu7qYTIuo4SKN7-z6MybO-T3ZBGfVav7y5FNpNIepNAWUFPaqR2flY9wJGtYT113NvTkLt3TuGLhomjGHWMYw-41lfifFldAcj3cc6nvu7GHSruz8Xf3qGOHA-v1wUaRXonFYfyWHvDtx5tXb7T8z29_U84w4gvyjN6GmCDld_EGhljRp9Lj9lgVqbR59QTdW_q9n5hTzAndgFaFqxqvJcx8A-8sbfD16vd0CAdFMMP2IGu5uSonwXYhoCtXAZ2Q-Y3gQ_hf6umqBXml9EZrkIFS4dx0JBldwlH-7hUn8bOweNEKYbiR-J8n2PpIFlZCxtbtjvf6S0ge2ijplynoHTd887z23dsefl3jiijEOThaNaz7CveLf5uLhg7-dsOK2bHPZvB43d40N1d7ZRm_ASeHF0DpLi6VKwNI-Hj5K8GHFsEiiGjWjjGyJxuXpzv2B0kDT3VElPbDZ8c9Tl2lnXhqPQuET6eVitgx-8DPyvBhM_Wpbkt4h3EGHbAAQBcKkZ8UvPy1_EPbGwDjX7_Uqw_EiQ3aR74C7Nzu6URdTI_RTFDMxZ-IC9woGXHeN8UESpHbOKskyd-Tr3KbDasvMgCYmgcSh574Xx7__kj-o311zQRu8sVbQCGFSmaaRkvqEXN1LcOo-atXD76gRe-_PARMcVEk3xjI1u-4cJbJDNQb7ji57NULeMY8Wbe7iEeLcAKgyHN3e3q0vOYXQpWOzatVWKnI1s2nS54tREp0HQ.-9f3flqUepYMc0GXwlQ7nA",
+        "visible":false,
+        "mutable":false
+      }
+    ]
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oaxk15yB0nwAYpTg0g3"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-data-phone-voice-then-sms-no-number.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-data-phone-voice-then-sms-no-number.json
@@ -1,0 +1,324 @@
+{
+  "stateHandle":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4BQNyMFP1RQojM0f.dIMxajkel5Sin9G9c8XjGYwcDH6q6rK2dWcZlDovCDQa3SmShn6Z_XgtuW8UpDtdBZYjLTTBcBmM6z_vdx7hhxZiDeAO6G-WRAs56bP-66O4l8aHok4zemRGRw1LLwviSF6LaqZ0ROL4l-wouvUd1nA2qBUABM-JYI6yBlUNy3biAGsUimKkohqhzYtKI99RBcXKHIeKhleVkKeLIBDUib64K1lAUaxXk-aIHuAp5_iAmdAvLXq3JBnBSduQTcrVtZuBwmcnCuDJD8vidINt1WSaayxguLSB4LbdY1CPoY1Le58c1-RWOMUeQwVMtWbdKDF2Lj-bLnPma62HFCtJuRmbzeUdFHUg9qwQ5wuaCy57dMKoymnVclkktcZ_ECC6DL2TrSpiJSMEBmzI-vYb91jxs5-Kov5IJSfMdCypqCBn49Zkthc-Fa3iLq7smqFMVZP2MH346YwCDtT8JJ6AhILFRzR3s-l9or8jlRkKtsqQ58yIPZiKGjGwTAP0RUSVQJDmOEhBo94uOH75YC8e5se8Iu8jm0BF8SHNeZwEvPSApGb6Bz_zKLC4p8YVq_9GWV-OLX1PByv4Af-Njkctcp8I-EW-b175SNKR4B66K_zd5x5CmH_yr3dsOp3mv6RgjKHToesUxjKXwToeFJnuP1HpcL133OdIbYQtk3T1CeEl-U37jBpTqm95ovu7qYTIuo4SKN7-z6MybO-T3ZBGfVav7y5FNpNIepNAWUFPaqR2flY9wJGtYT113NvTkLt3TuGLhomjGHWMYw-41lfifFldAcj3cc6nvu7GHSruz8Xf3qGOHA-v1wUaRXonFYfyWHvDtx5tXb7T8z29_U84w4gvyjN6GmCDld_EGhljRp9Lj9lgVqbR59QTdW_q9n5hTzAndgFaFqxqvJcx8A-8sbfD16vd0CAdFMMP2IGu5uSonwXYhoCtXAZ2Q-Y3gQ_hf6umqBXml9EZrkIFS4dx0JBldwlH-7hUn8bOweNEKYbiR-J8n2PpIFlZCxtbtjvf6S0ge2ijplynoHTd887z23dsefl3jiijEOThaNaz7CveLf5uLhg7-dsOK2bHPZvB43d40N1d7ZRm_ASeHF0DpLi6VKwNI-Hj5K8GHFsEiiGjWjjGyJxuXpzv2B0kDT3VElPbDZ8c9Tl2lnXhqPQuET6eVitgx-8DPyvBhM_Wpbkt4h3EGHbAAQBcKkZ8UvPy1_EPbGwDjX7_Uqw_EiQ3aR74C7Nzu6URdTI_RTFDMxZ-IC9woGXHeN8UESpHbOKskyd-Tr3KbDasvMgCYmgcSh574Xx7__kj-o311zQRu8sVbQCGFSmaaRkvqEXN1LcOo-atXD76gRe-_PARMcVEk3xjI1u-4cJbJDNQb7ji57NULeMY8Wbe7iEeLcAKgyHN3e3q0vOYXQpWOzatVWKnI1s2nS54tREp0HQ.-9f3flqUepYMc0GXwlQ7nA",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-16T21:30:21.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"authenticator-verification-data",
+        "href":"http://localhost:3000/idp/idx/challenge",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"authenticator",
+            "type":"object",
+            "label":"Phone Number",
+            "form":{
+              "value":[
+                {
+                  "name":"id",
+                  "required":true,
+                  "value":"autxl8PPhwHUpOpW60g3",
+                  "mutable":false
+                },
+                {
+                  "name":"methodType",
+                  "required":true,
+                  "options":[
+                    {
+                      "label":"VOICE",
+                      "value":"voice"
+                    },
+                    {
+                      "label":"SMS",
+                      "value":"sms"
+                    }
+                  ]
+                }
+              ]
+            },
+            "relatesTo":"$.authenticatorEnrollments.value[0]"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..bxH8DK0q1wAeq1IN.chFU_FKuKTYWBelYcUQcyw_wtVsyGk8UfRSXs8aQuzDIugGFWYQ9QC8lxyu1ltTVOvHakB_Wy_qqYmQSTm7QIP716ZThSGaA1oYVwmePTy0Rozo8NBcYpyhsvHwqrwMbRYTW3CUROu4rH8r_wXhAoEuA82XZ7m3FVMy9xmeEGgiHOSmD-uh2tX0mdii2EKrhUAXxbH_1oF49Et0_zP6sv9CQuW5fmS2DCUETMTSiMYyUrGAqBORDdyJGljXn5qSUP_gmp7Bh96fGzYA2QxsEh4LQofSxaHtQwt-JbP2jppDsnY7d-MhZcOr16IIhmYJwt7RC0C1OyiUp32d0fElK58NgP7iF8UHGicCKiIvQfI3X4p1bVt_-aSZtmwA8GDOIw4f97kVkcT2fO9RUTJEEy5qIlIG6WlG9F8sboBx4b-K33RDsYtoYrv7ISqH2TM84ztw80KBNyfsVTN7_EzP8O_4aB03A8dZT08-dZv6Tj_6eBvEjTN9tmT6G3O3zSjgQTxeXyxEEZJiWAbwdWVCge4AT-EdDKwXUZYrwCp8y_FBOqTsh2woyw75Ll7SEmCSc5IAvh01TfnbSNc5WfXdr0AdJN3WsYIv6PiGTlIgkigWZC_uQovJHA6gUknfD3q7Jc-VT2XrGX_trbK_fLa8pHoI9Er2thqF4sYtHK136uNKKxXNpuOndUW8r2qKreFMWZz_7MZbjz1urBbAWrLzmeMjvhfFuI7BdhjIQzex0AhQ0pgMk_Epw2V0J6b81t-IkXgQSayX5KYReSgXgJGeNAP_WbhHstFQ5qFzZf11ZmrAMLBbBAUFZx28esaQoqCODFho5m2PVDx5giQm9J75-AtqYpdJyESyWY6CZlUefKqcts9dAjHkE7YHWGQ7icHFXFuc3SGt8ro5z8JV_wA6MgXuaFkk5uruz-VbiMqhBkdNoBi_qAljH2icXuqkMhgl3E96IApJzFWS1yGZl4CelULScf7wOrlgwcAHYGzu8R1QNjSWQD8bUBQBEFXEktIpFtk-tZrF0PfVvzuVZ2Yurxb7s6zRCAPhFpgq81klAxBp7QI6Pf8KLkbrtO2GNWSN1iBsQvVMYfXTY-djDpQ-8Izz5hdlapJYa6v1eGmToqb8-OTjhVYOUXzGK1A_pF0XLFjAGViJqux-XGZitKIYSXl-4vLa_ZM5H4qRKAttvlldCkLwGmFn9dwOPAliJHq42eaDtWlZU3FQdHQVNo8tLJcyugxAPWPJrnbKrKk3BxM-xRT657FFVeZLbCCkIuJhEkG-o-fHfa3tWCAVeDkbN9fXP17JXpxOrHsJ5yfNL6aJpJj77pyu_7Qq1s-qA2a60Cu9Bmfh-iC4nNZ_Z1EIG3fjxw9TQWwdUBDbOzBZ-nAt8p25XlduduVJyUMLzugPBriZRoUj1ZGJX9JWbuuptmoFKQ10XCx-3BJ3-REmpQltYE7LHCaHj0IR4XmIqBIdSUgsocQ5YbI_QtVUab_wrbzEIZARnbNSIOQPwP03kZU1KCDlmoh4y44jqIDy1QZA_squT8a3_9hYmc_jIekVwoDcb9NzoX_NIC0VdTaLP5NFGxiigGnKOF3IMHXgOEJoX3ESjK83uIwtbT8YyaHhI8ZGKnmqDV4nTSbPqyP58E6qcef1oOc4hcEnZVZl8O3QNa7z9QWbwfhXLNC6N2yNwqQ.GR_YTlIP0iEYJ2C7x3XQXg",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "relatesTo": ["$.currentAuthenticatorEnrollment"]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment":{
+    "type":"object",
+    "value":{
+      "resend":{
+        "rel":[
+          "create-form"
+        ],
+        "name":"resend",
+        "href":"http://localhost:3000/idp/idx/challenge/resend",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      "profile": {},
+      "type":"phone",
+      "id":"pae133clYVnptmCwD0g4",
+      "displayName":"autxl8PPhwHUpOpW60g3",
+      "methods":[
+        {
+          "type":"voice"
+        },
+        {
+          "type":"sms"
+        }
+      ]
+    }
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "autwa6eD9o02iBbsta82"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u13370Y5HfTVTn10g4"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "accepts":"application/vnd.okta.v1+json",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4BQNyMFP1RQojM0f.dIMxajkel5Sin9G9c8XjGYwcDH6q6rK2dWcZlDovCDQa3SmShn6Z_XgtuW8UpDtdBZYjLTTBcBmM6z_vdx7hhxZiDeAO6G-WRAs56bP-66O4l8aHok4zemRGRw1LLwviSF6LaqZ0ROL4l-wouvUd1nA2qBUABM-JYI6yBlUNy3biAGsUimKkohqhzYtKI99RBcXKHIeKhleVkKeLIBDUib64K1lAUaxXk-aIHuAp5_iAmdAvLXq3JBnBSduQTcrVtZuBwmcnCuDJD8vidINt1WSaayxguLSB4LbdY1CPoY1Le58c1-RWOMUeQwVMtWbdKDF2Lj-bLnPma62HFCtJuRmbzeUdFHUg9qwQ5wuaCy57dMKoymnVclkktcZ_ECC6DL2TrSpiJSMEBmzI-vYb91jxs5-Kov5IJSfMdCypqCBn49Zkthc-Fa3iLq7smqFMVZP2MH346YwCDtT8JJ6AhILFRzR3s-l9or8jlRkKtsqQ58yIPZiKGjGwTAP0RUSVQJDmOEhBo94uOH75YC8e5se8Iu8jm0BF8SHNeZwEvPSApGb6Bz_zKLC4p8YVq_9GWV-OLX1PByv4Af-Njkctcp8I-EW-b175SNKR4B66K_zd5x5CmH_yr3dsOp3mv6RgjKHToesUxjKXwToeFJnuP1HpcL133OdIbYQtk3T1CeEl-U37jBpTqm95ovu7qYTIuo4SKN7-z6MybO-T3ZBGfVav7y5FNpNIepNAWUFPaqR2flY9wJGtYT113NvTkLt3TuGLhomjGHWMYw-41lfifFldAcj3cc6nvu7GHSruz8Xf3qGOHA-v1wUaRXonFYfyWHvDtx5tXb7T8z29_U84w4gvyjN6GmCDld_EGhljRp9Lj9lgVqbR59QTdW_q9n5hTzAndgFaFqxqvJcx8A-8sbfD16vd0CAdFMMP2IGu5uSonwXYhoCtXAZ2Q-Y3gQ_hf6umqBXml9EZrkIFS4dx0JBldwlH-7hUn8bOweNEKYbiR-J8n2PpIFlZCxtbtjvf6S0ge2ijplynoHTd887z23dsefl3jiijEOThaNaz7CveLf5uLhg7-dsOK2bHPZvB43d40N1d7ZRm_ASeHF0DpLi6VKwNI-Hj5K8GHFsEiiGjWjjGyJxuXpzv2B0kDT3VElPbDZ8c9Tl2lnXhqPQuET6eVitgx-8DPyvBhM_Wpbkt4h3EGHbAAQBcKkZ8UvPy1_EPbGwDjX7_Uqw_EiQ3aR74C7Nzu6URdTI_RTFDMxZ-IC9woGXHeN8UESpHbOKskyd-Tr3KbDasvMgCYmgcSh574Xx7__kj-o311zQRu8sVbQCGFSmaaRkvqEXN1LcOo-atXD76gRe-_PARMcVEk3xjI1u-4cJbJDNQb7ji57NULeMY8Wbe7iEeLcAKgyHN3e3q0vOYXQpWOzatVWKnI1s2nS54tREp0HQ.-9f3flqUepYMc0GXwlQ7nA",
+        "visible":false,
+        "mutable":false
+      }
+    ]
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oaxk15yB0nwAYpTg0g3"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-no-email.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-no-email.json
@@ -134,9 +134,7 @@
           "type":"email"
         }
       ],
-      "profile":{
-        "email":"i**a@h***o.net"
-      }
+      "profile":{}
     }
   },
   "authenticatorEnrollments":{

--- a/playground/mocks/data/idp/idx/authenticator-verification-phone-sms-no-number.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-phone-sms-no-number.json
@@ -1,0 +1,304 @@
+{
+  "stateHandle":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-16T21:30:44.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"challenge-authenticator",
+        "relatesTo":[
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"credentials",
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"Enter code"
+                }
+              ]
+            }
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment":{
+    "type":"object",
+    "value":{
+      "resend":{
+        "rel":[
+          "create-form"
+        ],
+        "name":"resend",
+        "href":"http://localhost:3000/idp/idx/challenge/resend",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      "profile": {},
+      "type":"phone",
+      "id":"pae133clYVnptmCwD0g4",
+      "displayName":"autxl8PPhwHUpOpW60g3",
+      "methods":[
+        {
+          "type":"sms"
+        }
+      ]
+    }
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "autwa6eD9o02iBbsta82"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u13370Y5HfTVTn10g4"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "accepts":"application/vnd.okta.v1+json",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+        "visible":false,
+        "mutable":false
+      }
+    ]
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oaxk15yB0nwAYpTg0g3"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-phone-voice-no-number.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-phone-voice-no-number.json
@@ -1,0 +1,304 @@
+{
+  "stateHandle":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-16T21:30:44.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"challenge-authenticator",
+        "relatesTo":[
+          "$.currentAuthenticatorEnrollment"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"credentials",
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"Enter code"
+                }
+              ]
+            }
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label": "Okta Phone",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0X1SLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label": "Okta Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aid568g3mXgtID0HHSLH",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment":{
+    "type":"object",
+    "value":{
+      "resend":{
+        "rel":[
+          "create-form"
+        ],
+        "name":"resend",
+        "href":"http://localhost:3000/idp/idx/challenge/resend",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      },
+      "profile": {},
+      "type":"phone",
+      "id":"pae133clYVnptmCwD0g4",
+      "displayName":"autxl8PPhwHUpOpW60g3",
+      "methods":[
+        {
+          "type":"voice"
+        }
+      ]
+    }
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "displayName": "Okta Phone",
+        "type": "phone",
+        "authenticatorId": "aid568g3mXgtID0X1SLH",
+        "id": "autwa6eD9o02iBbsta82"
+      },
+      {
+        "displayName": "Okta Security Question",
+        "type": "security_question",
+        "authenticatorId": "aid568g3mXgtID0HHSLH",
+        "id": "autwa6eD9o02iBbaaa82"
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id":"00u13370Y5HfTVTn10g4"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "accepts":"application/vnd.okta.v1+json",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdjRlUHM0eXFjT21TcDAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..s7Gfs2YilflIYdKn.tkNBqIeHotu-kYbP9k9Fsj4faVeEc8eNlZKkbL2eBrzcqZ7M9Qm6RUOEjYEVQZncpnLiE96iEG10DV8oKTRpfoECkeuzIwi4Cbhmd7ZSePZO1i3bE4PW70ZkLcJjy2G46u4VWlGgC9bm2eRJjLh-lB3lCfS5fn-XYwFyDSsCZ2cJNtgCQzs_VIpEM6qnzMYxthNPcMcIhseAag3tK7RtKQJVqo-JpEfcieovoikacx_ZS4SaYj2yzycbAGr3Vh2ysvVZEMECM2mztj1OTVdgr9xnBPph5rcvDKkF00BjwOaDSHGwhJuFfzJ7rJXYCFOtDb0fUw57Ze6q-onb8_cBqGy6xm6iF_b4vRY4gBEp9G46tp5Hr_DrMOiX6nAWk9C6Hre7_4BIxX3GdjUqmhxuMV39renVBByAGevWaRpu4m3SR-mesxLzFPRTZYa333gjRkxVZNK2Gy68BLcLah15VH1jNVdV7Ou3nc9hzE9zcV2ueRZoSYq6h7WZ0KjLjhQTqRKe3g9XGR_DL05a26czfGJL-R1omHxUuFDlYSCd_jtKZE4TseUXQ5qfUzk0X9syqqVA36HEiJ5_CWsQ2SpxIgqir4DztivsQE1ubJfVrvPZw_-6GU391NkXE8e_B64X6ZSqgUgm5H4LuXj9Eu2VKG5z4KLKWieuHDK0Hjc1RRGuxFqcYhzySnTtK41Za4abTqVM-YYxokb9ah2yxauzpveIO0rDqjGo3kqZdVDV81kdvIzqgclooUb5X1o_fdmPjB_IUkVDkIHN9sVu1F0HkqQWp7xDmhbokAB7kVa6WIiax08UtTUfPvVK4aOLP_R61VfzImlTZ6otI6yC1yZAETauuADIz1YkB9bcBOOpJeqrom3keGeVwCmU-i0dJYGi1NLEPDm0px0OhVW77Cpi1C0aBX295Dju4-luOM3EuaBad-U5FMwDAO00qi0c3XDiaY0Bgkrmcqeo1yIl5p4cktsBs2ArzpzpEzJAmpLaIbuaihov8uy1K6e9y0Ko2VcOR930K-Cfnr-0QxX_WLtf8pB9LYENR2Gx65BxVMi9E4M1_rLG5UwBq4ATEH72a1kkTeXvDgMpwMmhIEz_nPuCcDJVZ8UDQoZU8C_T3yzOrlUHc8x2qN-FEWG3mLBGw7SAdxs3pH4eZnnQQVN4Ch4Tuc_wqMrophaxMLtWAt7Sa0L0zBpJUJsCKg_pTKH6gkjL_Tco6eIY7o78JoX7M_GSFIdF9qR3FLj9rXJrvP0qeWMrbhwgy6DhJg_bBWeKNQdclh1uRLLmbKpdCZH--lqLubZGJtd8JlkEKWW_PnDYFdDGzMwMz83owDHvw8GQ9KpqoPME-Ty0SEoMwKKdeRHCwUf90ycp7D5Jc6yHY17tr8axpjy_yCNhyI7ChtK0cnyJVsQPwkCH5q5fiiQrwX-nEny95PCpwnJzA85qGyYJusFlBO-HH8Ojcp_jTJNr3GeiBwfPQtOwQZ7AkUL7tLsls7q6MiLzCju_MGQlsFSzvV2N7wyFkCoLf9zyk7vKpU3QxfZFA6jqR-f9FOEXrWHr_0Orsd1s2k-RZ8_-SicRI5VieZj7YApi6v0LHqklqkzluwOfH-wSI4tf0En-A-rrR-1yQei7JCa0s8YXpp0mVOE.EC3UkB3_VQpE75Jet9kM4g",
+        "visible":false,
+        "mutable":false
+      }
+    ]
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"Native client",
+      "id":"0oaxk15yB0nwAYpTg0g3"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-no-number.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-no-number.json
@@ -1,0 +1,290 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-05T23:34:09.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "fwftheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[1]"
+              },
+              {
+                "label": "FIDO2 (WebAuthn)",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "webauthn",
+                        "required": false,
+                        "mutable": false,
+                        "visible": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              },
+              {
+                "label": "Okta Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "aidtm56L8gXXHI1SD0g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "value": "email",
+                        "required": false,
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[3]"
+              },
+              {
+                "label":"Phone",
+                "value":{
+                  "form":{
+                    "value":[
+                      {
+                        "name":"id",
+                        "required":true,
+                        "value":"aut5v31Tb789KuCGY0g4",
+                        "mutable":false
+                      },
+                      {
+                        "name":"methodType",
+                        "type":"string",
+                        "required":false,
+                        "options":[
+                          {
+                            "label":"SMS",
+                            "value":"sms"
+                          },
+                          {
+                            "label":"Voice call",
+                            "value":"voice"
+                          }
+                        ]
+                      },
+                      {
+                        "name":"enrollmentId",
+                        "required":true,
+                        "value":"pae5ykx4eIvfslkO90g4",
+                        "mutable":false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo":"$.authenticatorEnrollments.value[4]"
+              },
+              {
+                "label":"Phone",
+                "value":{
+                  "form":{
+                    "value":[
+                      {
+                        "name":"id",
+                        "required":true,
+                        "value":"aut5v31Tb789KuCGY0g4",
+                        "mutable":false
+                      },
+                      {
+                        "name":"methodType",
+                        "type":"string",
+                        "required":false,
+                        "options":[
+                          {
+                            "label":"SMS",
+                            "value":"sms"
+                          },
+                          {
+                            "label":"Voice call",
+                            "value":"voice"
+                          }
+                        ]
+                      },
+                      {
+                        "name":"enrollmentId",
+                        "required":true,
+                        "value":"pae5ykzcnhmdfSMuQ0g4",
+                        "mutable":false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo":"$.authenticatorEnrollments.value[5]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "aidtheidkwh282hv8g3"
+      },
+      {
+        "displayName": "FIDO2 (WebAuthn)",
+        "type": "security_key",
+        "id": "autwa6eD9o02iBbtv0g2",
+        "authenticatorId": "fwftheidkwh282hv8g3"
+      },
+      {
+        "displayName": "Okta Email",
+        "type": "email",
+        "authenticatorId": "aidtm56L8gXXHI1SD0g3",
+        "id": "autwa6eD9o02iBbtv0g3",
+        "methods": [
+          {
+            "methodType": "email"
+          }
+        ]
+      },
+      {
+        "profile":{},
+        "type":"phone",
+        "id":"pae5ykx4eIvfslkO90g4",
+        "displayName":"Phone Number",
+        "methods":[
+          {
+            "type":"sms"
+          },
+          {
+            "type":"voice"
+          }
+        ]
+      },
+      {
+        "profile":{
+        },
+        "type":"phone",
+        "id":"pae5ykzcnhmdfSMuQ0g4",
+        "displayName":"Phone Number",
+        "methods":[
+          {
+            "type":"sms"
+          },
+          {
+            "type":"voice"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00uwb8GLwf1HED5Xs0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvdnhhU2NRWG9TbzJvMjAwZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..40AFMvA7ix6FA2oE.Q6jiZeKfCdON5wqqMdiDQCtgLctrIrpnQzKEwub6L5KvFWcgVpdEFcoOvT1WIq9EUVOg2m_vFLV7b-PVSoCBKhKzl0IujmkjC5XyTwnDBMmJt-2-BMez0kIkABNI1BpffStyt8uJiUqGifVrZ6AqXr6zCpkGK5f7-Mu_rVF8NS2P580n2_2p9MO9haf-z56-i3DfkX-xM1a3_AQXUGr_RzDXWPXZf6mPUhYtouJz7Qdpt6n9agvqasuSz8JLehX9TIN9Y4k_M7JKxaYfdOv9Bnp7zSEtVQeG2ADzbIMKBRXA1bP_TZ7EKHInCu4gz8JR3febZLz8EZq-kaknBB_S3AvkjtzkrUyfUNo31xZhoTWO2kiMJlo_zLRqMKW8xqPNYKjtYo9rXR_v4_wA3hOCKFyKkqCD8U1Y6bbVwoicDHOZ4fNZOtcAVB8BJ8HzpAYzF8bCKHCD9CLgIU8eCezTo_Fo90Zm138Hu0rJc0LCNlG26RFv7DZ89fJbFqobS_y8bbB-MC0wsBBxf1kx1lEFUCqZFNottzXtRnpYKqvurBj_IsV9YtO9T35WZanr2gfbl98R2YpRGMF4pfp3d_6ltntY8-a8VK9cUlkjzBNXH46O-MzOTeuWQ7XgcEqK_MNENs4JMGTixBUQeQjPaDvJ_djCigciq1qyf2peAZBDlR5lozoJbNNQtxnXTYBresTm5RvEQ7qWo5IQlNDnK9Ir5pQdgM1NTPYiVDEt4TFZ4ZjLgycdLSSOv6HSw9bS85avNswJBXwlYBDHML5NpfGL-6m8uoPmtRqCG1HTFgLdSo1iGkcPtO8zcymNlUpevIEhX8QAf0GTK66723e0Qmz8lLDcsVCBVmyvFAENJ2gnR48p4Dt96nH7KRnrXOXUYa1LxJZr_ZeT7K-5WXw5a-dESuxvg18M993Kw6yDwSHsZ-6UeppWg3PPo7dKRE1aX9fisQP1uRCJzk1CtWxPu2GcFs9UZpszLuv1Y8r9DDH7FSgzlyULzOXVcNaLzkm5-RH7jxeRTiOOZxhOBIUuVgUUnkm6x4K23-TYxf4HgV_vWrQmIdEjaP5NuYRPfLkdM8qAWCkuz5r48yjl6T5XRg1wKG7OX0JZLjbmcJsTNagXSHbPsXuBd0te_fgNYT54_eGkIIklr4LbOEhKGNpZSXSWPbTPT7zhbebrUGglldI37k8WldRGywq_ZvZX6W5hucD_yWBqqXBq45LW_iNlAvtUIXBkq4WuPgWaYRIjqWnUxbAZkL_5ejddr18MOmbwV8ftbtYhvnYbYqBvDaqpsXoVKBT0g8ZTXuSs36Rrxi6wyBnXVcM0RrC8YhU6ybBWiovNo2chyPSPhFAvmJVmVL2t3lbA7SoBnWQvNtspHY8Xd8KNf-MUSuhHKXfrSRPwWC23D9qSxoUC0ubIINYBLD-WHYv_Yn7RBU7IQ4fzoLJrE6mUBz9tZ79drLOLd7vbe8MPpWJI-MHCTHD6XTMAWqd5q22EGAUa29XV4Jl4E6xZg8CybaOUOVpuia35UPLpCKK0wDofdAAUcPCo-hj7OH3U0XsCccF0GHfo7cqoYQanqfu7mypeGEf9_471KYQVNSlc1TGrrngY6_KRBMKDcx7fZne4ypsJfumhrpfbEkeltfwFsGVs1--2bFksLI8esRxR1qUHzT0.hCv29YrLBFcW8TjKwSmCXQ",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  }
+}

--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
@@ -12,9 +12,11 @@ const CheckYourEmailTitle = View.extend({
     'data-se': 'o-form-explain',
   },
   template: hbs`
-    {{i18n code="oie.email.verify.sentText" bundle="login"}}&nbsp;
-    <span class="strong">{{email}}.</span>
-    &nbsp;{{i18n code="email.mfa.email.sent.description.emailCodeText" bundle="login"}}
+    {{#if email}}
+      {{i18n code="oie.email.verify.sentText" bundle="login" arguments="email" $1="<span class='strong'>$1</span>"}}
+    {{else}}
+      {{i18n code="oie.email.verify.alternate.sentText" bundle="login"}}
+    {{/if}}
   `,
 
   getTemplateData () {

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -33,10 +33,13 @@ const Body = BaseForm.extend(
       const sendText = ( this.model.get('primaryMode') === 'sms' )
         ? loc('oie.phone.verify.sms.sendText', 'login')
         : loc('oie.phone.verify.call.sendText', 'login');
+      const extraCssClasses =
+        this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login') ?
+          'strong' : '';
       // Courage doesn't support HTML, hence creating a subtitle here.
       this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">${sendText}
-        <div><span class="strong">${this.model.escape('phoneNumber')}</span></div>
-        </div>`);
+        <span ${ extraCssClasses ? 'class="' + extraCssClasses + '"' : ''}>${this.model.escape('phoneNumber')}</span>
+      </div>`);
     },
 
     getUISchema () {
@@ -82,7 +85,7 @@ export default BaseAuthenticatorView.extend({
         'type': 'string',
       },
       phoneNumber: {
-        'value': profile.phoneNumber,
+        'value': profile?.phoneNumber ? profile.phoneNumber : loc('oie.phone.alternate.title', 'login'),
         'type': 'string',
       },
     }, ModelClass.prototype.local);

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -74,7 +74,6 @@ const Body = BaseForm.extend(Object.assign(
         : loc('mfa.calling', 'login');
       const enterCodeText = loc('oie.phone.verify.enterCodeText', 'login');
 
-      // TODO: Clean-up post M1 when phoneNumber is available in all cases - enrollment & verification.
       const strongClass = this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login') ? 'strong' : '';
       // Courage doesn't support HTML, hence creating a subtitle here.
       this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">
@@ -109,7 +108,6 @@ export default BaseAuthenticatorView.extend({
         'type': 'string',
       },
       phoneNumber: {
-        // TODO: Clean-up post M1 when phoneNumber is available in all cases - enrollment & verification.
         'value': profile?.phoneNumber ? profile.phoneNumber : loc('oie.phone.alternate.title', 'login'),
         'type': 'string',
       }

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -4,6 +4,7 @@ import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPa
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 
 import emailVerification from '../../../playground/mocks/data/idp/idx/authenticator-verification-email';
+import emailVerificationNoEmail from '../../../playground/mocks/data/idp/idx/authenticator-verification-email-no-email';
 import success from '../../../playground/mocks/data/idp/idx/success';
 import invalidOTP from '../../../playground/mocks/data/idp/idx/error-email-verify';
 import magicLinkReturnTab from '../../../playground/mocks/data/idp/idx/terminal-return-email';
@@ -24,6 +25,16 @@ const validOTPmock = RequestMock()
   .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/resend')
   .respond(emailVerification)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(success);
+
+const validOTPmockNoEmail = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(emailVerificationNoEmail)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(emailVerificationNoEmail)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/resend')
+  .respond(emailVerificationNoEmail)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(success);
 
@@ -73,11 +84,19 @@ test
     await t.expect(saveBtnText).contains('Verify');
     await t.expect(pageTitle).contains('Verify with your email');
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .contains('An email was sent to');
+      .contains('Check i**a@h***o.net for a verification message. Click the verification button in your email or enter the code below to continue.');
+  });
+
+test
+  .requestHooks(validOTPmockNoEmail)('challenge email authenticator screen has right labels when email is not in profile', async t => {
+    const challengeEmailPageObject = await setup(t);
+
+    const pageTitle = challengeEmailPageObject.getPageTitle();
+    const saveBtnText = challengeEmailPageObject.getSaveButtonLabel();
+    await t.expect(saveBtnText).contains('Verify');
+    await t.expect(pageTitle).contains('Verify with your email');
     await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .contains('inca@hello.net.');
-    await t.expect(challengeEmailPageObject.getFormSubtitle())
-      .contains('Check your email and enter the code below.');
+      .contains('Check your email for a verification message. Click the verification button in your email or enter the code below to continue.');
   });
 
 test

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -4,6 +4,7 @@ import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticato
 import ChallengeFactorPageObject from '../framework/page-objects/ChallengeFactorPageObject';
 
 import xhrSelectAuthenticators from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator';
+import xhrSelectAuthenticatorsNoNumber from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-no-number';
 import xhrSelectAuthenticatorsOktaVerify from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2';
 import xhrSelectAuthenticatorsRecovery from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-for-recovery';
 import xhrAuthenticatorRequiredPassword from '../../../playground/mocks/data/idp/idx/authenticator-verification-password';
@@ -27,6 +28,10 @@ const mockChallengePassword = RequestMock()
   .respond(xhrSelectAuthenticators)
   .onRequestTo('http://localhost:3000/idp/idx/challenge')
   .respond(xhrAuthenticatorRequiredPassword);
+
+const mockAuthenticatorListNoNumber = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrSelectAuthenticatorsNoNumber);
 
 const mockChallengeEmail = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -127,6 +132,17 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();
   await t.expect(selectFactorPage.getSignoutLinkText()).eql('Sign Out');
 
+});
+
+test.requestHooks(mockAuthenticatorListNoNumber)('should not display phone number in description if not available', async t => {
+  const selectFactorPage = await setup(t);
+  await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Phone');
+  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(false);
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
+
+  await t.expect(selectFactorPage.getFactorLabelByIndex(4)).eql('Phone');
+  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(4)).eql(false);
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(4)).eql('Select');
 });
 
 test.requestHooks(mockSelectAuthenticatorForRecovery)('should load select authenticator list for recovery password', async t => {


### PR DESCRIPTION
Resolves: OKTA-343133

## Description:

Phone:

<img width="410" alt="Screen Shot 2020-11-06 at 11 36 53 AM" src="https://user-images.githubusercontent.com/26014318/98412412-bd35c680-202c-11eb-8c60-83e1e25c97a3.png">

<img width="412" alt="Screen Shot 2020-11-06 at 11 37 05 AM" src="https://user-images.githubusercontent.com/26014318/98412413-bdce5d00-202c-11eb-89a3-7e0b689b444f.png">

<img width="410" alt="Screen Shot 2020-11-06 at 11 37 14 AM" src="https://user-images.githubusercontent.com/26014318/98412415-be66f380-202c-11eb-837b-931a4e591160.png">

<img width="413" alt="Screen Shot 2020-11-06 at 11 36 35 AM" src="https://user-images.githubusercontent.com/26014318/98412406-bad36c80-202c-11eb-8a12-bb13c4b6e059.png">

<img width="410" alt="Screen Shot 2020-11-06 at 11 36 43 AM" src="https://user-images.githubusercontent.com/26014318/98412410-bc9d3000-202c-11eb-832d-a7bf2eb94d1c.png">

Phone number is now inline with message:

<img width="413" alt="Screen Shot 2020-11-06 at 1 41 11 PM" src="https://user-images.githubusercontent.com/26014318/98417483-d42ce680-2035-11eb-9b93-8c32b4752382.png">

Email

<img width="418" alt="Screen Shot 2020-11-06 at 12 27 00 PM" src="https://user-images.githubusercontent.com/26014318/98412418-be66f380-202c-11eb-87a5-251c2ea76377.png">

Email subtitle has changed for m1:

<img width="413" alt="Screen Shot 2020-11-06 at 12 28 01 PM" src="https://user-images.githubusercontent.com/26014318/98412425-beff8a00-202c-11eb-8e5f-217b6d6752cc.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-343133](https://oktainc.atlassian.net/browse/OKTA-343133)


