### PR TITLE
feat: Adds IDP factor enrollment to OIE

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -263,6 +263,7 @@ mfa.challenge.enterCode.placeholder = Enter Code
 mfa.challenge.enterCode.tooltip = Enter Code
 mfa.challenge.password.placeholder = Password
 mfa.backToFactors = Back to factor list
+mfa.enroll = Enroll
 mfa.phoneNumber.placeholder = Phone number
 mfa.phoneNumber.ext.placeholder = Extension
 mfa.sendCode = Send code
@@ -840,6 +841,14 @@ oie.duo.authenticator.description = Verify your identity using Duo Security.
 oie.duo.enroll.title = Set up Duo Security
 oie.duo.verify.title = Verify with Duo Security
 oie.duo.iFrameError = Error loading Duo. Try again or contact your admin for assistance.
+
+## IdP Authenticator
+# {0} refers to the display name of the authenticator for all IdP Authenticator values
+oie.idp.authenticator.description = Redirect to verify with {0}
+oie.idp.enroll.title = Set up {0}
+oie.idp.enroll.description = Clicking below will redirect to enrollment in {0}
+oie.idp.challenge.title=  Verify with {0}
+oie.idp.challenge.description = You will be redirected to verify with {0}
 
 ## Select authenticator enrollment
 oie.select.authenticators.enroll.title = Set up Authenticators

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -49,7 +49,7 @@ const idx = {
     // 'identify-with-third-party-idps',
     // 'identify-with-only-third-party-idps',
     // 'identify-with-only-one-third-party-idp',
-    //'identify-with-password',
+    // 'identify-with-password',
     // 'identify-with-universal-link',
     // 'success',
     // 'success-with-app-user',
@@ -74,7 +74,7 @@ const idx = {
   ],
   '/idp/idx/identify': [
     'authenticator-enroll-select-authenticator',
-    //'identify-with-only-one-third-party-idp',
+    // 'identify-with-only-one-third-party-idp',
     // 'error-identify-access-denied',
     // 'error-identify-user-locked-unable-challenge'
   ],
@@ -85,7 +85,7 @@ const idx = {
     'error-authenticator-enroll-security-question'
   ],
   '/idp/idx/challenge/send': [
-    //'authenticator-enroll-ov-sms',
+    // 'authenticator-enroll-ov-sms',
     'authenticator-enroll-ov-email',
   ],
   '/idp/idx/challenge/resend': [
@@ -94,7 +94,7 @@ const idx = {
   ],
   '/idp/idx/challenge/poll': [
     'success',
-    //'enroll-profile-new'
+    // 'enroll-profile-new'
     // 'authenticator-enroll-email',
     // 'authenticator-verification-okta-verify-push',
   ],
@@ -589,6 +589,20 @@ const passwordRecovery = {
     // 'error-identify-access-denied',
     'authenticator-verification-select-authenticator',
   ],
+};
+
+const idpAuthenticator = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-select-authenticator',
+    // 'authenticator-verification-select-authenticator',
+    'success',
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-idp',
+  ],
+  '/idp/idx/credential/enroll': [
+    'authenticator-enroll-idp',
+  ]
 };
 
 module.exports = {

--- a/playground/mocks/data/idp/idx/authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-idp.json
@@ -65,7 +65,6 @@
       "type": "federated",
       "id": "aut4mhtS1b84AR0iQ0g4",
       "displayName": "IDP Authenticator",
-      "contextualData": { "integrationType": "REDIRECT" },
       "methods": [
         { "type": "idp" }
       ]

--- a/playground/mocks/data/idp/idx/authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-idp.json
@@ -1,0 +1,132 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticator" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "contextualData": { "integrationType": "REDIRECT" },
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-enroll-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-select-authenticator.json
@@ -234,6 +234,22 @@
                   }
                 },
                 "relatesTo": "$.authenticators.value[8]"
+              },
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "0oa69chx4bZyx8O7l0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[9]"
               }
             ]
           },
@@ -332,6 +348,16 @@
         "key": "duo_native",
         "id": "aut32kl92UF8kfE4E0g4",
         "displayName": "Duo Security",
