### PR TITLE
fix: authParams passed to showSignInToGetTokens

### DIFF
--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -16,6 +16,21 @@ import Errors from './Errors';
 import Util from './Util';
 const util = {};
 
+// https://github.com/okta/okta-auth-js#authorize-options
+const AUTH_PARAMS = [
+  'responseType',
+  'scopes',
+  'state',
+  'nonce',
+  'idp',
+  'idpScope',
+  'display',
+  'prompt',
+  'maxAge',
+  'loginHint'
+];
+util.AUTH_PARAMS = AUTH_PARAMS;
+
 /**
  * Get the tokens in the OIDC/OAUTH flows
  *
@@ -45,10 +60,7 @@ util.getTokens = function (settings, params, controller) {
   _.extend(
     getTokenOptions,
     _.pick(options, 'clientId', 'redirectUri'),
-    _.pick(options.authParams,
-      // https://github.com/okta/okta-auth-js#authorize-options
-      'responseType', 'scopes', 'state', 'nonce', 'idp', 'idpScope', 'display', 'prompt', 'maxAge', 'loginHint'
-    ),
+    _.pick(options.authParams, AUTH_PARAMS),
     params
   );
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -2,6 +2,7 @@
 import _ from 'underscore';
 import Errors from 'util/Errors';
 import Util from 'util/Util';
+import OAuth2Util from 'util/OAuth2Util';
 import createAuthClient from 'widget/createAuthClient';
 import V1Router from 'LoginRouter';
 import V2Router from 'v2/WidgetRouter';
@@ -55,33 +56,22 @@ var OktaSignIn = (function () {
     }
 
     function buildRenderOptions (options = {}) {
-      const el = options.el || widgetOptions.el;
-      if (!el) {
+      const authParams = _.pick(options, OAuth2Util.AUTH_PARAMS);
+      const { el, clientId, redirectUri } = Object.assign({}, widgetOptions, options);
+      const renderOptions = Object.assign({}, { el, clientId, redirectUri, authParams });
+
+      if (!renderOptions.el) {
         throw new Errors.ConfigError('"el" is required');
       }
-      const clientId = options.clientId || widgetOptions.clientId;
-      if (!clientId) {
+
+      if (!renderOptions.clientId) {
         throw new Errors.ConfigError('"clientId" is required');
       }
-      const redirectUri = options.redirectUri || widgetOptions.redirectUri;
-      if (!redirectUri) {
+
+      if (!renderOptions.redirectUri) {
         throw new Errors.ConfigError('"redirectUri" is required');
       }
 
-      const authParams = {};
-      if (options.responseType) {
-        authParams.responseType = options.responseType;
-      }
-      if (options.scopes) {
-        authParams.scopes = options.scopes;
-      }
-
-      const renderOptions = {
-        el,
-        clientId,
-        redirectUri,
-        authParams
-      };
       return renderOptions;
     }
 
@@ -93,7 +83,7 @@ var OktaSignIn = (function () {
       const renderOptions = Object.assign(buildRenderOptions(options), {
         mode: 'relying-party'
       });
-      const promise = render.call(this, renderOptions).then(res => {
+      const promise = this.renderEl(renderOptions).then(res => {
         return res.tokens;
       });
       const authClient = router.settings.getAuthClient();
@@ -112,7 +102,7 @@ var OktaSignIn = (function () {
       const renderOptions = Object.assign(buildRenderOptions(options), {
         mode: 'remediation'
       });
-      return render.call(this, renderOptions);
+      return this.renderEl(renderOptions);
     }
 
     // Properties exposed on OktaSignIn object.

--- a/test/unit/.eslintrc.js
+++ b/test/unit/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'max-statements': 0,
     'jasmine/new-line-before-expect': 0,
     'jasmine/new-line-between-declarations': 0,
+    'jasmine/no-spec-dupes': [1, 'branch'],
 
     // Consider enabling these
     'jasmine/no-unsafe-spy': 0,


### PR DESCRIPTION
## Description:
Additional "authParams" which are passed to `showSignInToGetTokens` and `showSignInAndRedirect` will be passed to `renderEl`

We are calling this a "fix" since it is changing the behavior to align with customer expectations. The logic has technically been unchanged since the methods were created, but their usage has increased since we feature them in our samples now.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-361428](https://oktainc.atlassian.net/browse/OKTA-361428)


