### PR TITLE
fix: webauthn enroll and verificaiton on v1

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -430,6 +430,7 @@ $enroll-content-spacing: 15px;
   .okta-waiting-spinner {
     margin-top: 20px;
     margin-bottom: 20px;
+    display: none;
   }
 
   .u2f-devices-images {

--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -412,6 +412,11 @@ $enroll-content-spacing: 15px;
     margin-top: 15px;
   }
 }
+.verify-webauthn-form {
+  .okta-waiting-spinner {
+    display: none;
+  }
+}
 
 .verify-u2f-form,
 .enroll-u2f-form,
@@ -430,7 +435,6 @@ $enroll-content-spacing: 15px;
   .okta-waiting-spinner {
     margin-top: 20px;
     margin-bottom: 20px;
-    display: none;
   }
 
   .u2f-devices-images {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,7 @@ const rootDir = path.resolve(__dirname);
 module.exports = (config) => {
   const options = {
     basePath: './',
-    browsers: ['ChromeHeadlessNoSandbox'],
+    browsers: ['Chrome'],
     frameworks: ['karma-overrides', 'jasmine-jquery', 'jasmine'],
     files: [
       { pattern: './test/unit/main.js', watched: false },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,7 @@ const rootDir = path.resolve(__dirname);
 module.exports = (config) => {
   const options = {
     basePath: './',
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadlessNoSandbox'],
     frameworks: ['karma-overrides', 'jasmine-jquery', 'jasmine'],
     files: [
       { pattern: './test/unit/main.js', watched: false },

--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -91,13 +91,10 @@ export default FormController.extend({
           });
 
           self.webauthnAbortController = new AbortController();
-          return new Q(
-            navigator.credentials.create({
+          return navigator.credentials.create({
               publicKey: options,
               signal: self.webauthnAbortController.signal,
-            })
-          )
-            .then(function (newCredential) {
+            }).then(function (newCredential) {
               return transaction.activate({
                 attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
                 clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),

--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -204,7 +204,6 @@ export default FormController.extend({
 
   trapAuthResponse: function () {
     if (this.options.appState.get('isMfaEnrollActivate')) {
-      //this.model.activate();
       return true;
     }
   },

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -139,10 +139,10 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     hasSavingState: false,
-    title: _.partial(loc, 'factor.webauthn.biometric', 'login'),
+    title: loc('factor.webauthn.biometric', 'login'),
     className: 'verify-webauthn-form',
     noCancelButton: true,
-    save: _.partial(loc, 'verify.u2f.retry', 'login'),
+    save: loc('mfa.challenge.verify', 'login'),
     noButtonBar: function () {
       return !webauthn.isNewApiAvailable();
     },
@@ -197,16 +197,6 @@ export default FormController.extend({
       return children;
     },
 
-    postRender: function () {
-      _.defer(() => {
-        if (webauthn.isNewApiAvailable()) {
-          this.model.save();
-        } else {
-          this.$('[data-se="webauthn-waiting"]').hide();
-        }
-      });
-    },
-
     _startEnrollment: function () {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
@@ -214,6 +204,7 @@ export default FormController.extend({
 
     _stopEnrollment: function () {
       this.$('.okta-waiting-spinner').hide();
+      this.$('.o-form-button-bar .button-primary')[0].innerText = loc('retry', 'login');
       this.$('.o-form-button-bar').show();
     },
   },

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -21,17 +21,17 @@ const testAttestationObject = 'c29tZS1yYW5kb20tYXR0ZXN0YXRpb24tb2JqZWN0';
 const testClientData = 'c29tZS1yYW5kb20tY2xpZW50LWRhdGE=';
 
 Expect.describe('EnrollWebauthn', function () {
-  function setup (startRouter, onlyWebauthn) {
+  function setup (webauthnAvailable, onlyWebauthn) {
     const settings = {};
 
     settings['features.webauthn'] = true;
-
+    
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
     const successSpy = jasmine.createSpy('success');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
-    setNextResponse(onlyWebauthn ? resWebauthn : resAllFactors);
+    spyOn(webauthn, 'isNewApiAvailable').and.returnValue(webauthnAvailable);
     const router = new Router(
       _.extend(
         {
@@ -46,7 +46,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     router.on('afterError', afterErrorHandler);
     Util.registerRouter(router);
-    Util.mockRouterNavigate(router, startRouter);
+    Util.mockRouterNavigate(router, false);
 
     const test = {
       router: router,
@@ -64,14 +64,15 @@ Expect.describe('EnrollWebauthn', function () {
       return Expect.waitForEnrollChoices(test).then(function (test) {
         test.setNextResponse([resEnrollActivateWebauthn]);
         router.enrollWebauthn();
-        return Expect.wait(() => test.router.controller.model.get('__enrolled__'), test);
+        if (webauthnAvailable) {
+          return Expect.wait(() => test.router.controller.model.get('__enrolled__'), test);
+        } else {
+          return Expect.waitForEnrollWebauthn(test);
+        }
+        
       });
     };
-    if (startRouter) {
-      return Expect.waitForPrimaryAuth(test).then(enrollWebAuthn);
-    } else {
-      return enrollWebAuthn(test);
-    }
+    return enrollWebAuthn(test);
   }
 
   function mockWebauthn () {
@@ -80,7 +81,6 @@ Expect.describe('EnrollWebauthn', function () {
 
   function mockWebauthnSuccessRegistration (resolvePromise) {
     mockWebauthn();
-    spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
     spyOn(navigator.credentials, 'create').and.callFake(function () {
       const deferred = Q.defer();
 
@@ -109,15 +109,13 @@ Expect.describe('EnrollWebauthn', function () {
 
   Expect.describe('Header & Footer', function () {
     itp('displays the correct factorBeacon', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-webauthn')).toBe(true);
       });
     });
     itp('has a "back" link in the footer', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         Expect.isVisible(test.form.backLink());
       });
     });
@@ -125,8 +123,6 @@ Expect.describe('EnrollWebauthn', function () {
 
   Expect.describe('Enroll factor', function () {
     itp('shows error if browser does not support webauthn', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(false);
-
       return setup(false).then(function (test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
@@ -137,8 +133,6 @@ Expect.describe('EnrollWebauthn', function () {
     });
 
     itp('shows error if browser does not support webauthn and only one factor', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(false);
-
       return setup(false, true).then(function (test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
@@ -149,24 +143,21 @@ Expect.describe('EnrollWebauthn', function () {
     });
 
     itp('does not show error if browser supports webauthn', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         expect(test.form.errorHtml()).toHaveLength(0);
       });
     });
 
     itp('shows instructions and a register button', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.submitButton());
       });
     });
 
     itp('shows correct instructions for Edge browser', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isEdge').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollEdgeInstructions());
         expect(test.form.enrollEdgeInstructions().text()).toEqual(
@@ -179,11 +170,10 @@ Expect.describe('EnrollWebauthn', function () {
     });
 
     itp('shows a note on support restrictions for firefox on mac', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isFirefox').and.returnValue(true);
       spyOn(BrowserFeatures, 'isSafari').and.returnValue(false);
       spyOn(BrowserFeatures, 'isMac').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollRestrictions());
         expect(test.form.enrollRestrictions().text()).toEqual(
@@ -197,11 +187,10 @@ Expect.describe('EnrollWebauthn', function () {
     });
 
     itp('shows a note on support restrictions for safari on mac', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isFirefox').and.returnValue(false);
       spyOn(BrowserFeatures, 'isSafari').and.returnValue(true);
       spyOn(BrowserFeatures, 'isMac').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup(true).then(function (test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollRestrictions());
         expect(test.form.enrollRestrictions().text()).toEqual(
@@ -216,7 +205,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     itp('calls abort on appstate when switching to factor list after clicking enroll', function () {
       mockWebauthnSuccessRegistration(false);
-      return setup()
+      return setup(true)
         .then(function (test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn]);
@@ -240,7 +229,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     itp('shows a waiting spinner after submitting the form', function () {
       mockWebauthnSuccessRegistration(true);
-      return setup()
+      return setup(true)
         .then(function (test) {
           test.setNextResponse([resSuccess]);
           test.form.submit();
@@ -255,7 +244,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     itp('sends enroll request on initialize', function () {
       mockWebauthnSuccessRegistration(true);
-      return setup()
+      return setup(true)
         .then(function () {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(1), {
@@ -271,7 +260,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     itp('calls navigator.credentials.create and activates the factor', function () {
       mockWebauthnSuccessRegistration(true);
-      return setup()
+      return setup(true)
         .then(function (test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resSuccess]);
@@ -328,16 +317,14 @@ Expect.describe('EnrollWebauthn', function () {
         });
     });
 
-    itp('shows error when navigator.credentials.create failed', function () {
-      spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-
+    fitp('shows error when navigator.credentials.create failed', function () {
       mockWebauthnFailureRegistration();
-      return setup()
+      return setup(true)
         .then(function (test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resSuccess]);
           test.form.submit();
-          return Expect.waitForFormError(test.form, test);
+          return Expect.wait(() =>  test.form.errorBox().length === 1, test);
         })
         .then(function (test) {
           expect(navigator.credentials.create).toHaveBeenCalled();

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -16,7 +16,6 @@ import BrowserFeatures from 'util/BrowserFeatures';
 import CryptoUtil from 'util/CryptoUtil';
 import webauthn from 'util/webauthn';
 const itp = Expect.itp;
-const fitp = Expect.fitp;
 const testAttestationObject = 'c29tZS1yYW5kb20tYXR0ZXN0YXRpb24tb2JqZWN0';
 const testClientData = 'c29tZS1yYW5kb20tY2xpZW50LWRhdGE=';
 
@@ -46,7 +45,7 @@ Expect.describe('EnrollWebauthn', function () {
 
     router.on('afterError', afterErrorHandler);
     Util.registerRouter(router);
-    Util.mockRouterNavigate(router, false);
+    Util.mockRouterNavigate(router);
 
     const test = {
       router: router,
@@ -316,14 +315,14 @@ Expect.describe('EnrollWebauthn', function () {
         });
     });
 
-    fitp('shows error when navigator.credentials.create failed', function () {
+    itp('shows error when navigator.credentials.create failed', function () {
       mockWebauthnFailureRegistration();
       return setup(true)
         .then(function (test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resSuccess]);
           test.form.submit();
-          return Expect.wait(() =>  test.form.errorBox().length === 1, test);
+          return Expect.waitForCss('.infobox-error', test);
         })
         .then(function (test) {
           expect(navigator.credentials.create).toHaveBeenCalled();

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -101,7 +101,6 @@ Expect.describe('EnrollWebauthn', function () {
     mockWebauthn();
     spyOn(navigator.credentials, 'create').and.callFake(function () {
       const deferred = Q.defer();
-
       deferred.reject({ message: 'something went wrong' });
       return deferred.promise;
     });

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -225,6 +225,12 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
     });
   });
 
+  itp('doesnt make http request to factors api if webauthn is not supported by browser', function () {
+    return setupFn({ webauthnSupported: false }).then(function (test) {
+      expect(Util.numAjaxRequests()).toBe(1);
+    });
+  });
+
   itp('shows error if browser does not support webauthn', function () {
     return setupFn({ webauthnSupported: false }).then(function (test) {
       expect(test.form.el('o-form-error-html')).toHaveLength(1);
@@ -244,9 +250,17 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
     });
   });
 
+  itp('shows verify button and has spinner hidden when webauthn challenge page is loaded', function () {
+    return setupFn({ webauthnSupported: true }).then(function (test) {
+      expect(test.form.submitButton().css('display')).
+      expect(test.form.el('webauthn-waiting').css('display')).toBe('none');
+    });
+  });
+
   itp('shows a spinner while waiting for webauthn challenge', function () {
     return setupFn({ webauthnSupported: true }).then(function (test) {
-      expect(test.form.el('webauthn-waiting').length).toBe(1);
+      test.form.submit();
+      expect(test.form.el('webauthn-waiting').css('display')).toBe('block');
     });
   });
 
@@ -264,6 +278,7 @@ function testMultipleWebauthnFactor (setupFn) {
       signStatus: 'success',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -310,6 +325,7 @@ function testMultipleWebauthnFactor (setupFn) {
       rememberDevice: true,
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -356,6 +372,7 @@ function testMultipleWebauthnFactor (setupFn) {
       signStatus: 'fail',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -391,6 +408,7 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'success',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy, test);
       })
       .then(function (test) {
@@ -430,6 +448,7 @@ Expect.describe('Webauthn Factor', function () {
       rememberDevice: true,
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -468,6 +487,7 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'fail',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -507,6 +527,7 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('switching to another factor after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {
@@ -525,6 +546,7 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('SignOut after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {


### PR DESCRIPTION
 * Safari requires a direct user action to trigger the webauthn prompt, to allow use of platform authenticator.
 
 * For enroll, making the enroll activate call to backend and then invoking model save seems very convoluted and makes safari think that it is not a direct user interaction. Moving initial call outside save and to initialize section.

* For verify now the user has to click verify before seeing the prompt and we dont show webauthn prompts programmatically anymore.  

* Additionally for verify 
    
* Since other browsers also might adopt this security requirement making this fix for all browser flows. This serves as a general security fix for all browser and future proof.
    
RESOLVES: OKTA-357718

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/17267130/103944673-e2a48680-50e8-11eb-985f-a6abfa235199.mov


**Verify demo**
https://okta.box.com/s/g7xv07cyzxiszp9jeh2yhp3kppp24bm2 

### Reviewers:


### Issue:

- [OKTA-357718](https://oktainc.atlassian.net/browse/OKTA-357718)


