### PR TITLE
Improves MFA enrollment headings a11y

### DIFF
--- a/src/BarcodePushController.js
+++ b/src/BarcodePushController.js
@@ -38,7 +38,6 @@ export default FormController.extend({
 
       return loc('enroll.totp.title', 'login', [factorName]);
     },
-    subtitle: _.partial(loc, 'mfa.scanBarcode', 'login'),
     noButtonBar: true,
     attributes: { 'data-se': 'step-scan' },
     className: 'barcode-scan',

--- a/src/BarcodePushController.js
+++ b/src/BarcodePushController.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { _, loc } from 'okta';
+import { loc } from 'okta';
 import FactorUtil from 'util/FactorUtil';
 import FormController from 'util/FormController';
 import FormType from 'util/FormType';

--- a/src/BarcodeTotpController.js
+++ b/src/BarcodeTotpController.js
@@ -34,7 +34,6 @@ export default FormController.extend({
 
       return loc('enroll.totp.title', 'login', [factorName]);
     },
-    subtitle: _.partial(loc, 'mfa.scanBarcode', 'login'),
     save: _.partial(loc, 'oform.next', 'login'),
     noCancelButton: true,
     attributes: { 'data-se': 'step-scan' },

--- a/src/views/enroll-choices/FactorList.js
+++ b/src/views/enroll-choices/FactorList.js
@@ -100,7 +100,7 @@ export default ListView.extend({
   template: hbs(
     '\
       {{#if listTitle}}\
-        <div class="list-title">{{listTitle}}</div>\
+        <h3 class="list-title">{{listTitle}}</h3>\
       {{/if}}\
       <ul class="list-content"></ul>\
     '


### PR DESCRIPTION
## Description:

* Removes "Scan Barcode" heading text from TOTP and Okta Push barcode enrollment views to solve heading a11y violation
* Updates "Setup require" heading text from `div` to semantic `h3` on required enrollment list view to solve heading a11y violation
  * Note: Changes from regular font weight to **bold** (see screenshots)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

**Required enrollment list view before/after**

![Screen Shot 2021-03-15 at 5 29 25 PM](https://user-images.githubusercontent.com/72248639/111226783-fa502d80-85b7-11eb-8c4b-24e75ef0da94.png)


### Reviewers:


### Issue:

- [OKTA-369849](https://oktainc.atlassian.net/browse/OKTA-369849)


