### PR TITLE
refactor: Move device authenticator views and refactor internals

### DIFF
--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -1,6 +1,6 @@
 import Logger from 'util/Logger';
 import { AUTHENTICATOR_KEY, FORMS as RemediationForms } from '../ion/RemediationConstants';
-import BaseView from './internals/BaseView';
+import { BaseView } from './internals';
 
 // authenticator agnostic views
 import IdentifierView from './views/IdentifierView';

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -13,10 +13,10 @@ import AdminConsentView from './views/consent/AdminConsentView';
 import EnduserConsentView from './views/consent/EnduserConsentView';
 
 // Device (Okta Verify)
-import DeviceChallengePollView from './views/DeviceChallengePollView';
-import SSOExtensionView from './views/SSOExtensionView';
-import SignInDeviceView from './views/SignInDeviceView';
-import DeviceEnrollmentTerminalView from './views/DeviceEnrollmentTerminalView';
+import DeviceChallengePollView from './views/device/DeviceChallengePollView';
+import SSOExtensionView from './views/device/SSOExtensionView';
+import SignInDeviceView from './views/device/SignInDeviceView';
+import DeviceEnrollmentTerminalView from './views/device/DeviceEnrollmentTerminalView';
 
 // registration
 import EnrollProfileView from './views/EnrollProfileView';
@@ -51,7 +51,7 @@ import ChallengeWebauthnView from './views/webauthn/ChallengeWebauthnView';
 import EnrollAuthenticatorEmailView from './views/email/EnrollAuthenticatorEmailView';
 import ChallengeAuthenticatorEmailView from './views/email/ChallengeAuthenticatorEmailView';
 
-// app(okta verify)
+// app (okta verify)
 import EnrollPollOktaVerifyView from './views/ov/EnrollPollOktaVerifyView';
 import SelectEnrollmentChannelOktaVerifyView from './views/ov/SelectEnrollmentChannelOktaVerifyView';
 import EnrollementChannelDataOktaVerifyView from './views/ov/EnrollementChannelDataOktaVerifyView';
@@ -61,16 +61,16 @@ import ChallengeOktaVerifyResendPushView from './views/ov/ChallengeOktaVerifyRes
 import ChallengeAuthenticatorDataOktaVerifyView from './views/ov/ChallengeAuthenticatorDataOktaVerifyView';
 import ChallengeOktaVerifySSOExtensionView from './views/ov/ChallengeOktaVerifySSOExtensionView';
 
-// app(google authenticator)
+// app (google authenticator)
 import EnrollAuthenticatorGoogleAuthenticatorView
   from './views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView';
 import ChallengeGoogleAuthenticatorView from './views/google-authenticator/ChallengeGoogleAuthenticatorView';
 
-//on-prem mfa
+// on-prem mfa
 import EnrollAuthenticatorOnPremView from './views/on-prem/EnrollAuthenticatorOnPremView';
 import ChallengeAuthenticatorOnPremView from './views/on-prem/ChallengeAuthenticatorOnPremView';
 
-//duo mfa
+// duo mfa
 import EnrollDuoAuthenticatorView from './views/duo/EnrollDuoAuthenticatorView';
 import ChallengeDuoAuthenticatorView from './views/duo/ChallengeDuoAuthenticatorView';
 

