### PR TITLE
fix: hide error before switching to the next UI

### DIFF
--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -1,2 +1,3 @@
 export const SHOW_RESEND_TIMEOUT = 30000;
 export const WARNING_TIMEOUT = 30000;
+export const UNIVERSAL_LINK_POST_DELAY = 500;


### PR DESCRIPTION
## Description:

delay switching to the next UI for universal link approach in case the Okta Verify is not installed

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@sshen-okta @pradeepdewda-okta 

### Issue:

- [OKTA-350084](https://oktainc.atlassian.net/browse/OKTA-350084)


