### PR TITLE
fix: webauthn verificaiton on idx + v1 autotrigger

### DIFF
--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -20,6 +20,7 @@ import FactorUtil from 'util/FactorUtil';
 import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 import webauthn from 'util/webauthn';
+import BrowserFeatures from 'util/BrowserFeatures';
 import HtmlErrorMessageView from 'views/mfa-verify/HtmlErrorMessageView';
 import FooterSignout from 'views/shared/FooterSignout';
 
@@ -207,6 +208,15 @@ export default FormController.extend({
       this.$('.o-form-button-bar [type="submit"]')[0].value = loc('verify.u2f.retry', 'login');
       this.$('.o-form-button-bar').show();
     },
+  },
+
+  postRender: function () {
+    _.defer(() => {
+      // Trigger browser prompt automatically for other browsers for better UX.
+      if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {
+        this.model.save();
+      }
+    });
   },
 
   back: function () {

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -24,7 +24,6 @@ const Body = BaseForm.extend({
         title: loc('mfa.challenge.verify', 'login'),
         click: () => {
           this.getCredentialsAndSave();
-          this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
         }
       });
 
@@ -107,6 +106,7 @@ const Body = BaseForm.extend({
   _startVerification: function () {
     this.$('.okta-waiting-spinner').show();
     this.$('.retry-webauthn').hide();
+    this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
   },
 
   _stopVerification: function () {

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -3,6 +3,7 @@ import BaseForm from '../../internals/BaseForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import CryptoUtil from '../../../../util/CryptoUtil';
 import webauthn from '../../../../util/webauthn';
+import BrowserFeatures from '../../../../util/BrowserFeatures';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import ChallengeWebauthnInfoView from './ChallengeWebauthnInfoView';
 
@@ -20,9 +21,10 @@ const Body = BaseForm.extend({
     if (webauthn.isNewApiAvailable()) {
       const retryButton = createButton({
         className: 'retry-webauthn button-primary default-custom-button',
-        title: loc('retry', 'login'),
+        title: loc('mfa.challenge.verify', 'login'),
         click: () => {
           this.getCredentialsAndSave();
+          this.$('.retry-webauthn')[0].innerText = loc('retry', 'login');
         }
       });
 
@@ -118,7 +120,8 @@ export default BaseAuthenticatorView.extend({
   Footer: AuthenticatorVerifyFooter,
   postRender () {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
-    if (webauthn.isNewApiAvailable()) {
+    // Trigger browser prompt automatically for other browsers for better UX.
+    if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {
       this.form.getCredentialsAndSave();
     }
   },


### PR DESCRIPTION
* Keeping the original behavior of auto trigger webauthn prompt during verify
for other browsers except safari.

RESOLVES: OKTA-367776

Also we dont need to backport this change now. 
https://github.com/okta/okta-signin-widget/pull/1580/files


https://user-images.githubusercontent.com/17267130/106954692-00b1d680-66e9-11eb-87e0-a1c38f8bbf98.mov




https://user-images.githubusercontent.com/17267130/106954085-2094ca80-66e8-11eb-8e60-97d1a71f1684.mov


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-367776](https://oktainc.atlassian.net/browse/OKTA-367776)


