### PR TITLE
fix: webauthn enroll and verify fix on v1

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -413,6 +413,12 @@ $enroll-content-spacing: 15px;
   }
 }
 
+.verify-webauthn-form {
+  .okta-waiting-spinner {
+    display: none;
+  }
+}
+
 .verify-u2f-form,
 .enroll-u2f-form,
 .verify-webauthn-form,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "~4.5.0",
+    "@okta/okta-auth-js": "4.6.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -204,7 +204,7 @@ export default FormController.extend({
 
     _stopEnrollment: function () {
       this.$('.okta-waiting-spinner').hide();
-      this.$('.o-form-button-bar [type="submit"]')[0].value = loc('retry', 'login');
+      this.$('.o-form-button-bar [type="submit"]')[0].value = loc('verify.u2f.retry', 'login');
       this.$('.o-form-button-bar').show();
     },
   },

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -139,10 +139,10 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     hasSavingState: false,
-    title: _.partial(loc, 'factor.webauthn.biometric', 'login'),
+    title: loc('factor.webauthn.biometric', 'login'),
     className: 'verify-webauthn-form',
     noCancelButton: true,
-    save: _.partial(loc, 'verify.u2f.retry', 'login'),
+    save: loc('mfa.challenge.verify', 'login'),
     noButtonBar: function () {
       return !webauthn.isNewApiAvailable();
     },
@@ -197,16 +197,6 @@ export default FormController.extend({
       return children;
     },
 
-    postRender: function () {
-      _.defer(() => {
-        if (webauthn.isNewApiAvailable()) {
-          this.model.save();
-        } else {
-          this.$('[data-se="webauthn-waiting"]').hide();
-        }
-      });
-    },
-
     _startEnrollment: function () {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
@@ -214,6 +204,7 @@ export default FormController.extend({
 
     _stopEnrollment: function () {
       this.$('.okta-waiting-spinner').hide();
+      this.$('.o-form-button-bar [type="submit"]')[0].value = loc('retry', 'login');
       this.$('.o-form-button-bar').show();
     },
   },

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -139,10 +139,10 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     hasSavingState: false,
-    title: loc('factor.webauthn.biometric', 'login'),
+    title: _.partial(loc, 'factor.webauthn.biometric', 'login'),
     className: 'verify-webauthn-form',
     noCancelButton: true,
-    save: loc('mfa.challenge.verify', 'login'),
+    save: _.partial(loc, 'mfa.challenge.verify', 'login'),
     noButtonBar: function () {
       return !webauthn.isNewApiAvailable();
     },

--- a/test/unit/helpers/mocks/Util.js
+++ b/test/unit/helpers/mocks/Util.js
@@ -9,6 +9,7 @@ import wellKnown from '../xhr/well-known';
 import wellKnownSharedResource from '../xhr/well-known-shared-resource';
 let { Cookie } = internal.util;
 const fn = {};
+let globalFetch;
 let isAjaxMocked = false;
 
 afterEach(() => {
@@ -64,6 +65,8 @@ fn.mockDuo = function () {
 };
 
 fn.mockAjax = function (responses) {
+  globalFetch = window.fetch;
+  window.fetch = null;
   jasmine.Ajax.install();
   isAjaxMocked = true;
 
@@ -127,6 +130,7 @@ fn.getAjaxRequest = function (index) {
 };
 
 fn.unmockAjax = function () {
+  window.fetch = globalFetch;
   jasmine.Ajax.uninstall();
 };
 

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -244,9 +244,10 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
     });
   });
 
-  itp('shows a spinner while waiting for webauthn challenge', function () {
+  itp('shows verify button when webauthn challenge page is loaded', function () {
     return setupFn({ webauthnSupported: true }).then(function (test) {
-      expect(test.form.el('webauthn-waiting').length).toBe(1);
+      expect(test.form.submitButton().css('display')).toBe('block');
+      expect(test.form.submitButtonText()).toBe('Verify');
     });
   });
 
@@ -264,6 +265,7 @@ function testMultipleWebauthnFactor (setupFn) {
       signStatus: 'success',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -310,6 +312,7 @@ function testMultipleWebauthnFactor (setupFn) {
       rememberDevice: true,
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -349,13 +352,14 @@ function testMultipleWebauthnFactor (setupFn) {
       });
   });
 
-  itp('shows an error if navigator.credentials.get fails', function () {
+  itp('shows an error if navigator.credentials.get fails and displays retry button', function () {
     Expect.allowUnhandledPromiseRejection();
     return setupFn({
       webauthnSupported: true,
       signStatus: 'fail',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -364,6 +368,8 @@ function testMultipleWebauthnFactor (setupFn) {
         expect(test.form.errorBox()).toHaveLength(1);
         expect(test.form.errorMessage()).toEqual('something went wrong');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+        expect(test.form.submitButton().css('display')).toBe('block');
+        expect(test.form.submitButtonText()).toBe('Retry');
         expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
           {
             controller: 'mfa-verify verify-webauthn',
@@ -391,6 +397,7 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'success',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy, test);
       })
       .then(function (test) {
@@ -430,6 +437,7 @@ Expect.describe('Webauthn Factor', function () {
       rememberDevice: true,
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -468,6 +476,7 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'fail',
     })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -507,6 +516,7 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('switching to another factor after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {
@@ -525,6 +535,7 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('SignOut after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
+        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@~4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.5.0.tgz#df588fd99bb152ba4ec994cf829f04e12fc13370"
-  integrity sha512-r0YikMimF1idBJtvSbBbtKOEZxh4E6lBmmZMqAkQWmvO4Pln6ZVyt/yg0f35N5BkfZScV5WYkWWJoBpdmNwbaw==
+"@okta/okta-auth-js@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.6.0.tgz#4aed3429635f15dd87b4d791987e1da84cbeb101"
+  integrity sha512-QtpyuNuxuCSFmzAw0xWUTAbQJEHKfQ29tJdba8XQH+UlojWtA/adRCoHcekmaSN1EZ/oQNVleLFs4k+edNCvkw==
   dependencies:
     Base64 "0.3.0"
     core-js "^3.6.5"


### PR DESCRIPTION
    
    * Webauthn enroll and verify now works on v1 in safari on bigsur and ios13.
    * The change to verify flow is common across all browsers to make sure we are future proof
    and follow security best practices ( explicit user click before webauthn prompt)
    
    * This needs upgrade of auth js to 4.6.0 to consume fix that uses borwser fetch instead of cross fetch as
    cross fetch wraps fetch with unnecessary promises causing safari to think the call is programatic and not due to direct user interaction
    even if webauthn prompt is triggered on api callback after user click.
    
auth-js pr -    https://github.com/okta/okta-auth-js/pull/585
    
    RESOLVES: OKTA-357718
    


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://drive.google.com/file/d/1yJeN_b85EkM2gxh5JtqYAjt1WRKi0eRd/view?usp=sharing

### Reviewers:


### Issue:

- [OKTA-357718](https://oktainc.atlassian.net/browse/OKTA-357718)


