### PR TITLE
Tmm okta 312021 email authenticator terminal states

### DIFF
--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -153,10 +153,11 @@ export default Model.extend({
       && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
   },
 
-  containsMessageWithI18nKey (key) {
+  containsMessageWithI18nKey (keyOrKeys) {
+    const keys = [].concat(keyOrKeys);
     const messagesObjs = this.get('messages');
     return messagesObjs && Array.isArray(messagesObjs.value)
-      && messagesObjs.value.some(messagesObj => messagesObj.i18n?.key === key);
+      && messagesObjs.value.some(messagesObj => _.contains(keys, messagesObj.i18n?.key));
   },
 
   setIonResponse (transformedResponse) {

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -1,10 +1,21 @@
 import { createCallout, loc } from 'okta';
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
+import BaseHeader from '../internals/BaseHeader';
 import BaseFooter from '../internals/BaseFooter';
-import {getBackToSignInLink} from '../utils/LinksUtil';
+import HeaderBeacon from '../components/HeaderBeacon';
+import { getBackToSignInLink } from '../utils/LinksUtil';
+import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
 
 const RETURN_LINK_EXPIRED_KEY = 'idx.return.link.expired';
+const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
+  'idx.transferred.to.new.tab',
+  'idx.return.to.original.tab',
+  RETURN_LINK_EXPIRED_KEY,
+  'idx.return.stale',
+  'idx.return.error'
+];
+const EMAIL_AUTHENTICATOR_TYPE = 'email';
 
 const Body = BaseForm.extend({
   noButtonBar: true,
@@ -44,6 +55,16 @@ const Body = BaseForm.extend({
 
 });
 
+const HeaderBeaconTerminal = HeaderBeacon.extend({
+  getBeaconClassName: function () {
+    if (this.options.appState.containsMessageWithI18nKey(EMAIL_AUTHENTICATOR_TERMINAL_KEYS)) {
+      return getIconClassNameForBeacon(EMAIL_AUTHENTICATOR_TYPE);
+    } else {
+      return HeaderBeacon.prototype.getBeaconClassName.apply(this, arguments);
+    }
+  }
+});
+
 const Footer = BaseFooter.extend({
   links: function () {
     if (this.options.appState.containsMessageWithI18nKey(RETURN_LINK_EXPIRED_KEY)) {
@@ -53,6 +74,9 @@ const Footer = BaseFooter.extend({
 });
 
 export default BaseView.extend({
+  Header: BaseHeader.extend({
+    HeaderBeacon: HeaderBeaconTerminal,
+  }),
   Body,
   Footer
 });

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -1,7 +1,12 @@
+import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
 import CalloutObject from './components/CalloutObject';
 
 export default class TerminalPageObject extends BasePageObject {
+
+  constructor () {
+    this.beacon = new Selector('.beacon-container');
+  }
 
   getHeader() {
     return this.form.getTitle();
@@ -19,4 +24,7 @@ export default class TerminalPageObject extends BasePageObject {
     return this.form.waitForErrorBox();
   }
 
+  getBeaconClass() {
+    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
+  }
 }

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -4,7 +4,8 @@ import CalloutObject from './components/CalloutObject';
 
 export default class TerminalPageObject extends BasePageObject {
 
-  constructor () {
+  constructor (t) {
+    super(t);
     this.beacon = new Selector('.beacon-container');
   }
 

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -213,6 +213,7 @@ test
     await setup(t);
     const terminalPageObject = new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Please return to the original tab.');
+    await t.expect(terminalPageObject.getBeaconClass()).contains('mfa-okta-email');
 
     const { log } = await t.getBrowserConsoleMessages();
     await t.expect(log.length).eql(3);
@@ -230,6 +231,7 @@ test
     await setup(t);
     const terminalPageObject = new TerminalPageObject(t);
     await t.expect(terminalPageObject.getMessages()).eql('Flow continued in a new tab.');
+    await t.expect(terminalPageObject.getBeaconClass()).contains('mfa-okta-email');
   });
 
 test
@@ -238,6 +240,7 @@ test
     const terminalPageObject = new TerminalPageObject(t);
     await t.expect(terminalPageObject.getErrorMessages().isError()).eql(true);
     await t.expect(terminalPageObject.getErrorMessages().getTextContent()).eql('This email link has expired. To resend it, return to the screen where you requested it.');
+    await t.expect(terminalPageObject.getBeaconClass()).contains('mfa-okta-email');
     await t.expect(await terminalPageObject.goBackLinkExists()).ok();
     await t.expect(terminalPageObject.getFormTitle()).eql('Verify with your email');
   });

--- a/test/testcafe/spec/GenericErrorHandling_spec.js
+++ b/test/testcafe/spec/GenericErrorHandling_spec.js
@@ -33,10 +33,12 @@ test.requestHooks(noMessagesErrorMock)('should be able generic error when reques
   const terminalPage = await setup(t);
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('There was an unexpected internal error. Please try again.');
+  await t.expect(terminalPage.getBeaconClass()).notContains('mfa-okta-email');
 });
 
 test.requestHooks(securityAccessDeniedMock)('should be able display error when request failed ith 403 with no stateToken', async t => {
   const terminalPage = await setup(t);
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('You do not have permission to perform the requested action.');
+  await t.expect(terminalPage.getBeaconClass()).notContains('mfa-okta-email');
 });

--- a/test/testcafe/spec/Introspect_spec.js
+++ b/test/testcafe/spec/Introspect_spec.js
@@ -40,6 +40,7 @@ test.requestHooks(introspectRequestLogger, introspectMock)('shall display error 
 
   await t.expect(errors.isError()).ok();
   await t.expect(errors.getTextContent()).eql('Internal Server Error');
+  await t.expect(terminalPageObject.getBeaconClass()).notContains('mfa-okta-email');
 
   await t.expect(introspectRequestLogger.count(() => true)).eql(1);
   const req = introspectRequestLogger.requests[0].request;


### PR DESCRIPTION
## Description:

### Status

**WIP**.  The modified testcafe tests pass, but I must still be doing something wrong -- when I take the alpha build from this and use it in my local Rain, the terminal view (for the `idx.return.to.original.tab` key) still has the default beacon.



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [] Added unit tests?

- [X] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-312021](https://oktainc.atlassian.net/browse/OKTA-312021)


