### PR TITLE
Handle IdP Authenticator errors

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -618,6 +618,10 @@ const idpAuthenticator = {
     'authenticator-enroll-select-authenticator',
     // 'authenticator-verification-select-authenticator',
     'success',
+    // Errors:
+    //  - Unlike other authenticators, these occur during idx/introspect
+    // 'error-authenticator-enroll-idp',
+    // 'error-authenticator-verification-idp',
   ],
   '/idp/idx/challenge': [
     'authenticator-verification-idp',

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
@@ -1,0 +1,144 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Unable to enroll. Try again or contact your admin for assistance.",
+        "i18n": {
+          "key": "",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticator" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
@@ -1,0 +1,155 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Unable to verify. Try again or contact your admin for assistance.",
+        "i18n": {
+          "key": "",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticatorEnrollment" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "profile": { "provider": "Custom OIDC Provider" },
+        "type": "federated",
+        "key": "external_idp",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
+++ b/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
@@ -1,4 +1,4 @@
-import { loc } from 'okta';
+import { createCallout, loc } from 'okta';
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
@@ -16,6 +16,29 @@ const Body = BaseForm.extend({
     return this.options.isChallenge
       ? loc('oie.idp.challenge.description', 'login', [displayName])
       : loc('oie.idp.enroll.description', 'login', [displayName]);
+  },
+
+  showMessages () {
+    // IdP Authenticator error messages are not form errors
+    // Parse and display them here.
+    const messages = this.options.appState.get('messages') || {};
+    if (Array.isArray(messages.value)) {
+      this.add('<div class="ion-messages-container”></div>', '.o-form-error-container');
+
+      messages
+        .value
+        .forEach(messagesObj => {
+          const msg = messagesObj.message;
+          if (messagesObj.class === 'ERROR') {
+            this.add(createCallout({
+              content: msg,
+              type: 'error',
+            }), '.o-form-error-container');
+          } else {
+            this.add(`<p>${msg}</p>`, '.ion-messages-container');
+          }
+        });
+    }
   },
 
   save () {


### PR DESCRIPTION
## Description:

By default, the Widget will surface IDX errors from the `idx/introspect` response in the form of a **Terminal** error. This means there are the user is at a "dead stop" and must refresh the page to retry their login attempt. As a result, we will not be able to let the user proceed from the enroll/challenge page, as indicated in [this UX mock](https://www.figma.com/file/I1ebb1ApKB1j7EkIaAeWFH/OIE-Authenticators?node-id=783%3A400).

This is different than other authenticators because the IdP Authenticator relies on redirecting back to the Widget versus handling the response from `challenge/answer`. To address this, this PR adds:
- A `showMessages` override to display `messages` as a callout
- Special handling for the `redirect-idp` form **if and only if** we are in an error scenario.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

| Enrollment | Verification |
| ---------- | ----------- |
| ![Enrollment](http://g.recordit.co/J4bLRtdRfV.gif) | ![Verification](http://g.recordit.co/vluTNLLZ4m.gif) |
