### PR TITLE
fix: remove sign out link from the fastpass probing screen

### DIFF
--- a/src/v2/view-builder/views/SignInDeviceView.js
+++ b/src/v2/view-builder/views/SignInDeviceView.js
@@ -1,8 +1,9 @@
-import { loc } from 'okta';
+import { $, _, loc } from 'okta';
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
 import IdentifierFooter from '../components/IdentifierFooter';
 import SignInWithDeviceOption from './signin/SignInWithDeviceOption';
+import Link from '../components/Link';
 
 const Body = BaseForm.extend({
 
@@ -25,7 +26,26 @@ const Body = BaseForm.extend({
   },
 });
 
+// override the footer to add all the supported links except the sign out link
+// no session is granted at this point
+const Footer = IdentifierFooter.extend({
+  initialize () {
+    let links = _.resultCtx(this, 'links', this);
+    if (!Array.isArray(links)) {
+      links = [];
+    } else {
+      links = links.filter(l => $.isPlainObject(l));
+    }
+
+    links.forEach(link => {
+      this.add(Link, {
+        options: link,
+      });
+    });
+  }
+});
+
 export default BaseView.extend({
   Body,
-  Footer: IdentifierFooter,
+  Footer,
 });

--- a/test/testcafe/framework/page-objects/SignInDevicePageObject.js
+++ b/test/testcafe/framework/page-objects/SignInDevicePageObject.js
@@ -26,8 +26,16 @@ export default class SignInDeviceViewPageObject extends BasePageObject {
     return this.getTextContent('.okta-verify-container [data-se="button"]');
   }
 
-  getEnrollFooterLinkText() {
-    return this.footer.find('[data-se="enroll"]').innerText;
+  getEnrollFooterLink() {
+    return this.footer.find('[data-se="enroll"]');
+  }
+
+  getHelpFooterLink() {
+    return this.footer.find('[data-se="help"]');
+  }
+
+  getSignOutFooterLink() {
+    return this.footer.find('[data-se="cancel"]');
   }
 
   async clickLaunchOktaVerifyButton() {

--- a/test/testcafe/spec/SignInDeviceView_spec.js
+++ b/test/testcafe/spec/SignInDeviceView_spec.js
@@ -26,7 +26,6 @@ test('shows the correct content', async t => {
   await t.expect(signInDevicePage.getBeaconClass()).contains('undefined-user');
   await t.expect(signInDevicePage.getContentText()).eql('To access this resource, your organization requires you to sign in using your device.');
   await t.expect(signInDevicePage.getOVButtonLabel()).eql('Sign in using Okta Verify on this device');
-  await t.expect(signInDevicePage.getEnrollFooterLinkText()).eql('Sign Up');
 });
 
 test('clicking the launch Okta Verify button takes user to the right UI', async t => {
@@ -34,4 +33,11 @@ test('clicking the launch Okta Verify button takes user to the right UI', async 
   await signInDevicePage.clickLaunchOktaVerifyButton();
   const header = new Selector('h2[data-se="o-form-head"]');
   await t.expect(header.textContent).eql('Sign in using Okta Verify on this device');
+});
+
+test('shows the correct footer links', async t => {
+  const signInDevicePage = await setup(t);
+  await t.expect(signInDevicePage.getEnrollFooterLink().innerText).eql('Sign Up');
+  await t.expect(signInDevicePage.getHelpFooterLink().innerText).eql('Help');
+  await t.expect(signInDevicePage.getSignOutFooterLink().exists).eql(false);
 });


### PR DESCRIPTION
## Description:

While in the fastpass probing screen, user session has not be granted yet. The cancel/signout link takes the enduser back to the beginning of the sign in flow for retry. This may bring the enduser back to the same probing screen again. So remove the sign out link from the screen as there's no way to remove the cancel object from IDX API response.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
<img width="1058" alt="Screen Shot 2020-11-24 at 10 10 16 PM" src="https://user-images.githubusercontent.com/5066836/100189865-03e74580-2ea2-11eb-9f17-9f97de9fb078.png">

### Reviewers:
@pradeepdewda-okta @yannongli-okta @stevennguyen-okta 

### Issue:

- [OKTA-347068](https://oktainc.atlassian.net/browse/OKTA-347068)


