### PR TITLE
feat: Show error title for okta verify version upgrade

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -841,6 +841,9 @@ oie.on_prem.verify.passcode.label = Enter code
 oie.numberchallenge.warning = Haven't received a push notification yet? Try opening the Okta Verify app on your device, or <$1>resend the push notification</$1>.
 ## {0} refers to a number which is the correct answer for the number challenge
 oie.numberchallenge.instruction = On your mobile device, open the Okta Verify prompt, then tap <$1>{0}</$1> in Okta Verify to continue.
+oie.numberchallenge.force.upgrade.title = Update Okta Verify
+oie.numberchallenge.force.upgrade = Your response was received, but your Okta Verify version is no longer supported by your organization. To verify your identity with push notifcations, update Okta Verify to the latest version, then try again.
+
 
 ## RSA Authenticator
 oie.rsa.label = RSA SecurID

--- a/playground/mocks/data/idp/idx/okta-verify-version-upgrade.json
+++ b/playground/mocks/data/idp/idx/okta-verify-version-upgrade.json
@@ -1,0 +1,295 @@
+{
+  "stateHandle": "02ZKtFVdKvzW8tMRWh17SnFdrfMyUf7aWsA7SWbImX",
+  "version": "1.0.0",
+  "expiresAt": "2021-03-01T23:51:09.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "resend",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "label": "Okta Verify",
+            "value": {
+              "form": {
+                "value": [
+                  {
+                    "name": "id",
+                    "required": true,
+                    "value": "aut1kxbY4k3KnPvvd0g4",
+                    "mutable": false
+                  },
+                  {
+                    "name": "methodType",
+                    "required": false,
+                    "value": "push",
+                    "mutable": false
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ZKtFVdKvzW8tMRWh17SnFdrfMyUf7aWsA7SWbImX",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut1kwlmpxkrTTHpv0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "email",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              },
+              {
+                "label": "Okta Verify",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut1kxbY4k3KnPvvd0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "type": "string",
+                        "required": false,
+                        "options": [
+                          {
+                            "label": "Enter a code",
+                            "value": "totp"
+                          },
+                          {
+                            "label": "Get a push notification",
+                            "value": "push"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ZKtFVdKvzW8tMRWh17SnFdrfMyUf7aWsA7SWbImX",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Your response was received, but your Okta Verify version is no longer supported by your organization. To verify your identity with push notifcations, update Okta Verify to the latest version, then try again.",
+        "i18n":{
+            "key": "idx.authenticator.app.method.push.force.upgrade.number_challenge",
+            "params": []
+          },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "profile": {
+        "deviceName": "sdk_gphone_x86"
+      },
+      "resend": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "resend",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "required": true,
+            "value": {
+              "methodType": "push",
+              "id": "aut1kxbY4k3KnPvvd0g4"
+            },
+            "visible": false,
+            "mutable": false
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02ZKtFVdKvzW8tMRWh17SnFdrfMyUf7aWsA7SWbImX",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      "contextualData": {
+        "correctAnswer": "46"
+      },
+      "type": "app",
+      "key": "okta_verify",
+      "id": "aut1kxbY4k3KnPvvd0g4",
+      "displayName": "Okta Verify",
+      "methods": [
+        {
+          "type": "push"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "key": "okta_email",
+        "id": "aut1kwlmpxkrTTHpv0g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aut1kxbY4k3KnPvvd0g4",
+        "displayName": "Okta Verify",
+        "methods": [
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "profile": {
+          "email": "g***n@okta.com"
+        },
+        "type": "email",
+        "key": "okta_email",
+        "id": "eae1kw3Tb8MoAAaNs0g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "profile": {
+          "deviceName": "sdk_gphone_x86"
+        },
+        "type": "app",
+        "key": "okta_verify",
+        "id": "pfd1kw0V8hoOaMZ1e0g4",
+        "displayName": "Okta Verify",
+        "methods": [
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u1j0yJwwRvnJQa60g4"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02ZKtFVdKvzW8tMRWh17SnFdrfMyUf7aWsA7SWbImX",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "okta_enduser",
+      "label": "Okta Dashboard",
+      "id": "DEFAULT_APP"
+    }
+  }
+}

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
@@ -3,6 +3,8 @@ import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import AuthenticatorVerifyFooter from '../../components/AuthenticatorVerifyFooter';
 
+const OV_NMC_FORCE_UPGRAGE_SERVER_KEY = 'idx.authenticator.app.method.push.force.upgrade.number_challenge';
+
 const Body = BaseForm.extend(Object.assign(
   {
     className: 'okta-verify-resend-push',
@@ -25,10 +27,17 @@ const Body = BaseForm.extend(Object.assign(
         messagesObjs.value.forEach(messagesObj => {
           const msg = messagesObj.message;
           if (messagesObj?.class === 'ERROR') {
-            this.add(createCallout({
+            const options = {
               content: msg,
               type: 'error',
-            }), '.o-form-error-container');
+            };
+            if (this.options.appState.containsMessageWithI18nKey(OV_NMC_FORCE_UPGRAGE_SERVER_KEY)) {
+              // account for error customization
+              options.content = loc('oie.numberchallenge.force.upgrade', 'login');
+              // add a title for OV force upgrade
+              options.title = loc('oie.numberchallenge.force.upgrade.title', 'login');
+            }
+            this.add(createCallout(options), '.o-form-error-container');
           } else {
             this.add(`<p>${msg}</p>`, '.ion-messages-container');
           }

--- a/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
@@ -3,6 +3,7 @@ import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 const FORM_INFOBOX_WARNING = '.okta-form-infobox-warning';
 const FORM_INFOBOX_ERROR = '.o-form-error-container .infobox-error';
 const RESEND_NUMBER_CHALLENGE_BUTTON = '.okta-form-infobox-warning .resend-number-challenge';
+const FORM_INFOBOX_ERROR_TITLE = '.o-form-error-container .infobox-error > h3';
 
 export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPageObject {
   constructor(t) {
@@ -35,6 +36,10 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
 
   getErrorBox () {
     return this.form.getElement(FORM_INFOBOX_ERROR);
+  }
+
+  getErrorTitle() {
+    return this.form.getElement(FORM_INFOBOX_ERROR_TITLE);
   }
 
   getWarningBox () {

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -5,7 +5,6 @@ import { checkConsoleMessages } from '../framework/shared';
 
 import pushPoll from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push';
 import success from '../../../playground/mocks/data/idp/idx/success';
-import pushReject from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-reject-push';
 
 const logger = RequestLogger(/challenge|challenge\/poll/,
   {
@@ -19,12 +18,6 @@ const pushSuccessMock = RequestMock()
   .respond(pushPoll)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
   .respond(success);
-
-const pushRejectMock = RequestMock()
-  .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(pushPoll)
-  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(pushReject);
 
 const pushWaitMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -60,19 +53,6 @@ test
   });
 
 test
-  .requestHooks(pushRejectMock)('challenge okta verify with rejected push', async t => {
-    const challengeOktaVerifyPushPageObject = await setup(t);
-    await challengeOktaVerifyPushPageObject.waitForErrorBox();
-    const pageTitle = challengeOktaVerifyPushPageObject.getPageTitle();
-    await t.expect(pageTitle).contains('Get a push notification');
-    const errorBox = challengeOktaVerifyPushPageObject.getErrorBox();
-    await t.expect(errorBox.innerText).contains('You have chosen to reject this login.');
-    const resendPushBtn = challengeOktaVerifyPushPageObject.getResendPushButton();
-    await t.expect(resendPushBtn.value).contains('Resend push notification');
-    await t.expect(resendPushBtn.hasClass('link-button-disabled')).notOk();
-  });
-
-test
   .requestHooks(logger, pushSuccessMock)('challenge okta verify push request', async t => {
     await setup(t);
     const successPage = new SuccessPageObject(t);
@@ -93,31 +73,6 @@ test
     });
     await t.expect(answerRequestMethod).eql('post');
     await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/poll');
-  });
-
-test
-  .requestHooks(logger, pushRejectMock)('challenge okta verify resend push request', async t => {
-    const challengeOktaVerifyPushPageObject = await setup(t);
-    await challengeOktaVerifyPushPageObject.waitForErrorBox();
-    await challengeOktaVerifyPushPageObject.clickResendPushButton();
-
-    await t.expect(logger.count(() => true)).eql(2);
-    const { request: {
-      body: answerRequestBodyString,
-      method: answerRequestMethod,
-      url: answerRequestUrl,
-    }
-    } = logger.requests[1];
-    const answerRequestBody = JSON.parse(answerRequestBodyString);
-    await t.expect(answerRequestBody).eql({
-      authenticator: {
-        id: 'auteq0lLiL9o1cYoN0g4',
-        methodType: 'push',
-      },
-      stateHandle: '022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP'
-    });
-    await t.expect(answerRequestMethod).eql('post');
-    await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge');
   });
 
 test

--- a/test/testcafe/spec/ChallengeOktaVerifyResendPushView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyResendPushView_spec.js
@@ -1,0 +1,89 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import ChallengeOktaVerifyPushPageObject from '../framework/page-objects/ChallengeOktaVerifyPushPageObject';
+
+import pushPoll from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push';
+import pushReject from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-reject-push';
+import pushUpgradeOktaVerify from '../../../playground/mocks/data/idp/idx/okta-verify-version-upgrade';
+
+const logger = RequestLogger(/challenge|challenge\/poll/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+
+const pushRejectMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(pushPoll)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(pushReject);
+
+const pushOktaVerifyUpgradetMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(pushPoll)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(pushUpgradeOktaVerify);
+
+fixture('Challenge Okta Verify Push Resend');
+
+async function setup(t) {
+  const challengeOktaVerifyPushPageObject = new ChallengeOktaVerifyPushPageObject(t);
+  await challengeOktaVerifyPushPageObject.navigateToPage();
+  return challengeOktaVerifyPushPageObject;
+}
+
+test
+  .requestHooks(pushRejectMock)('challenge okta verify with rejected push', async t => {
+    const challengeOktaVerifyPushPageObject = await setup(t);
+    await challengeOktaVerifyPushPageObject.waitForErrorBox();
+    const pageTitle = challengeOktaVerifyPushPageObject.getPageTitle();
+    await t.expect(pageTitle).contains('Get a push notification');
+    const errorBox = challengeOktaVerifyPushPageObject.getErrorBox();
+    await t.expect(errorBox.innerText).contains('You have chosen to reject this login.');
+    const resendPushBtn = challengeOktaVerifyPushPageObject.getResendPushButton();
+    await t.expect(resendPushBtn.value).contains('Resend push notification');
+    await t.expect(resendPushBtn.hasClass('link-button-disabled')).notOk();
+  });
+
+test
+  .requestHooks(logger, pushRejectMock)('challenge okta verify resend push request', async t => {
+    const challengeOktaVerifyPushPageObject = await setup(t);
+    await challengeOktaVerifyPushPageObject.waitForErrorBox();
+    await challengeOktaVerifyPushPageObject.clickResendPushButton();
+
+    await t.expect(logger.count(() => true)).eql(2);
+    const { request: {
+      body: answerRequestBodyString,
+      method: answerRequestMethod,
+      url: answerRequestUrl,
+    }
+    } = logger.requests[1];
+    const answerRequestBody = JSON.parse(answerRequestBodyString);
+    await t.expect(answerRequestBody).eql({
+      authenticator: {
+        id: 'auteq0lLiL9o1cYoN0g4',
+        methodType: 'push',
+      },
+      stateHandle: '022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP'
+    });
+    await t.expect(answerRequestMethod).eql('post');
+    await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge');
+  });
+
+
+test
+  .requestHooks(logger, pushOktaVerifyUpgradetMock)('challenge okta verify resend push with version upgrade message', async t => {
+    const challengeOktaVerifyPushPageObject = await setup(t);
+    await challengeOktaVerifyPushPageObject.waitForErrorBox();
+    const pageTitle = challengeOktaVerifyPushPageObject.getFormTitle();
+    await t.expect(pageTitle).contains('Get a push notification');
+    const errorBox = challengeOktaVerifyPushPageObject.getErrorBox();
+    await t.expect(errorBox.innerText).contains('Your response was received, but your Okta Verify version is no longer supported by your organization. To verify your identity with push notifcations, update Okta Verify to the latest version, then try again.');
+    const errorTitle = challengeOktaVerifyPushPageObject.getErrorTitle();
+    await t.expect(errorTitle.innerText).contains('Update Okta Verify');
+    const resendPushBtn = challengeOktaVerifyPushPageObject.getResendPushButton();
+    await t.expect(resendPushBtn.value).contains('Resend push notification');
+    await t.expect(resendPushBtn.hasClass('link-button-disabled')).notOk();
+  });
+


### PR DESCRIPTION
Resolves: OKTA-373720

## Description:

- Add error message for okta verify push upgrade during number challenge 
- As per discussion in the widget design review, client will check for the i18n key and show the title within the callout.
- Moved some of the resend view related tests from `ChallengeOktaVerifyPush_spec.js` into its own file `ChallengeOktaVerifyResendPushView_spec.js`


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:



<img width="476" alt="Screen Shot 2021-03-03 at 4 48 46 PM" src="https://user-images.githubusercontent.com/23267876/109900543-65ab0e80-7c4c-11eb-957d-a79094497fc2.png">


### Reviewers:

@gowthamidommety-okta @jmelberg-okta @stevennguyen-okta 

### Issue:

- [OKTA-373720](https://oktainc.atlassian.net/browse/OKTA-373720)


