### PR TITLE
Update button text for push and num challenge error state

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -803,7 +803,7 @@ oie.okta_verify.totp.title = Enter a code
 oie.okta_verify.totp.enterCodeText = Enter code from Okta Verify app
 oie.okta_verify.push.title = Get a push notification
 oie.okta_verify.push.sent = Push notification sent
-oie.okta_verify.push.send = Send push notification
+oie.okta_verify.push.resend = Resend push notification
 oie.okta_verify.signed_nonce.label = Use Okta Verify on this device
 
 ## Google authenticator

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
@@ -12,7 +12,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     save () {
-      return loc('oie.okta_verify.push.send', 'login');
+      return loc('oie.okta_verify.push.resend', 'login');
     },
 
     showMessages () {

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -70,7 +70,7 @@ test
     const errorBox = challengeOktaVerifyPushPageObject.getErrorBox();
     await t.expect(errorBox.innerText).contains('You have chosen to reject this login.');
     const resendPushBtn = challengeOktaVerifyPushPageObject.getResendPushButton();
-    await t.expect(resendPushBtn.value).contains('Send push notification');
+    await t.expect(resendPushBtn.value).contains('Resend push notification');
     await t.expect(resendPushBtn.hasClass('link-button-disabled')).notOk();
   });
 


### PR DESCRIPTION
Resolves: OKTA-366355

## Description:

- Update button text for push and number challenge error state

![Screen Shot 2021-02-10 at 9 36 54 AM](https://user-images.githubusercontent.com/23267876/107548503-9931d600-6b83-11eb-8c71-915394e5fb58.png)



## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:

@gowthamidommety-okta @stevennguyen-okta 

### Issue:

- [ OKTA-366355](https://oktainc.atlassian.net/browse/ OKTA-366355)