+        "methods": [
+          {
+            "type": "idp"
+          }
+        ]
+      }, {
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "key": "external_idp",
+        "displayName": "IDP Authenticator",
         "methods": [
           {
             "type": "idp"

--- a/playground/mocks/data/idp/idx/authenticator-verification-idp.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-idp.json
@@ -65,7 +65,6 @@
       "type": "federated",
       "id": "aut4mhtS1b84AR0iQ0g4",
       "displayName": "IDP Authenticator",
-      "contextualData": { "integrationType": "REDIRECT" },
       "methods": [
         { "type": "idp" }
       ]
@@ -78,7 +77,6 @@
       "type": "federated",
       "id": "aut4mhtS1b84AR0iQ0g4",
       "displayName": "IDP Authenticator",
-      "contextualData": { "integrationType": "REDIRECT" },
       "methods": [
         { "type": "idp" }
       ]

--- a/playground/mocks/data/idp/idx/authenticator-verification-idp.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-idp.json
@@ -1,0 +1,144 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticatorEnrollment" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "contextualData": { "integrationType": "REDIRECT" },
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "contextualData": { "integrationType": "REDIRECT" },
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "profile": { "provider": "Custom OIDC Provider" },
+        "type": "federated",
+        "key": "external_idp",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
@@ -308,6 +308,22 @@
                   }
                 },
                 "relatesTo": "$.authenticatorEnrollments.value[11]"
+              },
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "0oa69chx4bZyx8O7l0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[12]"
               }
             ]
           },
@@ -451,6 +467,17 @@
         "id": "dsf36lrPqdONw2Xjv0g4",
         "displayName": "Duo Security",
         "credentialId": "",
