### PR TITLE
feat: poll requests when server is in safe or readonly mode

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -708,6 +708,9 @@ admin.consent.group.system = System
 
 # Polling state
 polling.title = There are too many users trying to sign in right now. We will automatically retry in {0} seconds.
+poll.form.title = Unable to complete your request
+poll.form.message = We will automatically retry in <$1>{0}</$1> seconds.
+
 
 ##--JSP page titles
 cert.authentication.title = Certificate authentication

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -476,6 +476,25 @@ const phoneEnroll = {
   ],
 };
 
+const safeModePoll = {
+  '/idp/idx/introspect': [
+    'identify-with-password',
+  ],
+  '/idp/idx/identify': [
+    'authenticator-enroll-select-authenticator',
+  ],
+  '/idp/idx/credential/enroll': [
+    'safe-mode-polling',
+  ],
+  '/idp/idx/poll': [
+    'safe-mode-polling',
+    'safe-mode-polling',
+    'safe-mode-polling',
+    'authenticator-enroll-ov-via-sms',
+    // 'terminal-polling-window-expired'
+  ],
+};
+
 module.exports = {
   mocks: idx,
 };

--- a/playground/mocks/data/idp/idx/safe-mode-polling.json
+++ b/playground/mocks/data/idp/idx/safe-mode-polling.json
@@ -1,0 +1,30 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name": "poll",
+        "href": "http://localhost:3000/idp/idx/poll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 100,
+        "value":[
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/terminal-polling-window-expired.json
+++ b/playground/mocks/data/idp/idx/terminal-polling-window-expired.json
@@ -1,0 +1,18 @@
+{
+  "stateHandle": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTloajh3Z0J5S2tHaXEwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..FbhwdeiWkij2ZLKW.uJ7dd-L-BZwal57lDs116naLD0GzizyDaeV2iQLepRitWpNpDQJPs-wZgTYBsgGz_SVtHDM41If-5LuVu5pv6Ha2DWwUXiiSCd8B8wfcNi91JC6naATC8MVgRsGGILyiTYePAIjW_CTP_pgKNIVs9HRsQDRzxSTRcEUvz8LHUZOFIOTyr5Erd_6b3NjwNKEartcBPwqGKd59pM-wgYap8hfwWkJNpbYRNZKxn2YDlnmg1w2YjE3SfecnMqZhT98Pi5e3rxwdgpXwZNBGgpry9nFCmUy3cUPW5v0imtqA5j0CEbAVVXmyUzSnJEaSGbPxy_fRJRY2MyoCU8P1ulvhcxT-tFojQyDJ9DqS0If6cpEWhfywStYQu9E0c6F7tNXiagqBMw-QChwqaBgdqydED6tkNQj-Szmsb6tZmSgMOm5Gk_cicb68YWvTtG7py2iZjvWZtZvv-95SpVREny1HTT9U1-3LLQwoYC79F6DytD7xZjiJOMyJbqx-mvFXUOAcx5A00gDBAToEhqxOGZcCNzd9M2PfA6LmJOyFwWzKtrJtgntaSgnU-2nFOdu2rZU5nu_KGl2dmq128EzlggV3C-0oHrXEe_0QEvPhgsoeURipAksHaEkBhBYnqnf-JJu92PLU29wsRsG8VTxow7AVn-T-0FkySxGvaUcCeLHWItLVaLz0nvdRG58tcwxvxyqlrMb-r295pZl4GxxmCe3d4Amfy4aKeHORxikTP5nmRa-uDpBM9f851x4boCYzohm-3WuRq5GQvU6K4Tt1U54ajQhcnDQbqNMHhjNirJsmfXB5CGrtuxPJ9PDwZW2JSbFJ11guYj9XJBUYi-uzI6eBeKd9Kge8oUkye-H9uinqourRCyoDEl8Xz1DD1UxXKYqXwWGA-IaySXgG6Wr7Iqh5SuzogaicyUY-SfFbiS4ltUVVh--Mf3rQqt53GVFoWNWE26UwW4bC9ipS76AO-7RBWO6b_UKZCL3LtWZElQ.mjplg_sjfIVKU78z5B4btA",
+  "version": "1.0.0",
+  "expiresAt": "2020-07-15T16:53:45.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Server is unable to respond at the moment.",
+        "i18n": {
+          "key": "E0000010"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/playground/mocks/spec-okta-api/idp/idx/index.js
+++ b/playground/mocks/spec-okta-api/idp/idx/index.js
@@ -21,6 +21,7 @@ const idx = [
   '/idp/idx/login/token/redirect',
   '/idp/idx/recover',
   '/idp/idx/skip',
+  '/idp/idx/poll'
 ].map(path => {
   return templateHelper({path});
 });

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -33,6 +33,7 @@ const FORMS = {
   REENROLL_AUTHENTICATOR_WARNING: 'reenroll-authenticator-warning',
   RESET_AUTHENTICATOR: 'reset-authenticator',
   SKIP: 'skip',
+  POLL: 'poll',
 
   SUCCESS_REDIRECT: 'success-redirect',
   REDIRECT_IDP: 'redirect-idp',

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -60,6 +60,9 @@ import ChallengeOktaVerifyTotpView from './views/ov/ChallengeOktaVerifyTotpView'
 import ChallengeOktaVerifyResendPushView from './views/ov/ChallengeOktaVerifyResendPushView';
 import ChallengeAuthenticatorDataOktaVerifyView from './views/ov/ChallengeAuthenticatorDataOktaVerifyView';
 
+// safe mode poll view
+import PollView from './views/PollView';
+
 const DEFAULT = '_';
 
 const VIEWS_MAPPING = {
@@ -96,7 +99,9 @@ const VIEWS_MAPPING = {
     password: RequiredFactorPasswordView,
     webauthn: RequiredFactorWebauthnView,
   },
-
+  [RemediationForms.POLL] : {
+    [DEFAULT] : PollView
+  },
   [RemediationForms.SELECT_AUTHENTICATOR_ENROLL]: {
     [DEFAULT]: SelectAuthenticatorEnrollView,
   },

--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -1,2 +1,3 @@
 export const SHOW_RESEND_TIMEOUT = 30000;
 export const WARNING_TIMEOUT = 30000;
+export const MS_PER_SEC = 1000;

--- a/src/v2/view-builder/views/PollView.js
+++ b/src/v2/view-builder/views/PollView.js
@@ -1,0 +1,55 @@
+import { loc, View } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+import BaseView from '../internals/BaseView';
+import BaseForm from '../internals/BaseForm';
+import polling from './shared/polling';
+import { MS_PER_SEC } from '../utils/Constants';
+
+const PollMessageView = View.extend({
+  template: hbs`
+    <div class="ion-messages-container">
+      {{i18n code="poll.form.message" 
+        bundle="login" arguments="countDownCounterValue" $1="<span class='strong'>$1</span>"}}
+    </div>
+    <div class="okta-waiting-spinner"></div>`
+  ,
+  getTemplateData () {
+    const countDownCounterValue = this.options;
+    return {
+      countDownCounterValue,
+    };
+  },
+});
+
+const Body = BaseForm.extend(Object.assign(
+  {
+    title () {
+      return  loc('poll.form.title', 'login');
+    },
+
+    noButtonBar: true,
+    
+    initialize () {
+      BaseForm.prototype.initialize.apply(this, arguments);
+      this.startPolling();
+    },
+
+    render () {
+      BaseForm.prototype.render.apply(this, arguments);
+      this.countDownCounterValue = Math.ceil(this.options.appState.getCurrentViewState().refresh / MS_PER_SEC);
+      this.add(new PollMessageView(this.countDownCounterValue));
+      this.startCountDown('.ion-messages-container span', MS_PER_SEC);
+    },
+
+    remove () {
+      BaseForm.prototype.remove.apply(this, arguments);
+      this.stopPolling();
+    }
+  },
+
+  polling,
+));
+
+export default BaseView.extend({
+  Body
+});

--- a/test/testcafe/framework/page-objects/PollingPageObject.js
+++ b/test/testcafe/framework/page-objects/PollingPageObject.js
@@ -1,0 +1,18 @@
+import { Selector } from 'testcafe';
+import BasePageObject from './BasePageObject';
+
+export default class PollingPageObject extends BasePageObject {
+
+  constructor (t) {
+    super(t);
+    this.spinner = new Selector('.okta-waiting-spinner');
+  }
+
+  getHeader() {
+    return this.form.getTitle();
+  }
+
+  hasSpinner() {
+    return !!this.spinner;
+  }
+}

--- a/test/testcafe/spec/PollView_spec.js
+++ b/test/testcafe/spec/PollView_spec.js
@@ -1,0 +1,49 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
+import EnrollOVViaSMSPageObject from '../framework/page-objects/EnrollOVViaSMSPageObject';
+
+import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
+import xhrSelectAuthenticatorEnroll from '../../../playground/mocks/data/idp/idx/authenticator-enroll-select-authenticator';
+import xhrSafeModepolling from '../../../playground/mocks/data/idp/idx/safe-mode-polling';
+import xhrSuccess from '../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-via-sms';
+
+const identifyMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentifyWithPassword)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrSelectAuthenticatorEnroll)
+  .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
+  .respond(xhrSafeModepolling)
+  .onRequestTo('http://localhost:3000/idp/idx/poll')
+  .respond(xhrSuccess);
+
+const requestLogger = RequestLogger(/poll/, {
+  logRequestBody: true,
+  stringifyRequestBody: true,
+});
+
+fixture('Polling');
+
+async function setup(t) {
+  const identityPage = new IdentityPageObject(t);
+  const selectFactorPageObject = new SelectFactorPageObject(t);
+
+  await identityPage.navigateToPage();  
+  return [identityPage , selectFactorPageObject];
+}  
+
+test.requestHooks(requestLogger, identifyMock)('should poll', async t => {
+  let [identityPage, selectFactorPage]  = await setup(t);
+
+  await identityPage.fillIdentifierField('username');
+  await identityPage.fillPasswordField('password');
+  await identityPage.clickNextButton();
+
+  selectFactorPage.selectFactorByIndex(0);
+
+  await t.expect(requestLogger.count(() => true)).eql(1);
+
+  const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
+  await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
+});


### PR DESCRIPTION
## Description:
1. When server is not in active mode, then requests that needs database write access can error out.
2. To avoid such errors introduce polling.
3. use cases are server is in safe-mode and rate limiting.

https://oktawiki.atlassian.net/wiki/spaces/eng/pages/1411254114/IdX+Polling+Transaction+Framework+1-Page


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
**update**: 
https://okta.box.com/s/9sazdq0sb6ffgnvkyswx0tsp9948gg97

**update:** Messages changed to:
![Screen Shot 2020-12-14 at 12 03 46 PM](https://user-images.githubusercontent.com/38230587/102132667-c45cab00-3e08-11eb-80ac-722dbded92dd.png)


on poll success
https://okta.box.com/s/f58w8wp5af891g235uebsyx524vbis1x

on poll expires
https://okta.box.com/s/acf08b6cpgb676s5v8a6vnq5n27bacnh

Poll usecase in IDX Org:
https://okta.box.com/s/31t9fu102g69u5wlosputsl15egnp495

### Reviewers:


### Issue:

- [OKTA-349707](https://oktainc.atlassian.net/browse/OKTA-349707)


