### PR TITLE
fix: fixing beacon for email terminal views

### DIFF
--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -153,10 +153,13 @@ export default Model.extend({
       && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
   },
 
-  containsMessageWithI18nKey (key) {
+  containsMessageWithI18nKey (keys) {
+    if (!Array.isArray(keys)) {
+      keys = [ keys ];
+    }
     const messagesObjs = this.get('messages');
     return messagesObjs && Array.isArray(messagesObjs.value)
-      && messagesObjs.value.some(messagesObj => messagesObj.i18n?.key === key);
+      && messagesObjs.value.some(messagesObj => _.contains(keys, messagesObj.i18n?.key));
   },
 
   setIonResponse (transformedResponse) {

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -2,9 +2,30 @@ import { createCallout, loc } from 'okta';
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
 import BaseFooter from '../internals/BaseFooter';
-import {getBackToSignInLink} from '../utils/LinksUtil';
+import BaseHeader from '../internals/BaseHeader';
+import HeaderBeacon from '../components/HeaderBeacon';
+import { getBackToSignInLink } from '../utils/LinksUtil';
+import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
 
 const RETURN_LINK_EXPIRED_KEY = 'idx.return.link.expired';
+
+const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
+  'idx.transferred.to.new.tab',
+  'idx.return.to.original.tab',
+  RETURN_LINK_EXPIRED_KEY,
+  'idx.return.stale',
+  'idx.return.error'
+];
+
+const EMAIL_AUTHENTICATOR_TYPE = 'email';
+
+const HeaderBeaconTerminal = HeaderBeacon.extend({
+  getBeaconClassName: function () {
+    return this.options.appState.containsMessageWithI18nKey(EMAIL_AUTHENTICATOR_TERMINAL_KEYS)
+      ? getIconClassNameForBeacon(EMAIL_AUTHENTICATOR_TYPE)
+      : HeaderBeacon.prototype.getBeaconClassName.apply(this, arguments);
+  }
+});
 
 const Body = BaseForm.extend({
   noButtonBar: true,
@@ -53,6 +74,9 @@ const Footer = BaseFooter.extend({
 });
 
 export default BaseView.extend({
+  Header: BaseHeader.extend({
+    HeaderBeacon: HeaderBeaconTerminal,
+  }),
   Body,
   Footer
 });

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -14,7 +14,8 @@ const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
   'idx.return.to.original.tab',
   RETURN_LINK_EXPIRED_KEY,
   'idx.return.stale',
-  'idx.return.error'
+  'idx.return.error',
+  'idx.email.verification.required'
 ];
 
 const EMAIL_AUTHENTICATOR_TYPE = 'email';

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -1,7 +1,13 @@
+import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
 import CalloutObject from './components/CalloutObject';
 
 export default class TerminalPageObject extends BasePageObject {
+
+  constructor (t) {
+    super(t);
+    this.beacon = new Selector('.beacon-container');
+  }
 
   getHeader() {
     return this.form.getTitle();
@@ -19,4 +25,7 @@ export default class TerminalPageObject extends BasePageObject {
     return this.form.waitForErrorBox();
   }
 
+  getBeaconClass() {
+    return this.beacon.find('[data-se="factor-beacon"]').getAttribute('class');
+  }
 }

--- a/test/testcafe/spec/GenericErrorHandling_spec.js
+++ b/test/testcafe/spec/GenericErrorHandling_spec.js
@@ -39,4 +39,5 @@ test.requestHooks(securityAccessDeniedMock)('should be able display error when r
   const terminalPage = await setup(t);
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('You do not have permission to perform the requested action.');
+  await t.expect(terminalPage.getBeaconClass()).notContains('mfa-okta-email');
 });

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -1,0 +1,40 @@
+import { RequestMock } from 'testcafe';
+import terminalReturnEmail from '../../../playground/mocks/data/idp/idx/terminal-return-email';
+import terminalTransferEmail from '../../../playground/mocks/data/idp/idx/terminal-transfered-email';
+import terminalReturnExpiredEmail from '../../../playground/mocks/data/idp/idx/terminal-return-expired-email';
+import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
+
+const terminalTransferredEmailMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(terminalTransferEmail);
+
+const terminalReturnEmailMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(terminalReturnEmail);
+
+const terminalReturnExpiredEmailMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(terminalReturnExpiredEmail);
+
+fixture('Terminal view');
+
+async function setup (t) {
+  const terminalPageObject = new TerminalPageObject(t);
+  await terminalPageObject.navigateToPage();
+  return terminalPageObject;
+}
+
+[
+  [ 'Shows the correct beacon for trasferred to new tab scenario for email terminalview',
+    terminalTransferredEmailMock ],
+  [ 'Shows the correct beacon for return to original tab scenario for email terminalview',
+    terminalReturnEmailMock ],
+  [ 'Shows the correct beacon for expired email terminalview',
+    terminalReturnExpiredEmailMock ],
+].forEach(([ testTitle, mock ]) => {
+  test
+    .requestHooks(mock)(testTitle, async t => {
+      const terminalViewPage = await setup(t);
+      await t.expect(terminalViewPage.getBeaconClass()).contains('mfa-okta-email');
+    });
+});

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -2,7 +2,9 @@ import { RequestMock } from 'testcafe';
 import terminalReturnEmail from '../../../playground/mocks/data/idp/idx/terminal-return-email';
 import terminalTransferEmail from '../../../playground/mocks/data/idp/idx/terminal-transfered-email';
 import terminalReturnExpiredEmail from '../../../playground/mocks/data/idp/idx/terminal-return-expired-email';
+import terminalRegistrationEmail from '../../../playground/mocks/data/idp/idx/terminal-registration';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
+
 
 const terminalTransferredEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -15,6 +17,10 @@ const terminalReturnEmailMock = RequestMock()
 const terminalReturnExpiredEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalReturnExpiredEmail);
+
+const terminalRegistrationEmailMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(terminalRegistrationEmail);
 
 fixture('Terminal view');
 
@@ -31,6 +37,7 @@ async function setup (t) {
     terminalReturnEmailMock ],
   [ 'Shows the correct beacon for expired email terminalview',
     terminalReturnExpiredEmailMock ],
+  [ 'Shows the correct beacon for email sent terminalview', terminalRegistrationEmailMock ]
 ].forEach(([ testTitle, mock ]) => {
   test
     .requestHooks(mock)(testTitle, async t => {


### PR DESCRIPTION
## Description:
Ref https://github.com/okta/okta-signin-widget/pull/1525/files


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Before - 
![image](https://user-images.githubusercontent.com/62976351/100143625-9ea04e00-2ebb-11eb-9e75-fc0834353021.png)

After -
![image](https://user-images.githubusercontent.com/62976351/99878121-35091100-2c29-11eb-94e9-c373754aa5b3.png)

### Reviewers:


### Issue:

- [OKTA-312021](https://oktainc.atlassian.net/browse/OKTA-312021)


