### PR TITLE
test: adds data-se attribute on buttons for authenticators select list

### DIFF
--- a/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
@@ -26,7 +26,7 @@ const AuthenticatorRow = View.extend({
           {{#if description}}\
             <p class="authenticator-description--text">{{description}}</p>\
           {{/if}}\
-          <div class="authenticator-button"></div>\
+          <div class="authenticator-button" {{#if buttonDataSeAttr}}data-se="{{buttonDataSeAttr}}"{{/if}}></div>\
         </div>\
       '),
   children: function () {

--- a/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
@@ -26,7 +26,7 @@ const AuthenticatorRow = View.extend({
               <p class="authenticator-description--text">{{description}}</p>\
             {{/if}}\
           </div>\
-          <div class="authenticator-button"></div>\
+          <div class="authenticator-button" {{#if buttonDataSeAttr}}data-se="{{buttonDataSeAttr}}"{{/if}}></div>\
         </div>\
       '),
   children: function (){

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -14,6 +14,15 @@ import FactorUtil from '../../../util/FactorUtil';
 
 const { getPasswordComplexityDescription, getPasswordComplexityDescriptionForHtmlList } = FactorUtil;
 
+const getButtonDataSeAttr = function (authenticator) {
+  if (authenticator.authenticatorType) {
+    const method = authenticator.value?.methodType ?
+      '-' + authenticator.value?.methodType : '';
+    return authenticator.authenticatorType + method;
+  }
+  return '';
+};
+
 /* eslint complexity: [2, 19] */
 const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
   const authenticatorType = authenticator.authenticatorType || authenticator.factorType;
@@ -26,6 +35,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.email.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-email',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -35,6 +45,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.password.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-password',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -44,6 +55,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? authenticator.relatesTo?.profile?.phoneNumber
         : loc('oie.phone.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-phone',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -53,6 +65,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.security.question.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-security-question',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -63,6 +76,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.webauthn.description', 'login'),
       iconClassName: 'mfa-webauthn',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -72,6 +86,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.webauthn.description', 'login'),
       iconClassName: 'mfa-webauthn',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
 
@@ -81,6 +96,7 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
         ? ''
         : loc('oie.okta_verify.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-verify',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
   }

--- a/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SelectAuthenticatorPageObject.js
@@ -5,6 +5,7 @@ const factorListRowSelector = '.authenticator-list .authenticator-row';
 const factorLabelSelector = `${factorListRowSelector} .authenticator-label`;
 const factorDescriptionSelector = `${factorListRowSelector} .authenticator-description .authenticator-description--text`;
 const factorIconSelector = `${factorListRowSelector} .authenticator-icon-container .authenticator-icon`;
+const factorSelectButtonDiv = `${factorListRowSelector} .authenticator-button`;
 const factorSelectButtonSelector = `${factorListRowSelector} .authenticator-button .button`;
 const skipOptionalEnrollmentSelector = '.authenticator-list .skip-all';
 const CUSTOM_SIGN_OUT_LINK_SELECTOR = '.auth-footer .js-cancel';
@@ -37,6 +38,10 @@ export default class SelectFactorPageObject extends BasePageObject {
 
   getFactorSelectButtonByIndex(index) {
     return this.form.getElement(factorSelectButtonSelector).nth(index).textContent;
+  }
+
+  getFactorSelectButtonDataSeByIndex(index) {
+    return this.form.getElement(factorSelectButtonDiv).nth(index).getAttribute('data-se');
   }
 
   async selectFactorByIndex(index) {

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -48,26 +48,31 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authentic
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Okta Password');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('password');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(0)).eql('Choose a password for your account');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Okta Phone');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-phone');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('phone');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(1)).eql('Verify with a code sent to your phone');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Security Key or Biometric Authenticator');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(2)).eql('Use a security key or a biometric authenticator to sign in');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-webauthn');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('security_key');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Okta Security Question');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-security-question');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(3)).eql('security_question');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(3)).eql('Choose a security question and answer that will be used for signing in');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(4)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(4)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(4)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(4)).eql('app');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(4))
     .eql('Okta Verify is an authenticator app, installed on your phone or computer, used to prove your identity');
 

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -95,38 +95,45 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('password');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Security Key or Biometric Authenticator');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-webauthn');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('security_key');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Okta Email');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-email');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('email');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Phone');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(true);
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(3)).eql('+1 XXX-XXX-5309');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-phone');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(3)).eql('phone');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(4)).eql('Phone');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(4)).eql(true);
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(4)).eql('+1 XXX-XXX-5310');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(4)).contains('mfa-okta-phone');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(4)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(4)).eql('phone');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(5)).eql('Okta Security Question');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(5)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(5)).contains('mfa-okta-security-question');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(5)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(5)).eql('security_question');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Use Okta Verify on this device');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(6)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(6)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(6)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(6)).eql('app-signed_nonce');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();
@@ -230,22 +237,26 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Get a push notification');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
-  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('app-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Enter a code');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('app-totp');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Okta Password');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('password');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Use Okta Verify on this device');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(3)).eql('app-signed_nonce');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();
@@ -262,21 +273,25 @@ test.requestHooks(mockSelectAuthenticatorKnownDevice)('should load signed_nonce 
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('app-signed_nonce');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Get a push notification');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('app-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Enter a code');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('app-totp');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Okta Password');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(3)).eql('password');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();
@@ -296,17 +311,20 @@ test.requestHooks(mockSelectAuthenticatorNoSignedNonce)('should not display sign
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Get a push notification');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
-  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('app-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Enter a code');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('app-totp');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Okta Password');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-password');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('password');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();

