### PR TITLE
Corrected sample for exists()

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,12 +466,14 @@ Returns the underlying [`@okta/okta-auth-js`](https://github.com/okta/okta-auth-
 
 ```javascript
 // Check for an existing authClient transaction
-signIn.authClient.tx.exists();
-if (exists) {
-  console.log('A session exists!');
-} else {
-  console.log('A session does not exist.');
-};
+signIn.authClient.session.exists()
+.then(function(exists) {
+  if (exists){
+    console.log('A session exists!');
+  } else {
+    console.log('A session does not exist.');
+  };
+});
 ```
 
 ## Configuration


### PR DESCRIPTION
## Description:
tx.exists is from a previous AuthJS version, and session.exists() should be used instead Also, the exists var was not being created/set


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


