### PR TITLE
feat: implement oda/mdm remediation for Okta Verify not installed case

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,44 +15,54 @@ You can learn more on the [Okta + JavaScript][lang-landing] page in our document
 
 <!-- TOC depthFrom:2 depthTo:3 -->
 
-- [Getting started](#getting-started)
-  - [Using the Okta CDN](#using-the-okta-cdn)
-  - [Using the npm module](#using-the-npm-module)
-- [Usage guide](#usage-guide)
-- [API Reference](#api-reference)
-  - [OktaSignIn](#oktasignin)
-  - [showSignInToGetTokens](#showsignintogettokens)
-  - [showSignInAndRedirect](#showsigninandredirect)
-  - [renderEl](#renderel)
-  - [hide](#hide)
-  - [show](#show)
-  - [remove](#remove)
-  - [on](#on)
-  - [off](#off)
-  - [authClient](#authclient)
-- [Configuration](#configuration)
-  - [Basic config options](#basic-config-options)
-  - [Username and password](#username-and-password)
-  - [Language and text](#language-and-text)
-  - [Colors](#colors)
-  - [Links](#links)
-  - [Buttons](#buttons)
-  - [Registration](#registration)
-  - [IdP Discovery](#idp-discovery)
-  - [OpenID Connect](#openid-connect)
-  - [Smart Card IdP](#smart-card-idp)
-  - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
-  - [Feature flags](#feature-flags)
-- [Events](#events)
-  - [ready](#ready)
-  - [afterError](#aftererror)
-  - [afterRender](#afterrender)
-  - [pageRendered](#pagerendered)
-- [Building the Widget](#building-the-widget)
-  - [The `.widgetrc.js` config file](#the-widgetrc-config-file)
-  - [Build and test commands](#build-and-test-commands)
-- [Browser support](#browser-support)
-- [Contributing](#contributing)
+- [Okta Sign-In Widget](#okta-sign-in-widget)
+  - [Getting started](#getting-started)
+    - [Using the Okta CDN](#using-the-okta-cdn)
+    - [Using the npm module](#using-the-npm-module)
+  - [Usage guide](#usage-guide)
+  - [Usage examples](#usage-examples)
+    - [OIDC login flow using PKCE (Proof Key for Code Exchange)](#oidc-login-flow-using-pkce-proof-key-for-code-exchange)
+    - [OIDC login flow using Authorization Code](#oidc-login-flow-using-authorization-code)
+  - [API Reference](#api-reference)
+    - [OktaSignIn](#oktasignin)
+    - [showSignInToGetTokens](#showsignintogettokens)
+    - [showSignInAndRedirect](#showsigninandredirect)
+    - [renderEl](#renderel)
+      - [success](#success)
+    - [hide](#hide)
+    - [show](#show)
+    - [remove](#remove)
+    - [on](#on)
+    - [off](#off)
+    - [authClient](#authclient)
+  - [Configuration](#configuration)
+    - [Basic config options](#basic-config-options)
+    - [Username and password](#username-and-password)
+    - [Language and text](#language-and-text)
+    - [Colors](#colors)
+    - [Links](#links)
+      - [Help Links](#help-links)
+      - [Sign Out Link](#sign-out-link)
+    - [Buttons](#buttons)
+      - [Custom Buttons](#custom-buttons)
+      - [Registration Button](#registration-button)
+    - [Registration](#registration)
+    - [IdP Discovery](#idp-discovery)
+      - [Additional configuration](#additional-configuration)
+    - [OpenID Connect](#openid-connect)
+    - [Smart Card IdP](#smart-card-idp)
+    - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
+    - [Feature flags](#feature-flags)
+  - [Events](#events)
+    - [ready](#ready)
+    - [afterError](#aftererror)
+    - [afterRender](#afterrender)
+    - [pageRendered](#pagerendered)
+  - [Building the Widget](#building-the-widget)
+    - [Build and test commands](#build-and-test-commands)
+    - [Local development workflow using `yarn link`](#local-development-workflow-using-yarn-link)
+  - [Browser support](#browser-support)
+  - [Contributing](#contributing)
 
 <!-- /TOC -->
 
@@ -346,63 +356,55 @@ Returns a Promise. Renders the widget to the DOM. On success, the promise will r
 
 > :warning: This method provides access to internal and/or undocumented features for non-OIDC flows. For OIDC flows, we recommend using [showSignInToGetTokens](#showsignintogettokens) or [showSignAndRedirect](#showsigninandredirect).
 
+
 - `options`
   - `el` *(optional)* - CSS selector which identifies the container element that the widget attaches to. If omitted, defaults to the value passed in during the construction of the Widget.
-- `success` *(optional)* - Function that is called when the user has completed an authentication flow. If an [OpenID Connect redirect flow](#openid-connect) is used, this function can be omitted.
+- `success` *(optional)* - Function that is called when the user has completed an authentication flow. If an [OpenID Connect redirect flow](#openid-connect) is used, this function can be omitted. See below for more details.
 - `error` *(optional)* - Function that is called when the widget has been initialized with invalid config options, or has entered a state it cannot recover from. If omitted, a default function is used to output errors to the console.
 
+#### success
+
+Function that handles non-error events, including the completion of a successful authentication flow by a user. Also handles other flows such as reset password and self-registration flows.
+
+_OIDC vs Non-OIDC Configurations:_
+
+New integrations are recommended to use OIDC as it uses a more lightweight REST-based protocol and has more widespread usage. Less common is the need for non-OIDC integrations in self-hosted applications, however one example of this usage is when using the Okta-hosted sign-in widget to redirect a user to the Okta Dashboard after authentication.
+
+*`res` parameter:*
+
+This `success` function will be called with an object, that can have various properties, depending on how the widget is configured:
+
 ```javascript
-signIn.renderEl({
-  // Assumes there is an empty element on the page with an id of 'osw-container'
-  el: '#osw-container'
+success({
+  status: String,
+  username: optional<string>,
+  activationToken: optional<object>,
+  tokens: optional<object>,
+  type: optional<string>,
+  user: optional<object>,
+  stepUp: optional<function>,
+  session: optional<object>,
+  next: optional<function>,
 })
-.then(function success(res) {
-  // The properties in the response object depend on two factors:
-  // 1. The type of authentication flow that has just completed, determined by res.status
-  // 2. What type of token the widget is returning
-
-  // The user has started the password recovery flow, and is on the confirmation
-  // screen letting them know that an email is on the way.
-  if (res.status === 'FORGOT_PASSWORD_EMAIL_SENT') {
-    // Any followup action you want to take
-    return;
-  }
-
-  // The user has started the unlock account flow, and is on the confirmation
-  // screen letting them know that an email is on the way.
-  if (res.status === 'UNLOCK_ACCOUNT_EMAIL_SENT') {
-    // Any followup action you want to take
-    return;
-  }
-
-  // The user has successfully completed the authentication flow
-  if (res.status === 'SUCCESS') {
-
-    // Handle success when the widget is not configured for OIDC
-    if (res.type === 'SESSION_STEP_UP') {
-      // Session step up response
-      // If the widget is not configured for OIDC and the authentication type is SESSION_STEP_UP,
-      // the response will contain user metadata and a stepUp object with the url of the resource
-      // and a 'finish' function to navigate to that url
-      console.log(res.user);
-      console.log('Target resource url: ' + res.stepUp.url);
-      res.stepUp.finish();
-      return;
-    } else {
-      // If the widget is not configured for OIDC, the response will contain
-      // user metadata and a sessionToken that can be converted to an Okta
-      // session cookie:
-      console.log(res.user);
-      res.session.setCookieAndRedirect('https://acme.com/app');
-      return;
-    }
-  }
-})
-.catch(function error(err) {
-  // This function is invoked with errors the widget cannot recover from:
-  // Known errors: CONFIG_ERROR, UNSUPPORTED_BROWSER_ERROR
-});
 ```
+
+- `status` *(string)* - Always present. One of: `FORGOT_PASSWORD_EMAIL_SENT`, `UNLOCK_ACCOUNT_EMAIL_SENT`, `ACTIVATION_EMAIL_SENT`, `REGISTRATION_COMPLETE`, or `SUCCESS`
+
+- `username` *(optional\<string\>)* - Only present when `status` is one of `FORGOT_PASSWORD_EMAIL_SENT`, `UNLOCK_ACCOUNT_EMAIL_SENT`, `ACTIVATION_EMAIL_SENT`, or `REGISTRATION_COMPLETE`.
+
+- `activationToken` *(optional\<object\>)* - Only present when `status` is `REGISTRATION_COMPLETE`.
+
+- `tokens` *(optional\<object\>)* - Only present when widget is in an OIDC configuration, and `status` is `SUCCESS`. Depending on the widget `responseType` configuration, this will contain an `accessToken` only or both `accessToken` and `idToken`.
+
+- `type` *(optional\<string\>)* - Only present when widget is in a non-OIDC configuration and `status` is `SUCCESS`. One of `SESSION_STEP_UP`, or `SESSION_SSO`.
+
+- `user` *(optional\<object\>)* - Only present when widget is in a non-OIDC configuration, `status` is `SUCCESS`, and `type` is `SESSION_STEP_UP`.
+
+- `stepUp` *(optional\<function\>)* - Only present when widget is in a non-OIDC configuration, `status` is `SUCCESS`, and `type` is `SESSION_STEP_UP`. `res.stepUp.finish()` call redirect the user to the URL at `res.stepUp.url`.
+
+- `next` *(optional\<function\>)* - May be present when widget is in a non-OIDC configuration, `status` is `SUCCESS`, and the response contains a redirect URL. Calling this function will redirect the user.
+
+- `session` *(optional\<object\>)* - Only present when widget is in a non-OIDC configuration, `status` is `SUCCESS`, and `type` is `SESSION_SSO`. `res.session.setCookieAndRedirect(url)` will redirect the user to the passed URL.
 
 ### hide
 

--- a/assets/sass/v2/_device-enrollment-terminal.scss
+++ b/assets/sass/v2/_device-enrollment-terminal.scss
@@ -11,7 +11,7 @@
       display: inline-block;
       position: absolute;
       left: 0;
-      width: 20px;;
+      width: 20px;
     }
   }
   .copy-clipboard-button {
@@ -40,5 +40,11 @@
     .ios-app-store-logo {
       background-image: url('../img/appstore/apple-app-store.svg');
     }
+  }
+  .copy {
+    font-size: 10px;
+    font-style: italic;
+    color: #6e6e78; // odyssey cv('gray', '600');
+    margin-top: 16px;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "^4.0.3",
+    "@okta/okta-auth-js": "~4.0.4",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/packages/@okta/courage-for-signin-widget/yarn.lock
+++ b/packages/@okta/courage-for-signin-widget/yarn.lock
@@ -349,8 +349,9 @@ bluebird@^3.5.1, bluebird@^3.5.5:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -391,7 +392,8 @@ braces@^2.3.1, braces@^2.3.2:
 
 brorand@^1.0.1:
   version "1.1.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -1039,8 +1041,9 @@ ejs@^2.6.1:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/ejs/-/ejs-2.6.2.tgz#3a32c63d1cd16d11266cd4703b14fec4e74ab4f6"
 
 elliptic@^6.0.0:
-  version "6.5.0"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/elliptic/-/elliptic-6.5.0.tgz#2b8ed4c891b7de3200e14412a5b8248c7af505ca"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -1648,14 +1651,16 @@ hash-base@^3.0.0:
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
@@ -2108,14 +2113,10 @@ lodash.sortby@^4.7.0:
   resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14:
-  version "4.17.15"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-
-lodash@^4.17.15:
-  version "4.17.19"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha1-5I3e2+MLMyF4PFtDAfvTU7weSks=
+lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2239,11 +2240,13 @@ mimic-fn@^1.0.0:
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
-  resolved "https://artifacts.aue1d.saasure.com:443/artifactory/api/npm/npm-okta-master/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 "minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -827,6 +827,8 @@ enroll.explanation.p1 = To sign in using Okta Verify, you will need to set up Ok
 enroll.explanation.p2 = In the app, follow the instructions to add an organizational account. When prompted, choose <span class="semi-strong">Sign In</span>, then enter the <span class="semi-strong">sign-in URL</span>:
 enroll.appleStore = the App Store
 enroll.googleStore = Google Play
+enroll.copy.ios = Apple®, App Store, and the Apple logo are trademarks of Apple Inc.
+enroll.copy.android = Google Play and the Google Play logo are trademarks of Google LLC.
 enroll.explanation.mdm = To access this app, your device needs to meet your organization\'s security requirements. Follow the instructions below to continue.
 enroll.mdm.copyLink = Copy link to clipboard
 enroll.mdm.copyLink.success = Link copied.

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -54,6 +54,10 @@ export default Model.extend({
     // IDX API VERSION
     apiVersion: ['string', true, '1.0.0'],
 
+    // attribute to hold proxy (fake) idx response
+    // to render static pages without initiating idx pipeline
+    proxyIdxResponse: ['object', false],
+
     // FEATURES
     'features.router': ['boolean', true, false],
     'features.securityImage': ['boolean', true, false],

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "src",
+  "version": "1.0.0",
+  "dependencies": {
+    
+  }
+}

--- a/src/v2/view-builder/components/OdaOktaVerifyTerminalView.js
+++ b/src/v2/view-builder/components/OdaOktaVerifyTerminalView.js
@@ -17,6 +17,9 @@ export default View.extend({
         <div class="app-store-logo {{appStoreLogoClass}}"></div>
       </a>
     </div>
+    <div class="copy">
+      {{copy}}
+    </div>
   `,
 
   getTemplateData () {
@@ -25,6 +28,7 @@ export default View.extend({
     const templateData = {
       signInUrl: deviceEnrollment.signInUrl,
       appStoreLogoClass: `${platform}-app-store-logo`,
+      copy: loc(`enroll.copy.${platform}`, 'login'),
     };
     if (platform === Enums.IOS) {
       templateData.appStoreName = loc('enroll.appleStore', 'login');

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -153,7 +153,7 @@ var OktaSignIn = (function () {
     var authClient = createAuthClient(authParams);
 
     var Router;
-    if (options.stateToken && !Util.isV1StateToken(options.stateToken)) {
+    if ((options.stateToken || options.proxyIdxResponse) && !Util.isV1StateToken(options.stateToken)) {
       Router = V2Router;
     } else {
       Router = V1Router;

--- a/test/e2e/angular-app/yarn.lock
+++ b/test/e2e/angular-app/yarn.lock
@@ -468,8 +468,8 @@ acorn-dynamic-import@^4.0.0:
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
 
 acorn@^6.0.5:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
 
 adm-zip@0.4.4:
   version "0.4.4"
@@ -901,8 +901,8 @@ bluebird@^3.3.0, bluebird@^3.5.1, bluebird@^3.5.3:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
 
 body-parser@1.18.3:
   version "1.18.3"
@@ -1693,7 +1693,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@^3.2.5, debug@^3.2.6:
+debug@^3.1.0, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -1898,8 +1898,8 @@ electron-to-chromium@^1.3.127:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz#205a0b7a276b3f56bc056f19178909243054252a"
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -2043,9 +2043,9 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-eventemitter3@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
 
 events@^3.0.0:
   version "3.0.0"
@@ -2372,10 +2372,8 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  dependencies:
-    debug "^3.2.6"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -2785,10 +2783,10 @@ http-proxy-middleware@~0.18.0:
     micromatch "^3.1.9"
 
 http-proxy@^1.13.0, http-proxy@^1.16.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   dependencies:
-    eventemitter3 "^3.0.0"
+    eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
@@ -2903,13 +2901,17 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@1.3.5, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
@@ -3564,8 +3566,8 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.mergewith@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
 
 lodash.tail@^4.1.1:
   version "4.1.1"
@@ -3886,8 +3888,8 @@ mississippi@^3.0.0:
     through2 "^2.0.0"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -6420,8 +6422,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
 
 whatwg-fetch@3.0.0:
   version "3.0.0"

--- a/test/e2e/react-app/yarn.lock
+++ b/test/e2e/react-app/yarn.lock
@@ -1127,8 +1127,8 @@ bluebird@^3.4.7:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
 
 body-parser@1.18.3:
   version "1.18.3"
@@ -2249,8 +2249,8 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz#205a0b7a276b3f56bc056f19178909243054252a"
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -3164,12 +3164,14 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
 
 handlebars@^4.0.3:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
+  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   dependencies:
+    minimist "^1.2.5"
     neo-async "^2.6.0"
-    optimist "^0.6.1"
     source-map "^0.6.1"
+    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -3515,13 +3517,17 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
@@ -4667,18 +4673,10 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
@@ -4694,8 +4692,8 @@ minizlib@^1.1.1:
     minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
@@ -4766,8 +4764,9 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
 
 neo-async@^2.5.0, neo-async@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 next-tick@^1.0.0:
   version "1.0.0"
@@ -5027,13 +5026,6 @@ opn@^5.1.0:
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
   dependencies:
     is-wsl "^1.1.0"
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
@@ -6524,6 +6516,7 @@ source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -7014,12 +7007,17 @@ uglify-js@^2.8.29:
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
 
-uglify-js@^3.0.13, uglify-js@^3.1.4:
+uglify-js@^3.0.13:
   version "3.5.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.10.tgz#652bef39f86d9dbfd6674407ee05a5e2d372cf2d"
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
+
+uglify-js@^3.1.4:
+  version "3.11.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.11.4.tgz#b47b7ae99d4bd1dca65b53aaa69caa0909e6fadf"
+  integrity sha512-FyYnoxVL1D6+jDGQpbK5jW6y/2JlVfRfEeQ67BPCUg5wfCjaKOpr2XeceE4QL+MkhxliLtf5EbrMDZgzpt2CNw==
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -7347,8 +7345,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
 
 whatwg-encoding@^1.0.1:
   version "1.0.5"
@@ -7419,11 +7417,7 @@ wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
-
-wordwrap@~1.0.0:
+wordwrap@^1.0.0, wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock } from 'testcafe';
+import {ClientFunction, RequestLogger, RequestMock} from 'testcafe';
 import DeviceEnrollmentTerminalPageObject from '../framework/page-objects/DeviceEnrollmentTerminalPageObject';
 import IOSOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-ios';
 import AndroidOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-android';
@@ -15,6 +15,11 @@ const androidOdaMock = RequestMock()
 const mdmMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(MdmEnrollment);
+
+const rerenderWidget = ClientFunction((settings) => {
+  // function `renderPlaygroundWidget` is defined in playground/main.js
+  window.renderPlaygroundWidget(settings);
+});
 
 fixture('Device enrollment terminal view for ODA and MDM');
 
@@ -68,4 +73,66 @@ test
     await t.expect(content).contains('Follow the instructions in your browser to set up Airwatch, then try accessing this app again');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
     await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://sampleEnrollmentlink.com');
+  });
+
+// Below two tests are covering a special use case in ODA Universal Link flow
+// When the user clicks on the button, if Okta Verify is not installed it will be redirected to /authenticators/ov-not-installed
+// And the endpoint will return a new SIW with proxyIdxResponse in config
+// These tests are testing SIW can directly render terminal page when receiving such proxyIdxResponse instead of making introspect call
+// The mocks and device enrollment values are intentionally set differently from above tests to make sure the we properly consume SIW config
+test
+  .requestHooks(logger, mdmMock)('shows the correct content in iOS ODA terminal view when Okta Verify is not installed in Universal Link flow', async t => {
+    const deviceEnrollmentTerminalPage = await setup(t);
+    await rerenderWidget({
+      'proxyIdxResponse': {
+        'deviceEnrollment': {
+          'type': 'object',
+          'value': {
+            'name': 'oda',
+            'platform': 'IOS',
+            'enrollmentLink': '',
+            'vendor': '',
+            'signInUrl': 'https://rain.okta1.com'
+          }
+        }
+      }
+    });
+    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
+    await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
+    const content = deviceEnrollmentTerminalPage.getContentText();
+    await t.expect(content).contains('To sign in using Okta Verify, you');
+    await t.expect(content).contains('ll need to set up Okta Verify on this device. Download the Okta Verify app on the App Store.');
+    await t.expect(content).contains('In the app, follow the instructions to add an organizational account.');
+    await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
+    await t.expect(content).contains('https://rain.okta1.com');
+    await t.expect(deviceEnrollmentTerminalPage.getAppStoreLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    await t.expect(deviceEnrollmentTerminalPage.getAppStoreLogo()).contains('ios-app-store-logo');
+  });
+
+test
+  .requestHooks(logger, iosOdaMock)('shows the correct content in iOS MDM terminal view when Okta Verify is not installed in Universal Link flow', async t => {
+    const deviceEnrollmentTerminalPage = await setup(t);
+    await rerenderWidget({
+      'proxyIdxResponse': {
+        'deviceEnrollment': {
+          'type': 'object',
+          'value': {
+            'name': 'mdm',
+            'platform': 'IOS',
+            'enrollmentLink': 'https://anotherSampleEnrollmentlink.com',
+            'vendor': 'MobileIron',
+            'signInUrl': ''
+          }
+        }
+      }
+    });
+    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
+    const content = deviceEnrollmentTerminalPage.getContentText();
+    await t.expect(content).contains('To access this app, your device needs to meet your organization');
+    await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');
+    await t.expect(content).contains('Tap the Copy Link button below.');
+    await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
+    await t.expect(content).contains('Follow the instructions in your browser to set up MobileIron, then try accessing this app again');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
+    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
   });

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -35,6 +35,7 @@ test
     await t.expect(content).contains('In the app, follow the instructions to add an organizational account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
+    await t.expect(content).contains('Apple®, App Store, and the Apple logo are trademarks of Apple Inc.');
     await t.expect(deviceEnrollmentTerminalPage.getAppStoreLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
     await t.expect(deviceEnrollmentTerminalPage.getAppStoreLogo()).contains('ios-app-store-logo');
   });
@@ -50,6 +51,7 @@ test
     await t.expect(content).contains('In the app, follow the instructions to add an organizational account.');
     await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
     await t.expect(content).contains('https://idx.okta1.com');
+    await t.expect(content).contains('Google Play and the Google Play logo are trademarks of Google LLC.');
     await t.expect(deviceEnrollmentTerminalPage.getAppStoreLink()).eql('https://play.google.com/store/apps/details?id=com.okta.android.auth');
     await t.expect(deviceEnrollmentTerminalPage.getAppStoreLogo()).contains('android-app-store-logo');
   });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -355,6 +355,30 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     return signIn.renderEl({ el: $sandbox });
   }
 
+  function setupProxyIdxResponse (options) {
+    signIn = new Widget(
+      Object.assign(
+        {
+          baseUrl: url,
+          proxyIdxResponse: {
+            deviceEnrollment: {
+              type: 'object',
+              value: {
+                name: options.enrollmentType,
+                platform: 'IOS',
+                enrollmentLink: 'https://sampleEnrollmentlink.com',
+                vendor: 'Airwatch',
+                signInUrl: 'https://idx.okta1.com'
+              }
+            }
+          }
+        },
+        options || {}
+      )
+    );
+    return signIn.renderEl({ el: $sandbox });
+  }
+
   Expect.describe('Introspects token and loads Identifier view for new pipeline', function () {
     itp('calls introspect API on page load using idx-js as client', function () {
       const form = new IdentifierForm($sandbox);
@@ -384,6 +408,14 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         expect(err.name).toBe('CONFIG_ERROR');
         expect(err.message.toString()).toEqual('Error: Unknown api version: 2.0.0.  Use an exact semver version.');
       });
+    });
+  });
+
+  itp('Gets proxyIdxResponse and render terminal view', function () {
+    setupProxyIdxResponse({ enrollmentType : 'mdm'});
+
+    return Expect.wait(() => {
+      return $('.siw-main-body').length === 1;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.0.3.tgz#edd1ac65e907842887603f8fb909906789ffe382"
-  integrity sha512-l7qrhXvpZih2o1F4pZy7b9sEVqGroPNgnmIix60/Jjxi+uIoeAz6UMIJq6LEX7C5TTWr2U0tTHuBcJJkcai9IA==
+"@okta/okta-auth-js@~4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.0.4.tgz#cb21774d402d7289f0ea95215d0a57f14db000a9"
+  integrity sha512-tRVHEhS+UNO/hnauymLNbmx5f3DWpm7PtebMAZu6NmnLdO6/WwCuM4Bay7n9U51VgMcxRupymejN93Rhd/gY2w==
   dependencies:
     Base64 "0.3.0"
     core-js "^3.6.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,8 +2718,9 @@ bluebird@^3.3.0, bluebird@^3.5.0, bluebird@^3.5.5:
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  version "4.11.9"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 body-parser@1.19.0, body-parser@^1.16.1:
   version "1.19.0"
@@ -2920,6 +2921,7 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 brotli@^1.3.1:
   version "1.3.2"
@@ -4215,7 +4217,7 @@ debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4615,8 +4617,9 @@ elegant-spinner@^1.0.1:
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -5056,15 +5059,10 @@ eventemitter2@~0.4.13:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
   integrity sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=
 
-eventemitter3@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
-  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
-
 eventemitter3@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
-  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 events@1.1.1:
   version "1.1.1"
@@ -5503,11 +5501,9 @@ follow-redirects@1.5.10:
     debug "=3.1.0"
 
 follow-redirects@^1.0.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.11.0.tgz#afa14f08ba12a52963140fe43212658897bc0ecb"
-  integrity sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==
-  dependencies:
-    debug "^3.0.0"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -6264,6 +6260,7 @@ hash-base@^3.0.0:
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
@@ -6293,6 +6290,7 @@ highlight-es@^1.0.0:
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
@@ -6420,20 +6418,12 @@ http-proxy-middleware@~0.17.4:
     lodash "^4.17.2"
     micromatch "^2.3.11"
 
-http-proxy@^1.13.0:
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
-  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+http-proxy@^1.13.0, http-proxy@^1.16.2:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
   dependencies:
     eventemitter3 "^4.0.0"
-    follow-redirects "^1.0.0"
-    requires-port "^1.0.0"
-
-http-proxy@^1.16.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
-  dependencies:
-    eventemitter3 "^3.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
@@ -8254,10 +8244,12 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@0.3:
   version "0.3.0"
@@ -13040,8 +13032,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 websocket-stream@^5.0.1:
   version "5.5.2"


### PR DESCRIPTION
## Description:

This is implementing a special use case in oda/mdm remediation flow. When Okta Verify is not installed and user clicks on the button, it will be first redirected to login.okta.com and then redirected back to /authenticators/ov-not-installed. This endpoint will return a new SIW along with a proxyIdxResponse value in SIW config which contains the device enrollment object values we need.

The way we implement it is: if SIW detects such a proxyIdxResponse in config, it will still go to V2 router but won't make an introspect call by default. This is to make it a more generic solution in case we have similar use case to pass some customized config from server side.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://okta.box.com/s/c6d7fit1wzxsxq475rhfg4t33nhl92y1

### Reviewers:

@haishengwu-okta @pradeepdewda-okta @jhe-okta 


### Issue:

- [OKTA-342925](https://oktainc.atlassian.net/browse/OKTA-342925)


