### PR TITLE
add showPasswordToggle flag for v2

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -144,6 +144,16 @@ export default Model.extend({
   },
 
   derived: {
+    showPasswordToggle: {
+      deps: ['features.showPasswordToggleOnSignInPage'],
+      fn: function () {
+        // showPasswordToggle is for OIE only.
+        // Used to default showPasswordToggleOnSignInPage to true.
+        return _.isUndefined(this.options.features?.showPasswordToggleOnSignInPage)
+          || this.get('features.showPasswordToggleOnSignInPage');
+      },
+      cache: true,
+    },
     redirectUtilFn: {
       deps: ['features.redirectByFormSubmit'],
       fn: function (redirectByFormSubmit) {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -149,8 +149,7 @@ export default Model.extend({
       fn: function () {
         // showPasswordToggle is for OIE only.
         // Used to default showPasswordToggleOnSignInPage to true.
-        return _.isUndefined(this.options.features?.showPasswordToggleOnSignInPage)
-          || this.get('features.showPasswordToggleOnSignInPage');
+        return this.options?.features?.showPasswordToggleOnSignInPage !== false;
       },
       cache: true,
     },

--- a/src/v2/ion/transformIdxResponse.js
+++ b/src/v2/ion/transformIdxResponse.js
@@ -19,7 +19,7 @@ import i18nTransformer from './i18nTransformer';
 export default function transformIdxResponse (settings, idxResponse) {
   const ionResponse = _.compose(
     i18nTransformer,
-    uiSchemaTransformer,
+    uiSchemaTransformer.bind({}, settings),
     responseTransformer.bind({}, settings),
   )(idxResponse);
   return ionResponse;

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -109,7 +109,7 @@ const getAuthenticatorsVerifyUiSchema = ({ options }) => {
 /**
   * Create ui schema for ION field that has type 'object'.
   */
-const createUiSchemaForObject = (ionFormField, remediationForm, transformedResp, createUISchema) => {
+const createUiSchemaForObject = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
   const uiSchema = {};
 
   if (ionFormField.name === 'authenticator' &&
@@ -135,7 +135,7 @@ const createUiSchemaForObject = (ionFormField, remediationForm, transformedResp,
             value: opt.value,
           }
         ]
-      });
+      }, settings);
     });
     uiSchema.options = ionFormField.options.map((opt, index) => {
       return { label: opt.label, value: index };

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -20,23 +20,23 @@ const ionOptionsToUiOptions = (options) => {
   return result;
 };
 
-const getPasswordUiSchema = () => ({
+const getPasswordUiSchema = (settings) => ({
   type: 'password',
   params: {
-    showPasswordToggle: true,
+    showPasswordToggle: settings.get('showPasswordToggle'),
   },
 });
 
 const shouldRenderAsRadio = (name) => name.indexOf('methodType') >= 0 || name.indexOf('channel') >= 0;
 
-const createUiSchemaForString = (ionFormField) => {
+const createUiSchemaForString = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
   const uiSchema = {
     type: 'text'
   };
 
   // e.g. { name: 'password', secret: true }
   if (ionFormField.secret === true) {
-    Object.assign(uiSchema, getPasswordUiSchema());
+    Object.assign(uiSchema, getPasswordUiSchema(settings));
   }
 
   if (Array.isArray(ionFormField.options)) {

--- a/src/v2/ion/uiSchemaTransformer.js
+++ b/src/v2/ion/uiSchemaTransformer.js
@@ -29,7 +29,7 @@ const UISchemaHandlers = {
  * @param {AuthResult} transformedResp
  * @param {IONForm} remeditationForm
  */
-const createUISchema = (transformedResp, remediationForm) => {
+const createUISchema = (transformedResp, remediationForm, settings) => {
 
   // For cases where field itself is a form, it has a formname and we are appending the formname to each field.
   // Sort of flat the structure in order to align Courage flatten Model. The flatten structure will be converted
@@ -63,7 +63,7 @@ const createUISchema = (transformedResp, remediationForm) => {
     };
     const fieldType = ionFormField.type || 'string';
     const uiSchemaHandler = UISchemaHandlers[fieldType];
-    const uiSchemaResult = uiSchemaHandler(ionFormField, remediationForm, transformedResp, createUISchema);
+    const uiSchemaResult = uiSchemaHandler(ionFormField, remediationForm, transformedResp, createUISchema, settings);
 
     return Object.assign(
       {},
@@ -78,10 +78,10 @@ const createUISchema = (transformedResp, remediationForm) => {
  *
  * @param {AuthResult} transformedResp
  */
-const insertUISchema = (transformedResp) => {
+const insertUISchema = (settings, transformedResp) => {
   if (transformedResp) {
     transformedResp.remediations = transformedResp.remediations.map(obj => {
-      obj.uiSchema = createUISchema(transformedResp, obj);
+      obj.uiSchema = createUISchema(transformedResp, obj, settings);
       return obj;
     });
   }

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -69,7 +69,7 @@ const Body = BaseForm.extend({
         type: 'password',
         'label-top': true,
         params: {
-          showPasswordToggle: true
+          showPasswordToggle: this.settings.get('showPasswordToggle'),
         }
       }
     ]);

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -84,6 +84,10 @@ export default class IdentityPageObject extends BasePageObject {
     return this.form.setTextBoxValue('credentials.passcode', value);
   }
 
+  async hasShowTogglePasswordIcon() {
+    return await Selector('.password-toggle').count;
+  }
+
   clickNextButton() {
     return this.form.clickSaveButton();
   }

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -33,13 +33,15 @@ async function setup(t) {
   return identityPage;
 }
 
-test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password field and forgot password link', async t => {
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password field, password toggle, and forgot password link', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('random password 123');
   await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();
   await t.expect(await identityPage.getForgotPasswordLinkText()).eql('Forgot password?');
+
+  await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
 
   await identityPage.clickNextButton();
 

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock, RequestLogger } from 'testcafe';
+import { ClientFunction, RequestMock, RequestLogger } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import { checkConsoleMessages } from '../framework/shared';
 import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
@@ -17,6 +17,10 @@ const identifyRequestLogger = RequestLogger(
     stringifyRequestBody: true,
   }
 );
+
+const rerenderWidget = ClientFunction((settings) => {
+  window.renderPlaygroundWidget(settings);
+});
 
 fixture('Identify + Password');
 
@@ -57,4 +61,20 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
+});
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password toggle if features.showPasswordToggleOnSignIn is true', async t => {
+  const identityPage = await setup(t);
+  await rerenderWidget({
+    features: {showPasswordToggleOnSignInPage: true},
+  });
+  await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
+});
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if features.showPasswordToggleOnSignIn is false', async t => {
+  const identityPage = await setup(t);
+  await rerenderWidget({
+    features: {showPasswordToggleOnSignInPage: false},
+  });
+  await t.expect(await identityPage.hasShowTogglePasswordIcon()).notOk();
 });

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -11,6 +11,7 @@ import XHRAuthenticatorEnrollDataPhone  from '../../../../../playground/mocks/da
 import XHRAuthenticatorEnrollSecurityQuestion  from '../../../../../playground/mocks/data/idp/idx/authenticator-enroll-security-question.json';
 import XHRAuthenticatorEnrollOktaVerifyQr from '../../../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
 import XHRIdentifyResponse from '../../../../../playground/mocks/data/idp/idx/identify.json';
+import XHRIdentifyWithPasswordResponse from '../../../../../playground/mocks/data/idp/idx/identify-with-password.json'
 
 describe('v2/ion/uiSchemaTransformer', function () {
   let testContext;
@@ -1375,6 +1376,172 @@ describe('v2/ion/uiSchemaTransformer', function () {
         'label-top': true,
         type: 'radio'
       }]);
+    });
+  });
+
+  it('sets showPasswordToggle to true if features.showPasswordToggleOnSignInPage is true', done => {
+    testContext.settings = new Settings({
+      baseUrl: 'http://localhost:3000',
+      features: {
+        showPasswordToggleOnSignInPage: true,
+      }
+    });
+
+    MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
+      expect(result.remediations[0]).toEqual(
+          {
+            name: 'identify',
+            href: 'http://localhost:3000/idp/idx/identify',
+            rel: ['create-form'],
+            accepts: 'application/vnd.okta.v1+json',
+            method: 'POST',
+            action: jasmine.any(Function),
+            value: [
+              {
+                name: 'identifier',
+                label: 'Username',
+              },
+              {
+                "form":  {
+                  "value": [
+                      {
+                      "label": "Password",
+                      "name": "passcode",
+                      "secret": true,
+                    },
+                  ],
+                },
+                "name": "credentials",
+                "required": true,
+                "type": "object",
+              },
+
+              {
+                name: 'rememberMe',
+                label: 'Remember Me',
+                type: 'boolean',
+              },
+              {
+                name: 'stateHandle',
+                required: true,
+                value: jasmine.any(String),
+                visible: false,
+                mutable: false,
+              },
+            ],
+            uiSchema: [
+              {
+                name: 'identifier',
+                label: 'Username',
+                type: 'text',
+                'label-top': true,
+              },
+              {
+                "label": "Password",
+                "label-top": true,
+                "name": "credentials.passcode",
+                "params":  {
+                  "showPasswordToggle": true,
+                },
+                "secret": true,
+                "type": "password",
+              },
+              {
+                name: 'rememberMe',
+                label: false,
+                type: 'checkbox',
+                placeholder: 'Remember Me',
+                modelType: 'boolean',
+                required: false,
+                'label-top': true,
+              },
+            ],
+          },
+      );
+    });
+  });
+
+  it('sets showPasswordToggle to false if features.showPasswordToggleOnSignInPage is false', done => {
+    testContext.settings = new Settings({
+      baseUrl: 'http://localhost:3000',
+      features: {
+        showPasswordToggleOnSignInPage: false,
+      }
+    });
+
+    MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
+      expect(result.remediations[0]).toEqual(
+          {
+            name: 'identify',
+            href: 'http://localhost:3000/idp/idx/identify',
+            rel: ['create-form'],
+            accepts: 'application/vnd.okta.v1+json',
+            method: 'POST',
+            action: jasmine.any(Function),
+            value: [
+              {
+                name: 'identifier',
+                label: 'Username',
+              },
+              {
+                "form":  {
+                  "value": [
+                      {
+                      "label": "Password",
+                      "name": "passcode",
+                      "secret": true,
+                    },
+                  ],
+                },
+                "name": "credentials",
+                "required": true,
+                "type": "object",
+              },
+
+              {
+                name: 'rememberMe',
+                label: 'Remember Me',
+                type: 'boolean',
+              },
+              {
+                name: 'stateHandle',
+                required: true,
+                value: jasmine.any(String),
+                visible: false,
+                mutable: false,
+              },
+            ],
+            uiSchema: [
+              {
+                name: 'identifier',
+                label: 'Username',
+                type: 'text',
+                'label-top': true,
+              },
+              {
+                "label": "Password",
+                "label-top": true,
+                "name": "credentials.passcode",
+                "params":  {
+                  "showPasswordToggle": false,
+                },
+                "secret": true,
+                "type": "password",
+              },
+              {
+                name: 'rememberMe',
+                label: false,
+                type: 'checkbox',
+                placeholder: 'Remember Me',
+                modelType: 'boolean',
+                required: false,
+                'label-top': true,
+              },
+            ],
+          },
+      );
     });
   });
 });

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -25,7 +25,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts response with fields as form for ENROLL_PROFILE', done => {
     MockUtil.mockIntrospect(done, XHREnrollProfile, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({
         remediations: [
           {
@@ -123,7 +123,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts authenticator require - email', done => {
     MockUtil.mockIntrospect(done, XHRAuthenticatorRequiredEmail, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({
         app: {
           name: 'oidc_client',
@@ -245,7 +245,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts authenticator enroll - authenticator list', done => {
     MockUtil.mockIntrospect(done, XHRAuthenticatorEnrollSelectAuthenticators, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({
         authenticators: _.pick(XHRAuthenticatorEnrollSelectAuthenticators.authenticators, 'value'),
         user: {
@@ -767,7 +767,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts authenticator enroll - phone', done => {
     MockUtil.mockIntrospect(done, XHRAuthenticatorEnrollDataPhone, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
 
       expect(result.authenticators).toEqual({
         value: XHRAuthenticatorEnrollDataPhone.authenticators.value,
@@ -1004,7 +1004,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts authenticator enroll - security question', done => {
     MockUtil.mockIntrospect(done, XHRAuthenticatorEnrollSecurityQuestion, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({
         currentAuthenticator: XHRAuthenticatorEnrollSecurityQuestion.currentAuthenticator.value,
         user: XHRAuthenticatorEnrollSecurityQuestion.user.value,
@@ -1276,7 +1276,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts identify remediation response', done => {
     MockUtil.mockIntrospect(done, XHRIdentifyResponse, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result).toEqual({
         remediations: [
           {
@@ -1348,7 +1348,7 @@ describe('v2/ion/uiSchemaTransformer', function () {
 
   it('converts select channel response for Okta verify', (done) => {
     MockUtil.mockIntrospect(done, XHRAuthenticatorEnrollOktaVerifyQr, idxResp => {
-      const result = _.compose(uiSchemaTransformer, responseTransformer.bind(null, testContext.settings))(idxResp);
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result.remediations[1].uiSchema).toEqual([{
         name: 'authenticator.id',
         value: 'aidtheidkwh282hv8g3',

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -11,7 +11,7 @@ import XHRAuthenticatorEnrollDataPhone  from '../../../../../playground/mocks/da
 import XHRAuthenticatorEnrollSecurityQuestion  from '../../../../../playground/mocks/data/idp/idx/authenticator-enroll-security-question.json';
 import XHRAuthenticatorEnrollOktaVerifyQr from '../../../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
 import XHRIdentifyResponse from '../../../../../playground/mocks/data/idp/idx/identify.json';
-import XHRIdentifyWithPasswordResponse from '../../../../../playground/mocks/data/idp/idx/identify-with-password.json'
+import XHRIdentifyWithPasswordResponse from '../../../../../playground/mocks/data/idp/idx/identify-with-password.json';
 
 describe('v2/ion/uiSchemaTransformer', function () {
   let testContext;
@@ -1390,74 +1390,74 @@ describe('v2/ion/uiSchemaTransformer', function () {
     MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
       const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result.remediations[0]).toEqual(
-          {
-            name: 'identify',
-            href: 'http://localhost:3000/idp/idx/identify',
-            rel: ['create-form'],
-            accepts: 'application/vnd.okta.v1+json',
-            method: 'POST',
-            action: jasmine.any(Function),
-            value: [
-              {
-                name: 'identifier',
-                label: 'Username',
+        {
+          name: 'identify',
+          href: 'http://localhost:3000/idp/idx/identify',
+          rel: ['create-form'],
+          accepts: 'application/vnd.okta.v1+json',
+          method: 'POST',
+          action: jasmine.any(Function),
+          value: [
+            {
+              name: 'identifier',
+              label: 'Username',
+            },
+            {
+              'form':  {
+                'value': [
+                  {
+                    'label': 'Password',
+                    'name': 'passcode',
+                    'secret': true,
+                  },
+                ],
               },
-              {
-                "form":  {
-                  "value": [
-                      {
-                      "label": "Password",
-                      "name": "passcode",
-                      "secret": true,
-                    },
-                  ],
-                },
-                "name": "credentials",
-                "required": true,
-                "type": "object",
-              },
+              'name': 'credentials',
+              'required': true,
+              'type': 'object',
+            },
 
-              {
-                name: 'rememberMe',
-                label: 'Remember Me',
-                type: 'boolean',
+            {
+              name: 'rememberMe',
+              label: 'Remember Me',
+              type: 'boolean',
+            },
+            {
+              name: 'stateHandle',
+              required: true,
+              value: jasmine.any(String),
+              visible: false,
+              mutable: false,
+            },
+          ],
+          uiSchema: [
+            {
+              name: 'identifier',
+              label: 'Username',
+              type: 'text',
+              'label-top': true,
+            },
+            {
+              'label': 'Password',
+              'label-top': true,
+              'name': 'credentials.passcode',
+              'params':  {
+                'showPasswordToggle': true,
               },
-              {
-                name: 'stateHandle',
-                required: true,
-                value: jasmine.any(String),
-                visible: false,
-                mutable: false,
-              },
-            ],
-            uiSchema: [
-              {
-                name: 'identifier',
-                label: 'Username',
-                type: 'text',
-                'label-top': true,
-              },
-              {
-                "label": "Password",
-                "label-top": true,
-                "name": "credentials.passcode",
-                "params":  {
-                  "showPasswordToggle": true,
-                },
-                "secret": true,
-                "type": "password",
-              },
-              {
-                name: 'rememberMe',
-                label: false,
-                type: 'checkbox',
-                placeholder: 'Remember Me',
-                modelType: 'boolean',
-                required: false,
-                'label-top': true,
-              },
-            ],
-          },
+              'secret': true,
+              'type': 'password',
+            },
+            {
+              name: 'rememberMe',
+              label: false,
+              type: 'checkbox',
+              placeholder: 'Remember Me',
+              modelType: 'boolean',
+              required: false,
+              'label-top': true,
+            },
+          ],
+        },
       );
     });
   });
@@ -1473,74 +1473,74 @@ describe('v2/ion/uiSchemaTransformer', function () {
     MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
       const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
       expect(result.remediations[0]).toEqual(
-          {
-            name: 'identify',
-            href: 'http://localhost:3000/idp/idx/identify',
-            rel: ['create-form'],
-            accepts: 'application/vnd.okta.v1+json',
-            method: 'POST',
-            action: jasmine.any(Function),
-            value: [
-              {
-                name: 'identifier',
-                label: 'Username',
+        {
+          name: 'identify',
+          href: 'http://localhost:3000/idp/idx/identify',
+          rel: ['create-form'],
+          accepts: 'application/vnd.okta.v1+json',
+          method: 'POST',
+          action: jasmine.any(Function),
+          value: [
+            {
+              name: 'identifier',
+              label: 'Username',
+            },
+            {
+              'form':  {
+                'value': [
+                  {
+                    'label': 'Password',
+                    'name': 'passcode',
+                    'secret': true,
+                  },
+                ],
               },
-              {
-                "form":  {
-                  "value": [
-                      {
-                      "label": "Password",
-                      "name": "passcode",
-                      "secret": true,
-                    },
-                  ],
-                },
-                "name": "credentials",
-                "required": true,
-                "type": "object",
-              },
+              'name': 'credentials',
+              'required': true,
+              'type': 'object',
+            },
 
-              {
-                name: 'rememberMe',
-                label: 'Remember Me',
-                type: 'boolean',
+            {
+              name: 'rememberMe',
+              label: 'Remember Me',
+              type: 'boolean',
+            },
+            {
+              name: 'stateHandle',
+              required: true,
+              value: jasmine.any(String),
+              visible: false,
+              mutable: false,
+            },
+          ],
+          uiSchema: [
+            {
+              name: 'identifier',
+              label: 'Username',
+              type: 'text',
+              'label-top': true,
+            },
+            {
+              'label': 'Password',
+              'label-top': true,
+              'name': 'credentials.passcode',
+              'params':  {
+                'showPasswordToggle': false,
               },
-              {
-                name: 'stateHandle',
-                required: true,
-                value: jasmine.any(String),
-                visible: false,
-                mutable: false,
-              },
-            ],
-            uiSchema: [
-              {
-                name: 'identifier',
-                label: 'Username',
-                type: 'text',
-                'label-top': true,
-              },
-              {
-                "label": "Password",
-                "label-top": true,
-                "name": "credentials.passcode",
-                "params":  {
-                  "showPasswordToggle": false,
-                },
-                "secret": true,
-                "type": "password",
-              },
-              {
-                name: 'rememberMe',
-                label: false,
-                type: 'checkbox',
-                placeholder: 'Remember Me',
-                modelType: 'boolean',
-                required: false,
-                'label-top': true,
-              },
-            ],
-          },
+              'secret': true,
+              'type': 'password',
+            },
+            {
+              name: 'rememberMe',
+              label: false,
+              type: 'checkbox',
+              placeholder: 'Remember Me',
+              modelType: 'boolean',
+              required: false,
+              'label-top': true,
+            },
+          ],
+        },
       );
     });
   });


### PR DESCRIPTION
## Description:
Adds features.showPasswordToggleOnSignInPage to v2 OIE.
Defaults to true (v1 defaults to false).

In .widgetrc.js:
```
features: {
  showPasswordToggleOnSignInPage: true,
}
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
By default, showPasswordToggleOnSignInPage is set to true and allows user to view their typed password by clicking the eye icon:
![Screenshot 2021-03-04 at 12 44 39 PM](https://user-images.githubusercontent.com/71431120/110040797-35b94500-7cf8-11eb-8fd7-6d6191cc6e27.png)

showPasswordToggleOnSignInPage: false
Identify with password, in responseConfig, under ''/idp/idx/introspect', set 'identify-with-password'
![Screenshot 2021-03-04 at 2 30 36 PM](https://user-images.githubusercontent.com/71431120/110040792-3356eb00-7cf8-11eb-86a7-86960f784a56.png)

showPasswordToggleOnSignInPage: false
ChallengeAuthenticatorPasswordView, in responseConfig, under '/idp/idx/credential/enroll', set 'authenticator-verification-password'
![Screenshot 2021-03-04 at 12 21 54 PM](https://user-images.githubusercontent.com/71431120/110040801-37830880-7cf8-11eb-9d4d-f9f810d334c4.png)

showPasswordToggleOnSignInPage: false
EnrollAuthenticatorPasswordView, in responseConfig, under '/idp/idx/credential/enroll', set 'authenticator-enroll-password'
![Screenshot 2021-03-04 at 12 21 31 PM](https://user-images.githubusercontent.com/71431120/110040805-394ccc00-7cf8-11eb-8be2-e929128317ba.png)


### Reviewers:


### Issue:

- [OKTA-375826](https://oktainc.atlassian.net/browse/OKTA-375826)