--- a/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
@@ -38,6 +38,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         factorType: 'password',
         iconClassName: 'mfa-okta-password',
         description: 'Choose a password for your account',
+        buttonDataSeAttr: '',
       },
       {
         label: 'Okta E-mail',
@@ -45,6 +46,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         factorType: 'email',
         iconClassName: 'mfa-okta-email',
         description: 'Verify with a link or code sent to your email',
+        buttonDataSeAttr: '',
       },
     ]);
     expect(opt).toEqual({
@@ -235,6 +237,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'password',
         description: '',
         iconClassName: 'mfa-okta-password',
+        buttonDataSeAttr: 'password',
       },
       {
         label: 'Security Key or Biometric Authenticator',
@@ -250,6 +253,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'security_key',
         description: '',
         iconClassName: 'mfa-webauthn',
+        buttonDataSeAttr: 'security_key',
       },
       {
         label: 'Okta Email',
@@ -270,6 +274,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'email',
         description: '',
         iconClassName: 'mfa-okta-email',
+        buttonDataSeAttr: 'email',
       },
       {
         label: 'Phone',
@@ -296,6 +301,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'phone',
         description: '+1 XXX-XXX-5309',
         iconClassName: 'mfa-okta-phone',
+        buttonDataSeAttr: 'phone',
       },
       {
         label: 'Phone',
@@ -322,6 +328,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'phone',
         description: '+1 XXX-XXX-5310',
         iconClassName: 'mfa-okta-phone',
+        buttonDataSeAttr: 'phone',
       },
       {
         label: 'Okta Security Question',
@@ -337,6 +344,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'security_question',
         description: '',
         iconClassName: 'mfa-okta-security-question',
+        buttonDataSeAttr: 'security_question',
       },
       {
         label: 'Okta Verify',
@@ -357,7 +365,8 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         },
         'authenticatorType':'app',
         'description': '',
-        'iconClassName':'mfa-okta-verify'
+        'iconClassName':'mfa-okta-verify',
+        buttonDataSeAttr: 'app-signed_nonce',
       }
     ]);
     // make sure input parameter is not mutated.
@@ -410,6 +419,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         },
         iconClassName: 'mfa-webauthn',
         description: '',
+        buttonDataSeAttr: 'security_key',
       },
       {
         label: 'Okta Password',
@@ -419,6 +429,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         },
         iconClassName: 'mfa-okta-password',
         description: '',
+        buttonDataSeAttr: 'password',
       },
     ]);
     // make sure input parameter is not mutated.
@@ -575,6 +586,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'password',
         description: 'Choose a password for your account',
         iconClassName: 'mfa-okta-password',
+        buttonDataSeAttr: 'password',
       },
       {
         label: 'Okta Phone',
@@ -590,6 +602,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'phone',
         description: 'Verify with a code sent to your phone',
         iconClassName: 'mfa-okta-phone',
+        buttonDataSeAttr: 'phone',
       },
       {
         label: 'Okta Email',
@@ -610,6 +623,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'email',
         description: 'Verify with a link or code sent to your email',
         iconClassName: 'mfa-okta-email',
+        buttonDataSeAttr: 'email',
       },
       {
         label: 'Security Key or Biometric Authenticator',
@@ -625,6 +639,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'security_key',
         description: 'Use a security key or a biometric authenticator to sign in',
         iconClassName: 'mfa-webauthn',
+        buttonDataSeAttr: 'security_key',
       },
       {
         label: 'Okta Security Question',
@@ -640,6 +655,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         authenticatorType: 'security_question',
         description: 'Choose a security question and answer that will be used for signing in',
         iconClassName: 'mfa-okta-security-question',
+        buttonDataSeAttr: 'security_question',
       },
       {
         label: 'Okta Verify',
@@ -660,7 +676,8 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
         },
         'authenticatorType':'app',
         'description':'Okta Verify is an authenticator app, installed on your phone or computer, used to prove your identity',
-        'iconClassName':'mfa-okta-verify'
+        'iconClassName':'mfa-okta-verify',
+        buttonDataSeAttr: 'app-signed_nonce',
       }
     ]);
     // make sure input parameter is not mutated.


### PR DESCRIPTION
Resolves: OKTA-347191

## Description:

Enroll:

![enrollAuthenticators](https://user-images.githubusercontent.com/26014318/99602731-ddfc0580-29b6-11eb-8e03-888744ffb2a5.gif)

Verify:

![verifyAuthenticators](https://user-images.githubusercontent.com/26014318/99602741-e2282300-29b6-11eb-841f-b6d3c312aee7.gif)

Verify OV:

![verifyAuthenticatorsOV](https://user-images.githubusercontent.com/26014318/99602764-e7856d80-29b6-11eb-8333-6eb96ca3a7df.gif)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-347191](https://oktainc.atlassian.net/browse/OKTA-347191)


