### PR TITLE
fix: add #okta-sign-in css prop for ie only

### DIFF
--- a/assets/sass/okta-theme.scss
+++ b/assets/sass/okta-theme.scss
@@ -81,8 +81,10 @@
 }
 
 #okta-sign-in.auth-container {
-  // for IE to support main tag's width
-  display: block;
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    // for IE to support main tag's width
+    display: block;
+  }
 
   &.main-container {
     /* -- Fonts and Text Colors -- */

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -364,6 +364,15 @@ Expect.describe('PrimaryAuth', function () {
         expect(explain.length).toBe(0);
       });
     });
+    itp('has css display:block', () => {
+      return setup().then(() => {
+        return Expect.waitForCss('.auth-container')
+          .then(() => {
+            const mainElement = $('.auth-container')[0];
+            expect(window.getComputedStyle(mainElement).display).toBe('block');
+          });
+      });
+    });
     itp('username field does not have explain when only label is customized', function () {
       const options = {
         language: 'en',


### PR DESCRIPTION
## Description:
scope `display: block` to IE browser

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
IE 11
![Screen Shot 2021-01-12 at 6 00 46 PM](https://user-images.githubusercontent.com/71431120/104396887-64891b00-5500-11eb-87c4-328eda2b78dd.png)
Chrome
![Screen Shot 2021-01-19 at 3 32 14 PM](https://user-images.githubusercontent.com/71431120/105106834-8ab43b00-5a6b-11eb-8625-8f6d76f7555b.png)


### Reviewers:


### Issue:

- [OKTA-351886](https://oktainc.atlassian.net/browse/OKTA-351886)


