### PR TITLE
fix: define main tag as block-level element

### DIFF
--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -80,6 +80,11 @@
   }
 }
 
+main#okta-sign-in {
+  // for IE 11 to render main tag's width
+  display: block;
+}
+
 #okta-sign-in.auth-container {
 
   &.main-container {


### PR DESCRIPTION
## Description:
Required for IE11 to apply the main container's width. 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-351767](https://oktainc.atlassian.net/browse/OKTA-351767)


