### PR TITLE
feat: support remediation mode (server-side web apps with interaction code flow)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/plugin-transform-runtime": "^7.10.3",
     "@babel/preset-env": "^7.10.3",
     "@babel/runtime-corejs3": "^7.10.3",
-    "@okta/okta-auth-js": "4.7.2",
+    "@okta/okta-auth-js": "4.8.0",
     "@okta/okta-idx-js": "0.11.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -34,9 +34,22 @@ export default Model.extend({
     baseUrl: ['string', true],
     recoveryToken: ['string', false, undefined],
     stateToken: ['string', false, undefined],
+    interactionHandle: ['string', false, undefined],
     username: ['string', false],
     signOutLink: ['string', false],
     relayState: ['string', false],
+
+    redirect: {
+      type: 'string',
+      values: ['never', 'always', 'auto'],
+      value: 'auto',
+    },
+
+    mode: {
+      type: 'string',
+      values: ['remediation', 'relying-party'],
+      value: 'relying-party',
+    },
 
     // Function to transform the username before passing it to the API
     // for Primary Auth, Forgot Password and Unlock Account.

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -113,6 +113,10 @@ export default Model.extend({
     // OAUTH2
     clientId: 'string',
     redirectUri: 'string',
+    state: 'string',
+    scopes: 'array',
+    codeChallenge: 'string',
+    codeChallengeMethod: 'string',
     oAuthTimeout: ['number', false],
 
     authScheme: ['string', false, 'OAUTH2'],

--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -86,7 +86,7 @@ util.getTokens = function (settings, params, controller) {
   // Redirect flow - this can be used when logging into an external IDP, or
   // converting the Okta sessionToken to an access_token, id_token, and/or
   // authorization code. Note: The authorization code flow will always redirect.
-  if (options.mode === 'remediation' || isAuthorizationCodeFlow) {
+  if (options.redirect === 'always' || isAuthorizationCodeFlow) {
     authClient.token.getWithRedirect(getTokenOptions).catch(error);
   } else if (getTokenOptions.sessionToken) {
     // Default flow if logging in with Okta as the IDP - convert sessionToken to

--- a/src/v2/client/interact.js
+++ b/src/v2/client/interact.js
@@ -27,7 +27,12 @@ export async function interact (settings) {
   if (interactionHandle) {
     // The transaction is owned by a client outside the widget
     settings.set('mode', 'remediation');
-    meta = {}; // do not load meta from client storage
+    meta = {
+      state: authClient.options.state,
+      scopes: authClient.options.scopes,
+      codeChallenge: settings.get('codeChallenge'),
+      codeChallengeMethod: settings.get('codeChallengeMethod')
+    };
   } else {
     // Try to load a saved transaction from client storage
     meta = await getTransactionMeta(settings);
@@ -49,9 +54,7 @@ export async function interact (settings) {
   let state;
   let scopes;
   if (!interactionHandle) {
-    // new transaction: prefer configured values
-    // TODO: remove dependency on authParams. OKTA-373096
-    state = settings.get('authParams.state') || authClient.options.state || meta.state;
+    state = authClient.options.state || meta.state;
     scopes = authClient.options.scopes || meta.scopes;
   } else {
     // saved transaction: use only saved values

--- a/src/v2/client/interact.js
+++ b/src/v2/client/interact.js
@@ -80,6 +80,13 @@ export async function interact (settings) {
     codeChallengeMethod
   })
     .then(response => {
+      // In remediation mode the transaction is owned by another client.
+      const isRemediationMode = settings.get('mode') === 'remediation';
+      if (isRemediationMode) {
+        // return idx response
+        return response;
+      }
+
       // If this is a new transaction an interactionHandle was returned
       if (!interactionHandle && response.toPersist.interactionHandle) {
         meta = Object.assign({}, meta, {

--- a/src/v2/client/interactionCodeFlow.js
+++ b/src/v2/client/interactionCodeFlow.js
@@ -20,7 +20,7 @@ export async function interactionCodeFlow (settings, idxResponse) {
   const { interactionCode } = idxResponse;
   const authClient = settings.getAuthClient();
   const transactionMeta = authClient.transactionManager.load();
-  const { state } = transactionMeta;
+  const state = authClient.options.state || transactionMeta.state;
 
   // In remediation mode the transaction is owned by another client.
   const isRemediationMode = settings.get('mode') === 'remediation';

--- a/src/v2/client/startLoginFlow.js
+++ b/src/v2/client/startLoginFlow.js
@@ -36,7 +36,8 @@ export async function startLoginFlow (settings) {
   }
   
   // Use or acquire interactionHandle
-  if (settings.get('useInteractionCodeFlow')) {
+  const useInteractionHandle = settings.get('useInteractionCodeFlow') || settings.get('interactionHandle');
+  if (useInteractionHandle) {
     return interact(settings);
   }
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -44,12 +44,12 @@ var OktaSignIn = (function () {
     }
 
     /**
-     * Renders the Widget and returns a promise that resolvess to OAuth tokens
+     * Renders the Widget and returns a promise that resolves to OAuth tokens
      * @param options - options for the signin widget
      */
     function showSignInToGetTokens (options = {}) {
       const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options), {
-        mode: 'relying-party'
+        redirect: 'never'
       });
       const promise = this.renderEl(renderOptions).then(res => {
         return res.tokens;
@@ -68,8 +68,17 @@ var OktaSignIn = (function () {
      */
     function showSignInAndRedirect (options = {}) {
       const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options), {
-        mode: 'remediation'
+        redirect: 'always'
       });
+      return this.renderEl(renderOptions);
+    }
+
+    /**
+     * Renders the widget. Either resolves the returned promise, or redirects.
+     * @param options - options for the signin widget
+     */
+    function showSignIn (options = {}) {
+      const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options));
       return this.renderEl(renderOptions);
     }
 
@@ -77,6 +86,7 @@ var OktaSignIn = (function () {
     return {
       renderEl: render,
       authClient: authClient,
+      showSignIn,
       showSignInToGetTokens,
       showSignInAndRedirect,
       hide,
@@ -111,7 +121,8 @@ var OktaSignIn = (function () {
     var authClient = options.authClient ? options.authClient : createAuthClient(authParams);
 
     // validate authClient configuration against widget options
-    if (options.useInteractionCodeFlow && authClient.isPKCE() === false) {
+    const useInteractionHandle = options.useInteractionCodeFlow || options.interactionHandle;
+    if (useInteractionHandle && authClient.isPKCE() === false) {
       throw new Errors.ConfigError(
         'The "useInteractionCodeFlow" option requires PKCE to be enabled on the authClient.'
       );
@@ -119,8 +130,8 @@ var OktaSignIn = (function () {
 
     var Router;
     if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) 
-        // Self hosted widget can use this flag to use V2Router
-        || options.useInteractionCodeFlow 
+        // Self hosted widget can use `useInteractionCodeFlow` or `interactionHandle` option to use V2Router
+        || useInteractionHandle
         || options.proxyIdxResponse) {
       Router = V2Router;
     } else {

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -111,7 +111,9 @@ var OktaSignIn = (function () {
 
     var authParams = _.extend({
       clientId: options.clientId,
-      redirectUri: options.redirectUri
+      redirectUri: options.redirectUri,
+      state: options.state,
+      scopes: options.scopes
     }, options.authParams);
 
     if (!authParams.issuer) {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1250,7 +1250,7 @@ Expect.describe('LoginRouter', function () {
 
     itp('can redirect with PKCE flow', function () {
       return setupOAuth2({
-        'mode': 'remediation'
+        'redirect': 'always'
       }, { mockWellKnown: true, expectRedirect: true }).then(
         expectCodeRedirect({
           responseType: 'code',
@@ -1261,7 +1261,7 @@ Expect.describe('LoginRouter', function () {
 
     itp('can redirect with PKCE flow and responseMode "fragment"', function () {
       return setupOAuth2({
-        'mode': 'remediation',
+        'redirect': 'always',
         'authParams.responseMode': 'fragment',
       }, { mockWellKnown: true, expectRedirect: true }).then(
         expectCodeRedirect({
@@ -1274,7 +1274,7 @@ Expect.describe('LoginRouter', function () {
 
     itp('can redirect with implicit flow', function () {
       return setupOAuth2({
-        'mode': 'remediation',
+        'redirect': 'always',
         'authParams.pkce': false,
       }, { expectRedirect: true }).then(
         expectCodeRedirect({

--- a/test/unit/spec/OAuth2Util_spec.js
+++ b/test/unit/spec/OAuth2Util_spec.js
@@ -93,10 +93,10 @@ describe('util/OAuth2Util', function () {
       }).catch(done.fail);
     });
 
-    it('retrieves tokens through redirect when widget is configured with \'remediation\' mode', function (done) {
+    it('retrieves tokens through redirect when widget is configured with "redirect" = "always"', function (done) {
       const settingsWithRemediationMode = new Settings({
         baseUrl: 'https://foo',
-        mode: 'remediation',
+        redirect: 'always',
       });
       settingsWithRemediationMode.setAuthClient(authClient);
 

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -437,7 +437,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams: {},
-        mode: 'relying-party'
+        redirect: 'never'
       });
     });
     it('throws error for authorization_code flow', () => {
@@ -474,7 +474,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams: {},
-        mode: 'relying-party'
+        redirect: 'never'
       });
     });
     it('Can pass additional authParams', () => {
@@ -495,7 +495,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams,
-        mode: 'relying-party'
+        redirect: 'never'
       });
     });
   });
@@ -514,7 +514,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams: {},
-        mode: 'remediation'
+        redirect: 'always'
       });
     });
     it('Can override el, clientId, redirectUri', () => {
@@ -530,7 +530,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams: {},
-        mode: 'remediation'
+        redirect: 'always'
       });
     });
     it('Can pass additional authParams', () => {
@@ -551,7 +551,7 @@ describe('OktaSignIn object API', function () {
         clientId,
         redirectUri,
         authParams,
-        mode: 'remediation'
+        redirect: 'always'
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,17 +1515,18 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@okta/okta-auth-js@4.7.2":
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.7.2.tgz#528a0dce0dcc82d31af71d31e2a77215d3f43477"
-  integrity sha512-eYoE7kPKMZ5JkYAak5+AlOpX2ZVn1dGIjqVrBLdgIUxO0FX7F3ys1rqPmC+eZMfgHGiLvA9/xHMD8BdX0sck2g==
+"@okta/okta-auth-js@4.8.0":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-4.8.0.tgz#b745bc826b0df16f51f481a07a89f3387d48ab45"
+  integrity sha512-uaF2jS6avN0BNJ8EuJYM+KIwm3KZRo4QNAnEUDppysnxRtPlgExU2ndMEPZoSyYbCRdEd1x8UuSWTxrXhXThKQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    Base64 "0.3.0"
+    Base64 "1.1.0"
     core-js "^3.6.5"
     cross-fetch "^3.0.6"
-    js-cookie "2.2.0"
-    node-cache "^4.2.0"
+    js-cookie "2.2.1"
+    karma-coverage "^2.0.3"
+    node-cache "^5.1.2"
     p-cancelable "^2.0.0"
     text-encoding "^0.7.0"
     tiny-emitter "1.1.0"
@@ -1739,9 +1740,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-Base64@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.3.0.tgz#6da261a4e80d4fa0f5c684254e5bccd16bbdce9f"
+Base64@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/Base64/-/Base64-1.1.0.tgz#810ef21afa8357df92ad7b5389188c446b9cb956"
+  integrity sha512-qeacf8dvGpf+XAT27ESHMh7z84uRzj/ua2pQdJg483m3bEXv/kVFtDnMgvf70BQGqzbZhR9t6BmASzKvqfJf3Q==
 
 abab@^2.0.3:
   version "2.0.5"
@@ -8096,7 +8098,7 @@ istanbul-lib-coverage@^3.0.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
   integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
-istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.3:
+istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.1, istanbul-lib-instrument@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
   integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
@@ -8124,7 +8126,7 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2:
+istanbul-reports@^3.0.0, istanbul-reports@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
   integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
@@ -8586,9 +8588,10 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
   integrity sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==
 
-js-cookie@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+js-cookie@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -8792,6 +8795,18 @@ karma-coverage@^1.1.2:
     lodash "^4.17.0"
     minimatch "^3.0.0"
     source-map "^0.5.1"
+
+karma-coverage@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/karma-coverage/-/karma-coverage-2.0.3.tgz#c10f4711f4cf5caaaa668b1d6f642e7da122d973"
+  integrity sha512-atDvLQqvPcLxhED0cmXYdsPMCQuh6Asa9FMZW1bhNqlVEhJoB9qyZ2BY1gu7D/rr5GLGb5QzYO4siQskxaWP/g==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^4.0.1"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.0"
+    minimatch "^3.0.4"
 
 karma-edge-launcher@^0.4.2:
   version "0.4.2"
@@ -9174,7 +9189,7 @@ lodash@4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.x, lodash@^4.17.0, lodash@^4.17.2, lodash@^4.6.1:
+lodash@^4.17.0, lodash@^4.17.2, lodash@^4.6.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -9908,12 +9923,12 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-cache@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-4.2.0.tgz#48ac796a874e762582692004a376d26dfa875811"
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
   dependencies:
     clone "2.x"
-    lodash "4.x"
 
 node-fetch@2.6.0:
   version "2.6.0"


### PR DESCRIPTION
## Description:

The widget can operate in "relying-party" mode (the default), in which case it owns the auth transaction from beginning to end. It will calculate the code challenge and retrieve tokens using the interaction_code.

Or it can operate in "remediation" mode, in which case another client owns the auth transaction. The other client has calculated the code challenge and retrieved an interaction handle for this transaction. The widget will use this interaction handle to proceed through remediations, however it will not (cannot) obtain tokens because it does not have the code challenge. At the end of the authentication flow, it will return the `interaction_code` to the owning client.

This option works along with another new option called "redirect". There are 3 values: "always", "never", and "auto" (default).

The existing method `showSignInAndRedirect` will use redirect = always
The existing method `showSignInToGetTokens` will use redirect = never
A new method is added `showSignIn` which does not define the redirect behavior.  In this case, the app may receive the interaction code either by promise or by redirect, depending on server policy.


Support web applications by taking an interactionHandle as a config option. When passed, it enables interaction code flow and mode=remediation.

Tested using auth-js test app from this branch: https://github.com/okta/okta-auth-js/pull/666

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-376654](https://oktainc.atlassian.net/browse/OKTA-376654)


