### PR TITLE
fix: Resolve render promise only on SUCCESS status

### DIFF
--- a/src/models/LoginModel.js
+++ b/src/models/LoginModel.js
@@ -19,7 +19,7 @@ export default BaseLoginModel.extend({
   },
   loginWithActivationToken: function (activationToken) {
     return this.startTransaction(function (authClient) {
-      return authClient.signIn({ token: activationToken });
+      return authClient.signInWithCredentials({ token: activationToken });
     });
   },
 });

--- a/src/widget/createRouter.js
+++ b/src/widget/createRouter.js
@@ -1,4 +1,5 @@
 import { $ } from 'okta';
+import Enums from 'util/Enums';
 
 export default function createRouter (Router, widgetOptions, renderOptions, authClient, successFn, errorFn) {
   let router;
@@ -8,7 +9,9 @@ export default function createRouter (Router, widgetOptions, renderOptions, auth
       authClient,
       globalSuccessFn: (res) => {
         successFn && successFn(res); // call success function if provided
-        resolve(res);
+        if (res.status === Enums.SUCCESS) {
+          resolve(res);
+        }
       },
       globalErrorFn: (error) => {
         errorFn && errorFn(error); // call error function if provided

--- a/src/widget/createRouter.js
+++ b/src/widget/createRouter.js
@@ -9,7 +9,7 @@ export default function createRouter (Router, widgetOptions, renderOptions, auth
       authClient,
       globalSuccessFn: (res) => {
         successFn && successFn(res); // call success function if provided
-        if (res.status === Enums.SUCCESS) {
+        if (res && res.status === Enums.SUCCESS) {
           resolve(res);
         }
       },


### PR DESCRIPTION
## Description:

Forgot password flow (as well as unlock account flow, sign-up flow) should not resolve `showSigninToGetTokens` promise


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-360093](https://oktainc.atlassian.net/browse/OKTA-360093)