+        "methods": [
+          {
+            "type": "idp"
+          }
+        ]
+      },
+      {
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "key": "external_idp",
+        "displayName": "IDP Authenticator",
         "methods": [
           {
             "type": "idp"

--- a/playground/mocks/spec-okta-api/oauth2/v1/authorize/callback.js
+++ b/playground/mocks/spec-okta-api/oauth2/v1/authorize/callback.js
@@ -1,0 +1,22 @@
+const apis = [
+  {
+    delay: [1000, 3000],
+    proxy: false,
+    path: '/oauth2/v1/authorize/callback',
+    method: 'GET',
+    template () {
+      // In a real case, `/oauth2/v1/authorize` would parse the `code`
+      // and `state` and handle it as any OAuth 2.0 request.
+      // To simplify the test flow, respond via a redirect with a new `stateToken`.
+      return `
+      <html>
+        <head>
+          <meta http-equiv="refresh" content="2;url=http://localhost:3000?stateToken=mockedStateToken123" />
+        </head>
+        <body></body>
+      </html>`;
+    },
+  },
+];
+
+module.exports = apis;

--- a/playground/mocks/spec-okta-api/sso/idps.js
+++ b/playground/mocks/spec-okta-api/sso/idps.js
@@ -5,10 +5,15 @@ const apis = [
     path: '/sso/idps/:idpId',
     method: 'GET',
     template (params) {
-      const idpId = params.idpId;
       // At real case, `/sso/idps/:id` would 302 to 3rd party login page.
       // To simplify the test flow, responds 200 instead.
-      return `<html><body><h1>Mimic a Login page of external IDP: ${idpId} </h1></body></html>`;
+      return `
+      <html>
+        <body>
+          <h1>Mimic a Login page of external IDP: ${params.idpId} </h1>
+          <a href="http://localhost:3000/oauth2/v1/authorize/callback?code=fooCode&state=fooState">Mock Login</a>
+        </body>
+      </html>`;
     },
   },
 ];

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -13,6 +13,8 @@ import { _, Controller } from 'okta';
 import ViewFactory from '../view-builder/ViewFactory';
 import IonResponseHelper from '../ion/IonResponseHelper';
 import { getV1ClassName } from '../ion/ViewClassNamesFactory';
+import { FORMS } from '../ion/RemediationConstants';
+import Util from '../../util/Util';
 
 export default Controller.extend({
   className: 'form-controller',
@@ -104,7 +106,7 @@ export default Controller.extend({
   },
 
   handleSwitchForm (formName) {
-    // trigger formname change to change view
+    // trigger formName change to change view
     this.options.appState.set('currentFormName', formName);
   },
 
@@ -147,6 +149,17 @@ export default Controller.extend({
 
     this.toggleFormButtonState(true);
     model.trigger('request');
+
+    // NOTE: okta-idx-js does not know whether a remediation
+    // is required to redirect or perform a GET request.
+    // As a result, we handle this accordingly by checking the formName
+    const fullPageRedirectForms = [ FORMS.REDIRECT_IDP ];
+    if (fullPageRedirectForms.includes(formName)) {
+      const currentViewState = this.options.appState.getCurrentViewState();
+      Util.redirectWithFormGet(currentViewState.href);
+      return;
+    }
+
     idx.proceed(formName, model.toJSON())
       .then(this.handleIdxSuccess.bind(this))
       .catch(error => {

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -84,7 +84,8 @@ const AUTHENTICATOR_KEY = {
   GOOGLE_AUTHENTICATOR: 'google_authenticator',
   ON_PREM: 'onprem_mfa',
   RSA: 'rsa_token',
-  DUO: 'duo_native'
+  DUO: 'duo_native',
+  IDP: 'external_idp',
 };
 
 export {

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -2,7 +2,7 @@ import Logger from 'util/Logger';
 import { AUTHENTICATOR_KEY, FORMS as RemediationForms } from '../ion/RemediationConstants';
 import BaseView from './internals/BaseView';
 
-// authenticator ignostic views
+// authenticator agnostic views
 import IdentifierView from './views/IdentifierView';
 import IdentifyRecoveryView from './views/IdentifyRecoveryView';
 import TerminalView from './views/TerminalView';
@@ -69,6 +69,9 @@ import ChallengeAuthenticatorOnPremView from './views/on-prem/ChallengeAuthentic
 import EnrollDuoAuthenticatorView from './views/duo/EnrollDuoAuthenticatorView';
 import ChallengeDuoAuthenticatorView from './views/duo/ChallengeDuoAuthenticatorView';
 
+// idp authenticator
+import AuthenticatorIdPView from './views/idp/AuthenticatorIdPView';
+
 // safe mode poll view
 import PollView from './views/PollView';
 
@@ -107,7 +110,6 @@ const VIEWS_MAPPING = {
     [AUTHENTICATOR_KEY.PHONE]: EnrollAuthenticatorDataPhoneView,
   },
   [RemediationForms.ENROLL_AUTHENTICATOR]: {
-
     [AUTHENTICATOR_KEY.PASSWORD]: EnrollAuthenticatorPasswordView,
     [AUTHENTICATOR_KEY.WEBAUTHN]: EnrollWebauthnView,
     [AUTHENTICATOR_KEY.PHONE]: EnrollAuthenticatorPhoneView,
@@ -173,6 +175,7 @@ const VIEWS_MAPPING = {
   // redirect-idp remediation object looks similar to identifier view
   [RemediationForms.REDIRECT_IDP]: {
     [DEFAULT]: IdentifierView,
+    [AUTHENTICATOR_KEY.IDP]: AuthenticatorIdPView,
   },
   [RemediationForms.DEVICE_ENROLLMENT_TERMINAL]: {
     [DEFAULT]: DeviceEnrollmentTerminalView,

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -24,7 +24,7 @@ const getButtonDataSeAttr = function (authenticator) {
   return '';
 };
 
-/* eslint complexity: [2, 22] */
+/* eslint complexity: [2, 25] */
 const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
   const authenticatorKey = authenticator.authenticatorKey;
   const key = _.isString(authenticatorKey) ? authenticatorKey.toLowerCase() : '';
@@ -130,6 +130,21 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),
     });
     break;
+
+  case AUTHENTICATOR_KEY.IDP: {
+    const idpName =  authenticator.relatesTo?.displayName;
+    const factorDescription = idpName
+      ? loc('oie.idp.authenticator.description', 'login', [idpName])
+      : loc('oie.idp.authenticator.description.default', 'login');
+    Object.assign(authenticatorData, {
+      description: isVerifyAuthenticator
+        ? ''
+        : factorDescription,
+      iconClassName: 'mfa-custom-factor',
+      buttonDataSeAttr: getButtonDataSeAttr(authenticator),
+    });
+    break;
+  }
   }
 
   return authenticatorData;

--- a/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
+++ b/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
@@ -1,0 +1,46 @@
+import { _, loc } from 'okta';
+import BaseForm from '../../internals/BaseForm';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
+import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
+
+const Body = BaseForm.extend({
+
+  title () {
+    return this.options.isChallenge
+      ? loc('oie.idp.challenge.title', 'login', [this.options.displayName])
+      : loc('oie.idp.enroll.title', 'login', [this.options.displayName]);
+  },
+
+  subtitle () {
+    return this.options.isChallenge
+      ? loc('oie.idp.challenge.description', 'login', [this.options.displayName])
+      : loc('oie.idp.enroll.description', 'login', [this.options.displayName]);
+  },
+
+  save () {
+    return this.options.isChallenge
+      ? loc('mfa.challenge.verify', 'login')
+      : loc('mfa.enroll', 'login');
+  },
+
+});
+
+export default BaseAuthenticatorView.extend({
+  initialize () {
+    BaseAuthenticatorView.prototype.initialize.apply(this, arguments);
+
+    const currentAuthenticator = this.options.appState.get('currentAuthenticator');
+    const authenticatorEnrollments = this.options.appState.get('authenticatorEnrollments')?.value || [];
+    const existingAuthenticator = _.find(authenticatorEnrollments, { id: currentAuthenticator.id });
+
+    // If the authenticator is already enrolled, we're in a challenge flow as opposed to enrollment
+    this.options.isChallenge = existingAuthenticator || false;
+    this.options.displayName = currentAuthenticator.displayName;
+
+    this.Footer = this.options.isChallenge
+      ? AuthenticatorVerifyFooter
+      : AuthenticatorEnrollFooter;
+  },
+  Body,
+});

--- a/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
@@ -1,0 +1,25 @@
+import { ClientFunction } from 'testcafe';
+import BasePageObject from './BasePageObject';
+
+export default class IdPAuthenticatorPageObject extends BasePageObject {
+  constructor (t) {
+    super(t);
+  }
+
+  async getPageUrl() {
+    const pageUrl = await ClientFunction(() => window.location.href)();
+    return pageUrl;
+  }
+
+  getPageTitle() {
+    return this.form.getElement('.okta-form-title').textContent;
+  }
+
+  getPageSubtitle() {
+    return this.form.getElement('.okta-form-subtitle').textContent;
+  }
+
+  submit() {
+    return this.form.clickSaveButton();
+  }
+}

--- a/test/testcafe/spec/AuthenticatorIdPView_spec.js
+++ b/test/testcafe/spec/AuthenticatorIdPView_spec.js
@@ -1,0 +1,73 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import IdPAuthenticatorPageObject from '../framework/page-objects/IdPAuthenticatorPageObject';
+import xhrEnrollIdPAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-enroll-idp.json';
+import xhrVerifyIdPAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-verification-idp.json';
+
+
+const logger = RequestLogger(/introspect/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+const enrollMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollIdPAuthenticator)
+  .onRequestTo('http://localhost:3000/idp/idx/credential/enroll')
+  .respond(xhrEnrollIdPAuthenticator)
+  .onRequestTo('http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk')
+  .respond('<html><h1>An external IdP login page for testcafe testing</h1></html>');
+
+const verifyMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrVerifyIdPAuthenticator)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .respond(xhrVerifyIdPAuthenticator)
+  .onRequestTo('http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk')
+  .respond('<html><h1>An external IdP login page for testcafe testing</h1></html>');
+
+async function setup(t) {
+  const pageObject = new IdPAuthenticatorPageObject(t);
+  await pageObject.navigateToPage();
+
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.length).eql(3);
+  await t.expect(log[0]).eql('===== playground widget ready event received =====');
+  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
+  await t.expect(JSON.parse(log[2])).eql({
+    controller: null,
+    formName:'redirect-idp',
+    authenticatorKey:'external_idp',
+    methodType: 'idp'
+  });
+  return pageObject;
+}
+
+fixture('Enroll IdP Authenticator');
+test
+  .requestHooks(logger, enrollMock)('enroll with IdP authenticator', async t => {
+    const pageObject = await setup(t);
+
+    await t.expect(pageObject.getPageTitle()).eql('Set up IDP Authenticator');
+    await t.expect(pageObject.getPageSubtitle()).eql('Clicking below will redirect to enrollment in IDP Authenticator');
+    await pageObject.submit();
+
+    const pageUrl = await pageObject.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk');
+  });
+
+fixture('Verify IdP Authenticator');
+test
+  .requestHooks(logger, verifyMock)('verify with IdP authenticator', async t => {
+    const pageObject = await setup(t);
+
+    await t.expect(pageObject.getPageTitle()).eql('Verify with IDP Authenticator');
+    await t.expect(pageObject.getPageSubtitle()).eql('You will be redirected to verify with IDP Authenticator');
+    await pageObject.submit();
+
+    const pageUrl = await pageObject.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk');
+  });

--- a/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
+++ b/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
@@ -24,13 +24,13 @@ const mockOnlyOneIdp = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identifyOnlyOneIdp)
   .onRequestTo('http://localhost:3000/sso/idps/facebook-idp-id-123?stateToken=inRUXNhsc6Evt7GAb8DPAA')
-  .respond('<html><h1>A external IdP login page for testcafe testing</h1></html>');
+  .respond('<html><h1>An external IdP login page for testcafe testing</h1></html>');
 
 const mockOnlyOneIdpAppUser = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identifyOnlyOneIdpAppUser)
   .onRequestTo('http://localhost:3000/sso/idps/facebook-idp-id-123?stateToken=inRUXNhsc6Evt7GAb8DPAA')
-  .respond('<html><h1>A external IdP login page for testcafe testing</h1></html>');
+  .respond('<html><h1>An external IdP login page for testcafe testing</h1></html>');
 
 
 fixture('Identify + IDPs');
@@ -111,7 +111,7 @@ test.requestHooks(logger, mockOnlyOneIdp)('should auto redirect to 3rd party IdP
   });
 
   // assert redirect to IdP login page eventually
-  await t.expect(Selector('h1').innerText).eql('A external IdP login page for testcafe testing');
+  await t.expect(Selector('h1').innerText).eql('An external IdP login page for testcafe testing');
   const pageUrl = await ClientFunction(() => window.location.href)();
   await t.expect(pageUrl).eql('http://localhost:3000/sso/idps/facebook-idp-id-123?stateToken=inRUXNhsc6Evt7GAb8DPAA');
 
@@ -132,7 +132,7 @@ test.requestHooks(logger, mockOnlyOneIdpAppUser)('should auto redirect to 3rd pa
   });
 
   // assert redirect to IdP login page eventually
-  await t.expect(Selector('h1').innerText).eql('A external IdP login page for testcafe testing');
+  await t.expect(Selector('h1').innerText).eql('An external IdP login page for testcafe testing');
   const pageUrl = await ClientFunction(() => window.location.href)();
   await t.expect(pageUrl).eql('http://localhost:3000/sso/idps/facebook-idp-id-123?stateToken=inRUXNhsc6Evt7GAb8DPAA');
 

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -43,7 +43,7 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authentic
   await t.expect(selectFactorPage.getFormTitle()).eql('Set up Authenticators');
   await t.expect(selectFactorPage.getFormSubtitle()).eql(
     'Set up authenticators to ensure that only you have access to your account.');
-  await t.expect(selectFactorPage.getFactorsCount()).eql(9);
+  await t.expect(selectFactorPage.getFactorsCount()).eql(10);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Password');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-password');
@@ -101,6 +101,13 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authentic
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(8)).eql('Set up');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(8)).eql('duo_native');
   await t.expect(selectFactorPage.getFactorDescriptionByIndex(8)).eql('Verify your identity using Duo Security.');
