### PR TITLE
fix: cancel loopback probing when polling is cancelled

### DIFF
--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -1,3 +1,4 @@
 export const SHOW_RESEND_TIMEOUT = 30000;
 export const WARNING_TIMEOUT = 30000;
 export const UNIVERSAL_LINK_POST_DELAY = 500;
+export const CANCEL_POLLING_ACTION = 'authenticatorChallenge-cancel';


### PR DESCRIPTION
## Description:
In loopback server, probing (check port and challenge) still happens even after the cancel link (cancel polling) from the footer is clicked. The change is to abort the probing once polling is cancelled.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@pradeepdewda-okta 

### Issue:

- [OKTA-353152](https://oktainc.atlassian.net/browse/OKTA-353152)


