### PR TITLE
fix: revert word break for oie

### DIFF
--- a/assets/sass/v2/_forms.scss
+++ b/assets/sass/v2/_forms.scss
@@ -22,4 +22,9 @@
       line-height: inherit;
     }
   }
+
+  .o-form-explain.o-form-input-error {
+    word-break: normal; // Change word-break for M1 to default value OKTA-345397
+  }
+
 }


### PR DESCRIPTION
## Description:
In M1 views, the sentence doesn't abruptly break in-between words now.

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/62976351/101390085-4cfab900-38e8-11eb-90a1-a9eb9c26115b.png)

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [X] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Reviewers:
@haishengwu-okta 

### Issue:

- [OKTA-345397](https://oktainc.atlassian.net/browse/OKTA-345397)