+
+  await t.expect(selectFactorPage.getFactorLabelByIndex(9)).eql('IDP Authenticator');
+  await t.expect(selectFactorPage.getFactorIconClassByIndex(9)).contains('mfa-custom-factor');
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(9)).eql('Set up');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(9)).eql('external_idp');
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(9))
+    .eql('Redirect to verify with IDP Authenticator');
 
   // no signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).notOk();

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -110,7 +110,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
-  await t.expect(selectFactorPage.getFactorsCount()).eql(11);
+  await t.expect(selectFactorPage.getFactorsCount()).eql(12);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Password');
   await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
@@ -179,6 +179,12 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorIconClassByIndex(10)).contains('mfa-duo');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(10)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(10)).eql('duo_native');
+
+  await t.expect(selectFactorPage.getFactorLabelByIndex(11)).eql('IDP Authenticator');
+  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(11)).eql(false);
+  await t.expect(selectFactorPage.getFactorIconClassByIndex(11)).contains('mfa-custom-factor');
+  await t.expect(selectFactorPage.getFactorSelectButtonByIndex(11)).eql('Select');
+  await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(11)).eql('external_idp');
 
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -561,7 +561,33 @@ describe('v2/ion/uiSchemaTransformer', function () {
                         }
                       ]
                     }
