### PR TITLE
fix: apply a11y colors to Consent screen only

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -22,10 +22,10 @@ $primary-bg-color: #fff;
 $secondary-bg-color: #f9f9f9;
 
 // Text Color
-$header-text-color: #1d1d21; // Gray 900 in Odyssey
+$header-text-color: #5e5e5e;
 $dark-text-color: #5e5e5e;
-$medium-text-color: #1d1d21; // Gray 900 in Odyssey
-$light-text-color: #6e6e78; // Gray 600 in Odyssey
+$medium-text-color: #777;
+$light-text-color: #a7a7a7;
 $link-text-color: #0074b3;
 $placeholder-text-color: #aaa;
 $error-text-color: #e34843;

--- a/assets/sass/modules/_consent.scss
+++ b/assets/sass/modules/_consent.scss
@@ -1,8 +1,15 @@
 $space-between-container: 25px;
 $space-of-last-container: $space-between-container - 14px; // 14px is margin between form body and form toolbar
 $image-size: 30px;
+// Consent theme colors, special case for accessibility
+$consent-text-color: #1d1d21; // Gray 900 in Odyssey
+$consent-light-text-color: #6e6e78; // Gray 600 in Odyssey
 
 .consent-required {
+  .title-text,
+  .scope-list {
+    color: $consent-text-color;
+  }
 
   .default-logo,
   .custom-logo {
@@ -55,7 +62,7 @@ $image-size: 30px;
 
   .consent-description {
     p {
-      color: $light-text-color;
+      color: $consent-light-text-color;
     }
   }
 


### PR DESCRIPTION
## Description:

The following colors:
```
$header-text-color: #1d1d21; // Gray 900 in Odyssey
$medium-text-color: #1d1d21; // Gray 900 in Odyssey
$light-text-color: #6e6e78; // Gray 600 in Odyssey
```

applies to Consent screen only and  the rest of SIW changes back to:

```
$header-text-color: #5e5e5e;
$medium-text-color: #777;
$light-text-color: #a7a7a7;
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Compare following with mock in https://oktainc.atlassian.net/browse/OKTA-334550:
![Screen Shot 2020-12-10 at 12 25 22 PM](https://user-images.githubusercontent.com/71431120/101826994-94e62f80-3ae4-11eb-9699-99f3d1d0c992.png)

Screens without these new colors:
![Screen Shot 2020-12-10 at 3 03 03 PM](https://user-images.githubusercontent.com/71431120/101840420-ed272c80-3af8-11eb-97a9-d064a449b00c.png)
![Screen Shot 2020-12-10 at 3 02 46 PM](https://user-images.githubusercontent.com/71431120/101840428-f0bab380-3af8-11eb-8260-d75e7b8238ab.png)


### Reviewers:


### Issue:

- [OKTA-352463](https://oktainc.atlassian.net/browse/OKTA-352463)


