### PR TITLE
fix: sign in button text wrap

### DIFF
--- a/assets/sass/v2/_identify.scss
+++ b/assets/sass/v2/_identify.scss
@@ -1,7 +1,7 @@
 .sign-in-with-device-option {
   .okta-verify-container {
     .okta-verify-authenticator {
-      margin-right: 0.83em;
+      margin: 0 0.83em 0 0;
     }
   }
 }
@@ -23,10 +23,17 @@
       margin-bottom: 0.83em;
     }
     .button {
-      display: block;
+      display: flex;
       position: relative;
-      height: 50px;
-      line-height: 50px;
+      min-height: 50px;
+      height: auto;
+      padding-top: 10px;
+      padding-bottom: 10px;
+      line-height: 1.4;
+      align-items: center;
+      .okta-verify-authenticator {
+        flex-shrink: 0;
+      }
     }
   }
   .separation-line {


### PR DESCRIPTION
sign in button text wrap

OKTA-350404

two line version:
<img width="506" alt="Screen Shot 2020-12-08 at 1 10 48 AM" src="https://user-images.githubusercontent.com/54867795/101416454-93551580-38f2-11eb-98fe-8cd4af87fcdd.png">

one line version:
<img width="538" alt="Screen Shot 2020-12-08 at 5 06 12 PM" src="https://user-images.githubusercontent.com/54867795/101501128-06549f80-3978-11eb-8d9f-6957751b9adf.png">

<img width="524" alt="Screen Shot 2020-12-08 at 7 30 47 PM" src="https://user-images.githubusercontent.com/54867795/101519594-052d6d80-398c-11eb-9321-84a2f153c369.png">


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Issue:

- [OKTA-350404](https://oktainc.atlassian.net/browse/OKTA-350404)