-                  }
+                  },
+                  {
+                    label: 'IDP Authenticator',
+                    value: {
+                      form: {
+                        value: [
+                          {
+                            name: 'id',
+                            required: true,
+                            value: '0oa69chx4bZyx8O7l0g4',
+                            mutable: false
+                          }
+                        ]
+                      }
+                    },
+                    relatesTo: {
+                      type: 'federated',
+                      id: 'aut4mhtS1b84AR0iQ0g4',
+                      key: 'external_idp',
+                      displayName: 'IDP Authenticator',
+                      methods: [
+                        {
+                          type: 'idp'
+                        }
+                      ]
+                    }
+                  },
                 ]
               },
               XHRAuthenticatorEnrollSelectAuthenticators.remediation.value[0].value[1],
@@ -647,6 +673,14 @@ describe('v2/ion/uiSchemaTransformer', function () {
                     authenticatorKey: 'duo_native',
                     relatesTo: XHRAuthenticatorEnrollSelectAuthenticators.authenticators.value[8]
                   },
+                  {
+                    label: 'IDP Authenticator',
+                    value: {
+                      id: '0oa69chx4bZyx8O7l0g4'
+                    },
+                    authenticatorKey: 'external_idp',
+                    relatesTo: XHRAuthenticatorEnrollSelectAuthenticators.authenticators.value[9]
+                  }
                 ]
               }
             ]
