### PR TITLE
add registration hooks for v2 OIE

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -102,7 +102,7 @@ export default BaseLoginController.extend({
         const activationToken = self.model.get('activationToken');
         const postSubmitData = activationToken ? activationToken : self.model.get('email');
 
-        self.settings.postSubmit(
+        self.settings.postRegistrationSubmit(
           postSubmitData,
           function () {
             self.doPostSubmit();
@@ -146,7 +146,7 @@ export default BaseLoginController.extend({
         return resp;
       },
       save: function () {
-        this.settings.preSubmit(
+        this.settings.preRegistrationSubmit(
           this.attributes,
           function (postData) {
             self.registerUser(postData);
@@ -162,7 +162,7 @@ export default BaseLoginController.extend({
   },
   showErrors: function (error, hideRegisterButton) {
     //for parseSchema error hide form and show error at form level
-    if (error.callback === 'parseSchema' && error.errorCauses) {
+    if (error.callback === 'parseRegistrationSchema' && error.errorCauses) {
       error.errorSummary = _.clone(error.errorCauses[0].errorSummary);
       delete error.errorCauses;
     }

--- a/src/models/RegistrationSchema.js
+++ b/src/models/RegistrationSchema.js
@@ -34,10 +34,6 @@ export default BaseSchema.Model.extend({
     BaseModel.apply(this, arguments);
   },
 
-  initialize: function () {
-    this.settings = this.settings || this.options.settings;
-  },
-
   parse: function (resp) {
     const parseResponseData = resp => {
       const requireFields = resp.schema.required;

--- a/src/models/RegistrationSchema.js
+++ b/src/models/RegistrationSchema.js
@@ -34,6 +34,10 @@ export default BaseSchema.Model.extend({
     BaseModel.apply(this, arguments);
   },
 
+  initialize: function () {
+    this.settings = this.settings || this.options.settings;
+  },
+
   parse: function (resp) {
     const parseResponseData = resp => {
       const requireFields = resp.schema.required;
@@ -74,7 +78,6 @@ export default BaseSchema.Model.extend({
     };
 
     const self = this;
-
     this.settings.parseRegistrationSchema(
       resp,
       function (resp) {

--- a/src/models/RegistrationSchema.js
+++ b/src/models/RegistrationSchema.js
@@ -75,7 +75,7 @@ export default BaseSchema.Model.extend({
 
     const self = this;
 
-    this.settings.parseSchema(
+    this.settings.parseRegistrationSchema(
       resp,
       function (resp) {
         if (resp.profileSchema) {

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -382,7 +382,7 @@ export default Model.extend({
     });
   },
 
-  parseSchema: function (schema, onSuccess, onFailure) {
+  parseRegistrationSchema: function (schema, onSuccess, onFailure) {
     const parseSchema = this.get('registration.parseSchema');
 
     //check for parseSchema callback
@@ -404,7 +404,7 @@ export default Model.extend({
     }
   },
 
-  preSubmit: function (postData, onSuccess, onFailure) {
+  preRegistrationSubmit: function (postData, onSuccess, onFailure) {
     const preSubmit = this.get('registration.preSubmit');
 
     //check for preSubmit callback
@@ -426,7 +426,7 @@ export default Model.extend({
     }
   },
 
-  postSubmit: function (response, onSuccess, onFailure) {
+  postRegistrationSubmit: function (response, onSuccess, onFailure) {
     const postSubmit = this.get('registration.postSubmit');
 
     //check for postSubmit callback

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -186,7 +186,9 @@ export default Controller.extend({
         if (formName === FORMS.ENROLL_PROFILE) {
           // call registration (aka enroll profile) hook
           this.settings.postSubmit(resp, onSuccess, (error) => {
-            throw error;
+            model.trigger('error', model, {
+              responseJSON: error,
+            })
           });
         } else {
           onSuccess(resp);

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -185,7 +185,7 @@ export default Controller.extend({
 
         if (formName === FORMS.ENROLL_PROFILE) {
           // call registration (aka enroll profile) hook
-          this.settings.postSubmit(resp, onSuccess, (error) => {
+          this.settings.postRegistrationSubmit(resp, onSuccess, (error) => {
             model.trigger('error', model, {
               responseJSON: error,
             });

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -180,8 +180,18 @@ export default Controller.extend({
     }
 
     idx.proceed(formName, modelJSON)
-      .then(this.handleIdxSuccess.bind(this))
-      .catch(error => {
+      .then((resp) => {
+        const onSuccess = this.handleIdxSuccess.bind(this);
+
+        if (formName === FORMS.ENROLL_PROFILE) {
+          // call registration (aka enroll profile) hook
+          this.settings.postSubmit(resp, onSuccess, (error) => {
+            throw error;
+          });
+        } else {
+          onSuccess(resp);
+        }
+      }).catch(error => {
         if (error.proceed && error.rawIdxState) {
           // Okta server responds 401 status code with WWW-Authenticate header and new remediation
           // so that the iOS/MacOS credential SSO extension (Okta Verify) can intercept

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -188,7 +188,7 @@ export default Controller.extend({
           this.settings.postSubmit(resp, onSuccess, (error) => {
             model.trigger('error', model, {
               responseJSON: error,
-            })
+            });
           });
         } else {
           onSuccess(resp);

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -1,19 +1,9 @@
-import { loc } from 'okta';
+import { loc, _ } from 'okta';
 import { BaseFooter } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
-  postRender () {
-    BaseFooter.prototype.postRender.apply(this, arguments);
-
-    const registrationClickHandler = this.options.settings.get('registration.click');
-
-    if (registrationClickHandler) {
-      this.$el.find('.js-enroll').click(registrationClickHandler);
-    }
-  },
-
   links () {
     let helpLinkHref;
     if (this.options.settings.get('helpLinks.help')) {
@@ -33,12 +23,17 @@ export default BaseFooter.extend({
 
     const signupLink = [];
     if (this.options.appState.hasRemediationObject(RemediationForms.SELECT_ENROLL_PROFILE)) {
-      signupLink.push({
+      const signupLinkData = {
         'type': 'link',
         'label': loc('signup', 'login'),
         'name': 'enroll',
-        'actionPath': RemediationForms.SELECT_ENROLL_PROFILE,
-      });
+      };
+      if (_.isFunction(this.options.settings.get('registration.click'))) {
+        signupLinkData.click = this.options.settings.get('registration.click');
+      } else {
+        signupLinkData.actionPath = RemediationForms.SELECT_ENROLL_PROFILE;
+      }
+      signupLink.push(signupLinkData);
     }
 
     const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -4,6 +4,16 @@ import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
+  postRender () {
+    BaseFooter.prototype.postRender.apply(this, arguments);
+
+    const registrationClickHandler = this.options.settings.get('registration.click');
+
+    if (registrationClickHandler) {
+      this.$el.find('.js-enroll').click(registrationClickHandler);
+    }
+  },
+
   links () {
     let helpLinkHref;
     if (this.options.settings.get('helpLinks.help')) {

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -1,7 +1,7 @@
-import { loc, _ } from 'okta';
+import { loc } from 'okta';
 import { BaseFooter } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
-import { getForgotPasswordLink } from '../utils/LinksUtil';
+import { getForgotPasswordLink, getSignUpLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
   links () {
@@ -21,20 +21,7 @@ export default BaseFooter.extend({
       },
     ];
 
-    const signupLink = [];
-    if (this.options.appState.hasRemediationObject(RemediationForms.SELECT_ENROLL_PROFILE)) {
-      const signupLinkData = {
-        'type': 'link',
-        'label': loc('signup', 'login'),
-        'name': 'enroll',
-      };
-      if (_.isFunction(this.options.settings.get('registration.click'))) {
-        signupLinkData.click = this.options.settings.get('registration.click');
-      } else {
-        signupLinkData.actionPath = RemediationForms.SELECT_ENROLL_PROFILE;
-      }
-      signupLink.push(signupLinkData);
-    }
+    const signUpLink = getSignUpLink(this.options.appState, this.options.settings);
 
     const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
 
@@ -60,7 +47,7 @@ export default BaseFooter.extend({
 
     return forgotPasswordLink
       .concat(unlockAccountLink)
-      .concat(signupLink)
+      .concat(signUpLink)
       .concat(helpLink)
       .concat(customHelpLinks);
   }

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -46,11 +46,11 @@ const Link = View.extend({
           appState,
           formName,
           actionPath,
-          click,
+          clickHandler,
         } = this.options;
 
-        if (click) {
-          click();
+        if (clickHandler) {
+          clickHandler();
         } else if (formName) {
           appState.trigger('switchForm', formName);
         } else if (actionPath) {

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -52,9 +52,9 @@ const Link = View.extend({
         if (click) {
           click();
         } else if (formName) {
-          appState.trigger('switchForm', formName)
+          appState.trigger('switchForm', formName);
         } else if (actionPath) {
-          appState.trigger('invokeAction', actionPath)
+          appState.trigger('invokeAction', actionPath);
         }
       });
     }

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -40,15 +40,21 @@ const Link = View.extend({
     // TODO OKTA-245224
     if (!this.options.href) {
       this.$el.click((event) => {
-        const appState = this.options.appState;
         event.preventDefault();
 
-        if (this.options.click) {
-          this.options.click();
-        } else if (this.options.formName) {
-          appState.trigger('switchForm', this.options.formName)
-        } else {
-          appState.trigger('invokeAction', this.options.actionPath)
+        const {
+          appState,
+          formName,
+          actionPath,
+          click,
+        } = this.options;
+
+        if (click) {
+          click();
+        } else if (formName) {
+          appState.trigger('switchForm', formName)
+        } else if (actionPath) {
+          appState.trigger('invokeAction', actionPath)
         }
       });
     }

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -42,8 +42,14 @@ const Link = View.extend({
       this.$el.click((event) => {
         const appState = this.options.appState;
         event.preventDefault();
-        this.options.formName? appState.trigger('switchForm', this.options.formName):
-          appState.trigger('invokeAction', this.options.actionPath);
+
+        if (this.options.click) {
+          this.options.click();
+        } else if (this.options.formName) {
+          appState.trigger('switchForm', this.options.formName)
+        } else {
+          appState.trigger('invokeAction', this.options.actionPath)
+        }
       });
     }
   }

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -66,7 +66,9 @@ export default View.extend({
     // Create Model
     const IonModel = this.createModelClass(
       this.options.currentViewState,
-      optionUiSchemaConfig);
+      optionUiSchemaConfig,
+      this.settings,
+    );
 
     const model = new IonModel ({
       formName: this.options.currentViewState.name,

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -1,4 +1,4 @@
-import { loc } from 'okta';
+import { loc, _ } from 'okta';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 
 const ENROLLED_PASSWORD_RECOVERY_LINK = 'currentAuthenticatorEnrollment-recover';
@@ -129,10 +129,31 @@ const getBackToSignInLink = (settings) => {
   ];
 };
 
+const getSignUpLink = (appState, settings) => {
+  const signupLink = [];
+
+  if (appState.hasRemediationObject(RemediationForms.SELECT_ENROLL_PROFILE)) {
+    const signupLinkData = {
+      'type': 'link',
+      'label': loc('signup', 'login'),
+      'name': 'enroll'
+    };
+    if (_.isFunction(settings.get('registration.click'))) {
+      signupLinkData.click = settings.get('registration.click');
+    } else {
+      signupLinkData.actionPath = RemediationForms.SELECT_ENROLL_PROFILE;
+    }
+    signupLink.push(signupLinkData);
+  }
+
+  return signupLink;
+};
+
 export {
   getSwitchAuthenticatorLink,
   getForgotPasswordLink,
   goBackLink,
+  getSignUpLink,
   getSignOutLink,
   getBackToSignInLink,
   getSkipSetupLink

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -139,7 +139,7 @@ const getSignUpLink = (appState, settings) => {
       'name': 'enroll'
     };
     if (_.isFunction(settings.get('registration.click'))) {
-      signupLinkData.click = settings.get('registration.click');
+      signupLinkData.clickHandler = settings.get('registration.click');
     } else {
       signupLinkData.actionPath = RemediationForms.SELECT_ENROLL_PROFILE;
     }

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -12,7 +12,7 @@ const Body = BaseForm.extend({
   },
   saveForm () {
     // SIW customization hook for registration
-    this.settings.preSubmit(this.model.toJSON(),
+    this.settings.preRegistrationSubmit(this.model.toJSON(),
       (postData) => {
         this.model.attributes = {...this.model.attributes, ...postData};
         BaseForm.prototype.saveForm.call(this, this.model);
@@ -46,7 +46,7 @@ export default BaseView.extend({
     let ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const currentSchema = JSON.parse(JSON.stringify((currentViewState.uiSchema)));
 
-    settings.parseSchema(currentSchema,
+    settings.parseRegistrationSchema(currentSchema,
       (schema) => {
         if (!_.isEqual(schema, currentViewState.uiSchema)) {
           currentViewState.uiSchema = schema;

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -9,6 +9,15 @@ const Body = BaseForm.extend({
 
   save () {
     return loc('registration.form.submit', 'login');
+  },
+
+  saveForm () {
+    this.settings.preSubmit(this.model.attributes,
+      () => BaseForm.prototype.saveForm.apply(this, arguments),
+      (error) => this.model.trigger('error', this.model, {
+        responseJSON: error,
+      })
+    );
   }
 });
 
@@ -29,5 +38,21 @@ const Footer = BaseFooter.extend({
 
 export default BaseView.extend({
   Body,
-  Footer
+  Footer,
+  createModelClass (currentViewState, optionUiSchemaConfig, settings) {
+    let modelClass = BaseView.prototype.createModelClass.call(this, currentViewState, optionUiSchemaConfig);
+
+    settings.parseSchema(currentViewState.uiSchema,
+      (schema) => {
+        currentViewState.uiSchema = schema;
+        modelClass = BaseView.prototype.createModelClass.call(self, currentViewState, optionUiSchemaConfig);
+      },
+      (error) => {
+        this.options.appState.trigger('afterError', {
+          responseJSON: error,
+        });
+      }
+    );
+    return modelClass;
+  },
 });

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -11,8 +11,12 @@ const Body = BaseForm.extend({
     return loc('registration.form.submit', 'login');
   },
   saveForm () {
+    // SIW customization hook for registration
     this.settings.preSubmit(this.model.toJSON(),
-      () => BaseForm.prototype.saveForm.apply(this, arguments),
+      (postData) => {
+        this.model.attributes = {...this.model.attributes, ...postData};
+        BaseForm.prototype.saveForm.call(this, this.model);
+      },
       (error) => this.model.trigger('error', this.model, {
         responseJSON: error,
       })

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -40,19 +40,30 @@ export default BaseView.extend({
   Body,
   Footer,
   createModelClass (currentViewState, optionUiSchemaConfig, settings) {
-    let modelClass = BaseView.prototype.createModelClass.call(this, currentViewState, optionUiSchemaConfig);
+    let ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
 
     settings.parseSchema(currentViewState.uiSchema,
       (schema) => {
         currentViewState.uiSchema = schema;
-        modelClass = BaseView.prototype.createModelClass.call(self, currentViewState, optionUiSchemaConfig);
+        ModelClass = BaseView.prototype.createModelClass.apply(this, currentViewState, optionUiSchemaConfig);
       },
       (error) => {
-        this.options.appState.trigger('afterError', {
-          responseJSON: error,
+        ModelClass = ModelClass.extend({
+          props: { error: {...error, type: 'object'}, ...ModelClass.prototype.props},
         });
       }
     );
-    return modelClass;
+    return ModelClass;
   },
+  postRender () {
+    BaseView.prototype.postRender.apply(this, arguments);
+
+    const modelError = this.model.props.error;
+
+    if (modelError) {
+      this.model.trigger('error', this.model, {
+        responseJSON: modelError,
+      });
+    }
+  }
 });

--- a/test/testcafe/framework/page-objects/RegistrationPageObject.js
+++ b/test/testcafe/framework/page-objects/RegistrationPageObject.js
@@ -54,6 +54,10 @@ export default class RegistrationPageObject extends BasePageObject {
     return this.form.waitForErrorBox();
   }
 
+  getErrorBoxText() {
+    return this.form.getErrorBoxText();
+  }
+
   hasFirstNameError() {
     return this.form.hasTextBoxError(FIRSTNAME_FIELD);
   }

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -1,0 +1,141 @@
+import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
+import RegistrationPageObject from '../framework/page-objects/RegistrationPageObject';
+import enrollProfile from '../../../playground/mocks/data/idp/idx/enroll-profile';
+import success from '../../../playground/mocks/data/idp/idx/terminal-registration';
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(enrollProfile)
+  .onRequestTo('http://localhost:3000/idp/idx/enroll/new')
+  .respond(success);
+
+const rerenderWidget = ClientFunction((settings) => {
+  window.renderPlaygroundWidget(settings);
+});
+
+const logger = RequestLogger(
+  /enroll/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+
+fixture('EnrollProfile');
+
+async function setup(t) {
+  const registrationPage = new RegistrationPageObject(t);
+  await registrationPage.navigateToPage();
+  return registrationPage;
+}
+
+
+test.requestHooks(logger, mock)('should call settings.registration hooks onSuccess handlers', async t => {
+  logger.clear();
+  const registrationPage = await setup(t);
+
+  await rerenderWidget({
+    registration: {
+      parseSchema: function (resp, onSuccess) {
+        resp.find(({name}) => name === 'userProfile.firstName').required = false;
+        onSuccess(resp);
+      },
+      preSubmit: function (postData, onSuccess) {
+        postData.userProfile.extra = 'stuff';
+        onSuccess(postData);
+      },
+      postSubmit: function (postData, onSuccess) {
+        // eslint-disable-next-line
+        console.log('made it to postSubmit');
+        onSuccess(postData);
+      },
+    },
+  });
+  await registrationPage.fillLastNameField('bar');
+  await registrationPage.fillEmailField('email@email.com');
+  await registrationPage.clickRegisterButton();
+  // parseSchema removes requirement on first name field
+  await t.expect(registrationPage.hasFirstNameError()).notOk();
+  // preSubmit
+  const req = logger.requests[0].request;
+  const reqBody = JSON.parse(req.body);
+
+  await t.expect(reqBody).eql({
+    stateHandle: '01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82',
+    userProfile: {
+      lastName: 'bar',
+      email: 'email@email.com',
+      extra: 'stuff',
+    }
+  });
+  // postSubmit
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log.includes('made it to postSubmit')).ok();
+});
+
+test.requestHooks(logger, mock)('should call settings.registration hooks onFailure handlers', async t=> {
+  logger.clear();
+  const registrationPage = await setup(t);
+
+  await rerenderWidget({
+    registration: {
+      parseSchema: function (resp, onSuccess, onFailure) {
+        const error = {
+          'errorSummary': 'My parseSchema message'
+        };
+        onFailure(error);
+      },
+      preSubmit: function (postData, onSuccess, onFailure) {
+        const error = {
+          'errorSummary': 'My preSubmit message'
+        };
+        onFailure(error);
+      },
+      postSubmit: function (postData, onSuccess, onFailure) {
+        const error = {
+          'errorSummary': 'My postSubmit message'
+        };
+        onFailure(error);
+      },
+    },
+  });
+  await t.expect(registrationPage.getErrorBoxText()).eql('My parseSchema message');
+
+  await registrationPage.fillFirstNameField('xyz');
+  await registrationPage.fillLastNameField('xyz');
+  await registrationPage.fillEmailField('email@email.com');
+  await registrationPage.clickRegisterButton();
+
+  await t.expect(registrationPage.getErrorBoxText()).eql('My preSubmit message');
+
+  // no request because the form fails to submit
+  await t.expect(logger.requests.length).eql(0);
+});
+
+test.requestHooks(logger, mock)('should call settings.registration.postSubmit hook\'s onFailure handler', async t=> {
+  logger.clear();
+  const registrationPage = await setup(t);
+
+  await rerenderWidget({
+    registration: {
+      postSubmit: function (postData, onSuccess, onFailure) {
+        const error = {
+          'errorSummary': 'My postSubmit message'
+        };
+        onFailure(error);
+      },
+    },
+  });
+
+  await registrationPage.fillFirstNameField('xyz');
+  await registrationPage.fillLastNameField('xyz');
+  await registrationPage.fillEmailField('email@email.com');
+  await registrationPage.clickRegisterButton();
+
+  const req = logger.requests[0].request;
+  // there will be a POST request
+  await t.expect(req.method).eql('post');
+  // there will be an error box
+  await t.expect(registrationPage.getErrorBoxText()).eql('My postSubmit message');
+});

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -1,4 +1,4 @@
-import { RequestMock } from 'testcafe';
+import { RequestMock, ClientFunction } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import RegistrationPageObject from '../framework/page-objects/RegistrationPageObject';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
@@ -27,6 +27,9 @@ const enrollProfileFinishMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/enroll')
   .respond(enrollProfileFinish);
 
+const rerenderWidget = ClientFunction((settings) => {
+  window.renderPlaygroundWidget(settings);
+});
 
 fixture('Registration');
 
@@ -174,4 +177,21 @@ test.requestHooks(enrollProfileFinishMock)('should show terminal screen after re
   });
 
   await t.expect(registrationPage.getTerminalContent()).eql('An activation email has been sent to john@gmail.com. Follow instructions in the email to finish creating your account');
+});
+
+test.requestHooks(mock)('should call settings.registration.click on "Sign Up" click, instead of moving to registration page', async t => {
+  const identityPage = new IdentityPageObject(t);
+  await identityPage.navigateToPage();
+  await rerenderWidget({
+    baseUrl: 'http://localhost:3000',
+    registration: {
+      // eslint-disable-next-line
+      click: () => console.log('hello')
+    }
+  });
+
+  await identityPage.clickSignUpLink();
+  const { log } = await t.getBrowserConsoleMessages();
+
+  await t.expect(log[log.length-1]).eql('hello');
 });

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -186,12 +186,12 @@ test.requestHooks(mock)('should call settings.registration.click on "Sign Up" cl
     baseUrl: 'http://localhost:3000',
     registration: {
       // eslint-disable-next-line
-      click: () => console.log('hello')
+      click: () => console.log('registration click handler fired')
     }
   });
 
   await identityPage.clickSignUpLink();
   const { log } = await t.getBrowserConsoleMessages();
 
-  await t.expect(log[log.length-1]).eql('hello');
+  await t.expect(log[log.length-1]).eql('registration click handler fired');
 });

--- a/test/unit/spec/RegistrationSchema_spec.js
+++ b/test/unit/spec/RegistrationSchema_spec.js
@@ -1,7 +1,17 @@
 /* eslint max-params:[2, 28], max-statements:[2, 40], camelcase:0, max-len:[2, 180] */
 import RegistrationSchema from 'models/RegistrationSchema';
+import Settings from 'models/Settings';
 
 describe('RegistrationSchema', function () {
+  const init = () => {
+    const settings = new Settings({
+      baseUrl: 'http://localhost:3000',
+      parseSchema: function (response, onSuccess) {
+        return onSuccess(response);
+      },
+    });
+    return new RegistrationSchema({settings});
+  };
   describe('properties', function () {
     describe('string field', function () {
       beforeEach(function () {
@@ -18,12 +28,7 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = new RegistrationSchema();
-        this.schema.settings = {
-          parseSchema: function (response, onSuccess) {
-            return onSuccess(response);
-          },
-        };
+        this.schema = init();
         this.schema.parse(jsonResponse);
       });
 
@@ -69,12 +74,7 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = new RegistrationSchema();
-        this.schema.settings = {
-          parseSchema: function (response, onSuccess) {
-            return onSuccess(response);
-          },
-        };
+        this.schema = init();
         this.schema.parse(jsonResponse);
       });
 
@@ -101,12 +101,7 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = new RegistrationSchema();
-        this.schema.settings = {
-          parseSchema: function (response, onSuccess) {
-            return onSuccess(response);
-          },
-        };
+        this.schema = init();
         this.schema.parse(jsonResponse);
       });
 
@@ -140,12 +135,7 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = new RegistrationSchema();
-        this.schema.settings = {
-          parseSchema: function (response, onSuccess) {
-            return onSuccess(response);
-          },
-        };
+        this.schema = init();
         this.schema.parse(jsonResponse);
       });
 
@@ -197,12 +187,7 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = new RegistrationSchema();
-        this.schema.settings = {
-          parseSchema: function (response, onSuccess) {
-            return onSuccess(response);
-          },
-        };
+        this.schema = init();
         this.schema.parse(jsonResponse);
       });
 

--- a/test/unit/spec/RegistrationSchema_spec.js
+++ b/test/unit/spec/RegistrationSchema_spec.js
@@ -3,14 +3,13 @@ import RegistrationSchema from 'models/RegistrationSchema';
 import Settings from 'models/Settings';
 
 describe('RegistrationSchema', function () {
-  const init = () => {
-    const settings = new Settings({
+  const getSettings = () => {
+    return new Settings({
       baseUrl: 'http://localhost:3000',
       parseSchema: function (response, onSuccess) {
         return onSuccess(response);
       },
     });
-    return new RegistrationSchema({settings});
   };
   describe('properties', function () {
     describe('string field', function () {
@@ -28,7 +27,8 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = init();
+        this.schema = new RegistrationSchema();
+        this.schema.settings = getSettings();
         this.schema.parse(jsonResponse);
       });
 
@@ -74,7 +74,8 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = init();
+        this.schema = new RegistrationSchema();
+        this.schema.settings = getSettings();
         this.schema.parse(jsonResponse);
       });
 
@@ -101,7 +102,8 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = init();
+        this.schema = new RegistrationSchema();
+        this.schema.settings = getSettings();
         this.schema.parse(jsonResponse);
       });
 
@@ -135,7 +137,8 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = init();
+        this.schema = new RegistrationSchema();
+        this.schema.settings = getSettings();
         this.schema.parse(jsonResponse);
       });
 
@@ -187,7 +190,8 @@ describe('RegistrationSchema', function () {
           },
         };
 
-        this.schema = init();
+        this.schema = new RegistrationSchema();
+        this.schema.settings = getSettings();
         this.schema.parse(jsonResponse);
       });
 


### PR DESCRIPTION
## Description:
See https://github.com/okta/okta-signin-widget#registration for more info.
Adding
- registration.click
  - called instead of moving forward to profile enrollment view ("Create Account")
  - can use to redirect to another site for sign up
- registration.parseSchema
  - called before the model class is instantiated
  - can use to modify the model schema used for validation
- registration.preSubmit
  - called after the user submits the form
  - can use to modify data sent to the server
- registration.postSubmit
  - called after the form is sent to the server

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Testing:
Inside the idx object in responseConfig, swap 'identify' with 'enroll-profile-new'.
Then to test the success and failure cases, inside the idx object for the key '/idp/idx/enroll/new', use 'success' or 'error-new-signup-email'.

### Reviewers:


### Issue:

- [OKTA-312732](https://oktainc.atlassian.net/browse/OKTA-312732)


