### PR TITLE
feat: implement oda/mdm remediation for Okta Verify not installed case

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -54,6 +54,10 @@ export default Model.extend({
     // IDX API VERSION
     apiVersion: ['string', true, '1.0.0'],
 
+    // attribute to hold proxy (fake) idx response
+    // to render static pages without initiating idx pipeline
+    proxyIdxResponse: ['object', false],
+
     // FEATURES
     'features.router': ['boolean', true, false],
     'features.securityImage': ['boolean', true, false],

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -153,7 +153,7 @@ var OktaSignIn = (function () {
     var authClient = createAuthClient(authParams);
 
     var Router;
-    if (options.stateToken && !Util.isV1StateToken(options.stateToken)) {
+    if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) || options.proxyIdxResponse) {
       Router = V2Router;
     } else {
       Router = V1Router;

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock } from 'testcafe';
+import {ClientFunction, RequestLogger, RequestMock} from 'testcafe';
 import DeviceEnrollmentTerminalPageObject from '../framework/page-objects/DeviceEnrollmentTerminalPageObject';
 import IOSOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-ios';
 import AndroidOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-android';
@@ -15,6 +15,11 @@ const androidOdaMock = RequestMock()
 const mdmMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(MdmEnrollment);
+
+const rerenderWidget = ClientFunction((settings) => {
+  // function `renderPlaygroundWidget` is defined in playground/main.js
+  window.renderPlaygroundWidget(settings);
+});
 
 fixture('Device enrollment terminal view for ODA and MDM');
 
@@ -66,4 +71,66 @@ test
     await t.expect(content).contains('Follow the instructions in your browser to set up Airwatch, then try accessing this app again');
     await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
     await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://sampleEnrollmentlink.com');
+  });
+
+// Below two tests are covering a special use case in ODA Universal Link flow
+// When the user clicks on the button, if Okta Verify is not installed it will be redirected to /authenticators/ov-not-installed
+// And the endpoint will return a new SIW with proxyIdxResponse in config
+// These tests are testing SIW can directly render terminal page when receiving such proxyIdxResponse instead of making introspect call
+// The mocks and device enrollment values are intentionally set differently from above tests to make sure the we properly consume SIW config
+test
+  .requestHooks(logger, mdmMock)('shows the correct content in iOS ODA terminal view when Okta Verify is not installed in Universal Link flow', async t => {
+    const deviceEnrollmentTerminalPage = await setup(t);
+    await rerenderWidget({
+      'proxyIdxResponse': {
+        'deviceEnrollment': {
+          'type': 'object',
+          'value': {
+            'name': 'oda',
+            'platform': 'IOS',
+            'enrollmentLink': '',
+            'vendor': '',
+            'signInUrl': 'https://rain.okta1.com'
+          }
+        }
+      }
+    });
+    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Download Okta Verify');
+    await t.expect(deviceEnrollmentTerminalPage.getBeaconClass()).contains('mfa-okta-verify');
+    const content = deviceEnrollmentTerminalPage.getContentText();
+    await t.expect(content).contains('To sign in using Okta Verify, you');
+    await t.expect(content).contains('ll need to set up Okta Verify on this device. Download the Okta Verify app on the App Store.');
+    await t.expect(content).contains('In the app, follow the instructions to add an organizational account.');
+    await t.expect(content).contains('When prompted, choose Sign In, then enter the sign-in URL:');
+    await t.expect(content).contains('https://rain.okta1.com');
+    await t.expect(deviceEnrollmentTerminalPage.getAppStoreLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
+    await t.expect(deviceEnrollmentTerminalPage.getAppStoreLogo()).contains('ios-app-store-logo');
+  });
+
+test
+  .requestHooks(logger, iosOdaMock)('shows the correct content in iOS MDM terminal view when Okta Verify is not installed in Universal Link flow', async t => {
+    const deviceEnrollmentTerminalPage = await setup(t);
+    await rerenderWidget({
+      'proxyIdxResponse': {
+        'deviceEnrollment': {
+          'type': 'object',
+          'value': {
+            'name': 'mdm',
+            'platform': 'IOS',
+            'enrollmentLink': 'https://anotherSampleEnrollmentlink.com',
+            'vendor': 'MobileIron',
+            'signInUrl': ''
+          }
+        }
+      }
+    });
+    await t.expect(deviceEnrollmentTerminalPage.getHeader()).eql('Additional setup required');
+    const content = deviceEnrollmentTerminalPage.getContentText();
+    await t.expect(content).contains('To access this app, your device needs to meet your organization');
+    await t.expect(content).contains('s security requirements. Follow the instructions below to continue.');
+    await t.expect(content).contains('Tap the Copy Link button below.');
+    await t.expect(content).contains('On this device, open your browser, then paste the copied link into the address bar.');
+    await t.expect(content).contains('Follow the instructions in your browser to set up MobileIron, then try accessing this app again');
+    await t.expect(deviceEnrollmentTerminalPage.getCopyButtonLabel()).eql('Copy link to clipboard');
+    await t.expect(deviceEnrollmentTerminalPage.getCopiedValue()).eql('https://anotherSampleEnrollmentlink.com');
   });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -355,6 +355,30 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     return signIn.renderEl({ el: $sandbox });
   }
 
+  function setupProxyIdxResponse (options) {
+    signIn = new Widget(
+      Object.assign(
+        {
+          baseUrl: url,
+          proxyIdxResponse: {
+            deviceEnrollment: {
+              type: 'object',
+              value: {
+                name: options.enrollmentType,
+                platform: 'IOS',
+                enrollmentLink: 'https://sampleEnrollmentlink.com',
+                vendor: 'Airwatch',
+                signInUrl: 'https://idx.okta1.com'
+              }
+            }
+          }
+        },
+        options || {}
+      )
+    );
+    return signIn.renderEl({ el: $sandbox });
+  }
+
   Expect.describe('Introspects token and loads Identifier view for new pipeline', function () {
     itp('calls introspect API on page load using idx-js as client', function () {
       const form = new IdentifierForm($sandbox);
@@ -384,6 +408,14 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         expect(err.name).toBe('CONFIG_ERROR');
         expect(err.message.toString()).toEqual('Error: Unknown api version: 2.0.0.  Use an exact semver version.');
       });
+    });
+  });
+
+  itp('Gets proxyIdxResponse and render terminal view', function () {
+    setupProxyIdxResponse({ enrollmentType : 'mdm'});
+
+    return Expect.wait(() => {
+      return $('.siw-main-body').length === 1;
     });
   });
 });


### PR DESCRIPTION
## Description:

This is implementing a special use case in oda/mdm remediation flow. When Okta Verify is not installed and user clicks on the button, it will be first redirected to login.okta.com and then redirected back to /authenticators/ov-not-installed. This endpoint will return a new SIW along with a proxyIdxResponse value in SIW config which contains the device enrollment object values we need.

The way we implement it is: if SIW detects such a proxyIdxResponse in config, it will still go to V2 router but won't make an introspect call by default. This is to make it a more generic solution in case we have similar use case to pass some customized config from server side.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
https://okta.box.com/s/c6d7fit1wzxsxq475rhfg4t33nhl92y1

### Reviewers:


### Issue:

- [OKTA-342925](https://oktainc.atlassian.net/browse/OKTA-342925)


