### PR TITLE
Accessibility improvements for OAuth Consent view

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -22,10 +22,10 @@ $primary-bg-color: #fff;
 $secondary-bg-color: #f9f9f9;
 
 // Text Color
-$header-text-color: #5e5e5e;
+$header-text-color: #1d1d21; // Gray 900 in Odyssey
 $dark-text-color: #5e5e5e;
-$medium-text-color: #777;
-$light-text-color: #a7a7a7;
+$medium-text-color: #1d1d21; // Gray 900 in Odyssey
+$light-text-color: #6e6e78; // Gray 600 in Odyssey
 $link-text-color: #0074b3;
 $placeholder-text-color: #aaa;
 $error-text-color: #e34843;
@@ -84,6 +84,7 @@ $input-bg-color: #fff;
 $input-border-color: #bbb;
 $input-border-color-hover: #888;
 $input-border-color-focus: #0074b3;
+$input-shadow-color-focus: #51cbee;
 $input-icons-color: #a7a7a7;
 
 // Modal

--- a/assets/sass/modules/_admin-consent.scss
+++ b/assets/sass/modules/_admin-consent.scss
@@ -17,6 +17,9 @@ $image-size: 30px;
   .consent-title {
     text-align: center;
     word-wrap: break-word;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     span {
       padding-left: 10px;

--- a/assets/sass/modules/_consent.scss
+++ b/assets/sass/modules/_consent.scss
@@ -23,6 +23,9 @@ $image-size: 30px;
     text-align: center;
     word-wrap: break-word;
     font-size: 16px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     span {
       padding-left: 10px;
@@ -52,7 +55,7 @@ $image-size: 30px;
 
   .consent-description {
     p {
-      color: $text-color-light;
+      color: $light-text-color;
     }
   }
 

--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -54,6 +54,32 @@
   }
 }
 
+.skip-to-content-link {
+  font-family: "proxima nova", "montserrat", Arial, Helvetica, sans-serif;
+  text-decoration: none;
+  position: absolute;
+  top: 0;
+  left: 10px;
+  padding: 10px;
+  margin-top: 10px;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+  color: $primary-color;
+
+  &:visited,
+  &:hover,
+  &:active {
+    color: $primary-color;
+  }
+  &:hover {
+    text-decoration: underline;
+  }
+  &:focus {
+    // show only on focus (happens via tab key)
+    transform: translateY(0%);
+  }
+}
+
 #okta-sign-in.auth-container {
 
   &.main-container {
@@ -123,6 +149,11 @@
   input[type="button"] {
     /* -- Submit Buttons' Fonts -- */
     font-family: $fonts;
+
+    &:focus {
+      box-shadow: 0 0 8px $input-shadow-color-focus;
+      border-color: $input-border-color-focus;
+    }
   }
 
 

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -25,6 +25,8 @@ closeWindow = You can close this window
 country.label = Country
 phone.extention.label = Extension
 
+skip.to.main.content = Skip to main content
+
 # time units
 minutes.oneMinute = minute
 minutes = {0} minutes

--- a/src/AdminConsentRequiredController.js
+++ b/src/AdminConsentRequiredController.js
@@ -10,11 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import hbs from 'handlebars-inline-precompile';
 import { _, View, loc } from 'okta';
 import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 import ScopeList from 'views/admin-consent/ScopeList';
+import consentLogoHeaderTemplate from 'views/shared/templates/consentLogoHeaderTemplate';
 
 const ConsentModel = {
   props: {
@@ -44,21 +44,7 @@ const ConsentModel = {
 
 const ConsentHeader = View.extend({
   className: 'consent-title detail-row',
-  template: hbs`
-    {{#if clientURI}}
-     <a href="{{clientURI}}" class="client-logo-link" target="_blank">
-    {{/if}}
-    {{#if customLogo}}
-      <img class="client-logo custom-logo" src="{{customLogo}}" />
-    {{else}}
-      <img class="client-logo default-logo" src="{{defaultLogo}}" />
-    {{/if}}
-    {{#if clientURI}}
-      </a>
-    {{/if}}
-    <span class="title-text">{{{i18n code="consent.required.text" bundle="login" arguments="appName"}}}</span>
-    <div class="issuer"><span>{{issuer}}</span></div>
-   `,
+  template: consentLogoHeaderTemplate,
   getTemplateData: function () {
     var appState = this.options.appState;
     return {
@@ -99,6 +85,12 @@ const AdminConsentRequiredController = FormController.extend({
       this.model.cancel();
     });
   },
+
+  postRender: function () {
+    // Move buttons in DOM to match visual hierarchy to fix tab order.
+    const buttonContainer = this.form.$el.find('.o-form-button-bar');
+    this.form.$el.find('.button-primary').appendTo(buttonContainer);
+  }
 });
 
 module.exports = AdminConsentRequiredController;

--- a/src/ConsentRequiredController.js
+++ b/src/ConsentRequiredController.js
@@ -16,6 +16,8 @@ import hbs from 'handlebars-inline-precompile';
 import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 import ScopeList from 'views/consent/ScopeList';
+import consentLogoHeaderTemplate from 'views/shared/templates/consentLogoHeaderTemplate';
+
 export default FormController.extend({
   className: 'consent-required',
   initialize: function () {
@@ -25,6 +27,10 @@ export default FormController.extend({
   },
   postRender: function () {
     FormController.prototype.postRender.apply(this, arguments);
+
+    // Move buttons in DOM to match visual hierarchy to fix tab order.
+    const buttonContainer = this.form.$el.find('.o-form-button-bar');
+    this.form.$el.find('.button-primary').appendTo(buttonContainer);
 
     // Update the "don't allow" and "allow access" buttons to be neutral by changing "allow button" to be gray.
     this.$('.o-form-button-bar .button-primary').removeClass('button-primary');
@@ -68,22 +74,7 @@ export default FormController.extend({
         FormType.View({
           View: View.extend({
             className: 'consent-title detail-row',
-            template: hbs(
-              '\
-                {{#if clientURI}}\
-                  <a href="{{clientURI}}" class="client-logo-link" target="_blank">\
-                {{/if}}\
-                {{#if customLogo}}\
-                  <img class="client-logo custom-logo" src="{{customLogo}}" />\
-                {{else}}\
-                  <img class="client-logo default-logo" src="{{defaultLogo}}" />\
-                {{/if}}\
-                {{#if clientURI}}\
-                  </a>\
-                {{/if}}\
-                <span>{{{i18n code="consent.required.text" bundle="login" arguments="appName"}}}</span>\
-              '
-            ),
+            template: consentLogoHeaderTemplate,
             getTemplateData: function () {
               const appState = this.options.appState;
 

--- a/src/LoginRouter.js
+++ b/src/LoginRouter.js
@@ -67,6 +67,9 @@ import BaseLoginRouter from 'util/BaseLoginRouter';
 import FactorBeacon from 'views/shared/FactorBeacon';
 import PIVBeacon from 'views/shared/PIVBeacon';
 import SecurityBeacon from 'views/shared/SecurityBeacon';
+
+import Enums from 'util/Enums';
+
 export default BaseLoginRouter.extend({
   routes: {
     '': 'defaultAuth',
@@ -152,6 +155,10 @@ export default BaseLoginRouter.extend({
   ],
 
   defaultAuth: function () {
+    if (location.hash === `#${Enums.WIDGET_CONTAINER_ID}`) {
+      document.getElementById(Enums.WIDGET_CONTAINER_ID).focus();
+      return;
+    }
     if (this.settings.get('features.idpDiscovery')) {
       this.idpDiscovery();
     } else {

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -22,6 +22,7 @@ import Logger from 'util/Logger';
 import AuthContainer from 'views/shared/AuthContainer';
 import Header from 'views/shared/Header';
 import SecurityBeacon from 'views/shared/SecurityBeacon';
+import SkipLink from 'views/shared/SkipLink';
 import Animations from './Animations';
 import BrowserFeatures from './BrowserFeatures';
 import ColorsUtil from './ColorsUtil';
@@ -103,8 +104,9 @@ export default Router.extend({
     );
 
     const wrapper = new AuthContainer({ appState: this.appState });
+    const skipLink = new SkipLink();
 
-    $(options.el).append(wrapper.render().$el);
+    $(options.el).append([skipLink.render().$el, wrapper.render().$el]);
     this.el = `#${Enums.WIDGET_CONTAINER_ID}`;
 
     this.header = new Header({

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -24,11 +24,13 @@ import Logger from 'util/Logger';
 import LanguageUtil from 'util/LanguageUtil';
 import AuthContainer from 'views/shared/AuthContainer';
 import Header from 'views/shared/Header';
+import SkipLink from 'views/shared/SkipLink';
 import responseTransformer from './ion/responseTransformer';
 import uiSchemaTransformer from './ion/uiSchemaTransformer';
 import i18nTransformer from './ion/i18nTransformer';
 import AppState from './models/AppState';
 import idx from 'idx';
+
 
 const introspectStateToken = (settings) => {
   const domain = settings.get('baseUrl');
@@ -78,8 +80,9 @@ export default Router.extend({
     this.appState = new AppState();
 
     const wrapper = new AuthContainer({ appState: this.appState });
+    const skipLink = new SkipLink();
 
-    $(options.el).append(wrapper.render().$el);
+    $(options.el).append([skipLink.render().$el, wrapper.render().$el]);
     this.el = `#${Enums.WIDGET_CONTAINER_ID}`;
     this.header = new Header({
       el: this.el,

--- a/src/views/shared/AuthContainer.js
+++ b/src/views/shared/AuthContainer.js
@@ -14,9 +14,10 @@ import { View } from 'okta';
 import Enums from 'util/Enums';
 const CAN_REMOVE_BEACON_CLS = 'can-remove-beacon';
 export default View.extend({
+  tagName: 'main',
   className: 'auth-container main-container',
   id: Enums.WIDGET_CONTAINER_ID,
-  attributes: { 'data-se': 'auth-container' },
+  attributes: { 'data-se': 'auth-container', tabindex: '-1' },
   initialize: function (options) {
     this.listenTo(options.appState, 'change:beaconType', function (model, type) {
       this.$el.toggleClass(CAN_REMOVE_BEACON_CLS, type === 'security');

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -76,7 +76,7 @@ export default View.extend({
     '\
       <div class="okta-sign-in-header auth-header">\
         {{#if logo}}\
-        <img src="{{logo}}" class="auth-org-logo" alt="{{logoText}}">\
+        <img src="{{logo}}" class="auth-org-logo" alt="{{logoText}} logo" aria-label="{{logoText}} logo">\
         {{/if}}\
         <div data-type="beacon-container" class="beacon-container"></div>\
       </div>\

--- a/src/views/shared/SkipLink.js
+++ b/src/views/shared/SkipLink.js
@@ -1,0 +1,11 @@
+import { loc, View } from 'okta';
+import Enums from 'util/Enums';
+
+export default View.extend({
+  tagName: 'a',
+  className: 'skip-to-content-link',
+  attributes: { href: `#${Enums.WIDGET_CONTAINER_ID}` },
+  initialize: function initialize () {
+    this.$el.append(loc('skip.to.main.content', 'login'));
+  }
+});

--- a/src/views/shared/templates/consentLogoHeaderTemplate.js
+++ b/src/views/shared/templates/consentLogoHeaderTemplate.js
@@ -1,0 +1,21 @@
+import hbs from 'handlebars-inline-precompile';
+
+const consentLogoHeaderTemplate = hbs`{{#if clientURI}}
+ <a href="{{clientURI}}" class="client-logo-link" target="_blank">
+{{/if}}
+{{#if customLogo}}
+  <img class="client-logo custom-logo" src="{{customLogo}}" alt="aria logo" aria-hidden="true" />
+{{else}}
+  <img class="client-logo default-logo" src="{{defaultLogo}}" alt="aria logo" aria-hidden="true" />
+{{/if}}
+{{#if clientURI}}
+  </a>
+{{/if}}
+<h1>
+  <span class="title-text">{{{i18n code="consent.required.text" bundle="login" arguments="appName"}}}</span>
+  {{#if issuer}}
+    <div class="issuer"><span>{{issuer}}</span></div>
+  {{/if}}
+</h1>`;
+
+export default consentLogoHeaderTemplate;


### PR DESCRIPTION
## Description:
Accessibility improvements for OAuth Consent and AdminConsent required views:
- add focus state to input elements inside auth container
- add aria attributes for logo images
- match button tab order to visual hierarchy, i.e. `Don't allow` is focused via tab before `Allow`

Improvements for all of SIW:
- update font color variables `$header-text-color`, `$medium-text-color`, and `$text-color-light`
- add a main landmark to SIW 
- add a skip link to SIW

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Demo with screen reader: https://okta.box.com/s/7a4pkpk7596zs9ghpymgo2ptrm1dqctu

Skip link shows only on focus:
<img width="789" alt="Screen Shot 2020-11-20 at 12 19 33 PM" src="https://user-images.githubusercontent.com/71431120/99848279-5802ca80-2b2e-11eb-9a47-52137c0e8330.png">

Consent
<img width="467" alt="Screen Shot 2020-11-19 at 2 00 15 PM" src="https://user-images.githubusercontent.com/71431120/99729366-a9985000-2a6f-11eb-89de-addf21c2f85c.png">
<img width="448" alt="Screen Shot 2020-11-19 at 2 00 21 PM" src="https://user-images.githubusercontent.com/71431120/99729369-aac97d00-2a6f-11eb-9b63-51d7fc797818.png">

AdminConsent
<img width="434" alt="Screen Shot 2020-11-12 at 11 22 07 AM" src="https://user-images.githubusercontent.com/71431120/98986903-5b68d700-24da-11eb-9fd4-62a0be2d925c.png">
<img width="441" alt="Screen Shot 2020-11-12 at 11 22 00 AM" src="https://user-images.githubusercontent.com/71431120/98986899-5a37aa00-24da-11eb-9a8f-4f1d1dc9529f.png">

### Reviewers:


### Issue:

- [OKTA-334550](https://oktainc.atlassian.net/browse/OKTA-334550)
- [OKTA-334664](https://oktainc.atlassian.net/browse/OKTA-334664)
- [OKTA-337231](https://oktainc.atlassian.net/browse/OKTA-337231)
