### PR TITLE
OKTA-340939 add verify with something else button for universal link and custom uri in challenge view

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -438,6 +438,65 @@ const ovSignedNonceLoopback = {
   ],
 };
 
+// ov challenge m2 signed nonce - loopback server fallsback to custom uri
+const ovSignedNonceLoopbackFallback = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-ov-m2'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-signed-nonce-loopback'
+  ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+    'success'
+  ],
+};
+
+// ov challenge m2 signed nonce - credential sso extension fallback to universal link
+const ovSignedNonceCredentialSsoExtensionFallback = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-ov-m2'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-signed-nonce-credential-extension'
+  ],
+  '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+    'success',
+  ],
+};
+
+// ov challenge m2 signed nonce - custom uri
+const ovSignedNonceCustomUri = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-ov-m2'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri'
+  ],
+  '/idp/idx/authenticators/poll': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+    'success',
+  ],
+};
+
+// ov challenge m2 signed nonce - universal link
+const ovSignedNonceUniversalLink = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-select-authenticator-ov-m2'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-signed-nonce-universal-link'
+  ],
+  '/idp/idx/authenticators/poll': [
+    'authenticator-verification-okta-verify-signed-nonce-universal-link',
+    'success',
+  ],
+};
+
 // no profile available for verification
 const phoneVerificationNoPhoneNumber = {
   '/idp/idx/introspect': [

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-credential-extension.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-credential-extension.json
@@ -1,7 +1,7 @@
 {
-  "stateHandle":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+  "stateHandle":"02AsnBjciGzNu9WbpJHmNz3TAdYyLJlNqssTZg4oh7",
   "version":"1.0.0",
-  "expiresAt":"2020-12-08T06:57:17.000Z",
+  "expiresAt":"2020-12-08T06:19:04.000Z",
   "intent":"LOGIN",
   "remediation":{
     "type":"array",
@@ -10,18 +10,14 @@
         "rel":[
           "create-form"
         ],
-        "name":"challenge-poll",
-        "relatesTo":[
-          "$.currentAuthenticator"
-        ],
-        "href":"http://localhost:3000/idp/idx/authenticators/poll",
+        "name":"device-apple-sso-extension",
+        "href":"http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/ftz7G1ciF-aNDvJUwlbbrsbaBtbXO-E-oy/verify",
         "method":"POST",
-        "refresh":4000,
         "value":[
           {
             "name":"stateHandle",
             "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+            "value":"02AsnBjciGzNu9WbpJHmNz3TAdYyLJlNqssTZg4oh7",
             "visible":false,
             "mutable":false
           }
@@ -61,6 +57,10 @@
                             "value":"totp"
                           },
                           {
+                            "label":"Get a push notification",
+                            "value":"push"
+                          },
+                          {
                             "label":"Use Okta FastPass",
                             "value":"signed_nonce"
                           }
@@ -91,14 +91,14 @@
                     ]
                   }
                 },
-                "relatesTo":"$.authenticatorEnrollments.value[2]"
+                "relatesTo":"$.authenticatorEnrollments.value[1]"
               }
             ]
           },
           {
             "name":"stateHandle",
             "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+            "value":"02AsnBjciGzNu9WbpJHmNz3TAdYyLJlNqssTZg4oh7",
             "visible":false,
             "mutable":false
           }
