### PR TITLE
Revert "fix: webauthn enroll and verify fix on v1"

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -419,12 +419,6 @@ $enroll-content-spacing: 15px;
   }
 }
 
-.verify-webauthn-form {
-  .okta-waiting-spinner {
-    display: none;
-  }
-}
-
 .verify-u2f-form,
 .enroll-u2f-form,
 .verify-webauthn-form,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
     "@commitlint/travis-cli": "^8.1.0",
-    "@okta/okta-auth-js": "4.6.0",
+    "@okta/okta-auth-js": "~4.5.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -142,7 +142,7 @@ export default FormController.extend({
     title: _.partial(loc, 'factor.webauthn.biometric', 'login'),
     className: 'verify-webauthn-form',
     noCancelButton: true,
-    save: _.partial(loc, 'mfa.challenge.verify', 'login'),
+    save: _.partial(loc, 'verify.u2f.retry', 'login'),
     noButtonBar: function () {
       return !webauthn.isNewApiAvailable();
     },
@@ -197,6 +197,16 @@ export default FormController.extend({
       return children;
     },
 
+    postRender: function () {
+      _.defer(() => {
+        if (webauthn.isNewApiAvailable()) {
+          this.model.save();
+        } else {
+          this.$('[data-se="webauthn-waiting"]').hide();
+        }
+      });
+    },
+
     _startEnrollment: function () {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
@@ -204,7 +214,6 @@ export default FormController.extend({
 
     _stopEnrollment: function () {
       this.$('.okta-waiting-spinner').hide();
-      this.$('.o-form-button-bar [type="submit"]')[0].value = loc('verify.u2f.retry', 'login');
       this.$('.o-form-button-bar').show();
     },
   },

--- a/test/unit/helpers/mocks/Util.js
+++ b/test/unit/helpers/mocks/Util.js
@@ -9,7 +9,6 @@ import wellKnown from '../xhr/well-known';
 import wellKnownSharedResource from '../xhr/well-known-shared-resource';
 let { Cookie } = internal.util;
 const fn = {};
-let globalFetch;
 let isAjaxMocked = false;
 
 afterEach(() => {
@@ -65,8 +64,6 @@ fn.mockDuo = function () {
 };
 
 fn.mockAjax = function (responses) {
-  globalFetch = window.fetch;
-  window.fetch = null;
   jasmine.Ajax.install();
   isAjaxMocked = true;
 
@@ -130,7 +127,6 @@ fn.getAjaxRequest = function (index) {
 };
 
 fn.unmockAjax = function () {
-  window.fetch = globalFetch;
   jasmine.Ajax.uninstall();
 };
 

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -244,10 +244,9 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
     });
   });
 
-  itp('shows verify button when webauthn challenge page is loaded', function () {
+  itp('shows a spinner while waiting for webauthn challenge', function () {
     return setupFn({ webauthnSupported: true }).then(function (test) {
-      expect(test.form.submitButton().css('display')).toBe('block');
-      expect(test.form.submitButtonText()).toBe('Verify');
+      expect(test.form.el('webauthn-waiting').length).toBe(1);
     });
   });
 
@@ -265,7 +264,6 @@ function testMultipleWebauthnFactor (setupFn) {
       signStatus: 'success',
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -312,7 +310,6 @@ function testMultipleWebauthnFactor (setupFn) {
       rememberDevice: true,
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -352,14 +349,13 @@ function testMultipleWebauthnFactor (setupFn) {
       });
   });
 
-  itp('shows an error if navigator.credentials.get fails and displays retry button', function () {
+  itp('shows an error if navigator.credentials.get fails', function () {
     Expect.allowUnhandledPromiseRejection();
     return setupFn({
       webauthnSupported: true,
       signStatus: 'fail',
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -368,8 +364,6 @@ function testMultipleWebauthnFactor (setupFn) {
         expect(test.form.errorBox()).toHaveLength(1);
         expect(test.form.errorMessage()).toEqual('something went wrong');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
-        expect(test.form.submitButton().css('display')).toBe('block');
-        expect(test.form.submitButtonText()).toBe('Retry');
         expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
           {
             controller: 'mfa-verify verify-webauthn',
@@ -397,7 +391,6 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'success',
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy, test);
       })
       .then(function (test) {
@@ -437,7 +430,6 @@ Expect.describe('Webauthn Factor', function () {
       rememberDevice: true,
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
       .then(function () {
@@ -476,7 +468,6 @@ Expect.describe('Webauthn Factor', function () {
       signStatus: 'fail',
     })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
       .then(function (test) {
@@ -516,7 +507,6 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('switching to another factor after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {
@@ -535,7 +525,6 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
   itp('SignOut after initiating webauthn verify calls abort', function () {
     return setupMultipleWebauthn({ webauthnSupported: true })
       .then(function (test) {
-        test.form.submit();
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
       .then(function (test) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,10 +1222,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@4.6.0":
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.6.0.tgz#4aed3429635f15dd87b4d791987e1da84cbeb101"
-  integrity sha512-QtpyuNuxuCSFmzAw0xWUTAbQJEHKfQ29tJdba8XQH+UlojWtA/adRCoHcekmaSN1EZ/oQNVleLFs4k+edNCvkw==
+"@okta/okta-auth-js@~4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.5.0.tgz#df588fd99bb152ba4ec994cf829f04e12fc13370"
+  integrity sha512-r0YikMimF1idBJtvSbBbtKOEZxh4E6lBmmZMqAkQWmvO4Pln6ZVyt/yg0f35N5BkfZScV5WYkWWJoBpdmNwbaw==
   dependencies:
     Base64 "0.3.0"
     core-js "^3.6.5"


### PR DESCRIPTION
This reverts commit 4d3ea770eff8d2319bdbaf5aae22c7d2df879401.

We need to do this to unblock HF of https://github.com/okta/okta-signin-widget/pull/1642



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-367663](https://oktainc.atlassian.net/browse/OKTA-367663)


