### PR TITLE
feat: update registration input length error messages

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -642,6 +642,8 @@ registration.default.callbackhook.error=We could not process your registration a
 registration.error.userName.invalidEmail=Invalid email address
 registration.error.password.passwordRequirementsNotMet=Password requirements were not met
 registration.error.userName.notUniqueWithinOrg=An account with that email already exists
+registration.model.validation.field.string.too.short = Please enter something at least {0} characters long
+registration.model.validation.field.string.too.long = Please enter something shorter than {0} characters
 
 # PIV Auth
 piv.card=PIV Card

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -198,6 +198,18 @@ export default BaseLoginController.extend({
         noCancelButton: true,
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
+        initialize() {
+          this.listenTo(this.model, 'invalid error', (model, errorResp) => {
+            // overwrite courage errorResp object to show custom error message
+            for (let formFieldName in errorResp) {
+              if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {
+                errorResp[formFieldName] = loc('registration.model.validation.field.string.tooShort', 'login', [formFieldName, model.props[formFieldName].minLength]);
+              } else if (errorResp[formFieldName] === 'model.validation.field.string.maxLength') {
+                errorResp[formFieldName] = loc('registration.model.validation.field.string.tooLong', 'login', [formFieldName, model.props[formFieldName].maxLength]);
+              }
+            }
+          });
+        },
         parseErrorMessage: function (resp) {
           const hasErrorCauses = resp.errorCauses && resp.errorCauses.length;
 

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -199,7 +199,7 @@ export default BaseLoginController.extend({
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
         initialize () {
-          this.listenTo(this.model, 'invalid error', function (model, errorResp) {
+          this.listenTo(this.model, 'invalid', function (model, errorResp) {
             // overwrite courage errorResp object to show custom error message
             for (let formFieldName in errorResp) {
               if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -198,21 +198,20 @@ export default BaseLoginController.extend({
         noCancelButton: true,
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
-        initialize () {
-          this.listenTo(this.model, 'invalid', function (model, errorResp) {
-            // overwrite courage errorResp object to show custom error message
-            for (let formFieldName in errorResp) {
-              if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {
-                errorResp[formFieldName] = loc('registration.model.validation.field.string.too.short', 'login', 
-                  [model.props[formFieldName].minLength]
-                );
-              } else if (errorResp[formFieldName] === 'model.validation.field.string.maxLength') {
-                errorResp[formFieldName] = loc('registration.model.validation.field.string.too.long', 'login', 
-                  [model.props[formFieldName].maxLength + 1]
-                );
-              }
+        modelEvents : { 'invalid' : 'modifyErrors' },
+        modifyErrors: function (model, errorResp) {
+          // overwrite courage errorResp object to show custom error message
+          for (let formFieldName in errorResp) {
+            if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {
+              errorResp[formFieldName] = loc('registration.model.validation.field.string.too.short', 'login', 
+                [model.props[formFieldName].minLength]
+              );
+            } else if (errorResp[formFieldName] === 'model.validation.field.string.maxLength') {
+              errorResp[formFieldName] = loc('registration.model.validation.field.string.too.long', 'login', 
+                [model.props[formFieldName].maxLength + 1]
+              );
             }
-          });
+          }
         },
         parseErrorMessage: function (resp) {
           const hasErrorCauses = resp.errorCauses && resp.errorCauses.length;

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -198,14 +198,18 @@ export default BaseLoginController.extend({
         noCancelButton: true,
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
-        initialize() {
-          this.listenTo(this.model, 'invalid error', (model, errorResp) => {
+        initialize () {
+          this.listenTo(this.model, 'invalid error', function (model, errorResp) {
             // overwrite courage errorResp object to show custom error message
             for (let formFieldName in errorResp) {
               if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {
-                errorResp[formFieldName] = loc('registration.model.validation.field.string.tooShort', 'login', [formFieldName, model.props[formFieldName].minLength]);
+                errorResp[formFieldName] = loc('registration.model.validation.field.string.too.short', 'login', 
+                  [model.props[formFieldName].minLength]
+                );
               } else if (errorResp[formFieldName] === 'model.validation.field.string.maxLength') {
-                errorResp[formFieldName] = loc('registration.model.validation.field.string.tooLong', 'login', [formFieldName, model.props[formFieldName].maxLength]);
+                errorResp[formFieldName] = loc('registration.model.validation.field.string.too.long', 'login', 
+                  [model.props[formFieldName].maxLength + 1]
+                );
               }
             }
           });


### PR DESCRIPTION
## Description:

On the v1 Registration form, update string length validation error messages to be more helpful:

1.  
    - old message: "This field cannot be less than the minimum required characters"
    - new message: "Please enter something at least {x} characters long"
2.
   - old message: "This field cannot exceed the maximum allowed characters"
   - new message: "Please enter something shorter than {x} characters"

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Why does the css intentionally break on characters, pretty annoying
![Screen Shot 2021-01-27 at 1 57 39 PM](https://user-images.githubusercontent.com/71431120/106060386-d76dc680-60a8-11eb-871d-0a372425da33.png)
![Screen Shot 2021-01-27 at 1 57 29 PM](https://user-images.githubusercontent.com/71431120/106060389-d9378a00-60a8-11eb-9320-86b628a1a737.png)
![Screen Shot 2021-01-27 at 1 29 44 PM](https://user-images.githubusercontent.com/71431120/106060403-df2d6b00-60a8-11eb-96b8-30dbe503e8b9.png)


### Reviewers:


### Issue:

- [OKTA-347240](https://oktainc.atlassian.net/browse/OKTA-347240)


