### PR TITLE
feat: Adds feature to set default country code on SMS&Call enrolment

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ var config = {
   - `zh-CN` - Chinese (PRC)
   - `zh-TW` - Chinese (Taiwan)
 
-- **defaultCountryCode:** Set the default countryCode of the widget. If no `defaultCountryCode` is provided, defaults to `US`.
+- **defaultCountryCode:** Set the default countryCode of the widget. If no `defaultCountryCode` is provided, defaults to `US`. It sets the country calling code for phone number accordingly in the widget.
 
 - **i18n:** Override the text in the widget. The full list of properties can be found in the [login.properties](packages/@okta/i18n/src/properties/login.properties) and [country.properties](packages/@okta/i18n/src/properties/country.properties) files.
 

--- a/README.md
+++ b/README.md
@@ -853,6 +853,8 @@ var config = {
   - `zh-CN` - Chinese (PRC)
   - `zh-TW` - Chinese (Taiwan)
 
+- **defaultCountryCode:** Set the default countryCode of the widget. If no `defaultCountryCode` is provided, defaults to `US`.
+
 - **i18n:** Override the text in the widget. The full list of properties can be found in the [login.properties](packages/@okta/i18n/src/properties/login.properties) and [country.properties](packages/@okta/i18n/src/properties/country.properties) files.
 
     ```javascript

--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -56,7 +56,7 @@ function sendCode (e) {
   }
 }
 
-function isValidCountryCode(countryCode){
+function isValidCountryCode (countryCode){
   return CountryUtil.getCallingCodeForCountry(countryCode);
 }
 

--- a/src/EnrollCallAndSmsController.js
+++ b/src/EnrollCallAndSmsController.js
@@ -56,6 +56,10 @@ function sendCode (e) {
   }
 }
 
+function isValidCountryCode(countryCode){
+  return CountryUtil.getCallingCodeForCountry(countryCode);
+}
+
 export default FormController.extend({
   className: function () {
     return getClassName(this.options.factorType);
@@ -337,5 +341,8 @@ export default FormController.extend({
       this.model.set('hasExistingPhones', this.options.appState.get('hasExistingPhones'));
     }
     this.model.set('factorType', this.options.factorType);
+    if(isValidCountryCode(this.settings.get('smsAndCallMFACountryCode'))) {
+      this.model.set('countryCode', this.settings.get('smsAndCallMFACountryCode'));
+    }
   },
 });

--- a/src/ManualSetupPushController.js
+++ b/src/ManualSetupPushController.js
@@ -110,7 +110,7 @@ export default FormController.extend({
     return {
       local: {
         activationType: ['string', true, this.options.appState.get('factorActivationType') || 'SMS'],
-        countryCode: ['string', false, 'US'],
+        countryCode: ['string', false, this.options.appState.get('userCountryCode')],
         phoneNumber: 'string',
         SMS: ['string', false, this.options.appState.get('textActivationLinkUrl')],
         EMAIL: ['string', false, this.options.appState.get('emailActivationLinkUrl')],

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -746,6 +746,9 @@ export default Model.extend({
 
   parse: function (options) {
     this.settings = options.settings;
-    return _.extend(_.omit(options, 'settings'), { languageCode: this.settings.get('languageCode') });
+    return _.extend(_.omit(options, 'settings'), { 
+      languageCode: this.settings.get('languageCode'),
+      userCountryCode: this.settings.get('countryCode'),
+    });
   },
 });

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -83,6 +83,8 @@ export default Model.extend({
     'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
     'features.mfaOnlyFlow': ['boolean', false, false],
 
+    smsAndCallMFACountryCode: ['string', 'US'],
+
     // I18N
     language: ['any', false], // Can be a string or a function
     i18n: ['object', false],

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -21,6 +21,7 @@ import Errors from 'util/Errors';
 import IDP from 'util/IDP';
 import Logger from 'util/Logger';
 import Util from 'util/Util';
+import CountryUtil from 'util/CountryUtil';
 const SharedUtil = internal.util.Util;
 const DEFAULT_LANGUAGE = 'en';
 const ConfigError = Errors.ConfigError;
@@ -83,7 +84,7 @@ export default Model.extend({
     'features.showPasswordRequirementsAsHtmlList': ['boolean', false, false],
     'features.mfaOnlyFlow': ['boolean', false, false],
 
-    smsAndCallMFACountryCode: ['string', 'US'],
+    defaultCountryCode: ['string', false ,'US'],
 
     // I18N
     language: ['any', false], // Can be a string or a function
@@ -207,6 +208,14 @@ export default Model.extend({
             return supportedLanguages[supportedPos];
           }
         }
+      },
+    },
+    countryCode: {
+      deps: ['defaultCountryCode'],
+      fn: function (defaultCountryCode) {
+        const countries = CountryUtil.getCountries();
+        return Object.keys(countries).includes(defaultCountryCode)
+          ? defaultCountryCode : 'US';
       },
     },
     oauth2Enabled: {

--- a/test/unit/spec/EnrollCall_spec.js
+++ b/test/unit/spec/EnrollCall_spec.js
@@ -19,7 +19,7 @@ import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
 Expect.describe('EnrollCall', function () {
-  function setup (resp, startRouter) {
+  function setup (resp, startRouter, routerOptions = {}) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -28,6 +28,7 @@ Expect.describe('EnrollCall', function () {
       el: $sandbox,
       baseUrl: baseUrl,
       authClient: authClient,
+      defaultCountryCode: routerOptions.defaultCountryCode,
       'features.router': startRouter,
     });
 
@@ -181,6 +182,18 @@ Expect.describe('EnrollCall', function () {
       return setupFn().then(function (test) {
         expect(test.form.selectedCountry()).toBe('United States');
       });
+    });
+    itp('selects country based on defaultCountryCode from settings', function () {
+      return setupFn(undefined, undefined, { defaultCountryCode: 'GB' })
+        .then(function (test) {
+          expect(test.form.selectedCountry()).toBe('United Kingdom');
+        });
+    });
+    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function () {
+      return setupFn(undefined, undefined, { defaultCountryCode: 'FAKECODE' })
+        .then(function (test) {
+          expect(test.form.selectedCountry()).toBe('United States');
+        });
     });
     itp('updates the phone number country calling code when country is changed', function () {
       return setupFn().then(function (test) {

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -19,7 +19,7 @@ import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
 Expect.describe('EnrollSms', function () {
-  function setup (resp, startRouter) {
+  function setup (resp, startRouter, routerOptions = {}) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -28,6 +28,7 @@ Expect.describe('EnrollSms', function () {
       el: $sandbox,
       baseUrl: baseUrl,
       authClient: authClient,
+      defaultCountryCode: routerOptions.defaultCountryCode,
       'features.router': startRouter,
     });
 
@@ -215,6 +216,28 @@ Expect.describe('EnrollSms', function () {
     });
     itp('defaults to United States for the country', function () {
       return setup(allFactorsRes)
+        .then(function (test) {
+          return Expect.wait(function () {
+            return test.form.hasCountriesList();
+          }, test);
+        })
+        .then(function (test) {
+          expect(test.form.selectedCountry()).toBe('United States');
+        });
+    });
+    itp('selects country based on defaultCountryCode from settings', function () {
+      return setup(allFactorsRes, undefined, { defaultCountryCode: 'GB' })
+        .then(function (test) {
+          return Expect.wait(function () {
+            return test.form.hasCountriesList();
+          }, test);
+        })
+        .then(function (test) {
+          expect(test.form.selectedCountry()).toBe('United Kingdom');
+        });
+    });
+    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function () {
+      return setup(allFactorsRes, undefined, { defaultCountryCode: 'FAKECODE' })
         .then(function (test) {
           return Expect.wait(function () {
             return test.form.hasCountriesList();


### PR DESCRIPTION
## Description:

Converted from #1694 

Changes add based on the original PR:

1) expose `defaultCountryCode` as configuration for external use.
2) load `defaultCountryCode` into appState (userCountryCode)
3) use `userCountryCode` in controllers to pre-select the country from list.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-373007](https://oktainc.atlassian.net/browse/OKTA-373007)