@@ -1166,7 +1200,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
     });
   });
 
-  it('converts identify remidiation response', done => {
+  it('converts identify remediation response', done => {
     MockUtil.mockIntrospect(done, XHRIdentifyResponse, idxResp => {
       const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -68,7 +68,8 @@ module.exports = {
         '/idp/idx/',
         '/login/getimage/',
         '/sso/idps/',
-        '/app/UserHome'
+        '/app/UserHome',
+        '/oauth2/v1/authorize',
       ],
       target: `http://localhost:${MOCK_SERVER_PORT}`
     }],


### PR DESCRIPTION
## Description:

- Adds IDP factor enrollment and verification on the OIE pipeline
- Adds `/oauth2/v1/authorize/callback` mock logic for playground

### Screenshot/Video:

| | Video | Description |
| ---- | ------ | ---------- |
| **Enrollment** | ![Enrollment](http://g.recordit.co/TT5qy3mCc3.gif) | Basic enrollment flow given a variety of factors. <br><br> In practice, when a user selects **Enroll** the widget performs a full-page redirect to the IDP login page. Upon successful authentication, the IDP will redirect back to the login page via the `oauth2/v1/authorize/callback` URI scheme.
| **Verification** | ![Verification](http://g.recordit.co/56Dh6qhPWP.gif) | Factor challenge/verification flow given a variety of factors. <br><br> When a user selects **Verify**, the widget performs a full-page redirect to the IDP login page, similar to the enrollment flow.  |


### Issue:

- [OKTA-364505](https://oktainc.atlassian.net/browse/OKTA-364505)


