### PR TITLE
Handle IdP Authenticator errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-env": "^7.10.3",
     "@babel/runtime-corejs3": "^7.10.3",
     "@okta/okta-auth-js": "4.7.2",
-    "@okta/okta-idx-js": "0.10.0",
+    "@okta/okta-idx-js": "0.11.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -618,6 +618,10 @@ const idpAuthenticator = {
     'authenticator-enroll-select-authenticator',
     // 'authenticator-verification-select-authenticator',
     'success',
+    // Errors:
+    //  - Unlike other authenticators, these occur during idx/introspect
+    // 'error-authenticator-enroll-idp',
+    // 'error-authenticator-verification-idp',
   ],
   '/idp/idx/challenge': [
     'authenticator-verification-idp',

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
@@ -1,0 +1,144 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Unable to enroll. Try again or contact your admin for assistance.",
+        "i18n": {
+          "key": "",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticator" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
@@ -1,0 +1,155 @@
+{
+  "stateHandle": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+  "version": "1.0.0",
+  "expiresAt": "2021-01-19T15:10:35.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Unable to verify. Try again or contact your admin for assistance.",
+        "i18n": {
+          "key": "",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "name": "redirect-idp",
+        "type": "OIDC",
+        "idp": {
+          "id": "0oa69chx4bZyx8O7l0g4",
+          "name": "IDP Authenticator"
+        },
+        "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "method": "GET",
+        "relatesTo" : [ "$.currentAuthenticatorEnrollment" ]
+      },
+      {
+        "rel": [ "create-form" ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "IDP Authenticator",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut4mhtS1b84AR0iQ0g4",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticatorEnrollment": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "key": "external_idp",
+      "type": "federated",
+      "id": "aut4mhtS1b84AR0iQ0g4",
+      "displayName": "IDP Authenticator",
+      "methods": [
+        { "type": "idp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "key": "external_idp",
+        "type": "federated",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "profile": { "provider": "Custom OIDC Provider" },
+        "type": "federated",
+        "key": "external_idp",
+        "id": "aut4mhtS1b84AR0iQ0g4",
+        "displayName": "IDP Authenticator",
+        "methods": [
+          { "type": "idp" }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": { "id": "00u2m55pu8UZyeMMl0g4" }
+  },
+  "cancel": {
+    "rel": [ "create-form" ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Test OIDC App",
+      "id": "0oa11ch8m94eTn0Qe0g4"
+    }
+  }
+}

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -35,8 +35,8 @@ const isObject = x => _.isObject(x);
  */
 const getFirstLevelObjects = (resp) => {
   const result = {};
-  _.each(resp, (val, key) => {
-    // if key is remediation we dont do any transformation
+  _.each(resp, (val = {}, key) => {
+    // if key is remediation we don't do any transformation
     if (key === 'remediation') {
       return;
     }
@@ -87,7 +87,6 @@ const getRemediationValues = (idx) => {
         value: [],
       });
     }
-
   }
   return {
     remediations: [
@@ -194,7 +193,10 @@ const convert = (settings, idx = {}) => {
   );
 
   injectIdPConfigButtonToRemediation(settings, result);
-  convertRedirectIdPToSuccessRedirectIffOneIdp(result);
+  if (!result.messages) {
+    // Only redirect to the IdP if we are not in an error flow
+    convertRedirectIdPToSuccessRedirectIffOneIdp(result);
+  }
 
   return result;
 };

--- a/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
+++ b/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
@@ -1,4 +1,4 @@
-import { loc } from 'okta';
+import { createCallout, loc } from 'okta';
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
@@ -16,6 +16,29 @@ const Body = BaseForm.extend({
     return this.options.isChallenge
       ? loc('oie.idp.challenge.description', 'login', [displayName])
       : loc('oie.idp.enroll.description', 'login', [displayName]);
+  },
+
+  showMessages () {
+    // IdP Authenticator error messages are not form errors
+    // Parse and display them here.
+    const messages = this.options.appState.get('messages') || {};
+    if (Array.isArray(messages.value)) {
+      this.add('<div class="ion-messages-container”></div>', '.o-form-error-container');
+
+      messages
+        .value
+        .forEach(messagesObj => {
+          const msg = messagesObj.message;
+          if (messagesObj.class === 'ERROR') {
+            this.add(createCallout({
+              content: msg,
+              type: 'error',
+            }), '.o-form-error-container');
+          } else {
+            this.add(`<p>${msg}</p>`, '.ion-messages-container');
+          }
+        });
+    }
   },
 
   save () {

--- a/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
@@ -19,6 +19,10 @@ export default class IdPAuthenticatorPageObject extends BasePageObject {
     return this.form.getElement('.okta-form-subtitle').textContent;
   }
 
+  getErrorFromErrorBox() {
+    return this.form.getElement('.o-form-error-container').textContent;
+  }
+
   submit() {
     return this.form.clickSaveButton();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,10 +1532,10 @@
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
-"@okta/okta-idx-js@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.10.0.tgz#d8d7607b1d5b5963d74ef0b79c12dd8d560d1dc2"
-  integrity sha512-H98zpHfy8fvtZjzMd77QgPYLxZQzlu1VAEU8CDaOxW7W32g2lMya6SMOrJL/pSZXTKHp9L9si44z3cqmHXtvEw==
+"@okta/okta-idx-js@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.11.0.tgz#4a57773a03bb075b381a25367706a465d4a4ceb1"
+  integrity sha512-cdqK1L63VFmoizf6JbStobqoyOKsL0mcsesSNTtpm9rFC7bgWlxyFgDcir/sZDGSLfKkjqbMiYqcRBoS8XlyQw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"


### PR DESCRIPTION
## Description:

By default, the Widget will surface IDX errors from the `idx/introspect` response in the form of a **Terminal** error. This means there are the user is at a "dead stop" and must refresh the page to retry their login attempt, as all [remediations are dropped](https://github.com/okta/okta-signin-widget/blob/master/src/v2/BaseLoginRouter.js#L140).

This PR adds the ability for error responses that contain `remediation` values to be handled.

**Note**: Requires changes from `okta-idx-js` [#49](https://github.com/okta/okta-idx-js/pull/49) before merge.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added e2e tests

### Screenshot/Video:

| Enrollment | Verification |
| ---------- | ----------- |
| ![Enrollment](http://g.recordit.co/J4bLRtdRfV.gif) | ![Verification](http://g.recordit.co/vluTNLLZ4m.gif) |

### Resolves

- [OKTA-374550](https://oktainc.atlassian.net/browse/OKTA-374550)
