### PR TITLE
pass email only to postRegistrationSubmit hook for OIE

### DIFF
--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -192,7 +192,7 @@ export default Controller.extend({
 
         if (formName === FORMS.ENROLL_PROFILE) {
           // call registration (aka enroll profile) hook
-          this.settings.postRegistrationSubmit(modelJSON.userProfile.email, onSuccess, (error) => {
+          this.settings.postRegistrationSubmit(modelJSON?.userProfile?.email, onSuccess, (error) => {
             model.trigger('error', model, {
               responseJSON: error,
             });

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -188,17 +188,17 @@ export default Controller.extend({
 
     idx.proceed(formName, modelJSON)
       .then((resp) => {
-        const onSuccess = this.handleIdxSuccess.bind(this);
+        const onSuccess = this.handleIdxSuccess.bind(this, resp);
 
         if (formName === FORMS.ENROLL_PROFILE) {
           // call registration (aka enroll profile) hook
-          this.settings.postRegistrationSubmit(resp, onSuccess, (error) => {
+          this.settings.postRegistrationSubmit(modelJSON.userProfile.email, onSuccess, (error) => {
             model.trigger('error', model, {
               responseJSON: error,
             });
           });
         } else {
-          onSuccess(resp);
+          onSuccess();
         }
       }).catch(error => {
         if (error.proceed && error.rawIdxState) {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -47,7 +47,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
       },
       postSubmit: function (postData, onSuccess) {
         // eslint-disable-next-line
-        console.log('made it to postSubmit');
+        console.log(`made it to postSubmit ${postData}`);
         onSuccess(postData);
       },
     },
@@ -71,7 +71,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
   });
   // postSubmit
   const { log } = await t.getBrowserConsoleMessages();
-  await t.expect(log.includes('made it to postSubmit')).ok();
+  await t.expect(log.includes('made it to postSubmit email@email.com')).ok();
 });
 
 test.requestHooks(logger, mock)('should call settings.registration hooks onFailure handlers', async t=> {


### PR DESCRIPTION
## Description:
To match v1 behavior, pass only the email string. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-381511](https://oktainc.atlassian.net/browse/OKTA-381511)


