### PR TITLE
OKTA-353857: test SDK errors are emitted through triggerAfterError handler

### DIFF
--- a/test/unit/spec/OAuth2Util_spec.js
+++ b/test/unit/spec/OAuth2Util_spec.js
@@ -1,14 +1,122 @@
 /* eslint max-len: [2, 140] */
-import Util from 'util/OAuth2Util';
+import OAuth2Util from 'util/OAuth2Util';
+import Util from 'util/Util';
+import createAuthClient from 'widget/createAuthClient';
+import Settings from '../../../src/models/Settings';
+import { AuthSdkError } from '@okta/okta-auth-js';
+import Enums from '../../../src/util/Enums';
 
-// TODO: rewrite
+
 describe('util/OAuth2Util', function () {
-  
+  class MockModel {
+    constructor () {
+      this.trigger = function () {};
+    }
+  }
+
+  class MockController {
+    constructor () {
+      this.model = new MockModel();
+      this.trigger = function () {};
+    }
+  }
   describe('getTokens', function () {
-    // TODO
+    let controller;
+    let authClient;
+    let settings;
+
+    beforeEach(function () {
+      controller = new MockController();
+      authClient = createAuthClient({issuer: 'https://foo/default'});
+      settings = new Settings({
+        baseUrl: 'https://foo'
+      });
+      settings.setAuthClient(authClient);
+    });
 
     it('exists', () => {
-      expect(Util.getTokens).toBeTruthy();
+      expect(OAuth2Util.getTokens).toBeTruthy();
+    });
+
+    it('emits SDK errors through \'triggerAfterError\' event', function (done) {
+      spyOn(authClient.token, 'getWithPopup').and.callFake(function () {
+        return new Promise(function () {
+          throw new AuthSdkError('Auth SDK error');
+        });
+      });
+
+      return new Promise(function (resolve) {
+        spyOn(Util, 'triggerAfterError').and.callFake(resolve);
+        OAuth2Util.getTokens(settings, {}, controller);
+      }).then(function () {
+        expect(Util.triggerAfterError).toHaveBeenCalledTimes(1);
+        const exceptionMessage = Util.triggerAfterError.calls.mostRecent().args[1].message;
+        expect(exceptionMessage).toEqual('Auth SDK error');
+        done();
+      }).catch(done.fail);
+    });
+
+    it('invokes \'globalSuccessFn\' after successfull token retrieval', function (done) {
+      return new Promise(function (resolve) {
+        spyOn(settings, 'callGlobalSuccess').and.callFake(resolve);
+        spyOn(authClient.token, 'getWithPopup').and.callFake(function () {
+          return Promise.resolve({token: 'foobar'});
+        });
+        OAuth2Util.getTokens(settings, {}, controller);
+      }).then(function () {
+        expect(settings.callGlobalSuccess).toHaveBeenCalledTimes(1);
+        expect(settings.callGlobalSuccess).toHaveBeenCalledWith(Enums.SUCCESS, {token: 'foobar'});
+        done();
+      }).catch(done.fail);
+    });
+
+    it('gates non-allowlisted token parameters from widget config', function (done) {
+      const settingsWithAdditionalParams = new Settings({
+        baseUrl: 'https://foo',
+        clientId: 'foobar',
+        authOptions: {
+          responseMode: 'token'
+        }
+      });
+      settingsWithAdditionalParams.setAuthClient(authClient);
+
+      return new Promise(function (resolve) {
+        spyOn(authClient.token, 'getWithPopup').and.callFake(resolve);
+        OAuth2Util.getTokens(settingsWithAdditionalParams, { scopes: ['openid'] }, controller);
+      }).then(function () {
+        const tokenParameters = Object.keys(authClient.token.getWithPopup.calls.mostRecent().args[0]);
+        expect(tokenParameters).not.toContain('responseMode');
+        expect(tokenParameters).not.toContain('baseUrl');
+        expect(tokenParameters).toContain('clientId');
+        expect(tokenParameters).toContain('scopes');
+        done();
+      }).catch(done.fail);
+    });
+
+    it('retrieves tokens through redirect when widget is configured with \'remediation\' mode', function (done) {
+      const settingsWithRemediationMode = new Settings({
+        baseUrl: 'https://foo',
+        mode: 'remediation',
+      });
+      settingsWithRemediationMode.setAuthClient(authClient);
+
+      return new Promise(function (resolve) {
+        spyOn(authClient.token, 'getWithRedirect').and.callFake(resolve);
+        OAuth2Util.getTokens(settingsWithRemediationMode, {}, controller);
+      }).then(function () {
+        expect(authClient.token.getWithRedirect).toHaveBeenCalledTimes(1);
+        done();
+      }).catch(done.fail);
+    });
+
+    it('retrieves tokens via iframe when sessionToken is available', function (done) {
+      return new Promise(function (resolve) {
+        spyOn(authClient.token, 'getWithoutPrompt').and.callFake(resolve);
+        OAuth2Util.getTokens(settings, { sessionToken: 'foo'} , controller);
+      }).then(function () {
+        expect(authClient.token.getWithoutPrompt).toHaveBeenCalledTimes(1);
+        done();
+      }).catch(done.fail);
     });
   });
 });


### PR DESCRIPTION
## Description:
* test SDK errors are emitted through triggerAfterError handler
* add missing tests for OAuth2Util

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-353857](https://oktainc.atlassian.net/browse/OKTA-353857)
