### PR TITLE
fix: align sms form button with input

### DIFF
--- a/assets/sass/modules/_forgot-password.scss
+++ b/assets/sass/modules/_forgot-password.scss
@@ -35,6 +35,15 @@
     }
   }
 
+  .o-form-fieldset-container {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  .sms-request-button {
+    margin-left: 5px;
+  }
+
   .o-form-fieldset.enroll-sms-phone {
     // Need to verify what the correct dimensions should be for this
     // to match up with other forms
@@ -51,10 +60,6 @@
 
   .o-form-button-bar {
     padding-bottom: 15px;
-  }
-
-  a.button {
-    float: right;
   }
 
   .send-email-link {


### PR DESCRIPTION
## Description:
button sits inline with input form element

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Chrome fix:
![Screen Shot 2021-01-25 at 1 07 16 PM](https://user-images.githubusercontent.com/71431120/105766181-482cab80-5f0e-11eb-9abf-b2b6bf15af61.png)

IE fix:
![Screen Shot 2021-01-25 at 1 06 03 PM](https://user-images.githubusercontent.com/71431120/105766037-1a476700-5f0e-11eb-99da-183dbd426e26.png)

Bug:
![Screen Shot 2021-01-25 at 1 08 19 PM](https://user-images.githubusercontent.com/71431120/105766314-6d211e80-5f0e-11eb-897c-e4fb02feba2c.png)


### Reviewers:


### Issue:

- [OKTA-364334](https://oktainc.atlassian.net/browse/OKTA-364334)


