### PR TITLE
fix: webauthn verification on OIE 

### DIFF
--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -5,7 +5,6 @@ import CryptoUtil from '../../../../util/CryptoUtil';
 import webauthn from '../../../../util/webauthn';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import ChallengeWebauthnInfoView from './ChallengeWebauthnInfoView';
-import BrowserFeatures from '../../../../util/BrowserFeatures';
 
 const Body = BaseForm.extend({
 
@@ -19,16 +18,12 @@ const Body = BaseForm.extend({
     const schema = [];
     // Returning custom array so no input fields are displayed for webauthn
     if (webauthn.isNewApiAvailable()) {
-      const title = BrowserFeatures.isSafari() ? loc('mfa.challenge.verify', 'login') : loc('retry', 'login');
       const retryButton = createButton({
         className: 'retry-webauthn button-primary default-custom-button',
-        title,
+        title: loc('mfa.challenge.verify', 'login'),
         click: () => {
           this.getCredentialsAndSave();
-          // Update button text only when using safari.
-          if (BrowserFeatures.isSafari()) {
-            this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
-          }
+          this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
         }
       });
 
@@ -124,8 +119,5 @@ export default BaseAuthenticatorView.extend({
   Footer: AuthenticatorVerifyFooter,
   postRender () {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
-    if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {
-      this.form.getCredentialsAndSave();
-    }
   },
 });

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -5,6 +5,7 @@ import CryptoUtil from '../../../../util/CryptoUtil';
 import webauthn from '../../../../util/webauthn';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import ChallengeWebauthnInfoView from './ChallengeWebauthnInfoView';
+import BrowserFeatures from '../../../../util/BrowserFeatures';
 
 const Body = BaseForm.extend({
 
@@ -18,11 +19,16 @@ const Body = BaseForm.extend({
     const schema = [];
     // Returning custom array so no input fields are displayed for webauthn
     if (webauthn.isNewApiAvailable()) {
+      const title = BrowserFeatures.isSafari() ? loc('mfa.challenge.verify', 'login') : loc('retry', 'login');
       const retryButton = createButton({
         className: 'retry-webauthn button-primary default-custom-button',
-        title: loc('retry', 'login'),
+        title,
         click: () => {
           this.getCredentialsAndSave();
+          // Update button text only when using safari.
+          if (BrowserFeatures.isSafari()) {
+            this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
+          }
         }
       });
 
@@ -118,7 +124,7 @@ export default BaseAuthenticatorView.extend({
   Footer: AuthenticatorVerifyFooter,
   postRender () {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
-    if (webauthn.isNewApiAvailable()) {
+    if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {
       this.form.getCredentialsAndSave();
     }
   },

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -6,6 +6,7 @@ import webauthn from 'util/webauthn';
 import CryptoUtil from 'util/CryptoUtil';
 import $sandbox from 'sandbox';
 import Expect from 'helpers/util/Expect';
+import BrowserFeatures from '../../../../../../src/util/BrowserFeatures';
 import ChallengeWebauthnResponse
   from '../../../../../../playground/mocks/data/idp/idx/authenticator-verification-webauthn.json';
 
@@ -46,6 +47,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
 
   it('shows verify instructions and spinner when browser supports webauthn', function () {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => false);
     this.init();
     expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
       'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
@@ -54,6 +56,32 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(this.view.$('.retry-webauthn').text()).toBe('Retry');
     expect(this.view.$('.webauthn-not-supported').length).toBe(0);
     expect(this.view.$('.okta-waiting-spinner').css('display')).toBe('block');
+  });
+
+  it('shows verify instructions and button when browser supports webauthn and is safari', function () {
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
+    this.init();
+    expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
+      'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
+    );
+    expect(this.view.$('.retry-webauthn').css('display')).toBe('inline');
+    expect(this.view.$('.retry-webauthn').text()).toBe('Verify');
+    expect(this.view.$('.webauthn-not-supported').length).toBe(0);
+  });
+
+  it('updated button text to "Retry" on click in safari', function () {
+    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
+    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
+    this.init();
+    expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
+      'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
+    );
+    expect(this.view.$('.retry-webauthn').css('display')).toBe('inline');
+    expect(this.view.$('.retry-webauthn').text()).toBe('Verify');
+    this.view.$('.retry-webauthn').click();
+    expect(this.view.$('.retry-webauthn').css('display')).toBe('none');
+    expect(this.view.$('.retry-webauthn').text()).toBe('Retry');
   });
 
   it('shows verify instructions and spinner if there are existing enrollments', function () {

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -6,7 +6,6 @@ import webauthn from 'util/webauthn';
 import CryptoUtil from 'util/CryptoUtil';
 import $sandbox from 'sandbox';
 import Expect from 'helpers/util/Expect';
-import BrowserFeatures from '../../../../../../src/util/BrowserFeatures';
 import ChallengeWebauthnResponse
   from '../../../../../../playground/mocks/data/idp/idx/authenticator-verification-webauthn.json';
 
@@ -45,22 +44,8 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     $sandbox.empty();
   });
 
-  it('shows verify instructions and spinner when browser supports webauthn', function () {
+  it('shows verify instructions and button when browser supports webauthn', function () {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
-    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => false);
-    this.init();
-    expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
-      'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
-    );
-    expect(this.view.$('.retry-webauthn').css('display')).toBe('none');
-    expect(this.view.$('.retry-webauthn').text()).toBe('Retry');
-    expect(this.view.$('.webauthn-not-supported').length).toBe(0);
-    expect(this.view.$('.okta-waiting-spinner').css('display')).toBe('block');
-  });
-
-  it('shows verify instructions and button when browser supports webauthn and is safari', function () {
-    spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
-    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
     this.init();
     expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
       'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
@@ -70,9 +55,8 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(this.view.$('.webauthn-not-supported').length).toBe(0);
   });
 
-  it('updated button text to "Retry" on click in safari', function () {
+  it('updated button text to "Retry" on click', function () {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
-    spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
     this.init();
     expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
       'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
@@ -84,7 +68,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(this.view.$('.retry-webauthn').text()).toBe('Retry');
   });
 
-  it('shows verify instructions and spinner if there are existing enrollments', function () {
+  it('shows verify instructions if there are existing enrollments', function () {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     this.init(
       ChallengeWebauthnResponse.currentAuthenticatorEnrollment.value,
@@ -93,10 +77,9 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(this.view.$('.idx-webauthn-verify-text').text()).toBe(
       'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
     );
-    expect(this.view.$('.retry-webauthn').css('display')).toBe('none');
-    expect(this.view.$('.retry-webauthn').text()).toBe('Retry');
+    expect(this.view.$('.retry-webauthn').css('display')).toBe('inline');
+    expect(this.view.$('.retry-webauthn').text()).toBe('Verify');
     expect(this.view.$('.webauthn-not-supported').length).toBe(0);
-    expect(this.view.$('.okta-waiting-spinner').css('display')).toBe('block');
   });
 
   it('shows error when browser does not support webauthn', function () {
@@ -153,7 +136,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
       ChallengeWebauthnResponse.currentAuthenticatorEnrollment.value,
       ChallengeWebauthnResponse.authenticatorEnrollments
     );
-
+    this.view.$('.retry-webauthn').click();
     Expect.waitForSpyCall(this.view.form.saveForm)
       .then(() => {
         expect(navigator.credentials.get).toHaveBeenCalledWith({
@@ -199,7 +182,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     spyOn(navigator.credentials, 'get').and.returnValue(Promise.reject({ message: 'error from browser' }));
 
     this.init();
-
+    this.view.$('.retry-webauthn').click();
     Expect.waitForCss('.infobox-error')
       .then(() => {
         expect(this.view.$el.find('.infobox-error')[0].textContent.trim()).toBe('error from browser');


### PR DESCRIPTION
* Safari requires a direct user action to trigger the webauhtn prompt, to allow
use of platform authenticator.
* Since other browsers also might adopt this security requirement making this fix for all browser flows. 

RESOLVES: OKTA-355035

Tested on chrome/safari on bigsur and ios 14 and it works fine. 


<img width="1005" alt="Screen Shot 2020-12-21 at 10 20 50 AM" src="https://user-images.githubusercontent.com/17267130/102809577-18224380-4377-11eb-84b6-71beed8674dd.png">
<img width="806" alt="Screen Shot 2020-12-21 at 10 20 56 AM" src="https://user-images.githubusercontent.com/17267130/102809579-18bada00-4377-11eb-997e-5ab410598b41.png">
<img width="880" alt="Screen Shot 2020-12-21 at 10 21 09 AM" src="https://user-images.githubusercontent.com/17267130/102809580-19537080-4377-11eb-96c5-0bda68074453.png">
<img width="666" alt="Screen Shot 2020-12-21 at 10 21 17 AM" src="https://user-images.githubusercontent.com/17267130/102809582-19537080-4377-11eb-8d93-8bd07cf27522.png">




## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-355035](https://oktainc.atlassian.net/browse/OKTA-355035)


