### PR TITLE
set autocomplete attribute on inputs

### DIFF
--- a/src/ForgotPasswordController.js
+++ b/src/ForgotPasswordController.js
@@ -118,6 +118,7 @@ export default FormController.extend({
             name: 'username',
             input: TextBox,
             inputId: 'account-recovery-username',
+            autoComplete: 'username',
             type: 'text',
             inlineValidation: false,
           })

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -93,6 +93,7 @@ export default FormController.extend({
           name: 'newPassword',
           input: TextBox,
           type: 'password',
+          autoComplete: 'new-password',
         }),
         FormType.Input({
           label: loc('password.confirmPassword.placeholder', 'login'),
@@ -106,6 +107,7 @@ export default FormController.extend({
           name: 'confirmPassword',
           input: TextBox,
           type: 'password',
+          autoComplete: 'new-password',
         }),
       ]);
       return children;

--- a/src/views/enroll-factors/PhoneTextBox.js
+++ b/src/views/enroll-factors/PhoneTextBox.js
@@ -19,7 +19,7 @@ export default TextBox.extend({
       <span class="okta-form-label-inline o-form-label-inline">{{countryCallingCode}}</span>\
       <span class="okta-form-input-field input-fix o-form-control">\
         <input type="{{type}}" placeholder="{{placeholder}}" name="{{name}}" \
-          id="{{inputId}}" value="{{value}}" autocomplete="off">\
+          id="{{inputId}}" value="{{value}}" autocomplete="tel">\
       </span>\
     '
   ),

--- a/test/unit/helpers/dom/EnrollSmsForm.js
+++ b/test/unit/helpers/dom/EnrollSmsForm.js
@@ -23,6 +23,10 @@ export default Form.extend({
     return this.input(PHONE_FIELD);
   },
 
+  getPhoneNumberAutocomplete: function () {
+    return this.autocomplete(PHONE_FIELD);
+  },
+
   phonePrefixText: function () {
     return this.inlineLabel(PHONE_FIELD).trimmedText();
   },

--- a/test/unit/helpers/dom/PasswordResetForm.js
+++ b/test/unit/helpers/dom/PasswordResetForm.js
@@ -18,8 +18,16 @@ export default Form.extend({
     return this.input(NEW_PASSWORD_FIELD);
   },
 
+  getNewPasswordAutocomplete: function () {
+    return this.autocomplete(NEW_PASSWORD_FIELD);
+  },
+
   confirmPasswordField: function () {
     return this.input(CONFIRM_PASSWORD_FIELD);
+  },
+
+  getConfirmPasswordAutocomplete: function () {
+    return this.autocomplete(CONFIRM_PASSWORD_FIELD);
   },
 
   setNewPassword: function (val) {

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -236,6 +236,11 @@ Expect.describe('EnrollSms', function () {
         Expect.isTextField(test.form.phoneNumberField());
       });
     });
+    itp('allows autocomplete for phone number text field', function () {
+      return setup(allFactorsRes).then(function (test) {
+        expect(test.form.getPhoneNumberAutocomplete()).toBe('tel');
+      });
+    });
     itp('has a button with primary class and text "Send Code"', function () {
       return setup(allFactorsRes).then(function (test) {
         expectSendButton(test);

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -96,9 +96,9 @@ Expect.describe('ForgotPassword', function () {
         expect($usernameLabel.text().trim()).toEqual('Email or Username');
       });
     });
-    itp('does not allow autocomplete', function () {
+    itp('sets autocomplete for username', function () {
       return setup().then(function (test) {
-        expect(test.form.getUsernameAutocomplete()).toBe('off');
+        expect(test.form.getUsernameAutocomplete()).toBe('username');
       });
     });
     itp('does not have explain by default', function () {

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -627,9 +627,21 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
+  itp('has autocomplete set to new-password for new password field', function () {
+    return setup().then(function (test) {
+      expect(test.form.getNewPasswordAutocomplete()).toBe('new-password');
+    });
+  });
+
   itp('has a password field to confirm the new password', function () {
     return setup().then(function (test) {
       Expect.isPasswordField(test.form.confirmPasswordField());
+    });
+  });
+
+  itp('has autocomplete set to new-password for confirm password field', function () {
+    return setup().then(function (test) {
+      expect(test.form.getConfirmPasswordAutocomplete()).toBe('new-password');
     });
   });
 


### PR DESCRIPTION
## Description:

As part of the recent efforts to improve accessibility in the sign-in widget, set autocomplete attribute on username, password, and phone number inputs listed in the JIRA [OKTA-367800](https://oktainc.atlassian.net/browse/OKTA-367800) in the following scenarios:
- Sign-in with username/password
- Authenticate with phone, send code to number
- Forgot password, enter username
- Reset password, enter new and confirm password

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


https://drive.google.com/file/d/1pclCDoolUsrcWZOm8-OQMTzq1u9M6d4T/view?usp=sharing


### Reviewers:


### Issue:

- [OKTA-367800](https://oktainc.atlassian.net/browse/OKTA-367800)


