### PR TITLE
feat: accept authClient option

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,37 @@ signIn.authClient.session.exists()
 });
 ```
 
+The `authClient` can be set directly in the configuration:
+
+```javascript
+var authClient = new OktaAuth({
+  issuer: 'https://{yourOktaDomain}/oauth2/default',
+  clientId: '{yourClientId}'
+});
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authClient: authClient
+};
+
+var signIn = new OktaSignIn(config);
+// signIn.authClient === authClient
+```
+
+If no `authClient` option is set, an instance will be created using `authParams`:
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authParams: {
+    issuer: 'https://{yourOktaDomain}/oauth2/default',
+    clientId: '{yourClientId}'  
+  }
+};
+
+var signIn = new OktaSignIn(config);
+// signIn.authClient.options.clientId === '{yourClientId}'
+```
+
 ## Configuration
 
 The only required configuration option is `baseUrl`. All others are optional.
@@ -1206,7 +1237,10 @@ OIDC flow is required for [Social Login][].
     oAuthTimeout: 300000 // 5 minutes
     ```
 
-- **authParams:** An object containing configuration which is passed directly to the internal `authClient`. Selected options are described below. See the full set of [Configuration options](https://github.com/okta/okta-auth-js#configuration-options)
+- **authClient:** An [AuthJS](https://github.com/okta/okta-auth-js) instance. This will be available on the widget instance as the [authClient](#authclient) property. 
+ **Note:** If the `authClient` option is used, `authParams` will be ignored.
+
+- **authParams:** An object containing configuration which is used to create the internal [authClient`](#authclient). Selected options are described below. See the full set of [Configuration options](https://github.com/okta/okta-auth-js#configuration-options)
 
 - **authParams.pkce:** Set to `false` to disable [PKCE][] flow
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -1,7 +1,6 @@
 /*globals module, Promise */
 import _ from 'underscore';
 import Errors from 'util/Errors';
-import OAuth2Util from 'util/OAuth2Util';
 import Util from 'util/Util';
 import createAuthClient from 'widget/createAuthClient';
 import V1Router from 'LoginRouter';
@@ -97,7 +96,8 @@ var OktaSignIn = (function () {
       const promise = render.call(this, renderOptions).then(res => {
         return res.tokens;
       });
-      if (OAuth2Util.isAuthorizationCodeFlow(router.settings)) {
+      const authClient = router.settings.getAuthClient();
+      if (authClient.isAuthorizationCodeFlow() && !authClient.isPKCE()) {
         throw new Errors.ConfigError('"showSignInToGetTokens()" should not be used for authorization_code flow. ' + 
           'Use "showSignInAndRedirect()" instead');
       }
@@ -150,7 +150,7 @@ var OktaSignIn = (function () {
       authParams.issuer = options.baseUrl + '/oauth2/default';
     }
 
-    var authClient = createAuthClient(authParams);
+    var authClient = options.authClient ? options.authClient : createAuthClient(authParams);
 
     var Router;
     if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) 

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -72,6 +72,17 @@ Expect.describe('OktaSignIn initialization', function () {
   });
 
   describe('Auth Client', function () {
+    Expect.describe('authClient option', function () {
+      it('accepts an authClient option', function () {
+        const authClient = { foo: 'bar' };
+        signIn = new Widget({
+          baseUrl: url,
+          authClient,
+        });
+        expect(signIn.authClient).toBe(authClient);
+      });
+    });
+
     Expect.describe('Config', function () {
       it('has an options object', function () {
         expect(signIn.authClient.options).toBeDefined();


### PR DESCRIPTION
## Description:
Adds new option `authClient` which is an [AuthJS](https://github.com/okta/okta-auth-js) instance.
If `authClient` is passed, `authParams` will be ignored.

Used together with one of our other SDKs like [okta-react](https://github.com/okta/okta-react), this allows the SDKs to share a single instance of AuthJS. This will avoid some issues that can occur with multiple instances of AuthJS running on the same storage. A single instance ensures the same code is accessing the same storage with the same config in each SDK.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-361258](https://oktainc.atlassian.net/browse/OKTA-361258)


