### PR TITLE
make response config great again

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -14,8 +14,8 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
-    'error-feature-not-enabled',
+    'identify',
+    // 'error-feature-not-enabled',
     // 'error-403-security-access-denied',
     // 'authenticator-enroll-email',
     // 'error-internal-server-error',
@@ -26,7 +26,7 @@ const idx = {
     // 'authenticator-enroll-data-phone-voice',
     // 'authenticator-enroll-ov-local',
     // 'error-internal-server-error',
-    // 'authenticator-enroll-security-question',
+    'authenticator-enroll-security-question',
     // 'authenticator-enroll-select-authenticator',
     // 'authenticator-enroll-select-authenticator-with-skip',
     // 'authenticator-enroll-webauthn',


### PR DESCRIPTION
## Description:
Last PR left an error on the screen. This restores responseConfig to show identify / security question as before


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


