### PR TITLE
feat: make OV login as soon as challenge is done

### DIFF
--- a/src/v2/view-builder/views/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/DeviceChallengePollView.js
@@ -148,7 +148,10 @@ const Body = BaseForm.extend(Object.assign(
           // TODO: can we use standard ES6 promise methods, then/catch?
           .done(() => {
             this.probingXhr = onPortFound();
-            return this.probingXhr;
+            return this.probingXhr.done(() => {
+              // log in as soon as challenge request is finished
+              return this.trigger('save', this.model);
+            });
           })
           .fail(onFailure);
       };

--- a/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollViewFailure_spec.js
@@ -36,7 +36,6 @@ async function setup(t) {
 test('probing and polling APIs are sent and responded', async t => {
   const deviceChallengePollPageObject = await setup(t);
   await t.expect(deviceChallengePollPageObject.getHeader()).eql('Verifying your identity');
-  await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
   await t.expect(logger.count(
     record => record.response.statusCode === 200 &&
       record.request.url.match(/introspect|2000/)


### PR DESCRIPTION
## Description:

Log in as soon as challenge request is finished.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![ezgif-3-fd26a26aada0](https://user-images.githubusercontent.com/54867795/108242833-0c27e780-7156-11eb-8c0c-f1e42524ae1d.gif)

### Reviewers:


### Issue:

- [OKTA-367901](https://oktainc.atlassian.net/browse/OKTA-367901)


