### PR TITLE
fix: renamed text for okta verify fastpass

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -796,7 +796,7 @@ oie.okta_verify.totp.enterCodeText = Enter code from Okta Verify app
 oie.okta_verify.push.title = Get a push notification
 oie.okta_verify.push.sent = Push notification sent
 oie.okta_verify.push.send = Send push notification
-oie.okta_verify.signed_nonce.title = Use Okta FastPass
+oie.okta_verify.signed_nonce.label = Use Okta Verify on this device
 
 ## Select authenticator enrollment
 oie.select.authenticators.enroll.title = Set up Authenticators

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -57,11 +57,11 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-authenticate.authenticator.phone': 'oie.authenticator.phone.label',
   'select-authenticator-authenticate.authenticator.security_key': 'oie.authenticator.webauthn.label',
   'select-authenticator-authenticate.authenticator.security_question': 'oie.authenticator.security.question.label',
-  'select-authenticator-authenticate.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.title',
+  'select-authenticator-authenticate.authenticator.app.signed_nonce': 'oie.okta_verify.signed_nonce.label',
   'select-authenticator-authenticate.authenticator.app.push': 'oie.okta_verify.push.title',
   'select-authenticator-authenticate.authenticator.app.totp': 'oie.okta_verify.totp.title',
 
-  'authenticator-verification-data.app.authenticator.methodType.signed_nonce': 'oie.okta_verify.signed_nonce.title',
+  'authenticator-verification-data.app.authenticator.methodType.signed_nonce': 'oie.okta_verify.signed_nonce.label',
   'authenticator-verification-data.app.authenticator.methodType.push': 'oie.okta_verify.push.title',
   'authenticator-verification-data.app.authenticator.methodType.totp': 'oie.okta_verify.totp.title',
 

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -31,7 +31,7 @@ test.requestHooks(mockChallengeOVSelectMethod)('should load select method list w
   await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
   await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
   //await t.expect(selectAuthenticatorPage.getFactorsCount()).eql(3);
-  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(0)).eql('Use Okta FastPass');
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(0)).eql('Use Okta Verify on this device');
   await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(0)).eql('Select');

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -123,7 +123,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorIconClassByIndex(5)).contains('mfa-okta-security-question');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(5)).eql('Select');
 
-  await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Use Okta FastPass');
+  await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Use Okta Verify on this device');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(6)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(6)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(6)).eql('Select');
@@ -242,7 +242,7 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
 
-  await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Use Okta FastPass');
+  await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Use Okta Verify on this device');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
@@ -258,7 +258,7 @@ test.requestHooks(mockSelectAuthenticatorKnownDevice)('should load signed_nonce 
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(4);
 
-  await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Use Okta FastPass');
+  await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Use Okta Verify on this device');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -14,7 +14,7 @@ describe('v2/ion/i18nTransformer', function () {
       'oie.authenticator.phone.label': 'phone authenticator',
       'oie.webauthn': 'webauthn authenticator',
       'oie.authenticator.security.question.label': 'security question authenticator',
-      'oie.okta_verify.signed_nonce.title': 'okta verify fastpass',
+      'oie.okta_verify.signed_nonce.label': 'okta verify fastpass',
       'oie.okta_verify.push.title': 'okta verify push',
       'oie.okta_verify.totp.title': 'okta verify totp',
 


### PR DESCRIPTION
* Renamed "Use Okta Fastpass" to "Use Okta Verify on this device"
per UX recommendation.
*This applies to OIE only.

RESOLVES: OKTA-345207

<img width="706" alt="Screen Shot 2020-11-16 at 7 27 48 AM" src="https://user-images.githubusercontent.com/17267130/99273338-bdc51e80-27dd-11eb-85d2-3b0a9eafcd6c.png">


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-345207](https://oktainc.atlassian.net/browse/OKTA-345207)


