### PR TITLE
feat: trap errors from widget event handlers - OKTA-367626

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,9 +1468,9 @@ features: {
 
 Customize the widget logging behaviour with the following config options.
 
-#### logEventsError
+#### external
 
-Boolean that enable or disable browser console log for [custom event callbacks](#events). Defaults to `true`.
+Boolean that enable or disable browser console error for errors from `custom callback functions`. Defaults to `true`.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
   - [Smart Card IdP](#smart-card-idp)
   - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   - [Feature flags](#feature-flags)
-  - [Logging](#logging)
 - [Events](#events)
   - [ready](#ready)
   - [afterError](#aftererror)
@@ -1463,14 +1462,6 @@ features: {
 - **features.idpDiscovery** - Enable [IdP Discovery](#idp-discovery). Defaults to `false`.
 
 - **features.showPasswordToggleOnSignInPage** - End users can now toggle visibility of their password on the Okta Sign-In page, allowing end users to check their password before they click Sign In. This helps prevent account lock outs caused by end users exceeding your org's permitted number of failed sign-in attempts. Note that passwords are visible for 30 seconds and then hidden automatically. Defaults to `false`.
-
-### Logging
-
-Customize the widget logging behaviour with the following config options.
-
-#### external
-
-Boolean that enable or disable browser console error for errors from `custom callback functions`. Defaults to `true`.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
   - [Smart Card IdP](#smart-card-idp)
   - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   - [Feature flags](#feature-flags)
+  - [Logging](#logging)
 - [Events](#events)
   - [ready](#ready)
   - [afterError](#aftererror)
@@ -1462,6 +1463,14 @@ features: {
 - **features.idpDiscovery** - Enable [IdP Discovery](#idp-discovery). Defaults to `false`.
 
 - **features.showPasswordToggleOnSignInPage** - End users can now toggle visibility of their password on the Okta Sign-In page, allowing end users to check their password before they click Sign In. This helps prevent account lock outs caused by end users exceeding your org's permitted number of failed sign-in attempts. Note that passwords are visible for 30 seconds and then hidden automatically. Defaults to `false`.
+
+### Logging
+
+Customize the widget logging behaviour with the following config options.
+
+#### logEventsError
+
+Boolean that enable or disable browser console log for [custom event callbacks](#events). Defaults to `true`.
 
 ## Events
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -151,7 +151,9 @@ var OktaSignIn = (function () {
             try {
               callback.apply(this, callbackArgs);
             } catch (err) {
-              DEBUG && Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
+              if (options.logging?.logEventsError !== false) {
+                Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
+              }
             }
           };
         }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -151,7 +151,7 @@ var OktaSignIn = (function() {
             try {
               callback.apply(this, callbackArgs);
             } catch (err) {
-              if (options.logging?.logEventsError !== false) {
+              if (options.logging?.external !== false) {
                 Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
               }
             }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -149,7 +149,7 @@ var OktaSignIn = (function () {
         if (EVENTS_LIST.includes(event)) {
           onArgs[1] = function (...callbackArgs) {
             try {
-              callback.apply(null, callbackArgs);
+              callback.apply(this, callbackArgs);
             } catch (err) {
               Logger.error(`Error happens on ${event} event:`, err);
             }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -143,7 +143,7 @@ var OktaSignIn = (function () {
     }
 
     _.extend(this, Router.prototype.Events, {
-      on: function(...onArgs) {
+      on: function (...onArgs) {
         // custom events listener on widget instance to trap third-party callback errors
         const [event, callback] = onArgs;
         if (EVENTS_LIST.includes(event)) {
@@ -153,7 +153,7 @@ var OktaSignIn = (function () {
             } catch (err) {
               Logger.error(`Error happens on ${event} event:`, err);
             }
-          }
+          };
         }
         Router.prototype.Events.on.apply(this, onArgs);
       }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -1,13 +1,16 @@
 import _ from 'underscore';
 import Errors from 'util/Errors';
 import Util from 'util/Util';
+import Logger from 'util/Logger';
 import createAuthClient from 'widget/createAuthClient';
 import buildRenderOptions from 'widget/buildRenderOptions';
 import createRouter from 'widget/createRouter';
 import V1Router from 'LoginRouter';
 import V2Router from 'v2/WidgetRouter';
 
-var OktaSignIn = (function() {
+const EVENTS_LIST = ['ready', 'afterError', 'afterRender', 'pageRendered'];
+
+var OktaSignIn = (function () {
 
   var router;
 
@@ -139,7 +142,22 @@ var OktaSignIn = (function() {
       Router = V1Router;
     }
 
-    _.extend(this, Router.prototype.Events);
+    _.extend(this, Router.prototype.Events, {
+      on: function(...onArgs) {
+        // custom events listener on widget instance to trap third-party callback errors
+        const [event, callback] = onArgs;
+        if (EVENTS_LIST.includes(event)) {
+          onArgs[1] = function (...callbackArgs) {
+            try {
+              callback.apply(null, callbackArgs);
+            } catch (err) {
+              Logger.error(`Error happens on ${event} event:`, err);
+            }
+          }
+        }
+        Router.prototype.Events.on.apply(this, onArgs);
+      }
+    });
     _.extend(this, getProperties(authClient, Router, options));
 
     // Triggers the event up the chain so it is available to the consumers of the widget.

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -8,7 +8,7 @@ import createRouter from 'widget/createRouter';
 import V1Router from 'LoginRouter';
 import V2Router from 'v2/WidgetRouter';
 
-const EVENTS_LIST = ['ready', 'afterError', 'afterRender', 'pageRendered'];
+const EVENTS_LIST = ['ready', 'afterError', 'afterRender'];
 
 var OktaSignIn = (function () {
 
@@ -151,7 +151,7 @@ var OktaSignIn = (function () {
             try {
               callback.apply(this, callbackArgs);
             } catch (err) {
-              Logger.error(`Error happens on ${event} event:`, err);
+              DEBUG && Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
             }
           };
         }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -151,9 +151,7 @@ var OktaSignIn = (function() {
             try {
               callback.apply(this, callbackArgs);
             } catch (err) {
-              if (options.logging?.external !== false) {
-                Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
-              }
+              Logger.error(`[okta-signin-widget] "${event}" event handler error:`, err);
             }
           };
         }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -10,7 +10,7 @@ import V2Router from 'v2/WidgetRouter';
 
 const EVENTS_LIST = ['ready', 'afterError', 'afterRender'];
 
-var OktaSignIn = (function () {
+var OktaSignIn = (function() {
 
   var router;
 
@@ -143,11 +143,11 @@ var OktaSignIn = (function () {
     }
 
     _.extend(this, Router.prototype.Events, {
-      on: function (...onArgs) {
+      on: function(...onArgs) {
         // custom events listener on widget instance to trap third-party callback errors
         const [event, callback] = onArgs;
         if (EVENTS_LIST.includes(event)) {
-          onArgs[1] = function (...callbackArgs) {
+          onArgs[1] = function(...callbackArgs) {
             try {
               callback.apply(this, callbackArgs);
             } catch (err) {

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -256,21 +256,26 @@ Expect.describe('OktaSignIn initialization', function() {
     ['ready', 'afterError', 'afterRender'].forEach(event => {
       it(`traps third party errors (for ${event} event) in callbacks`, function() {
         const mockError = new Error('mockerror');
-        signIn.on(event, function() {
-          throw mockError;
-        });
-        signIn.trigger(event);
+        const fn = function() {
+          signIn.on(event, function() {
+            throw mockError;
+          });
+          signIn.trigger(event);
+        };
+        expect(fn).not.toThrowError(mockError);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
     });
     it('does not trap errors non-registered events', () => {
-      try {
+      const mockError = new Error('mockerror');
+      const fn = function() {
         signIn.on('not-widget-event', function() {
-          throw new Error('mockerror');
+          throw mockError;
         });
         signIn.trigger('not-widget-event');
-        expect(Logger.error).not.toHaveBeenCalled();
-      } catch (err) {} // eslint-disable-line no-empty
+      };
+      expect(fn).toThrowError(mockError);
+      expect(Logger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -262,11 +262,11 @@ Expect.describe('OktaSignIn initialization', function() {
         signIn.trigger(event);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
-      it(`traps third party errors (for ${event} event) in callbacks when logging.logEventsError config is true`, function() {
+      it(`traps third party errors (for ${event} event) in callbacks when logging.external config is true`, function() {
         signIn = new Widget({
           baseUrl: url,
           logging: {
-            logEventsError: true
+            external: true
           }
         });
         const mockError = new Error('mockerror');
@@ -276,11 +276,11 @@ Expect.describe('OktaSignIn initialization', function() {
         signIn.trigger(event);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
-      it('does not log errors when logging.logEventsError config is false', () => {
+      it('does not log errors when logging.external config is false', () => {
         signIn = new Widget({
           baseUrl: url,
           logging: {
-            logEventsError: false
+            external: false
           }
         });
         const mockError = new Error('mockerror');

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -199,7 +199,6 @@ Expect.describe('OktaSignIn initialization', function() {
     afterEach(function () {
       signIn.remove();
       signIn.off();
-      global.DEBUG = false;
     });
     it('triggers an afterRender event when the Widget renders a page', function(done) {
       signIn.renderEl({ el: $sandbox });
@@ -256,8 +255,6 @@ Expect.describe('OktaSignIn initialization', function() {
     });
     ['ready', 'afterError', 'afterRender'].forEach(event => {
       it(`traps third party errors (for ${event} event) in callbacks`, function () {
-        global.DEBUG = true;
-
         const mockError = new Error('mockerror');
         signIn.on(event, function () {
           throw mockError;
@@ -265,9 +262,27 @@ Expect.describe('OktaSignIn initialization', function() {
         signIn.trigger(event);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
-      it('does not log errors when not in dev mode', () => {
-        global.DEBUG = false;
-
+      it(`traps third party errors (for ${event} event) in callbacks when logging.logEventsError config is true`, function () {
+        signIn = new Widget({
+          baseUrl: url,
+          logging: {
+            logEventsError: true
+          }
+        });
+        const mockError = new Error('mockerror');
+        signIn.on(event, function () {
+          throw mockError;
+        });
+        signIn.trigger(event);
+        expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
+      });
+      it('does not log errors when logging.logEventsError config is false', () => {
+        signIn = new Widget({
+          baseUrl: url,
+          logging: {
+            logEventsError: false
+          }
+        });
         const mockError = new Error('mockerror');
         signIn.on(event, function () {
           throw mockError;

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -270,7 +270,7 @@ Expect.describe('OktaSignIn initialization', function() {
         });
         signIn.trigger('not-widget-event');
         expect(Logger.error).not.toHaveBeenCalled();
-      } catch (err) {}
+      } catch (err) {} // eslint-disable-line no-empty
     });
   });
 });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -192,11 +192,11 @@ Expect.describe('OktaSignIn initialization', function() {
     });
   });
 
-  Expect.describe('events', function () {
-    beforeEach(function () {
+  Expect.describe('events', function() {
+    beforeEach(function() {
       spyOn(Logger, 'error');
     });
-    afterEach(function () {
+    afterEach(function() {
       signIn.remove();
       signIn.off();
     });
@@ -254,15 +254,15 @@ Expect.describe('OktaSignIn initialization', function() {
       });
     });
     ['ready', 'afterError', 'afterRender'].forEach(event => {
-      it(`traps third party errors (for ${event} event) in callbacks`, function () {
+      it(`traps third party errors (for ${event} event) in callbacks`, function() {
         const mockError = new Error('mockerror');
-        signIn.on(event, function () {
+        signIn.on(event, function() {
           throw mockError;
         });
         signIn.trigger(event);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
-      it(`traps third party errors (for ${event} event) in callbacks when logging.logEventsError config is true`, function () {
+      it(`traps third party errors (for ${event} event) in callbacks when logging.logEventsError config is true`, function() {
         signIn = new Widget({
           baseUrl: url,
           logging: {
@@ -270,7 +270,7 @@ Expect.describe('OktaSignIn initialization', function() {
           }
         });
         const mockError = new Error('mockerror');
-        signIn.on(event, function () {
+        signIn.on(event, function() {
           throw mockError;
         });
         signIn.trigger(event);
@@ -284,7 +284,7 @@ Expect.describe('OktaSignIn initialization', function() {
           }
         });
         const mockError = new Error('mockerror');
-        signIn.on(event, function () {
+        signIn.on(event, function() {
           throw mockError;
         });
         signIn.trigger(event);
@@ -293,7 +293,7 @@ Expect.describe('OktaSignIn initialization', function() {
     });
     it('does not trap errors non-registered events', () => {
       try {
-        signIn.on('not-widget-event', function () {
+        signIn.on('not-widget-event', function() {
           throw new Error('mockerror');
         });
         signIn.trigger('not-widget-event');

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -262,34 +262,6 @@ Expect.describe('OktaSignIn initialization', function() {
         signIn.trigger(event);
         expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
       });
-      it(`traps third party errors (for ${event} event) in callbacks when logging.external config is true`, function() {
-        signIn = new Widget({
-          baseUrl: url,
-          logging: {
-            external: true
-          }
-        });
-        const mockError = new Error('mockerror');
-        signIn.on(event, function() {
-          throw mockError;
-        });
-        signIn.trigger(event);
-        expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
-      });
-      it('does not log errors when logging.external config is false', () => {
-        signIn = new Widget({
-          baseUrl: url,
-          logging: {
-            external: false
-          }
-        });
-        const mockError = new Error('mockerror');
-        signIn.on(event, function() {
-          throw mockError;
-        });
-        signIn.trigger(event);
-        expect(Logger.error).not.toHaveBeenCalled();
-      });  
     });
     it('does not trap errors non-registered events', () => {
       try {

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -199,6 +199,7 @@ Expect.describe('OktaSignIn initialization', function() {
     afterEach(function () {
       signIn.remove();
       signIn.off();
+      global.DEBUG = false;
     });
     it('triggers an afterRender event when the Widget renders a page', function(done) {
       signIn.renderEl({ el: $sandbox });
@@ -253,14 +254,26 @@ Expect.describe('OktaSignIn initialization', function() {
         }
       });
     });
-    ['ready', 'afterError', 'afterRender', 'pageRendered'].forEach(event => {
+    ['ready', 'afterError', 'afterRender'].forEach(event => {
       it(`traps third party errors (for ${event} event) in callbacks`, function () {
+        global.DEBUG = true;
+
         const mockError = new Error('mockerror');
         signIn.on(event, function () {
           throw mockError;
         });
         signIn.trigger(event);
-        expect(Logger.error).toHaveBeenCalledWith(`Error happens on ${event} event:`, mockError);
+        expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
+      });
+      it('does not log errors when not in dev mode', () => {
+        global.DEBUG = false;
+
+        const mockError = new Error('mockerror');
+        signIn.on(event, function () {
+          throw mockError;
+        });
+        signIn.trigger(event);
+        expect(Logger.error).not.toHaveBeenCalled();
       });  
     });
     it('does not trap errors non-registered events', () => {


### PR DESCRIPTION
## Description:

Trap and log event handler errors from customer apps based on the `logging` config. Defaults to log the error in browser console.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

throw error from event handler
```
signIn.on('ready', () => {
  // handle `ready` event.
  // use `console.log` in particular so that those logs can be retrived
  // in testcafe for assertion
  console.log('===== playground widget ready event received =====');
  throw new Error('event error');
});
```

Error is trapped and the widget still works properly.

![Screen Shot 2021-03-12 at 12 54 36 PM](https://user-images.githubusercontent.com/4027992/110979139-383c2000-8332-11eb-933f-0eaaa85c93b5.png)


### Reviewers:


### Issue:

- [OKTA-367626](https://oktainc.atlassian.net/browse/OKTA-367626)


