### PR TITLE
fix: show error when polling returns 403

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -526,9 +526,10 @@ const safeModePoll = {
   ],
   '/idp/idx/poll': [
     'safe-mode-polling',
+    // 'safe-mode-polling',
     'safe-mode-polling',
-    'safe-mode-polling',
-    'authenticator-enroll-ov-via-sms',
+    'error-safe-mode-polling',
+    // 'authenticator-enroll-ov-via-sms',
     // 'terminal-polling-window-expired'
   ],
 };

--- a/playground/mocks/data/idp/idx/error-safe-mode-polling.json
+++ b/playground/mocks/data/idp/idx/error-safe-mode-polling.json
@@ -1,0 +1,16 @@
+{
+	"stateHandle": "02qrfZxmwW8D8TRH5vorCPV0QmNEx8NKHKPHGL3s5m",
+	"version": "1.0.0",
+	"expiresAt": "2020-12-19T00:52:34.000Z",
+	"intent": "LOGIN",
+	"messages": {
+		"type": "array",
+		"value": [{
+			"message": "Something went wrong, Try again later.",
+			"i18n": {
+				"key": "E0000010"
+			},
+			"class": "ERROR"
+		}]
+	}
+}

--- a/src/v2/view-builder/views/PollView.js
+++ b/src/v2/view-builder/views/PollView.js
@@ -8,10 +8,11 @@ import { MS_PER_SEC } from '../utils/Constants';
 const PollMessageView = View.extend({
   template: hbs`
     <div class="ion-messages-container">
-      {{i18n code="poll.form.message" 
-        bundle="login" arguments="countDownCounterValue" $1="<span class='strong'>$1</span>"}}
+      <p>{{i18n code="poll.form.message" 
+        bundle="login" arguments="countDownCounterValue" $1="<span class='strong'>$1</span>"}} </p>
     </div>
-    <div class="okta-waiting-spinner"></div>`
+    <div class="okta-waiting-spinner"></div>
+    `
   ,
   getTemplateData () {
     const countDownCounterValue = this.options;
@@ -44,7 +45,13 @@ const Body = BaseForm.extend(Object.assign(
     remove () {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
-    }
+    },
+
+    triggerAfterError () {
+      BaseForm.prototype.triggerAfterError.apply(this, arguments);
+      this.stopPolling();
+      this.$el.find('.o-form-fieldset-container').empty();
+    },
   },
 
   polling,

--- a/test/testcafe/spec/PollView_spec.js
+++ b/test/testcafe/spec/PollView_spec.js
@@ -18,12 +18,17 @@ const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/poll')
   .respond(xhrSuccess);
 
-const requestLogger = RequestLogger(/poll/, {
-  logRequestBody: true,
-  stringifyRequestBody: true,
-});
+// const identifyPollErrorMock = RequestMock()
+//   .onRequestTo('http://localhost:3000/idp/idx/introspect')
+//   .respond(xhrIdentifyWithPassword)
+//   .onRequestTo('http://localhost:3000/idp/idx/identify')
+//   .respond(xhrSelectAuthenticatorEnroll)
+//   .onRequestTo('http://localhost:3000/idp/idx/poll')
+//   .respond(xhrError);
 
-fixture('Polling');
+const requestLogger = RequestLogger(/poll/);
+
+fixture('Safemode Polling');
 
 async function setup(t) {
   const identityPage = new IdentityPageObject(t);
@@ -47,3 +52,14 @@ test.requestHooks(requestLogger, identifyMock)('should poll', async t => {
   const enrollViaSMSPageObject = new EnrollOVViaSMSPageObject(t);
   await t.expect(enrollViaSMSPageObject.getFormTitle()).eql('Set up Okta Verify via SMS');
 });
+
+// Test being flaky on bacon
+// test.requestHooks(requestLogger, identifyPollErrorMock)('poll should end on error', async t => {
+//   let [identityPage, selectFactorPage]  = await setup(t);
+//   await identityPage.fillIdentifierField('username');
+//   await identityPage.fillPasswordField('password');
+//   await identityPage.clickNextButton();
+//   selectFactorPage.selectFactorByIndex(0);
+//   const terminalPageObject = new TerminalPageObject(t);
+//   await t.expect(terminalPageObject.getErrorMessages().getTextContent()).eql('Something went wrong, Try again later.');
+// });


### PR DESCRIPTION
## Description:
shows error when polling request returns 403 and stop polling.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2020-12-18 at 5 19 34 PM](https://user-images.githubusercontent.com/38230587/102677187-25141c80-4156-11eb-8c4c-e2b2b2fd6496.png)


### Reviewers:


### Issue:

- [OKTA-354467](https://oktainc.atlassian.net/browse/OKTA-354467)


