### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Okta provides several complete [sample applications](#sample-applications) which
 
 ### Okta-hosted signin page (customizable)
 
-Okta also provides a hosted signin page which can be customized so that it is available under a [custom domain][] which is a subdomain of your company's top-level domain. Although the page is hosted by Okta, you are able to [customize the template][] of this page in many powerful ways. See the [gallery][] for some examples of customized widgets.
+Okta also provides a hosted signin page which can be customized so that it is available under a [custom domain][] which is a subdomain of your company's top-level domain. Although the page is hosted by Okta, you are able to [customize the template][] of this page in many powerful ways.
 
 As far as your app is concerned, the customized widget behaves the same as the default Okta-hosted widget and you can use the same [hosted flow][].
 


### PR DESCRIPTION
removing reference and broken link to "Gallery" from the okta-hosted-signin-page-customizable section.

## Description:

Removed the reference to the Gallery page and the subsequent broken link to the Gallery page, since it no longer exists.

## PR Checklist

- [x ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-374827](https://oktainc.atlassian.net/browse/OKTA-374827)