@@ -110,37 +110,11 @@
   "currentAuthenticator":{
     "type":"object",
     "value":{
-      "cancel":{
-        "rel":[
-          "create-form"
-        ],
-        "name":"cancel-polling",
-        "href":"http://localhost:3000/idp/idx/authenticators/poll/cancel",
-        "method":"POST",
-        "value":[
-          {
-            "name":"stateHandle",
-            "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
-            "visible":false,
-            "mutable":false
-          }
-        ],
-        "accepts":"application/ion+json; okta-version=1.0.0"
-      },
       "contextualData":{
         "challenge":{
           "type":"object",
           "value":{
-            "challengeMethod":"LOOPBACK",
-            "challengeRequest":"eyJraWQiOiJW",
-            "domain":"http://localhost",
-            "ports":[
-              "2000",
-              "6511",
-              "6512",
-              "6513"
-            ]
+            "challengeMethod":"APPLE_SSO_EXTENSION"
           }
         }
       },
@@ -162,6 +136,9 @@
         "id":"autmho3zRhIfiSzOy0g4",
         "displayName":"Okta Verify",
         "methods":[
+          {
+            "type":"push"
+          },
           {
             "type":"signed_nonce"
           },
@@ -187,25 +164,18 @@
     "value":[
       {
         "profile":{
-          "deviceName":"DESKTOP-9AD225Q"
+          "deviceName":"iPhone"
         },
         "type":"app",
-        "id":"pfdtxkyRQrmwfWdIE0g4",
+        "id":"pfdtxl6TyTsah6luW0g4",
         "displayName":"Okta Verify",
         "methods":[
           {
+            "type":"push"
+          },
+          {
             "type":"signed_nonce"
-          }
-        ]
-      },
-      {
-        "profile":{
-          "deviceName":"Display Name"
-        },
-        "type":"app",
-        "id":"pfdty6xBgVN8y7hWG0g4",
-        "displayName":"Okta Verify",
-        "methods":[
+          },
           {
             "type":"totp"
           }
@@ -213,7 +183,7 @@
       },
       {
         "type":"password",
-        "id":"lae3obwhjXZOu3dfz0g4",
+        "id":"lae4b6h8K3ACquiMv0g4",
         "displayName":"Password",
         "methods":[
           {
@@ -226,7 +196,7 @@
   "user":{
     "type":"object",
     "value":{
-      "id":"00umhs3GeoyNPfD360g4"
+      "id":"00uq3zsIIc2d7fBdx0g4"
     }
   },
   "cancel":{
@@ -240,7 +210,7 @@
       {
         "name":"stateHandle",
         "required":true,
-        "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+        "value":"02AsnBjciGzNu9WbpJHmNz3TAdYyLJlNqssTZg4oh7",
         "visible":false,
         "mutable":false
       }

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri.json
@@ -1,7 +1,7 @@
 {
   "stateHandle":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
   "version":"1.0.0",
-  "expiresAt":"2020-12-08T06:57:17.000Z",
+  "expiresAt":"2020-12-08T06:57:18.000Z",
   "intent":"LOGIN",
   "remediation":{
     "type":"array",
@@ -132,15 +132,9 @@
         "challenge":{
           "type":"object",
           "value":{
-            "challengeMethod":"LOOPBACK",
-            "challengeRequest":"eyJraWQiOiJW",
-            "domain":"http://localhost",
-            "ports":[
-              "2000",
-              "6511",
-              "6512",
-              "6513"
-            ]
+            "challengeMethod":"CUSTOM_URI",
+            "href":"com-okta-authenticator:/deviceChallenge?challengeRequest=eyJraWQiOiJYaGZCUk1haWRja0NKa2JOalFTVGlkYThINURRbTIxdkhjSlkydTFhaVR3IiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL2lkeG0xLm9rdGExLmNvbSIsImF1ZCI6Im9rdGEuNjNjMDgxZGItMWYxMy01MDg0LTg4MmYtZTc5ZTFlNWUyZGE3IiwiZXhwIjoxNjA3NDEwNjM4LCJpYXQiOjE2MDc0MTAzMzgsImp0aSI6ImZ0MllTRE1TYjFKMHg3c1BFejk5SFl2M3lfTWdNVEp6dDQiLCJub25jZSI6Im5xRXZWOG9kZ3JXamRnekw4UGp3IiwidHJhbnNhY3Rpb25JZCI6ImZ0MllTRE1TYjFKMHg3c1BFejk5SFl2M3lfTWdNVEp6dDQiLCJzaWduYWxzIjpbImlkIiwiZGlzcGxheU5hbWUiLCJwbGF0Zm9ybSIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwib3NWZXJzaW9uIiwic2VyaWFsTnVtYmVyIiwidWRpZCIsInNpZCIsImltZWkiLCJtZWlkIiwidHBtUHVibGljS2V5SGFzaCIsInNlY3VyZUhhcmR3YXJlUHJlc2VudCIsImRldmljZUF0dGVzdGF0aW9uIiwiZGV2aWNlSW50ZWdyaXR5Il0sInZlcmlmaWNhdGlvblVyaSI6Imh0dHBzOi8vaWR4bTEub2t0YTEuY29tL2lkcC9hdXRoZW50aWNhdG9ycy9hdXRtaG8zelJoSWZpU3pPeTBnNC90cmFuc2FjdGlvbnMvZnQyWVNETVNiMUoweDdzUEV6OTlIWXYzeV9NZ01USnp0NC92ZXJpZnkiLCJjYVN1YmplY3ROYW1lcyI6WyJNSUdQTVJNd0VRWUtDWkltaVpQeUxHUUJHUllEWTI5dE1SUXdFZ1lLQ1pJbWlaUHlMR1FCR1JZRWIydDBZVEVWTUJNR0NnbVNKb21UOGl4a0FSa1dCV2xrZUcweE1SMHdHd1lEVlFRTERCUXdNRzl0YUdkMmNGRlNPVXhWV21KQlREQm5OREVzTUNvR0ExVUVBd3dqVDNKbllXNXBlbUYwYVc5dUlFbHVkR1Z5YldWa2FXRjBaU0JCZFhSb2IzSnBkSGs9Il0sIm1kbUF0dGVzdGF0aW9uSXNzdWVycyI6W3siaXNzdWVyRE4iOiJNSUdQTVJNd0VRWUtDWkltaVpQeUxHUUJHUllEWTI5dE1SUXdFZ1lLQ1pJbWlaUHlMR1FCR1JZRWIydDBZVEVWTUJNR0NnbVNKb21UOGl4a0FSa1dCV2xrZUcweE1SMHdHd1lEVlFRTERCUXdNRzl0YUdkMmNGRlNPVXhWV21KQlREQm5OREVzTUNvR0ExVUVBd3dqVDNKbllXNXBlbUYwYVc5dUlFbHVkR1Z5YldWa2FXRjBaU0JCZFhSb2IzSnBkSGs9IiwiYWtpIjoibTdCVy9CQVdCS0ZlZkNwdDlTeWdKVjdtdVFBPSJ9XSwia2V5VHlwZSI6InVzZXJWZXJpZmljYXRpb24iLCJrZXlUeXBlcyI6WyJ1c2VyVmVyaWZpY2F0aW9uIl0sImZhY3RvclR5cGUiOiJzaWduZWRfbm9uY2UiLCJvcmdJZCI6IjAwb21oZ3ZwUVI5TFVaYkFMMGc0IiwiYXBwSW5zdGFuY2VOYW1lIjoiU2FtcGxlIE9JREMiLCJtZXRob2QiOiJzaWduZWRfbm9uY2UiLCJ2ZXIiOjB9.CUJiYLwgBCy8_0VDamN6lhf5Egr7MeofqqCSEIlwT3zWVCRXXx4y7R23ba_XsagJSvL3Y2jhCFE3egyUTvMwjACdF_g5BWF7yAns2tGYtf64xStkAMHzno1JB2b6aTjd3Zv7y1dZfE_bkkhXLeM-GtJzFWXo3q8YuixzOlhBxins4wv7WN0aU8_uPlTn5V6HYzxYunruYRM2PD4J-YrOM6lpSpapWfzUwcjwYjPmwwn4pxnPCKbOWMyr7dKVn5wtJjvZ7HIwxpie4iqJr02AWYpWljTsw8k2B2xVYix8pS6PRmdDs4pmu8PZ9ikgmVsNKRRB-SiS4seVJozWmJfP0g",
+            "downloadHref":"http://localhost:3000/static/WindowsOktaVerify/OktaVerifySetup-1.1.7.0.exe"
           }
         }
       },

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link.json
@@ -1,7 +1,7 @@
 {
-  "stateHandle":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+  "stateHandle":"0264BffulsV-frOIiTSYIejXy3o89Jh0lydYkCWYlq",
   "version":"1.0.0",
-  "expiresAt":"2020-12-08T06:57:17.000Z",
+  "expiresAt":"2020-12-08T06:54:05.000Z",
   "intent":"LOGIN",
   "remediation":{
     "type":"array",
@@ -21,7 +21,7 @@
           {
             "name":"stateHandle",
             "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+            "value":"0264BffulsV-frOIiTSYIejXy3o89Jh0lydYkCWYlq",
             "visible":false,
             "mutable":false
           }
@@ -61,6 +61,10 @@
                             "value":"totp"
                           },
                           {
+                            "label":"Get a push notification",
+                            "value":"push"
+                          },
+                          {
                             "label":"Use Okta FastPass",
                             "value":"signed_nonce"
                           }
@@ -91,14 +95,14 @@
                     ]
                   }
                 },
-                "relatesTo":"$.authenticatorEnrollments.value[2]"
+                "relatesTo":"$.authenticatorEnrollments.value[1]"
               }
             ]
           },
           {
             "name":"stateHandle",
             "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+            "value":"0264BffulsV-frOIiTSYIejXy3o89Jh0lydYkCWYlq",
             "visible":false,
             "mutable":false
           }
@@ -121,7 +125,7 @@
           {
             "name":"stateHandle",
             "required":true,
-            "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+            "value":"0264BffulsV-frOIiTSYIejXy3o89Jh0lydYkCWYlq",
             "visible":false,
             "mutable":false
           }
@@ -132,15 +136,8 @@
         "challenge":{
           "type":"object",
           "value":{
-            "challengeMethod":"LOOPBACK",
-            "challengeRequest":"eyJraWQiOiJW",
-            "domain":"http://localhost",
-            "ports":[
-              "2000",
-              "6511",
-              "6512",
-              "6513"
-            ]
+            "challengeMethod":"UNIVERSAL_LINK",
+            "href":"https://login.trexcloud.com/auth/okta-verify/?challengeRequest=eyJraWQiOiJYaGZCUk1haWRja0NKa2JOalFTVGlkYThINURRbTIxdkhjSlkydTFhaVR3IiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL2lkeG0xLm9rdGExLmNvbSIsImF1ZCI6Im9rdGEuNjNjMDgxZGItMWYxMy01MDg0LTg4MmYtZTc5ZTFlNWUyZGE3IiwiZXhwIjoxNjA3NDEwNDQ1LCJpYXQiOjE2MDc0MTAxNDUsImp0aSI6ImZ0SEpfcDBIaWROWXFaQUxKZWJGV2ZLRGJDaEpEQzhLb0QiLCJub25jZSI6Ild6RWZ4TTZvTnRHOGxpR2ZCWFRrIiwidHJhbnNhY3Rpb25JZCI6ImZ0SEpfcDBIaWROWXFaQUxKZWJGV2ZLRGJDaEpEQzhLb0QiLCJzaWduYWxzIjpbImlkIiwiZGlzcGxheU5hbWUiLCJwbGF0Zm9ybSIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwib3NWZXJzaW9uIiwic2VyaWFsTnVtYmVyIiwidWRpZCIsInNpZCIsImltZWkiLCJtZWlkIiwidHBtUHVibGljS2V5SGFzaCIsInNlY3VyZUhhcmR3YXJlUHJlc2VudCIsImRldmljZUF0dGVzdGF0aW9uIiwiZGV2aWNlSW50ZWdyaXR5Il0sInZlcmlmaWNhdGlvblVyaSI6Imh0dHBzOi8vaWR4bTEub2t0YTEuY29tL2lkcC9hdXRoZW50aWNhdG9ycy9hdXRtaG8zelJoSWZpU3pPeTBnNC90cmFuc2FjdGlvbnMvZnRISl9wMEhpZE5ZcVpBTEplYkZXZktEYkNoSkRDOEtvRC92ZXJpZnkiLCJrZXlUeXBlIjoidXNlclZlcmlmaWNhdGlvbiIsImtleVR5cGVzIjpbInVzZXJWZXJpZmljYXRpb24iXSwiZmFjdG9yVHlwZSI6InNpZ25lZF9ub25jZSIsIm9yZ0lkIjoiMDBvbWhndnBRUjlMVVpiQUwwZzQiLCJhcHBJbnN0YW5jZU5hbWUiOiJTYW1wbGUgT0lEQyIsIm1ldGhvZCI6InNpZ25lZF9ub25jZSIsInZlciI6MH0.QR-EQZMkf0B1PuTkKenTaJfWbUoyzzT0MZjz1AJ36JiZ2a8MVES6gamJvhYuPCYPbrb-h1WCKtmCaSgOiL0vhhuq0LTdGiHcaToEXz6RQeV9rbZOAU9bRqZ-8HkmnoGEd9heLGQhgfNcncrTVef2unQXC-rA4mGk_6Y_oX-Ke2N0wesliK5fmqc-M1MGiyLFB8lFHRiNCpy4y39UxfEwvWr8utmlFxh2rIns9ifudw7_sHHzZEf45-O2YIQgFxIrHfYp-hlDMjOLZUEKZ9nKswH-m1U6exDJ2EAeMsgQnrRTQyulKlaNnARpVzvwMk_jPv3ZcDq0ZRlurNDi4cX2Jg&redirectUrl=https%3A%2F%2Flocalhost:3000%2Fauthenticators%2Fov-not-installed%3FdeviceEnrollment%3Doda"
           }
         }
       },
@@ -162,6 +159,9 @@
         "id":"autmho3zRhIfiSzOy0g4",
         "displayName":"Okta Verify",
         "methods":[
+          {
+            "type":"push"
+          },
           {
             "type":"signed_nonce"
           },
@@ -187,25 +187,18 @@
     "value":[
       {
         "profile":{
-          "deviceName":"DESKTOP-9AD225Q"
+          "deviceName":"iPhone"
         },
         "type":"app",
-        "id":"pfdtxkyRQrmwfWdIE0g4",
+        "id":"pfdtxl6TyTsah6luW0g4",
         "displayName":"Okta Verify",
         "methods":[
           {
+            "type":"push"
+          },
+          {
             "type":"signed_nonce"
-          }
-        ]
-      },
-      {
-        "profile":{
-          "deviceName":"Display Name"
-        },
-        "type":"app",
-        "id":"pfdty6xBgVN8y7hWG0g4",
-        "displayName":"Okta Verify",
-        "methods":[
+          },
           {
             "type":"totp"
           }
@@ -213,7 +206,7 @@
       },
       {
         "type":"password",
-        "id":"lae3obwhjXZOu3dfz0g4",
+        "id":"lae4b6h8K3ACquiMv0g4",
         "displayName":"Password",
         "methods":[
           {
@@ -226,7 +219,7 @@
   "user":{
     "type":"object",
     "value":{
-      "id":"00umhs3GeoyNPfD360g4"
+      "id":"00uq3zsIIc2d7fBdx0g4"
     }
   },
   "cancel":{
@@ -240,7 +233,7 @@
       {
         "name":"stateHandle",
         "required":true,
-        "value":"02HGzwyCSw51EOFBYfs4nOZW4QX25PJrzrpXoM-sRB",
+        "value":"0264BffulsV-frOIiTSYIejXy3o89Jh0lydYkCWYlq",
         "visible":false,
         "mutable":false
       }

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -157,4 +157,10 @@ const Body = BaseForm.extend(Object.assign(
   polling,
 ));
 
+Body.isSwitchAuthenticatorRequired = function isSwitchAuthenticatorRequired (options) {
+  const deviceChallengeMethod = options.currentViewState.relatesTo.value.contextualData.challenge.value.challengeMethod;
+  return Enums.CUSTOM_URI_CHALLENGE === deviceChallengeMethod
+    || Enums.UNIVERSAL_LINK_CHALLENGE === deviceChallengeMethod;
+};
+
 export default Body;

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
@@ -14,6 +14,9 @@ export default BaseAuthenticatorView.extend({
       this.Footer = AuthenticatorVerifyFooter;
     } else {
       this.Body = ChallengeOktaVerifyFastPassView;
+      if (ChallengeOktaVerifyFastPassView.isSwitchAuthenticatorRequired(this.options)) {
+        this.Footer = AuthenticatorVerifyFooter;
+      }
     }
   },
 });

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -53,4 +53,12 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
   async clickLaunchOktaVerifyLink() {
     await this.t.click(this.body.find('#launch-ov'));
   }
+
+  getSwitchAuthenticatorButtonText() {
+    return this.footer.find('.js-switchAuthenticator').textContent;
+  }
+
+  async clickSwitchAuthenticatorButton () {
+    await this.t.click(this.footer.find('.js-switchAuthenticator'));
+  }
 }

--- a/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
@@ -73,7 +73,7 @@ test.requestHooks(mockChallengeAuthenticatorPassword)('challenge password authen
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
 
-test.requestHooks(mockInvalidPassword)('challege password authenticator with invalid password', async t => {
+test.requestHooks(mockInvalidPassword)('challenge password authenticator with invalid password', async t => {
   const challengePasswordPage = await setup(t);
   await challengePasswordPage.switchAuthenticatorExists();
   await challengePasswordPage.verifyFactor('credentials.passcode', 'test');

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -7,12 +7,17 @@ import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx
 import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/identify-with-user-verification-custom-uri';
 import identifyWithSSOExtensionFallback from '../../../playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback';
 import identifyWithUserVerificationLaunchUniversalLink from '../../../playground/mocks/data/idp/idx/identify-with-user-verification-universal-link';
+import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
+import selectAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator-ov-m2';
+import challengeFastPassLoopback from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback.json';
+import challengeFastPassCustomUri from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri.json';
+import challengeFastPassUniversalLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link.json';
 
 const BEACON_CLASS = 'mfa-okta-verify';
 
 let probeSuccess = false;
 const loopbackSuccessLogger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
-const loopbackSuccesskMock = RequestMock()
+const loopbackSuccessMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
@@ -88,23 +93,24 @@ const universalLinkMock = RequestMock()
 
 fixture('Device Challenge Polling View for user verification with the Loopback Server, Custom URI and Universal Link approaches');
 
-async function setup(t) {
+async function setupDeviceChallengePollPage(t) {
   const deviceChallengePollPage = new DeviceChallengePollPageObject(t);
   await deviceChallengePollPage.navigateToPage();
   return deviceChallengePollPage;
 }
 
 async function setupLoopbackFallback(t) {
-  const deviceChallengeFalllbackPage = new IdentityPageObject(t);
-  await deviceChallengeFalllbackPage.navigateToPage();
-  return deviceChallengeFalllbackPage;
+  const deviceChallengeFallbackPage = new IdentityPageObject(t);
+  await deviceChallengeFallbackPage.navigateToPage();
+  return deviceChallengeFallbackPage;
 }
 
 test
-  .requestHooks(loopbackSuccessLogger, loopbackSuccesskMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
-    const deviceChallengePollPageObject = await setup(t);
+  .requestHooks(loopbackSuccessLogger, loopbackSuccessMock)('in loopback server approach, probing and polling requests are sent and responded', async t => {
+    const deviceChallengePollPageObject = await setupDeviceChallengePollPage(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
+    await t.expect(deviceChallengePollPageObject.getSwitchAuthenticatorButtonText().exists).notOk;
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|6512/)
@@ -129,8 +135,8 @@ test
 test
   .requestHooks(loopbackFallbackLogger, loopbackFallbackMock)('loopback fails and falls back to custom uri', async t => {
     loopbackFallbackLogger.clear();
-    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
-    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    const deviceChallengeFallbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFallbackPage.getPageTitle()).eql('Sign In');
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
@@ -143,20 +149,21 @@ test
       record => record.response.statusCode === 200 &&
         record.request.url.match(/authenticators\/poll\/cancel/)
     )).eql(1);
-    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    deviceChallengeFallbackPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
     await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
     await t.expect(deviceChallengePollPageObject.getContent())
       .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
+    await t.expect(deviceChallengePollPageObject.getSwitchAuthenticatorButtonText()).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterLink().exists).notOk;
   });
 
 const getPageUrl = ClientFunction(() => window.location.href);
 test
   .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify is launched', async t => {
-    const deviceChallengePollPageObject = await setup(t);
+    const deviceChallengePollPageObject = await setupDeviceChallengePollPage(t);
     await t.expect(customURILogger.count(
       record => record.request.url.match(/launch-okta-verify/)
     )).eql(1);
@@ -169,13 +176,13 @@ test
 test
   .requestHooks(loopbackFallbackLogger, universalLinkWithoutLaunchMock)('SSO Extension fails and falls back to universal link', async t => {
     loopbackFallbackLogger.clear();
-    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
-    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    const deviceChallengeFallbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFallbackPage.getPageTitle()).eql('Sign In');
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
     )).eql(1);
-    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    deviceChallengeFallbackPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Extra verification needed');
@@ -191,13 +198,135 @@ test
 test
   .requestHooks(loopbackFallbackLogger, universalLinkMock)('clicking the launch Okta Verify button opens the universal link', async t => {
     loopbackFallbackLogger.clear();
-    const deviceChallengeFalllbackPage = await setupLoopbackFallback(t);
-    await t.expect(deviceChallengeFalllbackPage.getPageTitle()).eql('Sign In');
+    const deviceChallengeFallbackPage = await setupLoopbackFallback(t);
+    await t.expect(deviceChallengeFallbackPage.getPageTitle()).eql('Sign In');
     await t.expect(loopbackFallbackLogger.count(
       record => record.response.statusCode === 200 &&
         record.request.url.match(/introspect/)
     )).eql(1);
-    deviceChallengeFalllbackPage.clickOktaVerifyButton();
+    deviceChallengeFallbackPage.clickOktaVerifyButton();
     await t.expect(getPageUrl()).contains(mockHttpCustomUri);
     await t.expect(Selector('h1').innerText).eql('open universal link');
+  });
+
+fixture('Device Challenge Polling View and verify with something else button after selecting FastPass authenticator in factor list');
+
+const selectFastPassWithLoopbackMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(selectAuthenticator)
+  .onRequestTo(/idp\/idx\/challenge/)
+  .respond(challengeFastPassLoopback)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond((req, res) => {
+    res.statusCode = '200';
+    if (probeSuccess) {
+      res.setBody(identify);
+    } else {
+      res.setBody(challengeFastPassLoopback);
+    }
+  })
+  .onRequestTo(/2000|6511\/probe/)
+  .respond(null, 500, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, { 'access-control-allow-origin': '*' })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  });
+
+const selectFastPassWithCustomUriMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(selectAuthenticator)
+  .onRequestTo(/idp\/idx\/challenge/)
+  .respond(challengeFastPassCustomUri)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(challengeFastPassCustomUri);
+
+const selectFastPassWithUniversalLinkMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(selectAuthenticator)
+  .onRequestTo(/idp\/idx\/challenge/)
+  .respond(challengeFastPassUniversalLink)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(challengeFastPassUniversalLink);
+
+async function setupSelectAuthenticatorPage(t) {
+  const selectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+  await selectAuthenticatorPageObject.navigateToPage();
+  return selectAuthenticatorPageObject;
+}
+
+test
+  .requestHooks(loopbackSuccessLogger, selectFastPassWithLoopbackMock)('select FastPass from factor list, triggers loopback server and succeeds', async t => {
+    const selectAuthenticatorPageObject = await setupSelectAuthenticatorPage(t);
+    await t.expect(selectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql('Select from the following options');
+    selectAuthenticatorPageObject.selectFactorByIndex(0);
+
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Signing in using Okta FastPass');
+    await t.expect(deviceChallengePollPageObject.getSwitchAuthenticatorButtonText().exists).notOk;
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/introspect|6512/)
+    )).eql(3);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/challenge/) &&
+        record.request.body.match(/challengeRequest":"eyJraWQiOiJW/)
+    )).eql(1);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/2000|6511/)
+    )).eql(2);
+    probeSuccess = true;
+    await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
+  });
+
+test
+  .requestHooks(customURILogger, selectFastPassWithCustomUriMock)('select FastPass from factor list, triggers custom uri, and select verify with something else', async t => {
+    loopbackFallbackLogger.clear();
+    const selectAuthenticatorPageObject = await setupSelectAuthenticatorPage(t);
+    await t.expect(selectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql('Select from the following options');
+    selectAuthenticatorPageObject.selectFactorByIndex(0);
+
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verify account access');
+    await t.expect(deviceChallengePollPageObject.getFormSubtitle()).eql('Launching Okta Verify...');
+    await t.expect(deviceChallengePollPageObject.getContent())
+      .eql('If nothing prompts from the browser, click here to launch Okta Verify, or make sure Okta Verify is installed.');
+    await t.expect(deviceChallengePollPageObject.getSwitchAuthenticatorButtonText()).eql('Verify with something else');
+    await t.expect(deviceChallengePollPageObject.getFooterLink().exists).notOk;
+
+    await deviceChallengePollPageObject.clickSwitchAuthenticatorButton();
+    const secondSelectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(secondSelectAuthenticatorPageObject.getFormSubtitle()).eql('Select from the following options');
+  });
+
+test
+  .requestHooks(loopbackFallbackLogger, selectFastPassWithUniversalLinkMock)('select FastPass from factor list, triggers universal link, and select verify with something else', async t => {
+    loopbackFallbackLogger.clear();
+    const selectAuthenticatorPageObject = await setupSelectAuthenticatorPage(t);
+    await t.expect(selectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql('Select from the following options');
+    selectAuthenticatorPageObject.selectFactorByIndex(0);
+
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Extra verification needed');
+    await t.expect(deviceChallengePollPageObject.getContent()).eql('' +
+      'Your organization needs extra verification to make sure it\'s you signing in.\n' +
+      'To continue, confirm your screen lock in Okta Verify.\n' +
+      'Confirm screen lock');
+
+    await deviceChallengePollPageObject.clickSwitchAuthenticatorButton();
+    const secondSelectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(secondSelectAuthenticatorPageObject.getFormSubtitle()).eql('Select from the following options');
   });


### PR DESCRIPTION
## Description:

Add verify with something else button for universal link and custom uri in challenge view. No need for loopback server and credential sso extension

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
<img width="818" alt="Screen Shot 2020-12-07 at 11 28 38 PM" src="https://user-images.githubusercontent.com/49395917/101453401-20dd3900-38e4-11eb-9728-65df653f1694.png">
<img width="911" alt="Screen Shot 2020-12-07 at 11 27 48 PM" src="https://user-images.githubusercontent.com/49395917/101453405-233f9300-38e4-11eb-93de-dd584d6a2e53.png">


### Reviewers:
@jhe-okta @stevennguyen-okta 

### Issue:

- [OKTA-340939](https://oktainc.atlassian.net/browse/OKTA-340939)


