### PR TITLE
feat: updates sign on success message

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -814,7 +814,9 @@ oie.select.authenticators.verify.title = Verify it\'s you with an authenticator
 oie.select.authenticators.verify.subtitle = Select from the following options
 
 ## Success Redirect
-oie.success.redirect = You are being redirected
+oie.success.text.signingIn = Signing in
+oie.success.text.signingIn.with.appName = Signing in to {0}
+oie.success.text.signingIn.with.appName.and.identifier = Signing in to {0} as {1}
 
 ## Footer
 oie.go.back = Go back

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -60,6 +60,7 @@ const idx = {
     // 'select-factor-authenticate',
     // 'select-factor-for-password-recovery',
     // 'success',
+    // 'success-with-app-user',
     // 'terminal-return-email',
     // 'terminal-return-error-email',
     // 'terminal-return-expired-email',

--- a/playground/mocks/data/idp/idx/identify-with-only-one-third-party-idp-app-user.json
+++ b/playground/mocks/data/idp/idx/identify-with-only-one-third-party-idp-app-user.json
@@ -1,0 +1,54 @@
+{
+  "stateHandle": "inRUXNhsc6Evt7GAb8DPAA",
+  "version": "1.0.0",
+  "expiresAt": "2020-04-13T22:55:53.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "FACEBOOK",
+        "idp": {
+          "id": "facebook-idp-id-123",
+          "name": "Facebook IDP"
+        },
+        "href": "http://localhost:3000/sso/idps/facebook-idp-id-123?stateToken=inRUXNhsc6Evt7GAb8DPAA",
+        "method": "GET"
+      }
+    ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "inRUXNhsc6Evt7GAb8DPAA",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00ub0ttoyz062NeVa0g4",
+      "identifier": "admin@idx.com"
+    }
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "saasure",
+      "label": "Okta Administration",
+      "id": "0oa1heimi0IDMJoo90g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/success-with-app-user.json
+++ b/playground/mocks/data/idp/idx/success-with-app-user.json
@@ -1,0 +1,43 @@
+{
+    "stateHandle": "02EQcms7FOAByCjwRqpUCKfzxNJj2wJ_nh3x7zheyD",
+    "version": "1.0.0",
+    "expiresAt": "2020-12-08T00:31:33.000Z",
+    "intent": "LOGIN",
+    "success": {
+        "name": "success-redirect",
+        "href": "http://localhost:3000/app/UserHome?stateToken=mockedStateToken123"
+    },
+    "user": {
+      "type": "object",
+      "value": {
+        "id": "00ub0ttoyz062NeVa0g4",
+        "identifier": "admin@idx.com"
+      }
+    },
+    "cancel": {
+      "rel": [
+        "create-form"
+      ],
+      "name": "cancel",
+      "href": "http://localhost:3000/idp/idx/cancel",
+      "method": "POST",
+      "value": [
+        {
+          "name": "stateHandle",
+          "required": true,
+          "value": "02EQcms7FOAByCjwRqpUCKfzxNJj2wJ_nh3x7zheyD",
+          "visible": false,
+          "mutable": false
+        }
+      ],
+      "accepts": "application/ion+json; okta-version=1.0.0"
+    },
+    "app": {
+      "type": "object",
+      "value": {
+        "name": "saasure",
+        "label": "Okta Administration",
+        "id": "0oa1heimi0IDMJoo90g4"
+      }
+    }
+  }

--- a/src/v2/view-builder/views/SuccessView.js
+++ b/src/v2/view-builder/views/SuccessView.js
@@ -1,11 +1,32 @@
+import { _, loc } from 'okta';
+
 import BaseView from '../internals/BaseView';
 import BaseForm from '../internals/BaseForm';
 import Util from '../../../util/Util';
-import { loc } from 'okta';
 
 const Body = BaseForm.extend({
   title () {
-    return  loc('oie.success.redirect', 'login');
+    let titleString = loc('oie.success.text.signingIn', 'login');
+    // For more info on the API response available in appState, see IdxResponseBuilder.java
+    const app = this.options.appState.get('app');
+    const user = this.options.appState.get('user');
+
+    if (_.isEmpty(app)) {
+      return titleString;
+    }
+
+    const {label: appInstanceName, name: appDisplayName} = app;
+    const {identifier: userEmail} = user;
+
+    const appName = appInstanceName ? appInstanceName : appDisplayName;
+
+    if (appName && userEmail) {
+      titleString = loc('oie.success.text.signingIn.with.appName.and.identifier', 'login', [appName, userEmail]);
+    } else if (appName) {
+      titleString = loc('oie.success.text.signingIn.with.appName', 'login', [appName]);
+    }
+
+    return titleString;
   },
   noButtonBar: true,
   initialize () {

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -10,6 +10,7 @@ import XHRErrorIdentifyAccessDenied
 import XHRServerSafeMode
   from '../../../../../playground/mocks/data/idp/idx/safe-mode-optional-enrollment.json';
 import XHRSuccess from '../../../../../playground/mocks/data/idp/idx/success.json';
+import XHRSuccessWithAppUser from '../../../../../playground/mocks/data/idp/idx/success-with-app-user.json';
 import XHRIdentify from '../../../../../playground/mocks/data/idp/idx/identify.json';
 import XHRIdentifyWithThirdPartyIdps
   from '../../../../../playground/mocks/data/idp/idx/identify-with-third-party-idps.json';
@@ -301,6 +302,27 @@ describe('v2/ion/responseTransformer', function () {
         ],
         user: {
           id: '00ub0ttoyz062NeVa0g4',
+        },
+        idx: idxResp,
+      });
+    });
+  });
+
+  it('converts success ion response with app and user', done => {
+    MockUtil.mockIntrospect(done, XHRSuccessWithAppUser, idxResp => {
+      const result = transformResponse(testContext.settings, idxResp);
+      expect(result).toEqual({
+        app: { name: 'saasure', label: 'Okta Administration', id: '0oa1heimi0IDMJoo90g4' },
+        remediations: [
+          {
+            name: 'success-redirect',
+            href: 'http://localhost:3000/app/UserHome?stateToken=mockedStateToken123',
+            value: [],
+          },
+        ],
+        user: {
+          id: '00ub0ttoyz062NeVa0g4',
+          identifier: 'admin@idx.com',
         },
         idx: idxResp,
       });


### PR DESCRIPTION
## Description:
Changes text from "You are being redirected" to "Signing in to {appInstanceName} as {identifier}" or "Signing in to {appInstanceName}" if no identifier has been set. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
App set and User identifier set:
![Screen Shot 2020-12-10 at 11 07 09 AM](https://user-images.githubusercontent.com/71431120/101817843-dde3b700-3ad7-11eb-9660-8613daf1dc0e.png)
App set and no User identifier set:
![Screen Shot 2020-12-10 at 11 05 46 AM](https://user-images.githubusercontent.com/71431120/101817739-af65dc00-3ad7-11eb-9367-0342d04b324b.png)
No App or User set:
![Screen Shot 2020-12-11 at 2 37 44 PM](https://user-images.githubusercontent.com/71431120/101962361-d5b37680-3bc0-11eb-9f07-c0040b45cbe9.png)


### Reviewers:


### Issue:

- [OKTA-341975](https://oktainc.atlassian.net/browse/OKTA-341975)


