### PR TITLE
feat: Adds feature to set default country code on SMS & call MFA enrollment pages

### DIFF
--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -53,6 +53,10 @@ function sendCode (e) {
   }
 }
 
+function isValidCountryCode(countryCode){
+  return CountryUtil.getCallingCodeForCountry(countryCode);
+}
+
 export default FormController.extend({
   className: function () {
     return getClassName(this.options.factorType);
@@ -334,5 +338,8 @@ export default FormController.extend({
       this.model.set('hasExistingPhones', this.options.appState.get('hasExistingPhones'));
     }
     this.model.set('factorType', this.options.factorType);
+    if(isValidCountryCode(this.settings.get('smsAndCallMFACountryCode'))) {
+      this.model.set('countryCode', this.settings.get('smsAndCallMFACountryCode'));
+    }
   },
 });

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -83,6 +83,8 @@ export default Model.extend({
     'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
     'features.mfaOnlyFlow': ['boolean', false, false],
 
+    smsAndCallMFACountryCode: ['string', 'US'],
+    
     // I18N
     language: ['any', false], // Can be a string or a function
     i18n: ['object', false],


### PR DESCRIPTION
## Description:

Adds feature to set default country code on SMS & voice call MFA enrollment page
Introduced additional option called "smsAndCallMFACountryCode" on the widget with default value set to: 'US'

## PR Checklist

- [y] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [y] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:


