### PR TITLE
fix: align sms form button with input

### DIFF
--- a/assets/sass/modules/_forgot-password.scss
+++ b/assets/sass/modules/_forgot-password.scss
@@ -35,6 +35,15 @@
     }
   }
 
+  .o-form-fieldset-container {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  .sms-request-button {
+    margin-left: 5px;
+  }
+
   .o-form-fieldset.enroll-sms-phone {
     // Need to verify what the correct dimensions should be for this
     // to match up with other forms
@@ -51,10 +60,6 @@
 
   .o-form-button-bar {
     padding-bottom: 15px;
-  }
-
-  a.button {
-    float: right;
   }
 
   .send-email-link {


### PR DESCRIPTION
OKTA-364334
<<<Jenkins Check-In of Tested SHA: 05d9b9bdd37ffe2dd6a117595624c38176e7e18d for eng_productivity_ci_bot_okta@okta.com>>>
Artifact: okta-signin-widget

## Description:

backport from 5.2.3

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


