### PR TITLE
Fix inconsistent check of features.hideSignOutLinkInMFA and features.mfaOnlyFlow

### DIFF
--- a/src/VerifyDuoController.js
+++ b/src/VerifyDuoController.js
@@ -122,8 +122,6 @@ export default FormController.extend({
     },
   },
 
-  Footer: FooterSignout,
-
   fetchInitialData: function () {
     const self = this;
 
@@ -161,5 +159,13 @@ export default FormController.extend({
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not
     // More details in OKTA-135060.
+  },
+
+  initialize: function () {
+    FormController.prototype.initialize.apply(this, arguments);
+    if (!this.settings.get('features.hideSignOutLinkInMFA') &&
+        !this.settings.get('features.mfaOnlyFlow')) {
+      this.addFooter(FooterSignout);
+    }
   },
 });

--- a/src/VerifyU2FController.js
+++ b/src/VerifyU2FController.js
@@ -213,5 +213,11 @@ export default FormController.extend({
     // More details in OKTA-135060.
   },
 
-  Footer: FooterSignout,
+  initialize: function () {
+    FormController.prototype.initialize.apply(this, arguments);
+    if (!this.settings.get('features.hideSignOutLinkInMFA') &&
+        !this.settings.get('features.mfaOnlyFlow')) {
+      this.addFooter(FooterSignout);
+    }
+  },
 });

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -216,5 +216,11 @@ export default FormController.extend({
     // More details in OKTA-135060.
   },
 
-  Footer: FooterSignout,
+  initialize: function () {
+    FormController.prototype.initialize.apply(this, arguments);
+    if (!this.settings.get('features.hideSignOutLinkInMFA') &&
+        !this.settings.get('features.mfaOnlyFlow')) {
+      this.addFooter(FooterSignout);
+    }
+  },
 });

--- a/src/VerifyWindowsHelloController.js
+++ b/src/VerifyWindowsHelloController.js
@@ -192,5 +192,11 @@ export default FormController.extend({
     // More details in OKTA-135060.
   },
 
-  Footer: FooterSignout,
+  initialize: function () {
+    FormController.prototype.initialize.apply(this, arguments);
+    if (!this.settings.get('features.hideSignOutLinkInMFA') &&
+        !this.settings.get('features.mfaOnlyFlow')) {
+      this.addFooter(FooterSignout);
+    }
+  },
 });

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -305,12 +305,13 @@ Expect.describe('MFA Verify', function () {
 
   const setupOktaPushWithRefreshAuth = _.partial(setup, resVerifyPushOnly, { factorType: 'push' });
 
-  const setupWindowsHello = _.partial(
-    setup,
-    resAllFactors,
-    { factorType: 'webauthn', provider: 'FIDO' },
-    { 'features.webauthn': false }
-  );
+  const setupWindowsHello = function (settings) {
+    return setup(
+      resAllFactors,
+      { factorType: 'webauthn', provider: 'FIDO' },
+      { ...settings, 'features.webauthn': false }
+    );
+  };
 
   const setupWindowsHelloWithBrandName = _.partial(
     setup,
@@ -389,7 +390,7 @@ Expect.describe('MFA Verify', function () {
       delete window.u2f;
     }
 
-    return setup(options.nextResponse ? options.nextResponse : resAllFactors, null, null, null, true)
+    return setup(options.nextResponse ? options.nextResponse : resAllFactors, null, options.settings, null, true)
       .then(function (test) {
         const responses = options.multipleU2F ? [resChallengeMultipleU2F] : [resChallengeU2F];
 
@@ -3652,6 +3653,21 @@ Expect.describe('MFA Verify', function () {
           });
         });
       });
+      itp('has a sign out link', function () {
+        return setupDuo().then(function (test) {
+          Expect.isVisible(test.form.signoutLink($sandbox));
+        });
+      });
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
+        return setupDuo({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
+        });
+      });
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
+        return setupDuo({ 'features.mfaOnlyFlow': true }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
+        });
+      });
       itp('makes the correct request when rememberDevice is checked', function () {
         return setupDuo()
           .then(function (test) {
@@ -3743,6 +3759,22 @@ Expect.describe('MFA Verify', function () {
         return emulateWindows().then(setupWindowsHello).then(function (test) {
           expect(test.form.el('o-form-error-html').length).toBe(0);
           expect(test.form.submitButton().length).toBe(1);
+        });
+      });
+
+      itp('has a sign out link', function () {
+        return setupWindowsHello().then(function (test) {
+          Expect.isVisible(test.form.signoutLink($sandbox));
+        });
+      });
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
+        return setupWindowsHello({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
+        });
+      });
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
+        return setupWindowsHello({ 'features.mfaOnlyFlow': true }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
 
@@ -3937,6 +3969,22 @@ Expect.describe('MFA Verify', function () {
       itp('has remember device checkbox', function () {
         return setupU2F({ u2f: true }).then(function (test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
+        });
+      });
+
+      itp('has a sign out link', function () {
+        return setupU2F({ u2f: true }).then(function (test) {
+          Expect.isVisible(test.form.signoutLink($sandbox));
+        });
+      });
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
+        return setupU2F({ u2f: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
+        });
+      });
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
+        return setupU2F({ u2f: true, settings: {'features.mfaOnlyFlow': true} }).then(function (test) {
+          expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
 

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -54,7 +54,7 @@ function setup (options) {
   const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
-  const router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });
+  const router = createRouter(baseUrl, authClient, successSpy, { ...options.settings, 'features.webauthn': true });
 
   router.on('afterError', afterErrorHandler);
   setNextResponse(options.multipleWebauthn ? [resMultipleWebauthnWithQuestion] : [resAllFactors]);
@@ -168,7 +168,7 @@ function setupMultipleWebauthnOnly (options) {
   const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
-  const router = createRouter(baseUrl, authClient, successSpy, { 'features.webauthn': true });
+  const router = createRouter(baseUrl, authClient, successSpy, { ...options.settings, 'features.webauthn': true });
 
   router.on('afterError', afterErrorHandler);
   const responses = [resMultipleWebauthn, resChallengeMultipleWebauthn];
@@ -254,6 +254,22 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
   itp('has remember device checkbox', function () {
     return setupFn({ webauthnSupported: true }).then(function (test) {
       Expect.isVisible(test.form.rememberDeviceCheckbox());
+    });
+  });
+
+  itp('has a sign out link', function () {
+    return setupFn({ webauthnSupported: true }).then(function (test) {
+      Expect.isVisible(test.form.signoutLink($sandbox));
+    });
+  });
+  itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
+    return setupFn({ webauthnSupported: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function (test) {
+      expect(test.form.signoutLink($sandbox).length).toBe(0);
+    });
+  });
+  itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
+    return setupFn({ webauthnSupported: true, settings: {'features.mfaOnlyFlow': true} }).then(function (test) {
+      expect(test.form.signoutLink($sandbox).length).toBe(0);
     });
   });
 }


### PR DESCRIPTION
## Description:

`VerifyDuo`, `VerifyU2F`, `VerifyWebauthn`, `VerifyWindowsHello` controllers should check features `features.hideSignOutLinkInMFA` and `features.mfaOnlyFlow`  before adding footer with `Sign out` link.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

 [OKTA-367884](https://oktainc.atlassian.net/browse/OKTA-367884)



