### PR TITLE
fix: parses contextualData for Duo Authenticator

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-duo.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-duo.json
@@ -114,7 +114,7 @@
             }
         ]
     },
-    "currentAuthenticator": {
+    "currentAuthenticatorEnrollment": {
         "type": "object",
         "value": {
             "contextualData": {
@@ -129,7 +129,7 @@
             "displayName": "Duo Security",
             "methods": [
                 {
-                    "type": "idp"
+                    "type": "duo"
                 }
             ]
         }

--- a/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
+++ b/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
@@ -7,7 +7,7 @@ export default BaseForm.extend({
   noButtonBar: true,
 
   postRender: function () {
-    const contextualData = this.options.appState.get('currentAuthenticator').contextualData;
+    const contextualData = this.getContextualData();
     // This is the place to check contextualData.integrationType once we support more types
     // Currently we only support IFRAME
     const duoFrame = this.add(`<iframe frameborder="0" title="'${this.title()}'"></iframe>`).last();
@@ -30,4 +30,8 @@ export default BaseForm.extend({
       console.error(e); // eslint-disable-line no-console
     }
   },
+
+  getContextualData () {
+    // to be overriden
+  }
 });

--- a/src/v2/view-builder/views/duo/ChallengeDuoAuthenticatorView.js
+++ b/src/v2/view-builder/views/duo/ChallengeDuoAuthenticatorView.js
@@ -6,6 +6,10 @@ const Body = BaseDuoAuthenticatorForm.extend({
   title () {
     return loc('oie.duo.verify.title', 'login');
   },
+
+  getContextualData () {
+    return this.options.appState.get('currentAuthenticatorEnrollment').contextualData;
+  },
 });
 
 export default BaseAuthenticatorView.extend({

--- a/src/v2/view-builder/views/duo/EnrollDuoAuthenticatorView.js
+++ b/src/v2/view-builder/views/duo/EnrollDuoAuthenticatorView.js
@@ -6,6 +6,10 @@ const Body = BaseDuoAuthenticatorForm.extend({
   title () {
     return loc('oie.duo.enroll.title', 'login');
   },
+
+  getContextualData () {
+    return this.options.appState.get('currentAuthenticator').contextualData;
+  },
 });
 
 export default BaseAuthenticatorView.extend({

--- a/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
@@ -33,7 +33,7 @@ async function setup(t) {
     controller: 'mfa-verify-duo',
     formName: 'challenge-authenticator',
     authenticatorKey: 'duo',
-    methodType: 'idp'
+    methodType: 'duo'
   });
 
   return challengeDuoPage;
@@ -51,7 +51,7 @@ test
       controller: 'mfa-verify-duo',
       formName: 'challenge-authenticator',
       authenticatorKey: 'duo',
-      methodType: 'idp',
+      methodType: 'duo',
     });
 
     // Check title


### PR DESCRIPTION
## Description:

- Duo Authenticator challenge flow has contextual data in currentAuthenticatorEnrollment. Previously it was in currentAuthenticator

Resolves: OKTA-379242


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] ~Added~ Fixed unit tests?
- [ ] Added e2e tests
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-379242](https://oktainc.atlassian.net/browse/OKTA-379242)