--- a/src/v2/view-builder/components/AuthenticatorEnrollFooter.js
+++ b/src/v2/view-builder/components/AuthenticatorEnrollFooter.js
@@ -1,4 +1,4 @@
-import BaseFooter from '../internals/BaseFooter';
+import { BaseFooter } from '../internals';
 import { getSwitchAuthenticatorLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({

--- a/src/v2/view-builder/components/AuthenticatorVerifyFooter.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyFooter.js
@@ -1,4 +1,4 @@
-import BaseFooter from '../internals/BaseFooter';
+import { BaseFooter } from '../internals';
 import { getSwitchAuthenticatorLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({

--- a/src/v2/view-builder/components/BaseAuthenticatorView.js
+++ b/src/v2/view-builder/components/BaseAuthenticatorView.js
@@ -1,5 +1,4 @@
-import BaseView from '../internals/BaseView';
-import BaseHeader from '../internals/BaseHeader';
+import { BaseHeader, BaseView } from '../internals';
 import HeaderBeacon from './HeaderBeacon';
 import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
 

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseFooter from '../internals/BaseFooter';
+import { BaseFooter } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 

--- a/src/v2/view-builder/internals/index.js
+++ b/src/v2/view-builder/internals/index.js
@@ -1,17 +1,7 @@
-import BaseHeader from './BaseHeader';
-import BaseFooter from './BaseFooter';
-import BaseForm from './BaseForm';
-import BaseFormWithPolling from './BaseFormWithPolling';
-import BaseModel from './BaseModel';
-import BaseView from './BaseView';
-import FormInputFactory from './FormInputFactory';
-
-export const { addCustomButton, createCustomButtons, createIdpButtons } = FormInputFactory;
-export {
-  BaseHeader,
-  BaseFooter,
-  BaseForm,
-  BaseFormWithPolling,
-  BaseModel,
-  BaseView,
-};
+export { default as BaseHeader } from './BaseHeader';
+export { default as BaseFooter } from './BaseFooter';
+export { default as BaseForm } from './BaseForm';
+export { default as BaseFormWithPolling } from './BaseFormWithPolling';
+export { default as BaseModel } from './BaseModel';
+export { default as BaseView } from './BaseView';
+export { addCustomButton, createCustomButtons, createIdpButtons } from './FormInputFactory';

--- a/src/v2/view-builder/internals/index.js
+++ b/src/v2/view-builder/internals/index.js
@@ -1,0 +1,17 @@
+import BaseHeader from './BaseHeader';
+import BaseFooter from './BaseFooter';
+import BaseForm from './BaseForm';
+import BaseFormWithPolling from './BaseFormWithPolling';
+import BaseModel from './BaseModel';
+import BaseView from './BaseView';
+import FormInputFactory from './FormInputFactory';
+
+export const { addCustomButton, createCustomButtons, createIdpButtons } = FormInputFactory;
+export {
+  BaseHeader,
+  BaseFooter,
+  BaseForm,
+  BaseFormWithPolling,
+  BaseModel,
+  BaseView,
+};

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -1,7 +1,5 @@
 import { loc } from 'okta';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import BaseFooter from '../internals/BaseFooter';
+import { BaseForm, BaseFooter, BaseView } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 
 const Body = BaseForm.extend({

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -1,13 +1,10 @@
 import { loc, createCallout } from 'okta';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
+import { BaseForm, BaseView, createIdpButtons, createCustomButtons } from '../internals';
 import IdentifierFooter from '../components/IdentifierFooter';
 import signInWithIdps from './signin/SignInWithIdps';
 import customButtonsView from './signin/CustomButtons';
 import signInWithDeviceOption from './signin/SignInWithDeviceOption';
-import { createIdpButtons, createCustomButtons } from '../internals/FormInputFactory';
-
 
 const Body = BaseForm.extend({
 

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -1,7 +1,5 @@
 import { loc } from 'okta';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import BaseFooter from '../internals/BaseFooter';
+import { BaseForm, BaseFooter, BaseView } from '../internals';
 
 const Body = BaseForm.extend({
 

--- a/src/v2/view-builder/views/PollView.js
+++ b/src/v2/view-builder/views/PollView.js
@@ -1,7 +1,6 @@
 import { loc, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
+import { BaseForm, BaseView } from '../internals';
 import polling from './shared/polling';
 import { MS_PER_SEC } from '../utils/Constants';
 

--- a/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
@@ -1,6 +1,4 @@
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-
+import { BaseForm, BaseView } from '../internals';
 import { loc } from 'okta';
 
 const Body = BaseForm.extend({

--- a/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
@@ -1,5 +1,4 @@
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
+import { BaseForm, BaseView } from '../internals';
 import { loc } from 'okta';
 
 export const Body = BaseForm.extend({

--- a/src/v2/view-builder/views/SuccessView.js
+++ b/src/v2/view-builder/views/SuccessView.js
@@ -1,7 +1,5 @@
 import { _, loc } from 'okta';
-
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
+import { BaseForm, BaseView } from '../internals';
 import Util from '../../../util/Util';
 
 const Body = BaseForm.extend({

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -1,8 +1,5 @@
 import { createCallout, loc } from 'okta';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import BaseFooter from '../internals/BaseFooter';
-import BaseHeader from '../internals/BaseHeader';
+import { BaseHeader, BaseForm, BaseFooter, BaseView } from '../internals';
 import HeaderBeacon from '../components/HeaderBeacon';
 import { getBackToSignInLink, getSkipSetupLink } from '../utils/LinksUtil';
 import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';

--- a/src/v2/view-builder/views/authenticator/SelectAuthenticatorUnlockAccountView.js
+++ b/src/v2/view-builder/views/authenticator/SelectAuthenticatorUnlockAccountView.js
@@ -1,5 +1,4 @@
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import { loc } from 'okta';
 
 const UnlockAccountView = BaseForm.extend({

--- a/src/v2/view-builder/views/consent/AdminConsentView.js
+++ b/src/v2/view-builder/views/consent/AdminConsentView.js
@@ -1,7 +1,6 @@
-import BaseView from '../../internals/BaseView';
+import { BaseView } from '../../internals';
 import AdminConsentViewHeader from './AdminConsentViewHeader';
 import ConsentViewForm from './ConsentViewForm';
-
 
 export default BaseView.extend({
   Header: AdminConsentViewHeader,

--- a/src/v2/view-builder/views/consent/ConsentViewForm.js
+++ b/src/v2/view-builder/views/consent/ConsentViewForm.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 
 export default BaseForm.extend(
   {

--- a/src/v2/view-builder/views/custom-otp/ChallengeCustomOTPAuthenticatorView.js
+++ b/src/v2/view-builder/views/custom-otp/ChallengeCustomOTPAuthenticatorView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -1,11 +1,8 @@
 /* global Promise */
 import { $, loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
-import BaseHeader from '../../internals/BaseHeader';
+import { BaseHeader, BaseForm, BaseFormWithPolling, BaseFooter, BaseView } from '../../internals';
 import HeaderBeacon from '../../components/HeaderBeacon';
-import BaseFooter from '../../internals/BaseFooter';
 import Logger from '../../../../util/Logger';
 import DeviceFingerprint from '../../../../util/DeviceFingerprint';
 import Util from '../../../../util/Util';
@@ -14,7 +11,6 @@ import { CANCEL_POLLING_ACTION } from '../../utils/Constants';
 import Link from '../../components/Link';
 import { getIconClassNameForBeacon } from '../../utils/AuthenticatorUtil';
 import { AUTHENTICATOR_KEY } from '../../../ion/RemediationConstants';
-import BaseFormWithPolling from '../../internals/BaseFormWithPolling';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -1,20 +1,20 @@
 /* global Promise */
 import { $, loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import BaseHeader from '../internals/BaseHeader';
-import HeaderBeacon from '../components/HeaderBeacon';
-import BaseFooter from '../internals//BaseFooter';
-import Logger from '../../../util/Logger';
-import DeviceFingerprint from '../../../util/DeviceFingerprint';
-import Util from '../../../util/Util';
-import Enums from '../../../util/Enums';
-import { CANCEL_POLLING_ACTION } from '../utils/Constants';
-import Link from '../components/Link';
-import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
-import { AUTHENTICATOR_KEY } from '../../ion/RemediationConstants';
-import BaseFormWithPolling from '../internals/BaseFormWithPolling';
+import BaseView from '../../internals/BaseView';
+import BaseForm from '../../internals/BaseForm';
+import BaseHeader from '../../internals/BaseHeader';
+import HeaderBeacon from '../../components/HeaderBeacon';
+import BaseFooter from '../../internals/BaseFooter';
+import Logger from '../../../../util/Logger';
+import DeviceFingerprint from '../../../../util/DeviceFingerprint';
+import Util from '../../../../util/Util';
+import Enums from '../../../../util/Enums';
+import { CANCEL_POLLING_ACTION } from '../../utils/Constants';
+import Link from '../../components/Link';
+import { getIconClassNameForBeacon } from '../../utils/AuthenticatorUtil';
+import { AUTHENTICATOR_KEY } from '../../../ion/RemediationConstants';
+import BaseFormWithPolling from '../../internals/BaseFormWithPolling';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({

--- a/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
+++ b/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
@@ -1,13 +1,13 @@
 import { loc } from 'okta';
-import BaseHeader from '../internals/BaseHeader';
-import HeaderBeacon from '../components/HeaderBeacon';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import OdaOktaVerifyTerminalView from '../components/OdaOktaVerifyTerminalView';
-import MdmOktaVerifyTerminalView from '../components/MdmOktaVerifyTerminalView';
+import BaseHeader from '../../internals/BaseHeader';
+import HeaderBeacon from '../../components/HeaderBeacon';
+import BaseView from '../../internals/BaseView';
+import BaseForm from '../../internals/BaseForm';
+import OdaOktaVerifyTerminalView from '../../components/OdaOktaVerifyTerminalView';
+import MdmOktaVerifyTerminalView from '../../components/MdmOktaVerifyTerminalView';
 import Enums from 'util/Enums';
-import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
-import { AUTHENTICATOR_KEY } from '../../ion/RemediationConstants';
+import { getIconClassNameForBeacon } from '../../utils/AuthenticatorUtil';
+import { AUTHENTICATOR_KEY } from '../../../ion/RemediationConstants';
 
 const ODAHeader = BaseHeader.extend({
   HeaderBeacon: HeaderBeacon.extend({

--- a/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
+++ b/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
@@ -1,8 +1,6 @@
 import { loc } from 'okta';
-import BaseHeader from '../../internals/BaseHeader';
+import { BaseHeader, BaseForm, BaseView } from '../../internals';
 import HeaderBeacon from '../../components/HeaderBeacon';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
 import OdaOktaVerifyTerminalView from '../../components/OdaOktaVerifyTerminalView';
 import MdmOktaVerifyTerminalView from '../../components/MdmOktaVerifyTerminalView';
 import Enums from 'util/Enums';

--- a/src/v2/view-builder/views/device/SSOExtensionView.js
+++ b/src/v2/view-builder/views/device/SSOExtensionView.js
@@ -1,6 +1,6 @@
-import BaseAuthenticatorView from '../components/BaseAuthenticatorView';
-import BaseForm from '../internals/BaseForm';
-import Util from '../../../util/Util';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
+import BaseForm from '../../internals/BaseForm';
+import Util from '../../../../util/Util';
 import { loc } from 'okta';
 
 // for BETA,

--- a/src/v2/view-builder/views/device/SSOExtensionView.js
+++ b/src/v2/view-builder/views/device/SSOExtensionView.js
@@ -1,5 +1,5 @@
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import Util from '../../../../util/Util';
 import { loc } from 'okta';
 

--- a/src/v2/view-builder/views/device/SignInDeviceView.js
+++ b/src/v2/view-builder/views/device/SignInDeviceView.js
@@ -1,6 +1,5 @@
 import { $, _, loc } from 'okta';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import IdentifierFooter from '../../components/IdentifierFooter';
 import SignInWithDeviceOption from '../signin/SignInWithDeviceOption';
 import Link from '../../components/Link';

--- a/src/v2/view-builder/views/device/SignInDeviceView.js
+++ b/src/v2/view-builder/views/device/SignInDeviceView.js
@@ -1,9 +1,9 @@
 import { $, _, loc } from 'okta';
-import BaseView from '../internals/BaseView';
-import BaseForm from '../internals/BaseForm';
-import IdentifierFooter from '../components/IdentifierFooter';
-import SignInWithDeviceOption from './signin/SignInWithDeviceOption';
-import Link from '../components/Link';
+import BaseView from '../../internals/BaseView';
+import BaseForm from '../../internals/BaseForm';
+import IdentifierFooter from '../../components/IdentifierFooter';
+import SignInWithDeviceOption from '../signin/SignInWithDeviceOption';
+import Link from '../../components/Link';
 
 const Body = BaseForm.extend({
 

--- a/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
+++ b/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
@@ -1,6 +1,6 @@
 import { loc, createCallout } from 'okta';
 import Duo from 'duo';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 
 export default BaseForm.extend({
 

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -1,5 +1,5 @@
 import { loc, View, createCallout, _ } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import email from '../shared/email';
 import polling from '../shared/polling';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';

--- a/src/v2/view-builder/views/google-authenticator/ChallengeGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/ChallengeGoogleAuthenticatorView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -1,12 +1,10 @@
 import { loc, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseForm from '../../internals/BaseForm';
-import BaseView from '../../internals/BaseView';
+import { addCustomButton, BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 import EnrollGoogleAuthenticatorBarcodeView from './EnrollGoogleAuthenticatorBarcodeView';
 import EnrollAuthenticatorManualSetupView from './EnrollAuthenticatorManualSetupView';
-import { addCustomButton } from '../../internals/FormInputFactory';
 
 const VIEW_TO_DISPLAY = 'viewToDisplay';
 const viewToDisplayState = {

--- a/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
+++ b/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
@@ -1,5 +1,5 @@
 import { _, loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';

--- a/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 

--- a/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 

--- a/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
@@ -1,5 +1,5 @@
 import { Collection } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyOptions from '../../components/AuthenticatorVerifyOptions';
 import { getAuthenticatorDataForVerification } from '../../utils/AuthenticatorUtil';

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,7 +1,7 @@
 /* global Promise */
 import { $, loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import Logger from '../../../../util/Logger';
 import DeviceFingerprint from '../../../../util/DeviceFingerprint';
 import polling from '../shared/polling';

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
@@ -1,6 +1,6 @@
 import { _, loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import polling from '../shared/polling';
 import { WARNING_TIMEOUT } from '../../utils/Constants';
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
@@ -1,5 +1,5 @@
 import { loc, createCallout } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
@@ -1,6 +1,6 @@
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import Util from '../../../../util/Util';
 import { loc } from 'okta';
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';

--- a/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
@@ -1,6 +1,5 @@
 import { loc, _, Model } from 'okta';
-import BaseForm from '../../internals/BaseForm';
-import BaseView from '../../internals/BaseView';
+import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 import CountryUtil from '../../../../util/CountryUtil';

--- a/src/v2/view-builder/views/ov/NumberChallengePushView.js
+++ b/src/v2/view-builder/views/ov/NumberChallengePushView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import polling from '../shared/polling';
 import ResendNumberChallengeView from './ResendNumberChallengeView';
 import NumberChallengePhoneView from './NumberChallengePhoneView';

--- a/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
@@ -1,5 +1,5 @@
 import { loc, _ } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 import BrowserFeatures from '../../../../util/BrowserFeatures';

--- a/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { getForgotPasswordLink } from '../../utils/LinksUtil';

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -1,6 +1,5 @@
 import { loc, View } from 'okta';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import {
   getPasswordComplexityDescriptionForHtmlList,

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseFooter from '../../internals/BaseFooter';
+import { BaseFooter } from '../../internals';
 import EnrollAuthenticatorPasswordView from './EnrollAuthenticatorPasswordView';
 
 const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -1,6 +1,5 @@
 import { _, loc } from 'okta';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -1,6 +1,5 @@
 import { loc, View, createCallout } from 'okta';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 import { SHOW_RESEND_TIMEOUT } from '../../utils/Constants';

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
@@ -1,6 +1,5 @@
 import { _, loc, Model } from 'okta';
-import BaseView from '../../internals/BaseView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import CountryUtil from '../../../../util/CountryUtil';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
@@ -3,7 +3,7 @@ import {
   default as ChallengeAuthenticatorPhoneView,
   ResendView
 } from './ChallengeAuthenticatorPhoneView';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 
 const EnrollResendView = ResendView.extend(
   {

--- a/src/v2/view-builder/views/security-question/ChallengeAuthenticatorSecurityQuestion.js
+++ b/src/v2/view-builder/views/security-question/ChallengeAuthenticatorSecurityQuestion.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 

--- a/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
+++ b/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorEnrollFooter from '../../components/AuthenticatorEnrollFooter';
 

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -1,5 +1,5 @@
 import { loc, createButton, createCallout } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import CryptoUtil from '../../../../util/CryptoUtil';
 import webauthn from '../../../../util/webauthn';

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -1,5 +1,5 @@
 import { _, loc, createCallout, createButton } from 'okta';
-import BaseForm from '../../internals/BaseForm';
+import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import webauthn from '../../../../util/webauthn';
 import CryptoUtil from '../../../../util/CryptoUtil';

--- a/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
@@ -1,4 +1,4 @@
-import BaseFooter from 'v2/view-builder/internals/BaseFooter';
+import { BaseFooter } from 'v2/view-builder/internals';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
 import Link from 'v2/view-builder/components/Link';

--- a/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
@@ -1,4 +1,4 @@
-import BaseModel from 'v2/view-builder/internals/BaseModel';
+import { BaseModel } from 'v2/view-builder/internals';
 
 describe('v2/view-builder/internals/BaseModel', function () {
   const createModelAndVerifyPropsAndLocal = ({ uiSchema, optionUiSchemaConfig }, props, local = {}) => {

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -1,5 +1,5 @@
 import ChallengeWebauthnView from 'v2/view-builder/views/webauthn/ChallengeWebauthnView';
-import BaseForm from 'v2/view-builder/internals/BaseForm';
+import { BaseForm } from 'v2/view-builder/internals';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
 import webauthn from 'util/webauthn';

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -1,5 +1,5 @@
 import EnrollWebauthnView from 'v2/view-builder/views/webauthn/EnrollWebauthnView';
-import BaseForm from 'v2/view-builder/internals/BaseForm';
+import { BaseForm } from 'v2/view-builder/internals';
 import CryptoUtil from 'util/CryptoUtil';
 import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';


### PR DESCRIPTION
## Description:

This is a refactoring commit that changes file locations and imports. Specifically:

- All device authenticator views for enroll and challenge are migrated into a `device` directory. This adheres to our new convention for authenticators.
- Allows `internals` to be imported using destructured ES6 named exports.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Reviewers:

- @haishengwu-okta 


