### PR TITLE
chore: remove space after function keyword or name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
     'curly': 2,
     'eqeqeq': 2,
     'guard-for-in': 2,
-    'indent': [2, 2, { 'VariableDeclarator': 2 } ],
+    'indent': [2, 2, { 'VariableDeclarator': 2 }],
     'max-depth': [2, 2],
     'max-len': [2, 120],
     'max-params': [2, 10],
@@ -50,7 +50,11 @@ module.exports = {
     'no-only-tests/no-only-tests': 'error',
     'quotes': [2, 'single'],
     'semi': 2,
-    'space-before-function-paren': 2,
+    'space-before-function-paren': [2, {
+      'anonymous': 'never',
+      'named': 'never',
+      'asyncArrow': 'always'
+    }],
     'strict': 0,
   },
   'root': true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@
 var ENV = require('./test/e2e/env');
 ENV.config();
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
 
   require('load-grunt-tasks')(grunt);
   require('time-grunt')(grunt);
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
             cwd: 'packages/@okta/qtip2/dist/',
             src: 'jquery.qtip.css',
             dest: 'target/sass/widgets',
-            rename: function () {
+            rename: function() {
               return 'target/sass/widgets/_jquery.qtip.scss';
             }
           }
@@ -71,7 +71,7 @@ module.exports = function (grunt) {
               'properties/{login,country}_id.properties'
             ],
             dest: I18N_SRC,
-            rename (dest, src) {
+            rename(dest, src) {
               var targetFile = `${dest}/${src.replace('_id', '_in')}`;
               grunt.log.write(`Generates _in properties: ${dest}/${src} to ${targetFile} \n`);
               return targetFile;
@@ -99,7 +99,7 @@ module.exports = function (grunt) {
             cwd: 'target/css',
             src: ['*.css', '*.css.map'],
             dest: DIST + '/css',
-            rename: function (dest, src) {
+            rename: function(dest, src) {
               if (src === 'okta-sign-in.css') {
                 return path.resolve(dest, 'okta-sign-in.min.css');
               }
@@ -111,7 +111,7 @@ module.exports = function (grunt) {
 
       'e2e': {
         options: {
-          process: function (content) {
+          process: function(content) {
             var browserName = grunt.option('browserName') || 'phantomjs',
                 tpl = Handlebars.compile(content),
                 tplVars = {
@@ -174,7 +174,7 @@ module.exports = function (grunt) {
 
       'e2e-pages': {
         options: {
-          process: function (content) {
+          process: function(content) {
             var cdnLayout = grunt.file.read('./test/e2e/layouts/cdn.tpl', {encoding: 'utf8'}),
                 devLayout = grunt.file.read('./test/e2e/layouts/cdn-dev.tpl', {encoding: 'utf8'}),
                 indexLayout = grunt.file.read('./test/e2e/layouts/index.tpl', {encoding: 'utf8'}),
@@ -199,7 +199,7 @@ module.exports = function (grunt) {
             cwd: 'test/e2e/templates/',
             src: '*.tpl',
             dest: 'target/',
-            rename: function (dest, src) {
+            rename: function(dest, src) {
               return dest + path.basename(src, '.tpl') + '.html';
             }
           },
@@ -224,7 +224,7 @@ module.exports = function (grunt) {
           failOnMatch: true,
           logFile: SEARCH_OUT_FILE,
           logFormat: 'xml',
-          onMatch: function (match) {
+          onMatch: function(match) {
             grunt.log.errorlns('URLs starting with \'/\' are not allowed in SCSS files. ' +
               'Fix this by replacing with a relative link.');
             grunt.log.errorlns('Found in file: ' + match.file + '. Line: ' + match.line);
@@ -331,7 +331,7 @@ module.exports = function (grunt) {
     'test-e2e',
     'Runs end to end webdriver tests. Pass in `--browserName {{browser}}` to ' +
     'override default phantomjs browser',
-    function () {
+    function() {
       // Print warnings for missing environment variables
       ENV.checkValues();
 
@@ -356,7 +356,7 @@ module.exports = function (grunt) {
     }
   );
 
-  grunt.task.registerTask('assets', function (target) {
+  grunt.task.registerTask('assets', function(target) {
     const prodBuild = target === 'release';
     const buildTasks = [
       'copy:generate-in-translation',
@@ -376,7 +376,7 @@ module.exports = function (grunt) {
     grunt.task.run(buildTasks);
   });
 
-  grunt.task.registerTask('build', function (target, mode) {
+  grunt.task.registerTask('build', function(target, mode) {
     const prodBuild = target === 'release';
     const buildTasks = [];
     const postBuildTasks = [];

--- a/buildtools/commands/generate-phone-codes.js
+++ b/buildtools/commands/generate-phone-codes.js
@@ -13,15 +13,15 @@ exports.describe = 'Downloads latest metadata from google libphonenumber and gen
 exports.handler = () => {
   console.log('Downloading latest metadata from google libphonenumber...');
   axios.get(METADATA_URI)
-    .then(function ({ data }) {
+    .then(function({ data }) {
       const regionCodesToCallingCodeMap = {};
-      const goog = { provide: function () { } };
+      const goog = { provide: function() { } };
       const i18n = { phonenumbers: { metadata: {} } };
       eval(data);
       Object.keys(i18n.phonenumbers.metadata.countryCodeToRegionCodeMap)
-        .forEach(function (callingCode) {
+        .forEach(function(callingCode) {
           const regionCodes = i18n.phonenumbers.metadata.countryCodeToRegionCodeMap[callingCode];
-          regionCodes.forEach(function (regionCode) {
+          regionCodes.forEach(function(regionCode) {
             regionCodesToCallingCodeMap[regionCode] = Number(callingCode);
           });
         });
@@ -44,7 +44,7 @@ exports.handler = () => {
 
       console.log(`Wrote to ${OUTPUT_FILE}`);
     })
-    .catch(function (error) {
+    .catch(function(error) {
       console.log(error);
     });
 

--- a/buildtools/commands/update-readme.js
+++ b/buildtools/commands/update-readme.js
@@ -4,7 +4,7 @@ const replace = require('replace-in-file');
 
 const ROOT_DIR = resolve(__dirname, '../../');
 
-function getPublishedWidgetVersion () {
+function getPublishedWidgetVersion() {
   const stdout = execSync('yarn info @okta/okta-signin-widget --json');
   const meta = JSON.parse(stdout);
   const version = meta.data['dist-tags'].latest;

--- a/buildtools/webpack/plugins.js
+++ b/buildtools/webpack/plugins.js
@@ -8,30 +8,30 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const UglifyJsPlugin = optimize.UglifyJsPlugin;
 
-function webpackBundleAnalyzer (reportFilename = 'okta-sign-in.analyzer') {
+function webpackBundleAnalyzer(reportFilename = 'okta-sign-in.analyzer') {
   return new BundleAnalyzerPlugin({
     openAnalyzer: false,
     reportFilename: `${reportFilename}.html`,
     analyzerMode: 'static',
   });
 }
-function emptyModule () {
+function emptyModule() {
   return new IgnorePlugin(/^\.\/locale$/, /moment$/);
 }
 
-function prodMode () {
+function prodMode() {
   return new DefinePlugin({
     DEBUG: false
   });
 }
 
-function devMode () {
+function devMode() {
   return new DefinePlugin({
     DEBUG: true
   });
 }
 
-function uglify () {
+function uglify() {
   return new UglifyJsPlugin({
     compress: {
       warnings: false,
@@ -80,22 +80,22 @@ function uglify () {
   });
 }
 
-function banner () {
+function banner() {
   // Add a single Okta license after removing others
   const license = readFileSync(join(__dirname, '../../src/widget/copyright.txt'), 'utf8');
   return new BannerPlugin(license);
 }
 
-function failOnBuildFail () {
-  return function () {
-    this.plugin('done', function (build) {
+function failOnBuildFail() {
+  return function() {
+    this.plugin('done', function(build) {
       // webpack 3.x and karma-webpack combo will fail to treat seom missing assets as build failures
       // See https://oktainc.atlassian.net/browse/OKTA-253137
       if( build.compilation.warnings.length || build.compilation.errors.length ) {
         [
           ...build.compilation.warnings,
           ...build.compilation.errors,
-        ].forEach(function ( warning ) { console.error( warning ); });
+        ].forEach(function( warning ) { console.error( warning ); });
         console.error('failOnBuildFail plugin Forcibly killing build because of webpack compile failure');
         throw new Error('Plugin failOnBuildFail forcing build abort');
       }
@@ -103,7 +103,7 @@ function failOnBuildFail () {
   };
 }
 
-function plugins (options = {}) {
+function plugins(options = {}) {
   const { isProduction, skipAnalyzer } = options;
   const list = isProduction ? 
     // Uglify and add license header

--- a/buildtools/webpack/polyfill.js
+++ b/buildtools/webpack/polyfill.js
@@ -1,5 +1,5 @@
 var useRuntime = require('./runtime');
-module.exports = function usePolyfill (webpackConfig) {
+module.exports = function usePolyfill(webpackConfig) {
   webpackConfig.entry.unshift('@babel/polyfill'); // needed for IE
   useRuntime(webpackConfig, { corejs: 3});
 };

--- a/buildtools/webpack/runtime.js
+++ b/buildtools/webpack/runtime.js
@@ -1,4 +1,4 @@
-module.exports = function addRuntime (webpackConfig, runtimeOptions) {
+module.exports = function addRuntime(webpackConfig, runtimeOptions) {
   const rules = webpackConfig.module.rules;
   const babelRule = rules.find(rule => rule.loader === 'babel-loader');
   babelRule.options.plugins = babelRule.options.plugins.concat([

--- a/playground/main.js
+++ b/playground/main.js
@@ -18,7 +18,7 @@ const renderPlaygroundWidget = (options = {}) => {
   signIn.renderEl(
     { el: '#okta-login-container' },
 
-    function success (res) {
+    function success(res) {
       // Password recovery flow
       if (res.status === 'FORGOT_PASSWORD_EMAIL_SENT') {
         alert('SUCCESS: Forgot password email sent');
@@ -54,7 +54,7 @@ const renderPlaygroundWidget = (options = {}) => {
       }
     },
 
-    function error (err) {
+    function error(err) {
       console.error('global error handler: ', err);
     }
   );
@@ -86,7 +86,7 @@ const renderPlaygroundWidget = (options = {}) => {
 
 };
 
-window.getWidgetInstance = function () {
+window.getWidgetInstance = function() {
   return signIn;
 };
 

--- a/playground/mocks/config/templateHelper.js
+++ b/playground/mocks/config/templateHelper.js
@@ -56,7 +56,7 @@ const configMock = (option) => {
       }
       next();
     },
-    template () {
+    template() {
       if (!hasChainedMockData) {
         return {
           errorSummary: `No mock found for ${apiPath}`,

--- a/playground/mocks/server.js
+++ b/playground/mocks/server.js
@@ -18,7 +18,7 @@ const configs = dyson.getConfigurations(options);
 const app = dyson.createServer(options);
 
 // enforce CSP
-app.use('/*', function (req, res, next){
+app.use('/*', function(req, res, next){
   res.header(
     'Content-Security-Policy',
     `script-src http://localhost:${DEV_SERVER_PORT}`

--- a/playground/mocks/spec-okta-api/app/userHome.js
+++ b/playground/mocks/spec-okta-api/app/userHome.js
@@ -4,7 +4,7 @@ const apis = [
     proxy: false,
     path: '/app/UserHome',
     method: 'GET',
-    template (params, query) {
+    template(params, query) {
       return `
         <h1>Mock User Dashboard</h1>
         <h2>Query parameters</h2>

--- a/playground/mocks/spec-okta-api/oauth2/v1/authorize/callback.js
+++ b/playground/mocks/spec-okta-api/oauth2/v1/authorize/callback.js
@@ -4,7 +4,7 @@ const apis = [
     proxy: false,
     path: '/oauth2/v1/authorize/callback',
     method: 'GET',
-    template () {
+    template() {
       // In a real case, `/oauth2/v1/authorize` would parse the `code`
       // and `state` and handle it as any OAuth 2.0 request.
       // To simplify the test flow, respond via a redirect with a new `stateToken`.

--- a/playground/mocks/spec-okta-api/sso/idps.js
+++ b/playground/mocks/spec-okta-api/sso/idps.js
@@ -4,7 +4,7 @@ const apis = [
     proxy: false,
     path: '/sso/idps/:idpId',
     method: 'GET',
-    template (params) {
+    template(params) {
       // At real case, `/sso/idps/:id` would 302 to 3rd party login page.
       // To simplify the test flow, responds 200 instead.
       return `

--- a/src/AccountUnlockedController.js
+++ b/src/AccountUnlockedController.js
@@ -16,7 +16,7 @@ import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 export default FormController.extend({
   className: 'account-unlocked',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         userFullName: ['string', false, this.options.appState.get('userFullName')],
@@ -29,13 +29,13 @@ export default FormController.extend({
     subtitle: _.partial(loc, 'account.unlock.unlocked.desc', 'login'),
     noButtonBar: true,
     attributes: { 'data-se': 'account-unlocked' },
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Button({
           title: loc('goback', 'login'),
           className: 'button button-primary button-wide',
           attributes: { 'data-se': 'back-button' },
-          click: function () {
+          click: function() {
             this.state.set('navigateDir', Enums.DIRECTION_BACK);
             this.options.appState.trigger('navigate', '');
           },

--- a/src/ActivateTotpController.js
+++ b/src/ActivateTotpController.js
@@ -15,7 +15,7 @@ import EnterPasscodeForm from 'views/enroll-factors/EnterPasscodeForm';
 import Footer from 'views/enroll-factors/Footer';
 export default FormController.extend({
   className: 'activate-totp',
-  Model: function () {
+  Model: function() {
     return {
       props: {
         factorId: ['string', true, this.options.appState.get('activatedFactorId')],
@@ -25,8 +25,8 @@ export default FormController.extend({
         __factorType__: ['string', false, this.options.factorType],
         __provider__: ['string', false, this.options.provider],
       },
-      save: function () {
-        return this.doTransaction(function (transaction) {
+      save: function() {
+        return this.doTransaction(function(transaction) {
           return transaction.activate({
             passCode: this.get('passCode'),
           });

--- a/src/AdminConsentRequiredController.js
+++ b/src/AdminConsentRequiredController.js
@@ -20,8 +20,8 @@ const ConsentModel = {
   props: {
     scopes: ['array', true]
   },
-  save: function () {
-    return this.doTransaction(function (transaction) {
+  save: function() {
+    return this.doTransaction(function(transaction) {
       return transaction.consent({
         consent: {
           scopes: _.pluck(this.get('scopes'), 'name')
@@ -29,11 +29,11 @@ const ConsentModel = {
       });
     });
   },
-  cancel: function () {
+  cancel: function() {
     var self = this;
-    return this.doTransaction(function (transaction) {
+    return this.doTransaction(function(transaction) {
       return transaction.cancel();
-    }).then(function () {
+    }).then(function() {
       var consentCancelFn = self.settings.get('consent.cancel');
       if (_.isFunction(consentCancelFn)) {
         consentCancelFn();
@@ -45,7 +45,7 @@ const ConsentModel = {
 const ConsentHeader = View.extend({
   className: 'consent-title detail-row',
   template: consentLogoHeaderTemplate,
-  getTemplateData: function () {
+  getTemplateData: function() {
     var appState = this.options.appState;
     return {
       appName: appState.escape('targetLabel'),
@@ -79,14 +79,14 @@ const AdminConsentRequiredController = FormController.extend({
 
   className: 'admin-consent-required',
 
-  initialize: function () {
+  initialize: function() {
     this.model.set('scopes', this.options.appState.get('scopes'));
     this.listenTo(this.form, 'cancel', () => {
       this.model.cancel();
     });
   },
 
-  postRender: function () {
+  postRender: function() {
     // Move buttons in DOM to match visual hierarchy to fix tab order.
     const buttonContainer = this.form.$el.find('.o-form-button-bar');
     this.form.$el.find('.button-primary').appendTo(buttonContainer);

--- a/src/BarcodePushController.js
+++ b/src/BarcodePushController.js
@@ -23,7 +23,7 @@ const PUSH_INTERVAL = 6000;
 
 export default FormController.extend({
   className: 'barcode-push',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         __factorType__: ['string', false, this.options.factorType],
@@ -33,7 +33,7 @@ export default FormController.extend({
   },
 
   Form: {
-    title: function () {
+    title: function() {
       const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
       return loc('enroll.totp.title', 'login', [factorName]);
@@ -41,8 +41,8 @@ export default FormController.extend({
     noButtonBar: true,
     attributes: { 'data-se': 'step-scan' },
     className: 'barcode-scan',
-    initialize: function () {
-      this.listenTo(this.model, 'error errors:clear', function () {
+    initialize: function() {
+      this.listenTo(this.model, 'error errors:clear', function() {
         this.clearErrors();
       });
     },
@@ -52,17 +52,17 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  initialize: function () {
+  initialize: function() {
     this.pollForEnrollment();
   },
 
-  pollForEnrollment: function () {
-    return this.model.doTransaction(function (transaction) {
+  pollForEnrollment: function() {
+    return this.model.doTransaction(function(transaction) {
       return transaction.poll(PUSH_INTERVAL);
     });
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       return true;
     }

--- a/src/BarcodeTotpController.js
+++ b/src/BarcodeTotpController.js
@@ -19,7 +19,7 @@ import BarcodeView from 'views/enroll-factors/BarcodeView';
 import Footer from 'views/enroll-factors/Footer';
 export default FormController.extend({
   className: 'barcode-totp',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         __factorType__: ['string', false, this.options.factorType],
@@ -29,7 +29,7 @@ export default FormController.extend({
   },
 
   Form: {
-    title: function () {
+    title: function() {
       const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
       return loc('enroll.totp.title', 'login', [factorName]);
@@ -44,8 +44,8 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  initialize: function () {
-    this.listenTo(this.form, 'save', function () {
+  initialize: function() {
+    this.listenTo(this.form, 'save', function() {
       const url = RouterUtil.createActivateFactorUrl(
         this.model.get('__provider__'),
         this.model.get('__factorType__'),

--- a/src/ConsentRequiredController.js
+++ b/src/ConsentRequiredController.js
@@ -22,7 +22,7 @@ import consentLogoHeaderTemplate from 'views/shared/templates/consentLogoHeaderT
 
 export default FormController.extend({
   className: 'consent-required',
-  initialize: function () {
+  initialize: function() {
     this.model.set('expiresAt', this.options.appState.get('expiresAt'));
     this.model.set('scopes', this.options.appState.get('scopes'));
     this.listenTo(this.form, 'cancel', _.bind(this.model.cancel, this.model));
@@ -31,7 +31,7 @@ export default FormController.extend({
     const skipLink = new SkipLink();
     $(`#${Enums.WIDGET_LOGIN_CONTAINER_ID}`).prepend(skipLink.render().$el);
   },
-  postRender: function () {
+  postRender: function() {
     FormController.prototype.postRender.apply(this, arguments);
 
     // Move buttons in DOM to match visual hierarchy to fix tab order.
@@ -46,8 +46,8 @@ export default FormController.extend({
       expiresAt: ['string', true],
       scopes: ['array', true],
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         return transaction.consent({
           consent: {
             expiresAt: this.get('expiresAt'),
@@ -56,12 +56,12 @@ export default FormController.extend({
         });
       });
     },
-    cancel: function () {
+    cancel: function() {
       const self = this;
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         return transaction.cancel();
-      }).then(function () {
+      }).then(function() {
         const consentCancelFn = self.settings.get('consent.cancel');
 
         if (_.isFunction(consentCancelFn)) {
@@ -75,13 +75,13 @@ export default FormController.extend({
     autoSave: true,
     save: _.partial(loc, 'consent.required.consentButton', 'login'),
     cancel: _.partial(loc, 'consent.required.cancelButton', 'login'),
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.View({
           View: View.extend({
             className: 'consent-title detail-row',
             template: consentLogoHeaderTemplate,
-            getTemplateData: function () {
+            getTemplateData: function() {
               const appState = this.options.appState;
 
               return {
@@ -124,7 +124,7 @@ export default FormController.extend({
         {{/if}}\
       '
     ),
-    getTemplateData: function () {
+    getTemplateData: function() {
       const appState = this.options.appState;
 
       return {

--- a/src/CustomPasswordExpiredController.js
+++ b/src/CustomPasswordExpiredController.js
@@ -20,7 +20,7 @@ export default FormController.extend({
   Model: {},
   Form: {
     noButtonBar: true,
-    title: function () {
+    title: function() {
       const expiringSoon = this.options.appState.get('isPwdExpiringSoon');
       const numDays = this.options.appState.get('passwordExpireDays');
 
@@ -36,7 +36,7 @@ export default FormController.extend({
           : loc('password.expired.title.generic', 'login');
       }
     },
-    subtitle: function () {
+    subtitle: function() {
       if (this.options.appState.get('isPwdExpiringSoon')) {
         const subtitle = this.settings.get('brandName')
           ? loc('password.expiring.subtitle.specific', 'login', [this.settings.get('brandName')])
@@ -47,7 +47,7 @@ export default FormController.extend({
 
       return loc('password.expired.custom.subtitle', 'login');
     },
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Button({
           title: _.partial(loc, 'password.expired.custom.submit', 'login', [
@@ -55,7 +55,7 @@ export default FormController.extend({
           ]),
           className: 'button button-primary button-wide',
           attributes: { 'data-se': 'custom-button' },
-          click: function () {
+          click: function() {
             Util.redirect(this.options.appState.get('passwordExpiredLinkUrl'));
           },
         }),

--- a/src/EnrollActivateCustomFactorController.js
+++ b/src/EnrollActivateCustomFactorController.js
@@ -22,7 +22,7 @@ export default EnrollCustomFactorController.extend({
       provider: 'string',
       factorType: 'string',
     },
-    save: function () {
+    save: function() {
       return this.manageTransaction(() => {
         const url = this.appState.get('enrollCustomFactorRedirectUrl');
 
@@ -33,7 +33,7 @@ export default EnrollCustomFactorController.extend({
     },
   },
 
-  Form: function () {
+  Form: function() {
     const factor = new Factor.Model(this.options.appState.get('factor'), this.toJSON());
     const vendorName = factor.get('vendorName');
     const subtitle = loc('enroll.customFactor.subtitle', 'login', [vendorName]);
@@ -44,7 +44,7 @@ export default EnrollCustomFactorController.extend({
       title: vendorName,
       subtitle: subtitle,
       save: saveText,
-      formChildren: function () {
+      formChildren: function() {
         const result = [];
 
         if (this.options.appState.get('isFactorResultFailed')) {

--- a/src/EnrollActivateEmailController.js
+++ b/src/EnrollActivateEmailController.js
@@ -22,24 +22,24 @@ const Model = {
     passCode: 'string',
   },
 
-  resend: function () {
+  resend: function() {
     this.trigger('form:clear-errors');
-    return this.doTransaction(function (transaction) {
+    return this.doTransaction(function(transaction) {
       // authn support multiple `resend` hence has to specify name.
       return transaction.resend('email');
     });
   },
 
-  save: function () {
+  save: function() {
     this.trigger('save');
     const formData = this.toJSON();
-    return this.doTransaction(function (transaction) {
+    return this.doTransaction(function(transaction) {
       return transaction.activate(formData);
     });
   },
 };
 
-const Form = function () {
+const Form = function() {
   return {
     title: _.partial(loc, 'email.enroll.title', 'login'),
     noButtonBar: false,
@@ -59,7 +59,7 @@ const Form = function () {
           //   is created via another handlebar template and used for bold the email address.
           template: hbs('{{{i18n code="email.mfa.email.sent.description" bundle="login" arguments="factorEmail"}}}'),
 
-          getTemplateData: function () {
+          getTemplateData: function() {
             const factor = this.options.appState.get('factor');
             const factorEmailVal = factor && factor.profile ? factor.profile.email : '';
             const factorEmail = hbs('<span class="mask-email">{{email}}</span>')({ email: factorEmailVal });

--- a/src/EnrollChoicesController.js
+++ b/src/EnrollChoicesController.js
@@ -34,13 +34,13 @@ export default FormController.extend({
 
     title: _.partial(loc, 'enroll.choices.title', 'login'),
 
-    noButtonBar: function () {
+    noButtonBar: function() {
       return this.state.get('pageType') === Enums.ALL_OPTIONAL_NONE_ENROLLED;
     },
 
     subtitle: ' ',
 
-    getSubtitle: function () {
+    getSubtitle: function() {
       switch (this.state.get('pageType')) {
       case Enums.ALL_OPTIONAL_SOME_ENROLLED:
       case Enums.HAS_REQUIRED_ALL_REQUIRED_ENROLLED:
@@ -56,19 +56,19 @@ export default FormController.extend({
       }
     },
 
-    getDefaultSubtitle: function () {
+    getDefaultSubtitle: function() {
       return this.settings.get('brandName')
         ? loc('enroll.choices.description.specific', 'login', [this.settings.get('brandName')])
         : loc('enroll.choices.description.generic', 'login');
     },
 
-    getGracePeriodSubtitle: function (remainingDays) {
+    getGracePeriodSubtitle: function(remainingDays) {
       return remainingDays >= 1
         ? loc('enroll.choices.description.gracePeriod.bold', 'login', [remainingDays])
         : loc('enroll.choices.description.gracePeriod.oneDay.bold', 'login');
     },
 
-    save: function () {
+    save: function() {
       switch (this.state.get('pageType')) {
       case Enums.ALL_OPTIONAL_SOME_ENROLLED:
       case Enums.HAS_REQUIRED_ALL_REQUIRED_ENROLLED:
@@ -82,8 +82,8 @@ export default FormController.extend({
       }
     },
 
-    initialize: function (options) {
-      this.listenTo(this, 'save', function () {
+    initialize: function(options) {
+      this.listenTo(this, 'save', function() {
         let current;
 
         switch (this.state.get('pageType')) {
@@ -96,14 +96,14 @@ export default FormController.extend({
           );
           break;
         default:
-          return this.model.doTransaction(function (transaction) {
+          return this.model.doTransaction(function(transaction) {
             return transaction.skip();
           });
         }
       });
     },
 
-    preRender: function () {
+    preRender: function() {
       // form subtitle does not support unescaped strings, and we need some html elements
       // in the subtitle for this form. So instead of a regular subtitle, we add a <span>
       // with the text we need
@@ -126,7 +126,7 @@ export default FormController.extend({
       case Enums.ALL_OPTIONAL_SOME_ENROLLED:
       case Enums.ALL_OPTIONAL_NONE_ENROLLED: {
         const enrolled = factors.where({ enrolled: true });
-        const notEnrolled = factors.filter(function (factor) {
+        const notEnrolled = factors.filter(function(factor) {
           // pick factors that are not enrolled or have additional enrollments
           return !factor.get('enrolled') || factor.get('additionalEnrollment');
         });
@@ -157,7 +157,7 @@ export default FormController.extend({
     },
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     let numRequiredEnrolled = 0;
     let numRequiredNotEnrolled = 0;
     let numOptionalEnrolled = 0;
@@ -165,7 +165,7 @@ export default FormController.extend({
     let hasRequired;
     let pageType;
 
-    options.appState.get('factors').each(function (factor) {
+    options.appState.get('factors').each(function(factor) {
       const required = factor.get('required');
       const enrolled = factor.get('enrolled');
       const additionalEnrollment = factor.get('additionalEnrollment');
@@ -213,7 +213,7 @@ export default FormController.extend({
       //    enrolled, among them there is OktaVerify with Push enrolled as totp
       //    (API return OktaVerify push factor as unenrolled in this case and as we always merge
       //    push and totp in UI so we redirect to skip link here).
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         return transaction.skip();
       });
     }

--- a/src/EnrollCustomFactorController.js
+++ b/src/EnrollCustomFactorController.js
@@ -21,7 +21,7 @@ export default FormController.extend({
       provider: 'string',
       factorType: 'string',
     },
-    save: function () {
+    save: function() {
       return this.manageTransaction((transaction, setTransaction) => {
         const factor = _.findWhere(transaction.factors, {
           provider: this.get('provider'),
@@ -38,14 +38,14 @@ export default FormController.extend({
               Util.redirect(url);
             }
           })
-          .catch(function (err) {
+          .catch(function(err) {
             throw err;
           });
       });
     },
   },
 
-  Form: function () {
+  Form: function() {
     const factors = this.options.appState.get('factors');
     const factor = factors.findWhere({
       provider: this.options.provider,
@@ -63,13 +63,13 @@ export default FormController.extend({
     };
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       return true;
     }
   },
 
-  initialize: function () {
+  initialize: function() {
     this.model.set('provider', this.options.provider);
     this.model.set('factorType', this.options.factorType);
   },

--- a/src/EnrollDuoController.js
+++ b/src/EnrollDuoController.js
@@ -28,8 +28,8 @@ export default FormController.extend({
       stateToken: 'string',
     },
 
-    getInitOptions: function () {
-      return this.doTransaction(function (transaction) {
+    getInitOptions: function() {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'web',
           provider: 'DUO',
@@ -39,7 +39,7 @@ export default FormController.extend({
       });
     },
 
-    activate: function (signedResponse) {
+    activate: function(signedResponse) {
       const url = this.get('postAction');
       const factorId = this.get('factorId');
       const self = this;
@@ -57,12 +57,12 @@ export default FormController.extend({
       // are the only two places where we actually do this.
       // NOTE - If we ever decide to change this, we should test this very carefully.
       return Q($.post(url, data))
-        .then(function () {
-          return self.doTransaction(function (transaction) {
+        .then(function() {
+          return self.doTransaction(function(transaction) {
             return transaction.poll();
           });
         })
-        .catch(function (err) {
+        .catch(function(err) {
           self.trigger('error', self, err.xhr);
         });
     },
@@ -73,7 +73,7 @@ export default FormController.extend({
     noButtonBar: true,
     title: _.partial(loc, 'enroll.duo.title', 'login'),
 
-    postRender: function () {
+    postRender: function() {
       this.add('<iframe frameborder="0" title="' + this.title() + '"></iframe>');
       Duo.init({
         host: this.model.get('host'),
@@ -86,10 +86,10 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     const self = this;
 
-    return this.model.getInitOptions(this.options.appState).then(function (trans) {
+    return this.model.getInitOptions(this.options.appState).then(function(trans) {
       const res = trans.data;
 
       if (
@@ -115,7 +115,7 @@ export default FormController.extend({
     });
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       return true;
     }

--- a/src/EnrollEmailController.js
+++ b/src/EnrollEmailController.js
@@ -21,10 +21,10 @@ const Model = {
     factorType: 'string',
     provider: 'string',
   },
-  save: function () {
+  save: function() {
     this.trigger('save');
     const factorOpt = this.pick('factorType', 'provider');
-    return this.doTransaction(function (transaction) {
+    return this.doTransaction(function(transaction) {
       const factor = _.findWhere(transaction.factors, factorOpt);
 
       return factor.enroll();
@@ -32,7 +32,7 @@ const Model = {
   },
 };
 
-const Form = function () {
+const Form = function() {
   return {
     title: _.partial(loc, 'email.enroll.title', 'login'),
     noButtonBar: false,
@@ -60,7 +60,7 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  initialize: function () {
+  initialize: function() {
     this.model.set(_.pick(this.options, 'factorType', 'provider'));
   },
 });

--- a/src/EnrollHotpController.js
+++ b/src/EnrollHotpController.js
@@ -17,7 +17,7 @@ import Footer from 'views/enroll-factors/Footer';
 import HtmlErrorMessageView from 'views/mfa-verify/HtmlErrorMessageView';
 export default FormController.extend({
   className: 'enroll-hotp',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         __factorType__: ['string', false, this.options.factorType],
@@ -26,7 +26,7 @@ export default FormController.extend({
     };
   },
   Form: {
-    title: function () {
+    title: function() {
       const factors = this.options.appState.get('factors');
       const hotpFactor = factors.findWhere({
         provider: this.model.get('__provider__'),
@@ -37,7 +37,7 @@ export default FormController.extend({
     noButtonBar: true,
     attributes: { 'data-se': 'restrict-enroll' },
 
-    formChildren: function () {
+    formChildren: function() {
       const children = [
         FormType.View({
           View: new HtmlErrorMessageView({ message: loc('enroll.hotp.restricted', 'login') }),

--- a/src/EnrollOnPremController.js
+++ b/src/EnrollOnPremController.js
@@ -17,19 +17,19 @@ import Util from 'util/Util';
 import Footer from 'views/enroll-factors/Footer';
 import TextBox from 'views/shared/TextBox';
 
-function isRSA (provider) {
+function isRSA(provider) {
   return provider === 'RSA';
 }
 
-function getClassName (provider) {
+function getClassName(provider) {
   return isRSA(provider) ? 'enroll-rsa' : 'enroll-onprem';
 }
 
 export default FormController.extend({
-  className: function () {
+  className: function() {
     return getClassName(this.options.provider);
   },
-  Model: function () {
+  Model: function() {
     const provider = this.options.provider;
     const factors = this.options.appState.get('factors');
     const factor = factors.findWhere(_.pick(this.options, 'provider', 'factorType'));
@@ -42,8 +42,8 @@ export default FormController.extend({
         passCode: ['string', true],
         factorId: 'string',
       },
-      save: function () {
-        return this.doTransaction(function (transaction) {
+      save: function() {
+        return this.doTransaction(function(transaction) {
           const factor = _.findWhere(transaction.factors, {
             factorType: 'token',
             provider: provider,
@@ -58,7 +58,7 @@ export default FormController.extend({
     };
   },
 
-  Form: function () {
+  Form: function() {
     const provider = this.options.provider;
     const factors = this.options.appState.get('factors');
     const factor = factors.findWhere(_.pick(this.options, 'provider', 'factorType'));
@@ -70,7 +70,7 @@ export default FormController.extend({
       noButtonBar: true,
       autoSave: true,
       className: getClassName(provider),
-      initialize: function () {
+      initialize: function() {
         this.listenTo(this.model, 'error', (source, error) => {
           if (error && error.status === 409) {
             // 409 means we are in change pin, so we should clear out answer input

--- a/src/EnrollPasswordController.js
+++ b/src/EnrollPasswordController.js
@@ -22,7 +22,7 @@ export default FormController.extend({
       password: ['string', true],
       confirmPassword: ['string', true],
     },
-    validate: function () {
+    validate: function() {
       return ValidationUtil.validateFieldsMatch(
         this,
         'password',
@@ -30,8 +30,8 @@ export default FormController.extend({
         loc('password.enroll.error.match', 'login')
       );
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'password',
           provider: 'OKTA',
@@ -49,7 +49,7 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     title: _.partial(loc, 'enroll.password.setup', 'login'),
-    inputs: function () {
+    inputs: function() {
       return [
         {
           label: loc('mfa.challenge.password.placeholder', 'login'),

--- a/src/EnrollQuestionController.js
+++ b/src/EnrollQuestionController.js
@@ -26,8 +26,8 @@ export default FormController.extend({
     local: {
       securityQuestions: 'object',
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'question',
           provider: 'OKTA',
@@ -46,7 +46,7 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     title: _.partial(loc, 'enroll.securityQuestion.setup', 'login'),
-    inputs: function () {
+    inputs: function() {
       return [
         {
           label: false,
@@ -54,7 +54,7 @@ export default FormController.extend({
           name: 'question',
           type: 'select',
           wide: true,
-          options: function () {
+          options: function() {
             return this.model.get('securityQuestions');
           },
           params: {
@@ -77,11 +77,11 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     const self = this;
 
     return this.model
-      .manageTransaction(function (transaction) {
+      .manageTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'question',
           provider: 'OKTA',
@@ -89,10 +89,10 @@ export default FormController.extend({
 
         return factor.questions();
       })
-      .then(function (questionsRes) {
+      .then(function(questionsRes) {
         const questions = {};
 
-        _.each(questionsRes, function (question) {
+        _.each(questionsRes, function(question) {
           questions[question.question] = FactorUtil.getSecurityQuestionLabel(question);
         });
         self.model.set('securityQuestions', questions);

--- a/src/EnrollSymantecVipController.js
+++ b/src/EnrollSymantecVipController.js
@@ -25,8 +25,8 @@ export default FormController.extend({
       nextPassCode: ['string', true],
       factorId: 'string',
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'token',
           provider: 'SYMANTEC',
@@ -47,7 +47,7 @@ export default FormController.extend({
     noButtonBar: true,
     autoSave: true,
     className: 'enroll-symantec',
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Input({
           label: loc('enroll.symantecVip.credentialId.placeholder', 'login'),

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -18,7 +18,7 @@ import FormType from 'util/FormType';
 import StoreLinks from 'util/StoreLinks';
 import Footer from 'views/enroll-factors/Footer';
 const showWhenDeviceTypeSelected = {
-  __deviceType__: function (val) {
+  __deviceType__: function(val) {
     return val !== undefined;
   },
 };
@@ -31,10 +31,10 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
       <p class="instructions">{{{appStoreLinkText}}}</p>\
     '
   ),
-  initialize: function () {
+  initialize: function() {
     this.listenTo(this.model, 'change:__deviceType__', this.render);
   },
-  getTemplateData: function () {
+  getTemplateData: function() {
     let appStoreLink;
     let appIcon;
     let appStoreName;
@@ -56,15 +56,15 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
 });
 const EnrollTotpControllerEnrollTotpController = FormController.extend({
   className: 'enroll-totp',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         __deviceType__: 'string',
         __factorType__: ['string', false, this.options.factorType],
         __provider__: ['string', false, this.options.provider],
       },
-      save: function () {
-        return this.doTransaction(function (transaction) {
+      save: function() {
+        return this.doTransaction(function(transaction) {
           const factor = _.findWhere(transaction.factors, {
             factorType: this.get('__factorType__'),
             provider: this.get('__provider__'),
@@ -77,7 +77,7 @@ const EnrollTotpControllerEnrollTotpController = FormController.extend({
   },
 
   Form: {
-    title: function () {
+    title: function() {
       const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
       return loc('enroll.totp.title', 'login', [factorName]);
@@ -87,7 +87,7 @@ const EnrollTotpControllerEnrollTotpController = FormController.extend({
     noButtonBar: true,
     attributes: { 'data-se': 'step-device-type' },
 
-    formChildren: function () {
+    formChildren: function() {
       const inputOptions = {
         APPLE: loc('iphone', 'login'),
         ANDROID: loc('android', 'login'),

--- a/src/EnrollU2FController.js
+++ b/src/EnrollU2FController.js
@@ -28,14 +28,14 @@ export default FormController.extend({
       __enrolled__: 'boolean',
     },
 
-    save: function () {
+    save: function() {
       this.trigger('request');
 
       if (this.get('__enrolled__')) {
         return this.activate();
       }
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'u2f',
           provider: 'FIDO',
@@ -45,11 +45,11 @@ export default FormController.extend({
       });
     },
 
-    activate: function () {
+    activate: function() {
       this.set('__enrolled__', true);
       this.trigger('errors:clear');
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const activation = transaction.factor.activation;
         const appId = activation.appId;
         const registerRequests = [
@@ -61,7 +61,7 @@ export default FormController.extend({
         const self = this;
         const deferred = Q.defer();
 
-        u2f.register(appId, registerRequests, [], function (data) {
+        u2f.register(appId, registerRequests, [], function(data) {
           self.trigger('errors:clear');
           if (data.errorCode && data.errorCode !== 0) {
             deferred.reject(
@@ -96,14 +96,14 @@ export default FormController.extend({
     hasSavingState: false,
     autoSave: true,
     className: 'enroll-u2f-form',
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !FidoUtil.isU2fAvailable();
     },
     modelEvents: {
       request: '_startEnrollment',
       error: '_stopEnrollment',
     },
-    formChildren: function () {
+    formChildren: function() {
       const result = [];
 
       if (!FidoUtil.isU2fAvailable()) {
@@ -156,13 +156,13 @@ export default FormController.extend({
       return result;
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.$('.u2f-instructions').addClass('hide');
       this.$('.u2f-enroll-text').removeClass('hide');
       this.$('.o-form-button-bar').hide();
     },
 
-    _stopEnrollment: function () {
+    _stopEnrollment: function() {
       this.$('.u2f-instructions').removeClass('hide');
       this.$('.u2f-enroll-text').addClass('hide');
       this.$('.o-form-button-bar').show();
@@ -171,7 +171,7 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       this.model.activate();
       return true;

--- a/src/EnrollUserController.js
+++ b/src/EnrollUserController.js
@@ -15,12 +15,12 @@ import EnrollUserForm from 'views/enrollUser/EnrollUserForm';
 import FooterWithBackLink from 'views/shared/FooterWithBackLink';
 export default BaseLoginController.extend({
   className: 'enroll-user',
-  initialize: function (options) {
+  initialize: function(options) {
     this.options = options || {};
     // create model
     this.model = new EnrollUser(this.options);
   },
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     // If user is unauthenticated and starts enroll flow make a post call to transition state to PROFILE_REQUIRED
     if (this.options.appState.get('isUnauthenticated')) {
       return this.model.getEnrollFormData();
@@ -28,12 +28,12 @@ export default BaseLoginController.extend({
       return BaseLoginController.prototype.fetchInitialData.call();
     }
   },
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isProfileRequired')) {
       return true;
     }
   },
-  postRender: function () {
+  postRender: function() {
     const form = new EnrollUserForm(this.toJSON());
 
     this.add(form);

--- a/src/EnrollWebauthnController.js
+++ b/src/EnrollWebauthnController.js
@@ -22,10 +22,10 @@ import webauthn from 'util/webauthn';
 import Footer from 'views/enroll-factors/Footer';
 import HtmlErrorMessageView from 'views/mfa-verify/HtmlErrorMessageView';
 
-function getExcludeCredentials (credentials) {
+function getExcludeCredentials(credentials) {
   const excludeCredentials = [];
 
-  _.each(credentials, function (credential) {
+  _.each(credentials, function(credential) {
     excludeCredentials.push({
       type: 'public-key',
       id: CryptoUtil.strToBin(credential.id),
@@ -41,14 +41,14 @@ export default FormController.extend({
       __enrolled__: 'boolean',
     },
 
-    save: function () {
+    save: function() {
       this.trigger('request');
 
       if (this.get('__enrolled__')) {
         return this.activate();
       }
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'webauthn',
           provider: 'FIDO',
@@ -58,7 +58,7 @@ export default FormController.extend({
       });
     },
 
-    activate: function () {
+    activate: function() {
       this.set('__enrolled__', true);
       this.trigger('errors:clear');
       this.appState.on('backToFactors', () => {
@@ -68,7 +68,7 @@ export default FormController.extend({
         }
       });
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const activation = transaction.factor.activation;
         // enroll via browser webauthn js
 
@@ -92,13 +92,13 @@ export default FormController.extend({
               signal: self.webauthnAbortController.signal,
             })
           )
-            .then(function (newCredential) {
+            .then(function(newCredential) {
               return transaction.activate({
                 attestation: CryptoUtil.binToStr(newCredential.response.attestationObject),
                 clientData: CryptoUtil.binToStr(newCredential.response.clientDataJSON),
               });
             })
-            .catch(function (error) {
+            .catch(function(error) {
               self.trigger('errors:clear');
               // Do not display if it is abort error triggered by code when switching.
               // self.webauthnAbortController would be null if abort was triggered by code.
@@ -110,7 +110,7 @@ export default FormController.extend({
                 });
               }
             })
-            .finally(function () {
+            .finally(function() {
               // unset webauthnAbortController on successful authentication or error
               self.webauthnAbortController = null;
             });
@@ -126,14 +126,14 @@ export default FormController.extend({
     hasSavingState: false,
     autoSave: true,
     className: 'enroll-webauthn-form',
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !webauthn.isNewApiAvailable();
     },
     modelEvents: {
       request: '_startEnrollment',
       error: '_stopEnrollment',
     },
-    formChildren: function () {
+    formChildren: function() {
       const children = [];
 
       if (webauthn.isNewApiAvailable()) {
@@ -160,7 +160,7 @@ export default FormController.extend({
                 <div data-se="webauthn-waiting" class="okta-waiting-spinner hide"></div>\
               '
               ),
-              getTemplateData: function () {
+              getTemplateData: function() {
                 return {
                   isEdge: BrowserFeatures.isEdge(),
                   onlySupportsSecurityKey: (BrowserFeatures.isFirefox() || BrowserFeatures.isSafari()) &&
@@ -187,12 +187,12 @@ export default FormController.extend({
       return children;
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
     },
 
-    _stopEnrollment: function () {
+    _stopEnrollment: function() {
       this.$('.okta-waiting-spinner').hide();
       this.$('.o-form-button-bar').show();
     },
@@ -200,7 +200,7 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       this.model.activate();
       return true;

--- a/src/EnrollWindowsHelloController.js
+++ b/src/EnrollWindowsHelloController.js
@@ -24,7 +24,7 @@ export default FormController.extend({
       __isEnrolled__: 'boolean',
     },
 
-    save: function () {
+    save: function() {
       if (!webauthn.isAvailable()) {
         return;
       }
@@ -35,12 +35,12 @@ export default FormController.extend({
         return this.activate();
       }
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         return this._enroll(transaction);
       });
     },
 
-    _enroll: function (transaction) {
+    _enroll: function(transaction) {
       const factor = _.findWhere(transaction.factors, {
         factorType: 'webauthn',
         provider: 'FIDO',
@@ -49,10 +49,10 @@ export default FormController.extend({
       return factor.enroll();
     },
 
-    activate: function () {
+    activate: function() {
       this.set('__isEnrolled__', true);
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const activation = transaction.factor.activation;
         const user = transaction.user;
         const model = this;
@@ -71,14 +71,14 @@ export default FormController.extend({
 
         return webauthn
           .makeCredential(accountInfo, cryptoParams, challenge)
-          .then(function (creds) {
+          .then(function(creds) {
             return transaction.activate({
               credentialId: creds.credential.id,
               publicKey: creds.publicKey,
               attestation: null,
             });
           })
-          .catch(function (error) {
+          .catch(function(error) {
             switch (error.message) {
             case 'AbortError':
             case 'NotFoundError':
@@ -97,7 +97,7 @@ export default FormController.extend({
     autoSave: true,
     hasSavingState: false,
     title: _.partial(loc, 'enroll.windowsHello.title', 'login'),
-    subtitle: function () {
+    subtitle: function() {
       return webauthn.isAvailable() ? loc('enroll.windowsHello.subtitle', 'login') : '';
     },
     save: _.partial(loc, 'enroll.windowsHello.save', 'login'),
@@ -106,7 +106,7 @@ export default FormController.extend({
       stop: 'abort',
     },
 
-    modelEvents: function () {
+    modelEvents: function() {
       if (!webauthn.isAvailable()) {
         return {};
       }
@@ -118,11 +118,11 @@ export default FormController.extend({
       };
     },
 
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !webauthn.isAvailable();
     },
 
-    formChildren: function () {
+    formChildren: function() {
       const result = [];
 
       if (!webauthn.isAvailable()) {
@@ -139,7 +139,7 @@ export default FormController.extend({
       return result;
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.subtitle = loc('enroll.windowsHello.subtitle.loading', 'login');
 
       this.model.trigger('spinner:show');
@@ -149,7 +149,7 @@ export default FormController.extend({
       this.$('.o-form-button-bar').addClass('hide');
     },
 
-    _stopEnrollment: function (errorMessage) {
+    _stopEnrollment: function(errorMessage) {
       this.subtitle = loc('enroll.windowsHello.subtitle', 'login');
 
       this.model.trigger('spinner:hide');
@@ -178,7 +178,7 @@ export default FormController.extend({
       this.$('.o-form-button-bar').removeClass('hide');
     },
 
-    _resetErrorMessage: function () {
+    _resetErrorMessage: function() {
       this._errorMessageView && this._errorMessageView.remove();
       this._errorMessageView = undefined;
       this.clearErrors();
@@ -187,7 +187,7 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate')) {
       this.model.activate();
       return true;

--- a/src/EnrollYubikeyController.js
+++ b/src/EnrollYubikeyController.js
@@ -22,8 +22,8 @@ export default FormController.extend({
       passCode: ['string', true],
       factorId: 'string',
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'token:hardware',
           provider: 'YUBICO',

--- a/src/EnrollmentLinkSentController.js
+++ b/src/EnrollmentLinkSentController.js
@@ -31,12 +31,12 @@ const EnrollmentLinkSentControllerFooter = View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
   },
-  back: function () {
+  back: function() {
     const url = RouterUtil.createActivateFactorUrl(
       this.options.appState.get('activatedFactorProvider'),
       this.options.appState.get('activatedFactorType'),
@@ -59,7 +59,7 @@ const emailSentForm = {
             <p class="email-address">{{email}}</p>\
           '
         ),
-        getTemplateData: function () {
+        getTemplateData: function() {
           return { email: this.options.appState.get('userEmail') };
         },
       }),
@@ -79,7 +79,7 @@ const smsSentForm = {
             <p class="phone-number">{{phoneNumber}}</p>\
           '
         ),
-        getTemplateData: function () {
+        getTemplateData: function() {
           return { phoneNumber: this.model.get('fullPhoneNumber') };
         },
       }),
@@ -88,7 +88,7 @@ const smsSentForm = {
 };
 export default FormController.extend({
   className: 'enroll-activation-link-sent',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         countryCode: ['string', false, this.options.appState.get('userCountryCode')],
@@ -99,13 +99,13 @@ export default FormController.extend({
       derived: {
         countryCallingCode: {
           deps: ['countryCode'],
-          fn: function (countryCode) {
+          fn: function(countryCode) {
             return '+' + CountryUtil.getCallingCodeForCountry(countryCode);
           },
         },
         fullPhoneNumber: {
           deps: ['countryCallingCode', 'phoneNumber'],
-          fn: function (countryCallingCode, phoneNumber) {
+          fn: function(countryCallingCode, phoneNumber) {
             return countryCallingCode + phoneNumber;
           },
         },
@@ -113,7 +113,7 @@ export default FormController.extend({
     };
   },
 
-  Form: function () {
+  Form: function() {
     const activationType = this.options.appState.get('factorActivationType');
 
     switch (activationType) {
@@ -128,21 +128,21 @@ export default FormController.extend({
 
   Footer: EnrollmentLinkSentControllerFooter,
 
-  initialize: function () {
+  initialize: function() {
     this.pollForEnrollment();
   },
 
-  remove: function () {
+  remove: function() {
     return FormController.prototype.remove.apply(this, arguments);
   },
 
-  pollForEnrollment: function () {
-    return this.model.doTransaction(function (transaction) {
+  pollForEnrollment: function() {
+    return this.model.doTransaction(function(transaction) {
       return transaction.poll(PUSH_INTERVAL);
     });
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isWaitingForActivation')) {
       this.pollForEnrollment();
       return true;

--- a/src/EnterPasscodePushFlowController.js
+++ b/src/EnterPasscodePushFlowController.js
@@ -25,12 +25,12 @@ const EnterPasscodePushFlowControllerFooter = View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
   },
-  back: function () {
+  back: function() {
     const url = RouterUtil.createActivateFactorUrl(
       this.options.appState.get('activatedFactorProvider'),
       'push',
@@ -42,7 +42,7 @@ const EnterPasscodePushFlowControllerFooter = View.extend({
 });
 export default FormController.extend({
   className: 'activate-push',
-  Model: function () {
+  Model: function() {
     return {
       props: {
         factorId: ['string', true, this.options.appState.get('activatedFactorId')],
@@ -52,8 +52,8 @@ export default FormController.extend({
         __factorType__: ['string', false, this.options.factorType],
         __provider__: ['string', false, this.options.provider],
       },
-      save: function () {
-        return this.doTransaction(function (transaction) {
+      save: function() {
+        return this.doTransaction(function(transaction) {
           return transaction.activate({
             passCode: this.get('passCode'),
           });

--- a/src/ForgotPasswordController.js
+++ b/src/ForgotPasswordController.js
@@ -44,23 +44,23 @@ const ForgotPasswordControllerFooter = View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
-    'click .js-contact-support': function (e) {
+    'click .js-contact-support': function(e) {
       e.preventDefault();
       this.state.trigger('contactSupport');
       this.$('.js-contact-support').hide();
     },
   },
-  getTemplateData: function () {
+  getTemplateData: function() {
     return {
       hideBackToSignInForReset: this.settings.get('features.hideBackToSignInForReset'),
       helpSupportNumber: this.settings.get('helpSupportNumber'),
     };
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     this.options.appState.trigger('navigate', '');
   },
@@ -72,20 +72,20 @@ export default FormController.extend({
       username: ['string', true],
       factorType: ['string', true],
     },
-    validate: function () {
+    validate: function() {
       return ValidationUtil.validateUsername(this);
     },
-    save: function () {
+    save: function() {
       const self = this;
       const relayState = this.settings.get('relayState');
 
-      this.startTransaction(function (authClient) {
+      this.startTransaction(function(authClient) {
         return authClient.forgotPassword({
           username: self.settings.transformUsername(self.get('username'), Enums.FORGOT_PASSWORD),
           factorType: self.get('factorType'),
           relayState: relayState,
         });
-      }).catch(function () {
+      }).catch(function() {
         //need empty fail handler on model to display errors on form
       });
     },
@@ -93,7 +93,7 @@ export default FormController.extend({
   Form: {
     noButtonBar: true,
     title: _.partial(loc, 'password.reset', 'login'),
-    formChildren: function () {
+    formChildren: function() {
       const smsEnabled = this.settings.get('features.smsRecovery');
       /*eslint complexity: [2, 9] max-statements: [2, 23] */
 
@@ -133,7 +133,7 @@ export default FormController.extend({
                     {{i18n code="recovery.mobile.hint" bundle="login" arguments="mobileFactors"}}\
                   </p>'
                 ),
-                getTemplateData: function () {
+                getTemplateData: function() {
                   let mobileFactors;
 
                   if (smsEnabled && callEnabled) {
@@ -189,27 +189,27 @@ export default FormController.extend({
 
       return formChildren;
     },
-    initialize: function () {
-      this.listenTo(this.state, 'contactSupport', function () {
+    initialize: function() {
+      this.listenTo(this.state, 'contactSupport', function() {
         this.add(ContactSupport, '.o-form-error-container');
       });
 
-      this.listenTo(this, 'save', function () {
+      this.listenTo(this, 'save', function() {
         this.options.appState.set('username', this.model.get('username'));
         this.model.save();
       });
     },
-    setDefaultFactorType: function (factorType) {
+    setDefaultFactorType: function(factorType) {
       if (_.isEmpty(this.model.get('factorType'))) {
         this.model.set('factorType', factorType);
       }
     },
-    createRecoveryFactorButton: function (className, labelCode, factorType, form) {
+    createRecoveryFactorButton: function(className, labelCode, factorType, form) {
       return FormType.Button({
         attributes: { 'data-se': className },
         className: 'button button-primary button-wide ' + className,
         title: loc(labelCode, 'login'),
-        click: function () {
+        click: function() {
           form.clearErrors();
           if (this.model.isValid()) {
             this.model.set('factorType', factorType);
@@ -221,7 +221,7 @@ export default FormController.extend({
   },
   Footer: ForgotPasswordControllerFooter,
 
-  initialize: function () {
+  initialize: function() {
     this.options.appState.unset('username');
   },
 });

--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -22,7 +22,7 @@ export default PrimaryAuthController.extend({
 
   View: IDPDiscoveryForm,
 
-  constructor: function (options) {
+  constructor: function(options) {
     options.appState.unset('username');
 
     this.model = new IDPDiscoveryModel(
@@ -55,10 +55,10 @@ export default PrimaryAuthController.extend({
     this.setUsername();
   },
 
-  initialize: function () {
+  initialize: function() {
     PrimaryAuthController.prototype.initialize.apply(this);
 
-    this.listenTo(this.model, 'goToPrimaryAuth', function () {
+    this.listenTo(this.model, 'goToPrimaryAuth', function() {
       this.settings.set('username', this.model.get('username'));
       if (this.settings.get('features.passwordlessAuth')) {
         const primaryAuthModel = new PrimaryAuthModel(

--- a/src/LoginRouter.js
+++ b/src/LoginRouter.js
@@ -154,7 +154,7 @@ export default BaseLoginRouter.extend({
     'verifyPIV',
   ],
 
-  defaultAuth: function () {
+  defaultAuth: function() {
     if (location.hash === `#${Enums.WIDGET_CONTAINER_ID}`) {
       document.getElementById(Enums.WIDGET_CONTAINER_ID).focus();
       return;
@@ -166,15 +166,15 @@ export default BaseLoginRouter.extend({
     }
   },
 
-  idpDiscovery: function () {
+  idpDiscovery: function() {
     this.render(IDPDiscoveryController, { Beacon: SecurityBeacon });
   },
 
-  primaryAuth: function () {
+  primaryAuth: function() {
     this.render(PrimaryAuthController, { Beacon: SecurityBeacon });
   },
 
-  verifyDuo: function () {
+  verifyDuo: function() {
     this.render(VerifyDuoController, {
       provider: 'DUO',
       factorType: 'web',
@@ -182,15 +182,15 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verifyPIV: function () {
+  verifyPIV: function() {
     this.render(VerifyPIVController, { Beacon: PIVBeacon });
   },
 
-  poll: function () {
+  poll: function() {
     this.render(PollController);
   },
 
-  verifyWebauthn: function () {
+  verifyWebauthn: function() {
     if (this.settings.get('features.webauthn')) {
       this.render(VerifyWebauthnController, {
         provider: 'FIDO',
@@ -206,7 +206,7 @@ export default BaseLoginRouter.extend({
     }
   },
 
-  verifyU2F: function () {
+  verifyU2F: function() {
     this.render(VerifyU2FController, {
       provider: 'FIDO',
       factorType: 'u2f',
@@ -214,7 +214,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verifySAMLFactor: function () {
+  verifySAMLFactor: function() {
     this.render(VerifyCustomFactorController, {
       provider: 'GENERIC_SAML',
       factorType: 'assertion:saml2',
@@ -222,7 +222,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verifyOIDCFactor: function () {
+  verifyOIDCFactor: function() {
     this.render(VerifyCustomFactorController, {
       provider: 'GENERIC_OIDC',
       factorType: 'assertion:oidc',
@@ -230,7 +230,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verifyClaimsFactor: function () {
+  verifyClaimsFactor: function() {
     this.render(VerifyCustomFactorController, {
       provider: 'CUSTOM',
       factorType: 'claims_provider',
@@ -238,7 +238,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verify: function (provider, factorType, factorIndex) {
+  verify: function(provider, factorType, factorIndex) {
     this.render(MfaVerifyController, {
       provider: provider.toUpperCase(),
       factorType: factorType,
@@ -247,18 +247,18 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  verifyNoProvider: function (factorType) {
+  verifyNoProvider: function(factorType) {
     this.render(MfaVerifyController, {
       factorType: factorType,
       Beacon: FactorBeacon,
     });
   },
 
-  enrollChoices: function () {
+  enrollChoices: function() {
     this.render(EnrollChoicesController, { Beacon: SecurityBeacon });
   },
 
-  enrollDuo: function () {
+  enrollDuo: function() {
     this.render(EnrollDuoController, {
       provider: 'DUO',
       factorType: 'web',
@@ -266,7 +266,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollQuestion: function () {
+  enrollQuestion: function() {
     this.render(EnrollQuestionController, {
       provider: 'OKTA',
       factorType: 'question',
@@ -274,7 +274,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollPassword: function () {
+  enrollPassword: function() {
     this.render(EnrollPasswordController, {
       provider: 'OKTA',
       factorType: 'password',
@@ -282,7 +282,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollSms: function () {
+  enrollSms: function() {
     this.render(EnrollCallAndSmsController, {
       provider: 'OKTA',
       factorType: 'sms',
@@ -290,7 +290,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollCall: function () {
+  enrollCall: function() {
     this.render(EnrollCallAndSmsController, {
       provider: 'OKTA',
       factorType: 'call',
@@ -298,7 +298,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollEmail: function () {
+  enrollEmail: function() {
     this.render(EnrollEmailController, {
       provider: 'OKTA',
       factorType: 'email',
@@ -306,7 +306,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollActivateEmail: function () {
+  enrollActivateEmail: function() {
     this.render(EnrollActivateEmailController, {
       provider: 'OKTA',
       factorType: 'email',
@@ -314,7 +314,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollRsa: function () {
+  enrollRsa: function() {
     this.render(EnrollOnPremController, {
       provider: 'RSA',
       factorType: 'token',
@@ -322,7 +322,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollOnPrem: function () {
+  enrollOnPrem: function() {
     this.render(EnrollOnPremController, {
       provider: 'DEL_OATH',
       factorType: 'token',
@@ -330,7 +330,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollSymantecVip: function () {
+  enrollSymantecVip: function() {
     this.render(EnrollSymantecVipController, {
       provider: 'SYMANTEC',
       factorType: 'token',
@@ -338,7 +338,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollYubikey: function () {
+  enrollYubikey: function() {
     this.render(EnrollYubikeyController, {
       provider: 'YUBICO',
       factorType: 'token:hardware',
@@ -346,7 +346,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollSAMLFactor: function () {
+  enrollSAMLFactor: function() {
     this.render(EnrollCustomFactorController, {
       provider: 'GENERIC_SAML',
       factorType: 'assertion:saml2',
@@ -354,7 +354,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollOIDCFactor: function () {
+  enrollOIDCFactor: function() {
     this.render(EnrollCustomFactorController, {
       provider: 'GENERIC_OIDC',
       factorType: 'assertion:oidc',
@@ -362,7 +362,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollClaimsFactor: function () {
+  enrollClaimsFactor: function() {
     this.render(EnrollCustomFactorController, {
       provider: 'CUSTOM',
       factorType: 'claims_provider',
@@ -370,7 +370,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollActivateClaimsFactor: function () {
+  enrollActivateClaimsFactor: function() {
     this.render(EnrollActivateCustomFactorController, {
       provider: 'CUSTOM',
       factorType: 'claims_provider',
@@ -378,7 +378,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollTotpFactor: function (provider, factorType) {
+  enrollTotpFactor: function(provider, factorType) {
     this.render(EnrollTotpController, {
       provider: provider.toUpperCase(),
       factorType: factorType,
@@ -386,7 +386,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollHotpFactor: function () {
+  enrollHotpFactor: function() {
     this.render(EnrollHotpController, {
       provider: 'CUSTOM',
       factorType: 'token:hotp',
@@ -394,7 +394,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enrollWebauthn: function () {
+  enrollWebauthn: function() {
     if (this.settings.get('features.webauthn')) {
       this.render(EnrollWebauthnController, {
         provider: 'FIDO',
@@ -410,7 +410,7 @@ export default BaseLoginRouter.extend({
     }
   },
 
-  enrollU2F: function () {
+  enrollU2F: function() {
     this.render(EnrollU2FController, {
       provider: 'FIDO',
       factorType: 'u2f',
@@ -418,7 +418,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  scanBarcodeTotpFactor: function (provider, factorType) {
+  scanBarcodeTotpFactor: function(provider, factorType) {
     this.render(BarcodeTotpController, {
       provider: provider.toUpperCase(),
       factorType: factorType,
@@ -426,7 +426,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  scanBarcodePushFactor: function () {
+  scanBarcodePushFactor: function() {
     this.render(BarcodePushController, {
       provider: 'OKTA',
       factorType: 'push',
@@ -434,7 +434,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  activateTotpFactor: function (provider, factorType) {
+  activateTotpFactor: function(provider, factorType) {
     this.render(ActivateTotpController, {
       provider: provider.toUpperCase(),
       factorType: factorType,
@@ -442,7 +442,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  manualSetupTotpFactor: function (provider, factorType) {
+  manualSetupTotpFactor: function(provider, factorType) {
     this.render(ManualSetupTotpController, {
       provider: provider.toUpperCase(),
       factorType: factorType,
@@ -450,7 +450,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  manualSetupPushFactor: function () {
+  manualSetupPushFactor: function() {
     this.render(ManualSetupPushController, {
       provider: 'OKTA',
       factorType: 'push',
@@ -458,7 +458,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  activationLinkSent: function () {
+  activationLinkSent: function() {
     this.render(EnrollmentLinkSentController, {
       provider: 'OKTA',
       factorType: 'push',
@@ -466,7 +466,7 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  enterPasscodeInPushEnrollmentFlow: function () {
+  enterPasscodeInPushEnrollmentFlow: function() {
     this.render(EnterPasscodePushFlowController, {
       provider: 'OKTA',
       factorType: 'token:software:totp',
@@ -474,81 +474,81 @@ export default BaseLoginRouter.extend({
     });
   },
 
-  passwordExpired: function () {
+  passwordExpired: function() {
     this.render(PasswordExpiredController, { Beacon: SecurityBeacon });
   },
 
-  customPasswordExpired: function () {
+  customPasswordExpired: function() {
     this.render(CustomPasswordExpiredController, { Beacon: SecurityBeacon });
   },
 
-  forgotPassword: function () {
+  forgotPassword: function() {
     this.render(ForgotPasswordController);
   },
 
-  recoveryChallenge: function () {
+  recoveryChallenge: function() {
     this.render(RecoveryChallengeController, { Beacon: SecurityBeacon });
   },
 
-  recoveryEmailSent: function () {
+  recoveryEmailSent: function() {
     this.render(PwdResetEmailSentController, { Beacon: SecurityBeacon });
   },
 
-  unlockEmailSent: function () {
+  unlockEmailSent: function() {
     this.render(UnlockEmailSentController, { Beacon: SecurityBeacon });
   },
 
-  recoveryQuestion: function () {
+  recoveryQuestion: function() {
     this.render(RecoveryQuestionController, { Beacon: SecurityBeacon });
   },
 
-  passwordReset: function () {
+  passwordReset: function() {
     this.render(PasswordResetController, { Beacon: SecurityBeacon });
   },
 
-  recoveryLoading: function (token) {
+  recoveryLoading: function(token) {
     this.render(RecoveryLoadingController, {
       token: token,
       Beacon: SecurityBeacon,
     });
   },
 
-  unlockAccount: function () {
+  unlockAccount: function() {
     this.render(UnlockAccountController);
   },
 
-  accountUnlocked: function () {
+  accountUnlocked: function() {
     this.render(AccountUnlockedController, { Beacon: SecurityBeacon });
   },
 
-  refreshAuthState: function (token) {
+  refreshAuthState: function(token) {
     this.render(RefreshAuthStateController, {
       token: token,
       Beacon: SecurityBeacon,
     });
   },
 
-  register: function () {
+  register: function() {
     this.render(RegistrationController);
   },
 
-  registerComplete: function () {
+  registerComplete: function() {
     this.render(RegistrationCompleteController);
   },
 
-  errorState: function () {
+  errorState: function() {
     this.render(ErrorStateController, { Beacon: SecurityBeacon });
   },
 
-  consentRequired: function () {
+  consentRequired: function() {
     this.render(ConsentRequiredController);
   },
 
-  adminConsentRequired: function () {
+  adminConsentRequired: function() {
     this.render(AdminConsentRequiredController);
   },
 
-  enrollUser: function () {
+  enrollUser: function() {
     this.render(EnrollUserController);
   },
 });

--- a/src/ManualSetupPushController.js
+++ b/src/ManualSetupPushController.js
@@ -21,7 +21,7 @@ import Footer from 'views/enroll-factors/ManualSetupPushFooter';
 import PhoneTextBox from 'views/enroll-factors/PhoneTextBox';
 import TextBox from 'views/shared/TextBox';
 
-function goToFactorActivation (view, step) {
+function goToFactorActivation(view, step) {
   const url = RouterUtil.createActivateFactorUrl(
     view.options.appState.get('activatedFactorProvider'),
     view.options.appState.get('activatedFactorType'),
@@ -31,7 +31,7 @@ function goToFactorActivation (view, step) {
   view.options.appState.trigger('navigate', url);
 }
 
-function setStateValues (view) {
+function setStateValues(view) {
   let userPhoneNumber;
   let userCountryCode;
 
@@ -46,11 +46,11 @@ function setStateValues (view) {
   });
 }
 
-function enrollFactor (view, factorType) {
-  return view.model.doTransaction(function (transaction) {
+function enrollFactor(view, factorType) {
+  return view.model.doTransaction(function(transaction) {
     return transaction
       .prev()
-      .then(function (trans) {
+      .then(function(trans) {
         const factor = _.findWhere(trans.factors, {
           factorType: factorType,
           provider: 'OKTA',
@@ -58,7 +58,7 @@ function enrollFactor (view, factorType) {
 
         return factor.enroll();
       })
-      .then(function (trans) {
+      .then(function(trans) {
         let textActivationLinkUrl;
         let emailActivationLinkUrl;
         let sharedSecret;
@@ -106,7 +106,7 @@ function enrollFactor (view, factorType) {
 
 export default FormController.extend({
   className: 'enroll-manual-push',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         activationType: ['string', true, this.options.appState.get('factorActivationType') || 'SMS'],
@@ -121,13 +121,13 @@ export default FormController.extend({
       derived: {
         countryCallingCode: {
           deps: ['countryCode'],
-          fn: function (countryCode) {
+          fn: function(countryCode) {
             return '+' + CountryUtil.getCallingCodeForCountry(countryCode);
           },
         },
         fullPhoneNumber: {
           deps: ['countryCallingCode', 'phoneNumber'],
-          fn: function (countryCallingCode, phoneNumber) {
+          fn: function(countryCallingCode, phoneNumber) {
             return countryCallingCode + phoneNumber;
           },
         },
@@ -136,7 +136,7 @@ export default FormController.extend({
   },
 
   Form: {
-    title: function () {
+    title: function() {
       const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
       return loc('enroll.totp.title', 'login', [factorName]);
@@ -145,7 +145,7 @@ export default FormController.extend({
     noButtonBar: true,
     attributes: { 'data-se': 'step-manual-setup' },
 
-    formChildren: function () {
+    formChildren: function() {
       const instructions = this.settings.get('brandName')
         ? loc('enroll.totp.sharedSecretInstructions.specific', 'login', [this.settings.get('brandName')])
         : loc('enroll.totp.sharedSecretInstructions.generic', 'login');
@@ -185,7 +185,7 @@ export default FormController.extend({
                 </p>\
               '
             ),
-            getTemplateData: function () {
+            getTemplateData: function() {
               return {
                 instructions: instructions,
               };
@@ -199,7 +199,7 @@ export default FormController.extend({
           type: 'text',
           disabled: true,
           showWhen: { activationType: 'MANUAL' },
-          initialize: function () {
+          initialize: function() {
             this.listenTo(this.model, 'change:sharedSecret', this.render);
           },
         }),
@@ -225,7 +225,7 @@ export default FormController.extend({
           noCancelButton: true,
           save: loc('oform.send', 'login'),
           showWhen: {
-            activationType: function (val) {
+            activationType: function(val) {
               return val === 'SMS' || val === 'EMAIL';
             },
           },
@@ -238,13 +238,13 @@ export default FormController.extend({
 
   Footer: Footer,
 
-  initialize: function () {
+  initialize: function() {
     this.setInitialModel();
     // Move this logic to a model when AuthClient supports sending email and sms
-    this.listenTo(this.form, 'save', function () {
+    this.listenTo(this.form, 'save', function() {
       const self = this;
 
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         const activationType = this.get('activationType').toLowerCase();
         const opts = {};
 
@@ -252,12 +252,12 @@ export default FormController.extend({
           opts.profile = { phoneNumber: this.get('fullPhoneNumber') };
         }
 
-        return transaction.factor.activation.send(activationType, opts).then(function (trans) {
+        return transaction.factor.activation.send(activationType, opts).then(function(trans) {
           setStateValues(self);
           // Note: Need to defer because OktaAuth calls our router success
           // handler on the next tick - if we immediately called, appState would
           // still be populated with the last response
-          _.defer(function () {
+          _.defer(function() {
             goToFactorActivation(self, 'sent');
           });
           return trans;
@@ -265,7 +265,7 @@ export default FormController.extend({
       });
     });
 
-    this.listenTo(this.model, 'change:activationType', function (model, value) {
+    this.listenTo(this.model, 'change:activationType', function(model, value) {
       this.form.clearErrors();
       if (value === 'MANUAL' && this.options.appState.get('activatedFactorType') !== 'token:software:totp') {
         enrollFactor(this, 'token:software:totp');
@@ -275,7 +275,7 @@ export default FormController.extend({
     });
   },
 
-  setInitialModel: function () {
+  setInitialModel: function() {
     if (this.options.appState.get('factorActivationType') === 'SMS') {
       this.model.set({
         countryCode: this.options.appState.get('userCountryCode') || 'US',
@@ -284,7 +284,7 @@ export default FormController.extend({
     }
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaEnrollActivate') || this.options.appState.get('isMfaEnroll')) {
       return true;
     }

--- a/src/ManualSetupTotpController.js
+++ b/src/ManualSetupTotpController.js
@@ -20,7 +20,7 @@ import ManualSetupFooter from 'views/enroll-factors/ManualSetupFooter';
 import TextBox from 'views/shared/TextBox';
 export default FormController.extend({
   className: 'enroll-manual-totp',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         sharedSecret: ['string', false, this.options.appState.get('sharedSecret')],
@@ -31,7 +31,7 @@ export default FormController.extend({
   },
 
   Form: {
-    title: function () {
+    title: function() {
       const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
       return loc('enroll.totp.title', 'login', [factorName]);
@@ -40,7 +40,7 @@ export default FormController.extend({
     noButtonBar: true,
     attributes: { 'data-se': 'step-manual-setup' },
 
-    formChildren: function () {
+    formChildren: function() {
       const instructions = this.settings.get('brandName')
         ? loc('enroll.totp.manualSetupInstructions.specific', 'login', [this.settings.get('brandName')])
         : loc('enroll.totp.manualSetupInstructions.generic', 'login');
@@ -55,7 +55,7 @@ export default FormController.extend({
                 </p>\
               '
             ),
-            getTemplateData: function () {
+            getTemplateData: function() {
               return {
                 instructions: instructions,
               };
@@ -78,8 +78,8 @@ export default FormController.extend({
 
   Footer: ManualSetupFooter,
 
-  initialize: function () {
-    this.listenTo(this.form, 'save', function () {
+  initialize: function() {
+    this.listenTo(this.form, 'save', function() {
       const url = RouterUtil.createActivateFactorUrl(
         this.model.get('__provider__'),
         this.model.get('__factorType__'),

--- a/src/MfaVerifyController.js
+++ b/src/MfaVerifyController.js
@@ -27,7 +27,7 @@ let { CheckBox } = internal.views.forms.inputs;
 export default BaseLoginController.extend({
   className: 'mfa-verify',
 
-  initialize: function (options) {
+  initialize: function(options) {
     const factorType = options.factorType;
     let View;
 
@@ -112,13 +112,13 @@ export default BaseLoginController.extend({
       }
       // Set rememberDevice on the backup factor (totp) if available
       if (this.model.get('backupFactor')) {
-        this.listenTo(this.model, 'change:rememberDevice', function (model, rememberDevice) {
+        this.listenTo(this.model, 'change:rememberDevice', function(model, rememberDevice) {
           model.get('backupFactor').set('rememberDevice', rememberDevice);
         });
       }
     }
 
-    this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', function (
+    this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', function(
       state,
       isWaitingForNumberChallenge
     ) {
@@ -136,7 +136,7 @@ export default BaseLoginController.extend({
     this.add(new FooterMFA(this.toJSON()));
   },
 
-  findModel: function (factorType, options) {
+  findModel: function(factorType, options) {
     const factors = options.appState.get('factors');
     const provider = options.provider;
     const factorIndex = options.factorIndex;
@@ -150,7 +150,7 @@ export default BaseLoginController.extend({
     }
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (
       (this.options.appState.get('isMfaRequired') && this.options.appState.get('trapMfaRequiredResponse')) ||
       this.options.appState.get('isMfaChallenge')
@@ -161,7 +161,7 @@ export default BaseLoginController.extend({
     return false;
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/PasswordExpiredController.js
+++ b/src/PasswordExpiredController.js
@@ -28,12 +28,12 @@ export default FormController.extend({
       newPassword: ['string', true],
       confirmPassword: ['string', true],
     },
-    validate: function () {
+    validate: function() {
       return ValidationUtil.validatePasswordMatch(this);
     },
-    save: function () {
+    save: function() {
       this.trigger('save');
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         return transaction.changePassword({
           oldPassword: this.get('oldPassword'),
           newPassword: this.get('newPassword'),
@@ -43,7 +43,7 @@ export default FormController.extend({
   },
   Form: {
     save: _.partial(loc, 'password.expired.submit', 'login'),
-    title: function () {
+    title: function() {
       const expiringSoon = this.options.appState.get('isPwdExpiringSoon');
       const numDays = this.options.appState.get('passwordExpireDays');
 
@@ -59,7 +59,7 @@ export default FormController.extend({
           : loc('password.expired.title.generic', 'login');
       }
     },
-    subtitle: function () {
+    subtitle: function() {
       if (this.options.appState.get('isPwdExpiringSoon')) {
         return this.settings.get('brandName')
           ? loc('password.expiring.subtitle.specific', 'login', [this.settings.get('brandName')])
@@ -74,7 +74,7 @@ export default FormController.extend({
 
       return FactorUtil.getPasswordComplexityDescription(policy);
     },
-    parseErrorMessage: function (responseJSON) {
+    parseErrorMessage: function(responseJSON) {
       const policy = this.options.appState.get('policy');
 
       if (!!policy && this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
@@ -90,7 +90,7 @@ export default FormController.extend({
       }
       return responseJSON;
     },
-    formChildren: function () {
+    formChildren: function() {
       let children = [];
 
       if (this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
@@ -142,8 +142,8 @@ export default FormController.extend({
   },
   Footer: Footer,
 
-  initialize: function () {
-    this.listenTo(this.form, 'save', function () {
+  initialize: function() {
+    this.listenTo(this.form, 'save', function() {
       const creds = {
         username: this.options.appState.get('userEmail'),
         password: this.model.get('newPassword'),

--- a/src/PasswordResetController.js
+++ b/src/PasswordResetController.js
@@ -26,14 +26,14 @@ export default FormController.extend({
       newPassword: ['string', true],
       confirmPassword: ['string', true],
     },
-    validate: function () {
+    validate: function() {
       return ValidationUtil.validatePasswordMatch(this);
     },
-    save: function () {
+    save: function() {
       this.trigger('save');
       const self = this;
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         return transaction.resetPassword({
           newPassword: self.get('newPassword'),
         });
@@ -42,12 +42,12 @@ export default FormController.extend({
   },
   Form: {
     save: _.partial(loc, 'password.reset', 'login'),
-    title: function () {
+    title: function() {
       return this.settings.get('brandName')
         ? loc('password.reset.title.specific', 'login', [this.settings.get('brandName')])
         : loc('password.reset.title.generic', 'login');
     },
-    subtitle: function () {
+    subtitle: function() {
       const policy = this.options.appState.get('policy');
 
       if (!policy || this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
@@ -56,7 +56,7 @@ export default FormController.extend({
 
       return FactorUtil.getPasswordComplexityDescription(policy);
     },
-    parseErrorMessage: function (responseJSON) {
+    parseErrorMessage: function(responseJSON) {
       const policy = this.options.appState.get('policy');
 
       if (!!policy && this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
@@ -72,7 +72,7 @@ export default FormController.extend({
       }
       return responseJSON;
     },
-    formChildren: function () {
+    formChildren: function() {
       let children = [];
 
       if (this.settings.get('features.showPasswordRequirementsAsHtmlList')) {
@@ -114,8 +114,8 @@ export default FormController.extend({
     },
   },
 
-  initialize: function () {
-    this.listenTo(this.form, 'save', function () {
+  initialize: function() {
+    this.listenTo(this.form, 'save', function() {
       const creds = {
         username: this.options.appState.get('userEmail'),
         password: this.model.get('newPassword'),

--- a/src/PollController.js
+++ b/src/PollController.js
@@ -16,7 +16,7 @@ import FormType from 'util/FormType';
 export default FormController.extend({
   className: 'poll',
   Model: {
-    save: function () {
+    save: function() {
       this.trigger('cancelRequest');
       return this.appState
         .get('transaction')
@@ -33,7 +33,7 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     hasSavingState: false,
-    title: function () {
+    title: function() {
       return this.title;
     },
     className: 'poll-controller',
@@ -49,7 +49,7 @@ export default FormController.extend({
              </div>',
       }),
     ],
-    _checkStatus: function () {
+    _checkStatus: function() {
       // start polling request
       this.transactionObject
         .poll()
@@ -67,7 +67,7 @@ export default FormController.extend({
         });
     },
 
-    _startCountDown: function (factorPollingIntervalSeconds) {
+    _startCountDown: function(factorPollingIntervalSeconds) {
       // start one second countdown for next poll request
       this.countDown = setInterval(() => {
         // update title after every second and check if countdown == 1 to poll again
@@ -91,12 +91,12 @@ export default FormController.extend({
       }, 1000);
     },
 
-    _updateTitle: function (factorPollingIntervalSeconds) {
+    _updateTitle: function(factorPollingIntervalSeconds) {
       this.title = loc('polling.title', 'login', [factorPollingIntervalSeconds]);
       this.$el.find('.okta-form-title').text(this.title);
     },
 
-    _stopCountDown: function () {
+    _stopCountDown: function() {
       // clear countdown setInterval
       if (this.countDown) {
         clearInterval(this.countDown);
@@ -107,7 +107,7 @@ export default FormController.extend({
       }
     },
 
-    initialize: function (options) {
+    initialize: function(options) {
       this.transactionObject = options.appState.get('transaction');
       this.factorPollingIntervalSeconds = Math.ceil(this.transactionObject.transaction.profile.refresh / 1000);
       this._updateTitle(this.factorPollingIntervalSeconds);
@@ -115,14 +115,14 @@ export default FormController.extend({
     },
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not
     // More details in OKTA-135060.
   },
 
-  remove: function () {
+  remove: function() {
     this.form._stopCountDown();
   },
 });

--- a/src/PrimaryAuthController.js
+++ b/src/PrimaryAuthController.js
@@ -25,7 +25,7 @@ export default BaseLoginController.extend({
 
   View: PrimaryAuthForm,
 
-  constructor: function (options) {
+  constructor: function(options) {
     options.appState.unset('username');
 
     this.model = new PrimaryAuthModel(
@@ -58,7 +58,7 @@ export default BaseLoginController.extend({
     this.setUsername();
   },
 
-  addFooter: function (options) {
+  addFooter: function(options) {
     this.add(new Footer(this.toJSON({ appState: options.appState })));
 
     if (options.settings.get('features.registration') || options.appState.get('isIdxStateToken')) {
@@ -71,7 +71,7 @@ export default BaseLoginController.extend({
     }
   },
 
-  setUsername: function () {
+  setUsername: function() {
     const username = this.model.get('username');
 
     if (username) {
@@ -80,31 +80,31 @@ export default BaseLoginController.extend({
   },
 
   events: {
-    'focusout input[name=username]': function () {
+    'focusout input[name=username]': function() {
       if (this.shouldComputeDeviceFingerprint() && this.model.get('username')) {
         const self = this;
 
         this.options.appState.trigger('loading', true);
         DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
-          .then(function (fingerprint) {
+          .then(function(fingerprint) {
             self.options.appState.set('deviceFingerprint', fingerprint);
             self.options.appState.set('username', self.model.get('username'));
           })
-          .catch(function () {
+          .catch(function() {
             // Keep going even if device fingerprint fails
             self.options.appState.set('username', self.model.get('username'));
           })
-          .finally(function () {
+          .finally(function() {
             self.options.appState.trigger('loading', false);
           });
       } else {
         this.options.appState.set('username', this.model.get('username'));
       }
     },
-    'focusin input': function (e) {
+    'focusin input': function(e) {
       $(e.target.parentElement).addClass('focused-input');
     },
-    'focusout input': function (e) {
+    'focusout input': function(e) {
       $(e.target.parentElement).removeClass('focused-input');
     },
   },
@@ -112,26 +112,26 @@ export default BaseLoginController.extend({
   // This model and the AppState both have a username property.
   // The controller updates the AppState's username when the user is
   // done editing (on blur) or deletes the username (see below).
-  initialize: function () {
+  initialize: function() {
     this.options.appState.unset('deviceFingerprint');
-    this.listenTo(this.model, 'change:username', function (model, value) {
+    this.listenTo(this.model, 'change:username', function(model, value) {
       if (!value) {
         // reset AppState to an undefined user.
         this.options.appState.set('username', '');
       }
     });
-    this.listenTo(this.model, 'save', function () {
+    this.listenTo(this.model, 'save', function() {
       this.state.set('enabled', false);
     });
-    this.listenTo(this.model, 'error', function () {
+    this.listenTo(this.model, 'error', function() {
       this.state.set('enabled', true);
     });
-    this.listenTo(this.state, 'togglePrimaryAuthButton', function (buttonState) {
+    this.listenTo(this.state, 'togglePrimaryAuthButton', function(buttonState) {
       this.toggleButtonState(buttonState);
     });
   },
 
-  shouldComputeDeviceFingerprint: function () {
+  shouldComputeDeviceFingerprint: function() {
     return (
       this.settings.get('features.securityImage') &&
       this.settings.get('features.deviceFingerprinting') &&

--- a/src/PwdResetEmailSentController.js
+++ b/src/PwdResetEmailSentController.js
@@ -17,7 +17,7 @@ import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 export default FormController.extend({
   className: 'password-reset-email-sent',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         userFullName: ['string', false, this.options.appState.get('userFullName')],
@@ -27,14 +27,14 @@ export default FormController.extend({
 
   Form: {
     title: _.partial(loc, 'password.forgot.emailSent.title', 'login'),
-    subtitle: function () {
+    subtitle: function() {
       const username = this.options.appState.get('username');
 
       return loc('password.forgot.emailSent.desc', 'login', [username]);
     },
     noButtonBar: true,
     attributes: { 'data-se': 'pwd-reset-email-sent' },
-    formChildren: function () {
+    formChildren: function() {
       let children = [
         FormType.View({
           View: View.extend({
@@ -43,7 +43,7 @@ export default FormController.extend({
               <span class="accessibility-text" role="status">{{alert}}</span>\
               '
             ),
-            getTemplateData: function () {
+            getTemplateData: function() {
               return { alert: loc('password.forgot.emailSent.title', 'login') };
             },
           }),
@@ -56,14 +56,14 @@ export default FormController.extend({
             title: loc('goback', 'login'),
             className: 'button button-primary button-wide',
             attributes: { 'data-se': 'back-button' },
-            click: function () {
+            click: function() {
               const self = this;
 
               return this.model
-                .doTransaction(function (transaction) {
+                .doTransaction(function(transaction) {
                   return transaction.cancel();
                 })
-                .then(function () {
+                .then(function() {
                   self.state.set('navigateDir', Enums.DIRECTION_BACK);
                   self.options.appState.trigger('navigate', '');
                 });
@@ -76,7 +76,7 @@ export default FormController.extend({
     },
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     this.settings.callGlobalSuccess(Enums.FORGOT_PASSWORD_EMAIL_SENT, {
       username: options.appState.get('username'),
     });

--- a/src/RecoveryChallengeController.js
+++ b/src/RecoveryChallengeController.js
@@ -26,20 +26,20 @@ export default FormController.extend({
     local: {
       ableToResend: 'boolean',
     },
-    resendCode: function () {
+    resendCode: function() {
       // Note: This does not require a trapAuthResponse because Backbone's
       // router will not navigate if the url path is the same
       this.limitResending();
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         return transaction.resend();
       });
     },
-    limitResending: function () {
+    limitResending: function() {
       this.set({ ableToResend: false });
       _.delay(_.bind(this.set, this), Enums.API_RATE_LIMIT, { ableToResend: true });
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         return transaction.verify({
           passCode: this.get('passCode'),
         });
@@ -49,7 +49,7 @@ export default FormController.extend({
   Form: {
     autoSave: true,
     save: _.partial(loc, 'mfa.challenge.verify', 'login'),
-    title: function () {
+    title: function() {
       if (this.options.appState.get('factorType') === Enums.RECOVERY_FACTOR_TYPE_CALL) {
         return loc('recoveryChallenge.call.title', 'login');
       } else {
@@ -57,22 +57,22 @@ export default FormController.extend({
       }
     },
     className: 'recovery-challenge',
-    initialize: function () {
-      this.listenTo(this.model, 'error', function () {
+    initialize: function() {
+      this.listenTo(this.model, 'error', function() {
         this.clearErrors();
       });
     },
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Button({
           title: loc('mfa.resendCode', 'login'),
           attributes: { 'data-se': 'resend-button' },
           className: 'button sms-request-button margin-top-30',
-          click: function () {
+          click: function() {
             this.model.resendCode();
           },
-          initialize: function () {
-            this.listenTo(this.model, 'change:ableToResend', function (model, ableToResend) {
+          initialize: function() {
+            this.listenTo(this.model, 'change:ableToResend', function(model, ableToResend) {
               if (ableToResend) {
                 this.options.title = loc('mfa.resendCode', 'login');
                 this.enable();
@@ -98,13 +98,13 @@ export default FormController.extend({
   },
 
   events: {
-    'click .send-email-link': function (e) {
+    'click .send-email-link': function(e) {
       e.preventDefault();
       const settings = this.model.settings;
       const username = this.options.appState.get('username');
       const recoveryType = this.options.appState.get('recoveryType');
 
-      this.model.startTransaction(function (authClient) {
+      this.model.startTransaction(function(authClient) {
         // The user could have landed here via the Forgot Password/Unlock Account flow
         switch (recoveryType) {
         case Enums.RECOVERY_TYPE_PASSWORD:
@@ -124,7 +124,7 @@ export default FormController.extend({
     },
   },
 
-  initialize: function () {
+  initialize: function() {
     const recoveryType = this.options.appState.get('recoveryType');
     let sendEmailLink;
 
@@ -158,7 +158,7 @@ export default FormController.extend({
     }
   },
 
-  postRender: function () {
+  postRender: function() {
     this.model.limitResending();
   },
 });

--- a/src/RecoveryLoadingController.js
+++ b/src/RecoveryLoadingController.js
@@ -19,26 +19,26 @@ export default FormController.extend({
     noButtonBar: true,
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     const self = this;
 
     return this.model
-      .startTransaction(function (authClient) {
+      .startTransaction(function(authClient) {
         return authClient.verifyRecoveryToken({
           recoveryToken: options.token,
         });
       })
-      .catch(function () {
+      .catch(function() {
         self.options.appState.trigger('loading', false);
         self.options.appState.trigger('removeLoading');
       });
   },
 
-  preRender: function () {
+  preRender: function() {
     this.options.appState.trigger('loading', true);
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     this.options.appState.trigger('loading', false);
     return false;
   },

--- a/src/RecoveryQuestionController.js
+++ b/src/RecoveryQuestionController.js
@@ -22,15 +22,15 @@ export default FormController.extend({
       answer: ['string', true],
       showAnswer: 'boolean',
     },
-    save: function () {
-      return this.doTransaction(function (transaction) {
+    save: function() {
+      return this.doTransaction(function(transaction) {
         return transaction.answer({ answer: this.get('answer') });
       });
     },
   },
   Form: {
     autoSave: true,
-    save: function () {
+    save: function() {
       switch (this.options.appState.get('recoveryType')) {
       case 'PASSWORD':
         return loc('password.forgot.question.submit', 'login');
@@ -40,7 +40,7 @@ export default FormController.extend({
         return loc('mfa.challenge.verify', 'login');
       }
     },
-    title: function () {
+    title: function() {
       switch (this.options.appState.get('recoveryType')) {
       case 'PASSWORD':
         return loc('password.forgot.question.title', 'login');
@@ -50,7 +50,7 @@ export default FormController.extend({
         return '';
       }
     },
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Input({
           label: this.options.appState.get('recoveryQuestion'),
@@ -58,8 +58,8 @@ export default FormController.extend({
           name: 'answer',
           input: TextBox,
           type: 'password',
-          initialize: function () {
-            this.listenTo(this.model, 'change:showAnswer', function () {
+          initialize: function() {
+            this.listenTo(this.model, 'change:showAnswer', function() {
               const type = this.model.get('showAnswer') ? 'text' : 'password';
 
               this.getInputs()[0].changeType(type);
@@ -77,7 +77,7 @@ export default FormController.extend({
       ];
     },
   },
-  initialize: function () {
+  initialize: function() {
     if (!this.settings.get('features.hideBackToSignInForReset')) {
       this.addFooter(FooterSignout, { linkText: loc('goback', 'login'), linkClassName: '' });
     }

--- a/src/RefreshAuthStateController.js
+++ b/src/RefreshAuthStateController.js
@@ -21,11 +21,11 @@ export default FormController.extend({
     noButtonBar: true,
   },
 
-  preRender: function () {
+  preRender: function() {
     const appState = this.options.appState;
     const token = this.options.token;
 
-    this.model.startTransaction(function (authClient) {
+    this.model.startTransaction(function(authClient) {
       appState.trigger('loading', true);
       if (token) {
         return authClient.tx.introspect({
@@ -43,7 +43,7 @@ export default FormController.extend({
     });
   },
 
-  remove: function () {
+  remove: function() {
     this.options.appState.trigger('loading', false);
     return FormController.prototype.remove.apply(this, arguments);
   },

--- a/src/RegistrationCompleteController.js
+++ b/src/RegistrationCompleteController.js
@@ -17,25 +17,25 @@ import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 export default FormController.extend({
   events: {
-    'click .back-btn': function (e) {
+    'click .back-btn': function(e) {
       e.preventDefault();
       this.back();
     },
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     this.options.appState.trigger('navigate', '');
   },
   className: 'registration-complete',
-  Model: function () {},
-  initialize: function () {
+  Model: function() {},
+  initialize: function() {
     this.settings.callGlobalSuccess(Enums.ACTIVATION_EMAIL_SENT, {
       username: this.options.appState.get('username'),
     });
   },
   Form: {
     noButtonBar: true,
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.View({
           View: View.extend({
@@ -51,7 +51,7 @@ export default FormController.extend({
               </a>\
               '
             ),
-            getTemplateData: function () {
+            getTemplateData: function() {
               return {
                 desc: loc('registration.complete.confirm.text', 'login'),
                 title: loc('registration.complete.title', 'login'),

--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -30,19 +30,19 @@ const RegistrationControllerFooter = View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .help': function (e) {
+    'click .help': function(e) {
       e.preventDefault();
       this.back();
     },
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     this.options.appState.trigger('navigate', '');
   },
 });
 export default BaseLoginController.extend({
   className: 'registration',
-  initialize: function () {
+  initialize: function() {
     const RegistrationControllerSchema = RegistrationSchema.extend({
       settings: this.options.settings,
       url: this.options.settings.get('baseUrl') + '/api/v1/registration/form',
@@ -53,7 +53,7 @@ export default BaseLoginController.extend({
 
     this.state.set('schema', schema);
   },
-  getRegistrationApiUrl: function () {
+  getRegistrationApiUrl: function() {
     const defaultPolicyId = this.settings.get('defaultPolicyId');
     // default policyId
 
@@ -66,10 +66,10 @@ export default BaseLoginController.extend({
 
     return apiUrl;
   },
-  getRegistrationPolicyApi: function (policyId) {
+  getRegistrationPolicyApi: function(policyId) {
     return this.options.settings.get('baseUrl') + '/api/v1/registration/' + policyId;
   },
-  doPostSubmit: function () {
+  doPostSubmit: function() {
     if (this.model.get('activationToken')) {
       const self = this;
       // register via activation token
@@ -82,7 +82,7 @@ export default BaseLoginController.extend({
         settings: self.model.appState.settings,
       });
 
-      loginModel.loginWithActivationToken(this.model.get('activationToken')).then(function (transaction) {
+      loginModel.loginWithActivationToken(this.model.get('activationToken')).then(function(transaction) {
         self.model.trigger('setTransaction', transaction);
       });
     } else {
@@ -91,28 +91,28 @@ export default BaseLoginController.extend({
       this.model.appState.trigger('navigate', 'signin/register-complete');
     }
   },
-  registerUser: function (postData) {
+  registerUser: function(postData) {
     const self = this;
 
     this.model.attributes = postData;
     // Model.save returns a jqXHR
     Backbone.Model.prototype.save
       .call(this.model)
-      .then(function () {
+      .then(function() {
         const activationToken = self.model.get('activationToken');
         const postSubmitData = activationToken ? activationToken : self.model.get('email');
 
         self.settings.postRegistrationSubmit(
           postSubmitData,
-          function () {
+          function() {
             self.doPostSubmit();
           },
-          function (errors) {
+          function(errors) {
             self.showErrors(errors);
           }
         );
       })
-      .fail(function (err) {
+      .fail(function(err) {
         const responseJSON = err.responseJSON;
 
         if (responseJSON && responseJSON.errorCauses.length) {
@@ -122,7 +122,7 @@ export default BaseLoginController.extend({
         }
       });
   },
-  createRegistrationModel: function (modelProperties) {
+  createRegistrationModel: function(modelProperties) {
     const self = this;
     const RegistrationControllerModel = Model.extend({
       url: self.getRegistrationApiUrl() + '/register',
@@ -132,7 +132,7 @@ export default BaseLoginController.extend({
       local: {
         activationToken: 'string',
       },
-      toJSON: function () {
+      toJSON: function() {
         const data = Model.prototype.toJSON.apply(this, arguments);
 
         return {
@@ -140,18 +140,18 @@ export default BaseLoginController.extend({
           relayState: this.settings.get('relayState'),
         };
       },
-      parse: function (resp) {
+      parse: function(resp) {
         this.set('activationToken', resp.activationToken);
         delete resp.activationToken;
         return resp;
       },
-      save: function () {
+      save: function() {
         this.settings.preRegistrationSubmit(
           this.attributes,
-          function (postData) {
+          function(postData) {
             self.registerUser(postData);
           },
-          function (errors) {
+          function(errors) {
             self.showErrors(errors);
           }
         );
@@ -160,7 +160,7 @@ export default BaseLoginController.extend({
 
     return new RegistrationControllerModel();
   },
-  showErrors: function (error, hideRegisterButton) {
+  showErrors: function(error, hideRegisterButton) {
     //for parseSchema error hide form and show error at form level
     if (error.callback === 'parseRegistrationSchema' && error.errorCauses) {
       error.errorSummary = _.clone(error.errorCauses[0].errorSummary);
@@ -180,11 +180,11 @@ export default BaseLoginController.extend({
       this.$el.find('.button-primary').hide();
     }
   },
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     const self = this;
 
     // register parse complete event listener
-    self.state.get('schema').on('parseComplete', function (updatedSchema) {
+    self.state.get('schema').on('parseComplete', function(updatedSchema) {
       const modelProperties = updatedSchema.properties.createModelProperties();
 
       self.settings.set('defaultPolicyId', updatedSchema.properties.defaultPolicyId);
@@ -199,7 +199,7 @@ export default BaseLoginController.extend({
         title: loc('registration.form.title', 'login'),
         save: loc('registration.form.submit', 'login'),
         modelEvents : { 'invalid' : 'modifyErrors' },
-        modifyErrors: function (model, errorResp) {
+        modifyErrors: function(model, errorResp) {
           // overwrite courage errorResp object to show custom error message
           for (let formFieldName in errorResp) {
             if (errorResp[formFieldName] === 'model.validation.field.string.minLength') {
@@ -213,7 +213,7 @@ export default BaseLoginController.extend({
             }
           }
         },
-        parseErrorMessage: function (resp) {
+        parseErrorMessage: function(resp) {
           const hasErrorCauses = resp.errorCauses && resp.errorCauses.length;
 
           if (hasErrorCauses) {
@@ -239,7 +239,7 @@ export default BaseLoginController.extend({
         self.showErrors(updatedSchema.error, true);
       } else {
         // add fields
-        updatedSchema.properties.each(function (schemaProperty) {
+        updatedSchema.properties.each(function(schemaProperty) {
           const inputOptions = RegistrationFormFactory.createInputOptions(schemaProperty);
           const subSchemas = schemaProperty.get('subSchemas');
           const name = schemaProperty.get('name');

--- a/src/UnlockAccountController.js
+++ b/src/UnlockAccountController.js
@@ -42,20 +42,20 @@ const UnlockAccountControllerFooter = View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
-    'click .js-contact-support': function (e) {
+    'click .js-contact-support': function(e) {
       e.preventDefault();
       this.state.trigger('contactSupport');
       this.$('.js-contact-support').hide();
     },
   },
-  getTemplateData: function () {
+  getTemplateData: function() {
     return this.settings.pick('helpSupportNumber');
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     this.options.appState.trigger('navigate', '');
   },
@@ -67,18 +67,18 @@ export default FormController.extend({
       username: ['string', true],
       factorType: ['string', true],
     },
-    validate: function () {
+    validate: function() {
       return ValidationUtil.validateUsername(this);
     },
-    save: function () {
+    save: function() {
       const self = this;
 
-      return this.startTransaction(function (authClient) {
+      return this.startTransaction(function(authClient) {
         return authClient.unlockAccount({
           username: self.settings.transformUsername(self.get('username'), Enums.UNLOCK_ACCOUNT),
           factorType: self.get('factorType'),
         });
-      }).catch(function () {
+      }).catch(function() {
         //need empty fail handler on model to display errors on form
       });
     },
@@ -86,7 +86,7 @@ export default FormController.extend({
   Form: {
     noButtonBar: true,
     title: _.partial(loc, 'account.unlock.title', 'login'),
-    formChildren: function () {
+    formChildren: function() {
       const smsEnabled = this.settings.get('features.smsRecovery');
       /*eslint complexity: [2, 9] max-statements: [2, 24] */
 
@@ -127,7 +127,7 @@ export default FormController.extend({
                     {{i18n code="recovery.mobile.hint" bundle="login" arguments="mobileFactors"}}\
                   </p>'
                 ),
-                getTemplateData: function () {
+                getTemplateData: function() {
                   let mobileFactors;
 
                   if (smsEnabled && callEnabled) {
@@ -184,27 +184,27 @@ export default FormController.extend({
 
       return formChildren;
     },
-    initialize: function () {
-      this.listenTo(this, 'save', function () {
+    initialize: function() {
+      this.listenTo(this, 'save', function() {
         this.options.appState.set('username', this.model.get('username'));
         this.model.save();
       });
 
-      this.listenTo(this.state, 'contactSupport', function () {
+      this.listenTo(this.state, 'contactSupport', function() {
         this.add(ContactSupport, '.o-form-error-container');
       });
     },
-    setDefaultFactorType: function (factorType) {
+    setDefaultFactorType: function(factorType) {
       if (_.isEmpty(this.model.get('factorType'))) {
         this.model.set('factorType', factorType);
       }
     },
-    createRecoveryFactorButton: function (className, labelCode, factorType, form) {
+    createRecoveryFactorButton: function(className, labelCode, factorType, form) {
       return FormType.Button({
         attributes: { 'data-se': className },
         className: 'button button-primary button-wide ' + className,
         title: loc(labelCode, 'login'),
-        click: function () {
+        click: function() {
           form.clearErrors();
           if (this.model.isValid()) {
             this.model.set('factorType', factorType);

--- a/src/UnlockEmailSentController.js
+++ b/src/UnlockEmailSentController.js
@@ -16,7 +16,7 @@ import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 export default FormController.extend({
   className: 'account-unlock-email-sent',
-  Model: function () {
+  Model: function() {
     return {
       local: {
         userFullName: ['string', false, this.options.appState.get('userFullName')],
@@ -26,20 +26,20 @@ export default FormController.extend({
 
   Form: {
     title: _.partial(loc, 'account.unlock.emailSent.title', 'login'),
-    subtitle: function () {
+    subtitle: function() {
       const username = this.options.appState.get('username');
 
       return loc('account.unlock.emailSent.desc', 'login', [username]);
     },
     noButtonBar: true,
     attributes: { 'data-se': 'unlock-email-sent' },
-    formChildren: function () {
+    formChildren: function() {
       return [
         FormType.Button({
           title: loc('goback', 'login'),
           className: 'button button-primary button-wide',
           attributes: { 'data-se': 'back-button' },
-          click: function () {
+          click: function() {
             this.state.set('navigateDir', Enums.DIRECTION_BACK);
             this.options.appState.trigger('navigate', '');
           },
@@ -48,7 +48,7 @@ export default FormController.extend({
     },
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     this.settings.callGlobalSuccess(Enums.UNLOCK_ACCOUNT_EMAIL_SENT, {
       username: options.appState.get('username'),
     });

--- a/src/VerifyCustomFactorController.js
+++ b/src/VerifyCustomFactorController.js
@@ -25,7 +25,7 @@ export default FormController.extend({
       rememberDevice: 'boolean',
     },
 
-    initialize: function () {
+    initialize: function() {
       const rememberDevice = FactorUtil.getRememberDeviceValue(this.appState);
 
       // set the initial value for remember device (Cannot do this while defining the
@@ -33,7 +33,7 @@ export default FormController.extend({
       this.set('rememberDevice', rememberDevice);
     },
 
-    save: function () {
+    save: function() {
       const rememberDevice = !!this.get('rememberDevice');
 
       return this.manageTransaction((transaction, setTransaction) => {
@@ -56,14 +56,14 @@ export default FormController.extend({
               Util.redirect(url);
             }
           })
-          .catch(function (err) {
+          .catch(function(err) {
             throw err;
           });
       });
     },
   },
 
-  Form: function () {
+  Form: function() {
     const factors = this.options.appState.get('factors');
     const factor = factors.findWhere({
       provider: this.options.provider,
@@ -79,7 +79,7 @@ export default FormController.extend({
       save: saveText,
       subtitle: subtitle,
       attributes: { 'data-se': 'factor-custom' },
-      initialize: function () {
+      initialize: function() {
         if (this.options.appState.get('allowRememberDevice')) {
           this.addInput({
             label: false,
@@ -91,7 +91,7 @@ export default FormController.extend({
           });
         }
       },
-      formChildren: function () {
+      formChildren: function() {
         const result = [];
         const lastFailedChallengeFactorData = this.options.appState.get('lastFailedChallengeFactorData');
 
@@ -108,20 +108,20 @@ export default FormController.extend({
     };
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaChallenge')) {
       return true;
     }
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not
     // More details in OKTA-135060.
   },
 
-  initialize: function () {
+  initialize: function() {
     this.model.set('provider', this.options.provider);
     this.model.set('factorType', this.options.factorType);
     this.addFooter(FooterMFA);

--- a/src/VerifyDuoController.js
+++ b/src/VerifyDuoController.js
@@ -31,7 +31,7 @@ export default FormController.extend({
       rememberDevice: 'boolean',
     },
 
-    initialize: function () {
+    initialize: function() {
       const rememberDevice = FactorUtil.getRememberDeviceValue(this.appState);
 
       // set the initial value for remember device (Cannot do this while defining the
@@ -39,10 +39,10 @@ export default FormController.extend({
       this.set('rememberDevice', rememberDevice);
     },
 
-    getInitOptions: function () {
+    getInitOptions: function() {
       const rememberDevice = !!this.get('rememberDevice');
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const data = {
           rememberDevice: rememberDevice,
         };
@@ -52,14 +52,14 @@ export default FormController.extend({
           factorType: 'web',
         });
 
-        return factor.verify(data).catch(function (err) {
+        return factor.verify(data).catch(function(err) {
           // Clean up the cookie on failure.
           throw err;
         });
       }, true /* rethrow errors */);
     },
 
-    verify: function (signedResponse) {
+    verify: function(signedResponse) {
       const url = this.get('postAction');
       const factorId = this.get('factorId');
       const self = this;
@@ -79,8 +79,8 @@ export default FormController.extend({
       // NOTE - If we ever decide to change this, we should test this very carefully.
 
       return Q($.post(url, data))
-        .then(function () {
-          return self.doTransaction(function (transaction) {
+        .then(function() {
+          return self.doTransaction(function(transaction) {
             let data;
 
             if (rememberDevice) {
@@ -89,7 +89,7 @@ export default FormController.extend({
             return transaction.poll(data);
           });
         })
-        .catch(function (err) {
+        .catch(function(err) {
           self.trigger('error', self, err.xhr);
         });
     },
@@ -101,7 +101,7 @@ export default FormController.extend({
     title: _.partial(loc, 'factor.duo'),
     attributes: { 'data-se': 'factor-duo' },
 
-    postRender: function () {
+    postRender: function() {
       this.add('<iframe frameborder="0" title="' + this.title() + '"></iframe>');
       if (this.options.appState.get('allowRememberDevice')) {
         this.addInput({
@@ -122,10 +122,10 @@ export default FormController.extend({
     },
   },
 
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     const self = this;
 
-    return this.model.getInitOptions().then(function (trans) {
+    return this.model.getInitOptions().then(function(trans) {
       const res = trans.data;
 
       if (
@@ -148,13 +148,13 @@ export default FormController.extend({
     });
   },
 
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     if (this.options.appState.get('isMfaChallenge')) {
       return true;
     }
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/VerifyPIVController.js
+++ b/src/VerifyPIVController.js
@@ -20,7 +20,7 @@ let { Util } = internal.util;
 export default FormController.extend({
   className: 'piv-cac-card',
   Model: {
-    save: async function () {
+    save: async function() {
       this.trigger('request');
       const self = this;
       const pivConfig = this.settings.get('piv');
@@ -43,13 +43,13 @@ export default FormController.extend({
       }
     },
 
-    getCert: function (certAuthUrl) {
+    getCert: function(certAuthUrl) {
       return $.get({
         url: certAuthUrl,
         xhrFields: {
           withCredentials: true,
         },
-        beforeSend: function () {
+        beforeSend: function() {
           // overriding this function to prevent our jquery-wrapper from
           // setting headers. Need to keep this a simple request in order for
           // PIV / CAC to work in IE.
@@ -57,7 +57,7 @@ export default FormController.extend({
       });
     },
 
-    postCert: function (certAuthUrl, data) {
+    postCert: function(certAuthUrl, data) {
       return $.post({
         url: certAuthUrl,
         xhrFields: {
@@ -65,7 +65,7 @@ export default FormController.extend({
         },
         data: JSON.stringify(data),
         contentType: 'text/plain',
-        beforeSend: function () {
+        beforeSend: function() {
           // overriding this function to prevent our jquery-wrapper from
           // setting headers. Need to keep this a simple request in order for
           // PIV / CAC to work in IE.
@@ -99,24 +99,24 @@ export default FormController.extend({
       }),
     ],
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
     },
 
-    _stopEnrollment: function () {
+    _stopEnrollment: function() {
       this.$('.okta-waiting-spinner').hide();
       this.$('.o-form-button-bar').show();
     },
 
-    postRender: function () {
+    postRender: function() {
       _.defer(() => {
         this.model.save();
       });
     },
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/VerifyU2FController.js
+++ b/src/VerifyU2FController.js
@@ -23,10 +23,10 @@ import FormType from 'util/FormType';
 import HtmlErrorMessageView from 'views/mfa-verify/HtmlErrorMessageView';
 import FooterMFA from 'views/shared/FooterMFA';
 
-function getRegisteredKeysSequence (factors) {
+function getRegisteredKeysSequence(factors) {
   const keys = [];
 
-  _.each(factors, function (factor) {
+  _.each(factors, function(factor) {
     keys.push({
       version: factor.profile.version,
       keyHandle: factor.profile.credentialId,
@@ -42,7 +42,7 @@ export default FormController.extend({
       rememberDevice: 'boolean',
     },
 
-    initialize: function () {
+    initialize: function() {
       const rememberDevice = FactorUtil.getRememberDeviceValue(this.appState);
 
       // set the initial value for remember device (Cannot do this while defining the
@@ -50,10 +50,10 @@ export default FormController.extend({
       this.set('rememberDevice', rememberDevice);
     },
 
-    save: function () {
+    save: function() {
       this.trigger('request');
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         let factor;
 
         if (transaction.factorTypes) {
@@ -68,7 +68,7 @@ export default FormController.extend({
         }
         const self = this;
 
-        return factor.verify().then(function (transaction) {
+        return factor.verify().then(function(transaction) {
           let registeredKeys;
           let appId;
           let nonce;
@@ -90,7 +90,7 @@ export default FormController.extend({
 
           const deferred = Q.defer();
 
-          u2f.sign(appId, nonce, registeredKeys, function (data) {
+          u2f.sign(appId, nonce, registeredKeys, function(data) {
             self.trigger('errors:clear');
             if (data.errorCode && data.errorCode !== 0) {
               const isOneFactor = self.options.appState.get('factors').length === 1;
@@ -129,7 +129,7 @@ export default FormController.extend({
     className: 'verify-u2f-form',
     noCancelButton: true,
     save: _.partial(loc, 'verify.u2f.retry', 'login'),
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !FidoUtil.isU2fAvailable();
     },
     modelEvents: {
@@ -137,7 +137,7 @@ export default FormController.extend({
       error: '_stopEnrollment',
     },
 
-    formChildren: function () {
+    formChildren: function() {
       const result = [];
 
       if (!FidoUtil.isU2fAvailable()) {
@@ -185,7 +185,7 @@ export default FormController.extend({
       return result;
     },
 
-    postRender: function () {
+    postRender: function() {
       _.defer(() => {
         if (FidoUtil.isU2fAvailable()) {
           this.model.save();
@@ -195,18 +195,18 @@ export default FormController.extend({
       });
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.$('.okta-waiting-spinner').removeClass('hide');
       this.$('.o-form-button-bar').hide();
     },
 
-    _stopEnrollment: function () {
+    _stopEnrollment: function() {
       this.$('.okta-waiting-spinner').addClass('hide');
       this.$('.o-form-button-bar').show();
     },
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/VerifyWebauthnController.js
+++ b/src/VerifyWebauthnController.js
@@ -24,10 +24,10 @@ import BrowserFeatures from 'util/BrowserFeatures';
 import HtmlErrorMessageView from 'views/mfa-verify/HtmlErrorMessageView';
 import FooterMFA from 'views/shared/FooterMFA';
 
-function getAllowCredentials (factors) {
+function getAllowCredentials(factors) {
   const allowCredentials = [];
 
-  _.each(factors, function (factor) {
+  _.each(factors, function(factor) {
     allowCredentials.push({
       type: 'public-key',
       id: CryptoUtil.strToBin(factor.profile.credentialId),
@@ -43,7 +43,7 @@ export default FormController.extend({
       rememberDevice: 'boolean',
     },
 
-    initialize: function () {
+    initialize: function() {
       const rememberDevice = FactorUtil.getRememberDeviceValue(this.appState);
 
       // set the initial value for remember device (Cannot do this while defining the
@@ -57,10 +57,10 @@ export default FormController.extend({
       });
     },
 
-    save: function () {
+    save: function() {
       this.trigger('request');
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         let factor;
 
         if (transaction.factorTypes) {
@@ -76,7 +76,7 @@ export default FormController.extend({
 
         const self = this;
 
-        return factor.verify().then(function (transaction) {
+        return factor.verify().then(function(transaction) {
           let allowCredentials;
           let challenge;
 
@@ -106,7 +106,7 @@ export default FormController.extend({
               signal: self.webauthnAbortController.signal,
             })
           )
-            .then(function (assertion) {
+            .then(function(assertion) {
               const rememberDevice = !!self.get('rememberDevice');
 
               return factor.verify({
@@ -116,7 +116,7 @@ export default FormController.extend({
                 rememberDevice: rememberDevice,
               });
             })
-            .catch(function (error) {
+            .catch(function(error) {
               self.trigger('errors:clear');
               // Do not display if it is abort error triggered by code when switching.
               // self.webauthnAbortController would be null if abort was triggered by code.
@@ -128,7 +128,7 @@ export default FormController.extend({
                 });
               }
             })
-            .finally(function () {
+            .finally(function() {
               // unset webauthnAbortController on successful authentication or error
               self.webauthnAbortController = null;
             });
@@ -144,7 +144,7 @@ export default FormController.extend({
     className: 'verify-webauthn-form',
     noCancelButton: true,
     save: _.partial(loc, 'mfa.challenge.verify', 'login'),
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !webauthn.isNewApiAvailable();
     },
     modelEvents: {
@@ -152,7 +152,7 @@ export default FormController.extend({
       error: '_stopEnrollment',
     },
 
-    formChildren: function () {
+    formChildren: function() {
       const children = [];
 
       if (webauthn.isNewApiAvailable()) {
@@ -198,19 +198,19 @@ export default FormController.extend({
       return children;
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.$('.okta-waiting-spinner').show();
       this.$('.o-form-button-bar').hide();
     },
 
-    _stopEnrollment: function () {
+    _stopEnrollment: function() {
       this.$('.okta-waiting-spinner').hide();
       this.$('.o-form-button-bar [type="submit"]')[0].value = loc('verify.u2f.retry', 'login');
       this.$('.o-form-button-bar').show();
     },
   },
 
-  postRender: function () {
+  postRender: function() {
     _.defer(() => {
       // Trigger browser prompt automatically for other browsers for better UX.
       if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {
@@ -219,7 +219,7 @@ export default FormController.extend({
     });
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/VerifyWindowsHelloController.js
+++ b/src/VerifyWindowsHelloController.js
@@ -24,7 +24,7 @@ export default FormController.extend({
       __autoTriggered__: 'boolean',
     },
 
-    save: function () {
+    save: function() {
       if (!webauthn.isAvailable()) {
         return;
       }
@@ -32,30 +32,30 @@ export default FormController.extend({
       this.trigger('request');
       const model = this;
 
-      return this.doTransaction(function (transaction) {
+      return this.doTransaction(function(transaction) {
         const factor = _.findWhere(transaction.factors, {
           factorType: 'webauthn',
           provider: 'FIDO',
         });
 
-        return factor.verify().then(function (verifyData) {
+        return factor.verify().then(function(verifyData) {
           const factorData = verifyData.factor;
 
           return webauthn
             .getAssertion(factorData.challenge.nonce, [{ id: factorData.profile.credentialId }])
-            .then(function (assertion) {
+            .then(function(assertion) {
               return factor.verify({
                 authenticatorData: assertion.authenticatorData,
                 clientData: assertion.clientData,
                 signatureData: assertion.signature,
               });
             })
-            .then(function (data) {
+            .then(function(data) {
               model.trigger('sync');
               model.trigger('signIn');
               return data;
             })
-            .catch(function (error) {
+            .catch(function(error) {
               switch (error.message) {
               case 'AbortError':
               case 'NotFoundError':
@@ -75,7 +75,7 @@ export default FormController.extend({
     autoSave: true,
     hasSavingState: false,
     title: _.partial(loc, 'factor.windowsHello', 'login'),
-    subtitle: function () {
+    subtitle: function() {
       return webauthn.isAvailable() ? loc('verify.windowsHello.subtitle', 'login') : '';
     },
     save: _.partial(loc, 'verify.windowsHello.save', 'login'),
@@ -84,7 +84,7 @@ export default FormController.extend({
       stop: 'abort',
     },
 
-    modelEvents: function () {
+    modelEvents: function() {
       if (!webauthn.isAvailable()) {
         return {};
       }
@@ -97,11 +97,11 @@ export default FormController.extend({
       };
     },
 
-    noButtonBar: function () {
+    noButtonBar: function() {
       return !webauthn.isAvailable();
     },
 
-    formChildren: function () {
+    formChildren: function() {
       const result = [];
 
       if (!webauthn.isAvailable()) {
@@ -118,14 +118,14 @@ export default FormController.extend({
       return result;
     },
 
-    postRender: function () {
+    postRender: function() {
       if (this.options.appState.get('factors').length === 1 && !this.model.get('__autoTriggered__')) {
         this.model.set('__autoTriggered__', true);
         this.model.save();
       }
     },
 
-    _startEnrollment: function () {
+    _startEnrollment: function() {
       this.subtitle = loc('verify.windowsHello.subtitle.loading', 'login');
 
       this.model.trigger('spinner:show');
@@ -135,7 +135,7 @@ export default FormController.extend({
       this.$('.o-form-button-bar').addClass('hide');
     },
 
-    _stopEnrollment: function (errorMessage) {
+    _stopEnrollment: function(errorMessage) {
       this.subtitle = loc('verify.windowsHello.subtitle', 'login');
 
       this.model.trigger('spinner:hide');
@@ -170,7 +170,7 @@ export default FormController.extend({
       this.render();
     },
 
-    _successEnrollment: function () {
+    _successEnrollment: function() {
       this.subtitle = this.settings.get('brandName')
         ? loc('verify.windowsHello.subtitle.signingIn.specific', 'login', [this.settings.get('brandName')])
         : loc('verify.windowsHello.subtitle.signingIn.generic', 'login');
@@ -178,14 +178,14 @@ export default FormController.extend({
       this.$('.o-form-button-bar').addClass('hide');
     },
 
-    _resetErrorMessage: function () {
+    _resetErrorMessage: function() {
       this._errorMessageView && this._errorMessageView.remove();
       this._errorMessageView = undefined;
       this.clearErrors();
     },
   },
 
-  back: function () {
+  back: function() {
     // Empty function on verify controllers to prevent users
     // from navigating back during 'verify' using the browser's
     // back button. The URL will still change, but the view will not

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -31,7 +31,7 @@ const UNDEFINED_USER_IMAGE_DESCRIPTION = '';
 const UNKNOWN_IMAGE_DESCRIPTION = '';
 const securityImageUrlTpl = hbs('{{baseUrl}}/login/getimage?username={{username}}');
 
-function getSecurityImage (baseUrl, username, deviceFingerprint) {
+function getSecurityImage(baseUrl, username, deviceFingerprint) {
   // When the username is empty, we want to show the default image.
   if (_.isEmpty(username) || _.isUndefined(username)) {
     return Q({
@@ -51,7 +51,7 @@ function getSecurityImage (baseUrl, username, deviceFingerprint) {
   if (deviceFingerprint) {
     data['headers'] = { 'X-Device-Fingerprint': deviceFingerprint };
   }
-  return Q($.ajax(data)).then(function (res) {
+  return Q($.ajax(data)).then(function(res) {
     if (res.pwdImg === USER_NOT_SEEN_ON_DEVICE) {
       // When we get an unknown.png security image from OKTA,
       // we want to show the unknown-device security image.
@@ -69,7 +69,7 @@ function getSecurityImage (baseUrl, username, deviceFingerprint) {
   });
 }
 
-function getMinutesString (factorLifetimeInMinutes) {
+function getMinutesString(factorLifetimeInMinutes) {
   if (factorLifetimeInMinutes > 60 && factorLifetimeInMinutes <= 1440) {
     const lifetimeInHours = factorLifetimeInMinutes / 60;
 
@@ -86,18 +86,18 @@ function getMinutesString (factorLifetimeInMinutes) {
   return loc('minutes', 'login', [factorLifetimeInMinutes]);
 }
 
-function getGracePeriodRemainingDays (gracePeriodEndDate) {
+function getGracePeriodRemainingDays(gracePeriodEndDate) {
   const endDate = new Date(gracePeriodEndDate).getTime();
   const remainingDays = Math.floor((endDate - new Date().getTime()) / (1000 * 3600 * 24));
 
   return remainingDays;
 }
 
-function combineFactorsObjects (factorTypes, factors) {
+function combineFactorsObjects(factorTypes, factors) {
   const addedFactorTypes = [];
   const combinedFactors = [];
 
-  _.each(factors, function (factor) {
+  _.each(factors, function(factor) {
     const factorType = factor.factorType;
 
     if (!_.contains(addedFactorTypes, factorType)) {
@@ -115,20 +115,20 @@ function combineFactorsObjects (factorTypes, factors) {
 }
 
 export default Model.extend({
-  initialize: function () {
+  initialize: function() {
     // Handle this in initialize (as opposed to a derived property) because
     // the operation is asynchronous
     if (this.settings.get('features.securityImage')) {
       const self = this;
 
-      this.listenTo(this, 'change:username', function (model, username) {
+      this.listenTo(this, 'change:username', function(model, username) {
         getSecurityImage(this.get('baseUrl'), username, this.get('deviceFingerprint'))
-          .then(function (image) {
+          .then(function(image) {
             model.set('securityImage', image.securityImage);
             model.set('securityImageDescription', image.securityImageDescription);
             model.unset('deviceFingerprint'); //Fingerprint can only be used once
           })
-          .fail(function (jqXhr) {
+          .fail(function(jqXhr) {
             // Only notify the consumer on a CORS error
             if (BrowserFeatures.corsIsNotEnabled(jqXhr)) {
               self.settings.callGlobalError(new Errors.UnsupportedBrowserError(loc('error.enabled.cors')));
@@ -171,7 +171,7 @@ export default Model.extend({
     lastFailedChallengeFactorData: ['object', false],
   },
 
-  setAuthResponse: function (res) {
+  setAuthResponse: function(res) {
     // Because of MFA_CHALLENGE (i.e. DUO), we need to remember factors
     // across auth responses. Not doing this, for example, results in being
     // unable to switch away from the duo factor dropdown.
@@ -198,55 +198,55 @@ export default Model.extend({
     this.set('lastAuthResponse', res);
   },
 
-  clearLastAuthResponse: function () {
+  clearLastAuthResponse: function() {
     this.set('lastAuthResponse', {});
   },
 
-  setLastFailedChallengeFactorData: function () {
+  setLastFailedChallengeFactorData: function() {
     this.set('lastFailedChallengeFactorData', {
       factor: this.get('factor'),
       errorMessage: this.get('factorResultErrorMessage'),
     });
   },
 
-  clearLastFailedChallengeFactorData: function () {
+  clearLastFailedChallengeFactorData: function() {
     this.unset('lastFailedChallengeFactorData');
   },
 
   derived: {
     isSuccessResponse: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'SUCCESS';
       },
     },
     isMfaRequired: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'MFA_REQUIRED' || res.status === 'FACTOR_REQUIRED';
       },
     },
     isProfileRequired: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'PROFILE_REQUIRED';
       },
     },
     isMfaEnroll: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'MFA_ENROLL' || res.status === 'FACTOR_ENROLL';
       },
     },
     isMfaChallenge: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'MFA_CHALLENGE' || res.status === 'FACTOR_CHALLENGE';
       },
     },
     isUnauthenticated: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'UNAUTHENTICATED';
       },
     },
@@ -256,31 +256,31 @@ export default Model.extend({
       // user clicks 'deny' on his phone or OV app
       // version is below a required version no.
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.factorResult === 'REJECTED';
       },
     },
     isMfaTimeout: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.factorResult === 'TIMEOUT';
       },
     },
     isMfaEnrollActivate: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'MFA_ENROLL_ACTIVATE' || res.status === 'FACTOR_ENROLL_ACTIVATE';
       },
     },
     isWaitingForActivation: {
       deps: ['isMfaEnrollActivate', 'lastAuthResponse'],
-      fn: function (isMfaEnrollActivate, res) {
+      fn: function(isMfaEnrollActivate, res) {
         return isMfaEnrollActivate && res.factorResult === 'WAITING';
       },
     },
     isWaitingForNumberChallenge: {
       deps: ['lastAuthResponse', 'isMfaChallenge'],
-      fn: function (res, isMfaChallenge) {
+      fn: function(res, isMfaChallenge) {
         if (
           isMfaChallenge &&
           res &&
@@ -297,7 +297,7 @@ export default Model.extend({
     },
     hasMultipleFactorsAvailable: {
       deps: ['factors', 'isMfaRequired', 'isMfaChallenge', 'isUnauthenticated'],
-      fn: function (factors, isMfaRequired, isMfaChallenge, isUnauthenticated) {
+      fn: function(factors, isMfaRequired, isMfaChallenge, isUnauthenticated) {
         if (!isMfaRequired && !isMfaChallenge && !isUnauthenticated) {
           return false;
         }
@@ -306,7 +306,7 @@ export default Model.extend({
     },
     promptForFactorInUnauthenticated: {
       deps: ['lastAuthResponse', 'factors'],
-      fn: function (res, factors) {
+      fn: function(res, factors) {
         if (res.status !== 'UNAUTHENTICATED') {
           return false;
         }
@@ -315,7 +315,7 @@ export default Model.extend({
     },
     userId: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.user) {
           return null;
         }
@@ -324,19 +324,19 @@ export default Model.extend({
     },
     isIdxStateToken: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res && _.isString(res.stateToken) && res.stateToken.startsWith('01');
       },
     },
     isPwdExpiringSoon: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.status === 'PASSWORD_WARN';
       },
     },
     passwordExpireDays: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.policy || !res._embedded.policy.expiration) {
           return null;
         }
@@ -345,7 +345,7 @@ export default Model.extend({
     },
     isPwdManagedByOkta: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._links || !res._links.next || !res._links.next.title) {
           return true;
         }
@@ -354,7 +354,7 @@ export default Model.extend({
     },
     passwordExpiredWebsiteName: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._links || !res._links.next || !res._links.next.title) {
           return null;
         }
@@ -363,7 +363,7 @@ export default Model.extend({
     },
     passwordExpiredLinkUrl: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._links || !res._links.next || !res._links.next.title || !res._links.next.href) {
           return null;
         }
@@ -372,19 +372,19 @@ export default Model.extend({
     },
     recoveryType: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.recoveryType;
       },
     },
     factorType: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.factorType;
       },
     },
     factor: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.factor) {
           return null;
         }
@@ -393,25 +393,25 @@ export default Model.extend({
     },
     activatedFactorId: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         return factor ? factor.id : null;
       },
     },
     activatedFactorType: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         return factor ? factor.factorType : null;
       },
     },
     activatedFactorProvider: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         return factor ? factor.provider : null;
       },
     },
     qrcode: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         try {
           return factor._embedded.activation._links.qrcode.href;
         } catch (err) {
@@ -421,7 +421,7 @@ export default Model.extend({
     },
     activationSendLinks: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         let sendLinks;
 
         try {
@@ -434,7 +434,7 @@ export default Model.extend({
     },
     textActivationLinkUrl: {
       deps: ['activationSendLinks'],
-      fn: function (activationSendLinks) {
+      fn: function(activationSendLinks) {
         const item = _.findWhere(activationSendLinks, { name: 'sms' });
 
         return item ? item.href : null;
@@ -442,7 +442,7 @@ export default Model.extend({
     },
     emailActivationLinkUrl: {
       deps: ['activationSendLinks'],
-      fn: function (activationSendLinks) {
+      fn: function(activationSendLinks) {
         const item = _.findWhere(activationSendLinks, { name: 'email' });
 
         return item ? item.href : null;
@@ -450,7 +450,7 @@ export default Model.extend({
     },
     sharedSecret: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         try {
           return factor._embedded.activation.sharedSecret;
         } catch (err) {
@@ -460,7 +460,7 @@ export default Model.extend({
     },
     duoEnrollActivation: {
       deps: ['factor'],
-      fn: function (factor) {
+      fn: function(factor) {
         if (!factor || !factor._embedded || !factor._embedded.activation) {
           return null;
         }
@@ -469,7 +469,7 @@ export default Model.extend({
     },
     prevLink: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (res._links && res._links.prev) {
           return res._links.prev.href;
         }
@@ -478,7 +478,7 @@ export default Model.extend({
     },
     skipLink: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (res._links && res._links.skip) {
           return res._links.skip.href;
         }
@@ -487,7 +487,7 @@ export default Model.extend({
     },
     gracePeriodRemainingDays: {
       deps: ['policy'],
-      fn: function (policy) {
+      fn: function(policy) {
         if (policy && policy.gracePeriod && policy.gracePeriod.endDate) {
           return getGracePeriodRemainingDays(policy.gracePeriod.endDate);
         }
@@ -496,7 +496,7 @@ export default Model.extend({
     },
     user: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.user) {
           return null;
         }
@@ -505,7 +505,7 @@ export default Model.extend({
     },
     recoveryQuestion: {
       deps: ['user'],
-      fn: function (user) {
+      fn: function(user) {
         if (!user || !user.recovery_question) {
           return null;
         }
@@ -514,7 +514,7 @@ export default Model.extend({
     },
     userProfile: {
       deps: ['user'],
-      fn: function (user) {
+      fn: function(user) {
         if (!user || !user.profile) {
           return null;
         }
@@ -523,7 +523,7 @@ export default Model.extend({
     },
     userConsentName: {
       deps: ['userProfile', 'username'],
-      fn: function (userProfile, username) {
+      fn: function(userProfile, username) {
         if (!userProfile || _.isEmpty(userProfile.firstName)) {
           return username;
         }
@@ -535,7 +535,7 @@ export default Model.extend({
     },
     userEmail: {
       deps: ['userProfile'],
-      fn: function (userProfile) {
+      fn: function(userProfile) {
         if (!userProfile || !userProfile.login) {
           return null;
         }
@@ -544,7 +544,7 @@ export default Model.extend({
     },
     userFullName: {
       deps: ['userProfile'],
-      fn: function (userProfile) {
+      fn: function(userProfile) {
         if (!userProfile || (!userProfile.firstName && !userProfile.lastName)) {
           return '';
         }
@@ -553,19 +553,19 @@ export default Model.extend({
     },
     defaultAppLogo: {
       deps: ['baseUrl'],
-      fn: function (baseUrl) {
+      fn: function(baseUrl) {
         return baseUrl + DEFAULT_APP_LOGO;
       },
     },
     expiresAt: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.expiresAt;
       },
     },
     target: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded) {
           return null;
         }
@@ -574,7 +574,7 @@ export default Model.extend({
     },
     targetLabel: {
       deps: ['target'],
-      fn: function (target) {
+      fn: function(target) {
         if (!target) {
           return null;
         }
@@ -583,7 +583,7 @@ export default Model.extend({
     },
     targetLogo: {
       deps: ['target'],
-      fn: function (target) {
+      fn: function(target) {
         if (!target || !target._links) {
           return null;
         }
@@ -592,7 +592,7 @@ export default Model.extend({
     },
     targetTermsOfService: {
       deps: ['target'],
-      fn: function (target) {
+      fn: function(target) {
         if (!target || !target._links) {
           return null;
         }
@@ -601,7 +601,7 @@ export default Model.extend({
     },
     targetPrivacyPolicy: {
       deps: ['target'],
-      fn: function (target) {
+      fn: function(target) {
         if (!target || !target._links) {
           return null;
         }
@@ -610,7 +610,7 @@ export default Model.extend({
     },
     targetClientURI: {
       deps: ['target'],
-      fn: function (target) {
+      fn: function(target) {
         if (!target || !target._links) {
           return null;
         }
@@ -619,7 +619,7 @@ export default Model.extend({
     },
     scopes: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded) {
           return null;
         }
@@ -628,13 +628,13 @@ export default Model.extend({
     },
     issuer: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res?._embedded?.authentication?.issuer?.uri;
       }
     },
     hasExistingPhones: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.factors) {
           return false;
         }
@@ -651,7 +651,7 @@ export default Model.extend({
     },
     hasExistingPhonesForCall: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._embedded || !res._embedded.factors) {
           return false;
         }
@@ -668,25 +668,25 @@ export default Model.extend({
     },
     isUndefinedUser: {
       deps: ['securityImage'],
-      fn: function (securityImage) {
+      fn: function(securityImage) {
         return securityImage === UNDEFINED_USER;
       },
     },
     isNewUser: {
       deps: ['securityImage'],
-      fn: function (securityImage) {
+      fn: function(securityImage) {
         return securityImage === NEW_USER;
       },
     },
     allowRememberDevice: {
       deps: ['policy'],
-      fn: function (policy) {
+      fn: function(policy) {
         return policy && policy.allowRememberDevice;
       },
     },
     rememberDeviceLabel: {
       deps: ['policy'],
-      fn: function (policy) {
+      fn: function(policy) {
         if (policy && policy.rememberDeviceLifetimeInMinutes > 0) {
           const timeString = getMinutesString(policy.rememberDeviceLifetimeInMinutes);
 
@@ -699,19 +699,19 @@ export default Model.extend({
     },
     rememberDeviceByDefault: {
       deps: ['policy'],
-      fn: function (policy) {
+      fn: function(policy) {
         return policy && policy.rememberDeviceByDefault;
       },
     },
     factorsPolicyInfo: {
       deps: ['policy'],
-      fn: function (policy) {
+      fn: function(policy) {
         return policy && policy.factorsPolicyInfo ? policy.factorsPolicyInfo : null;
       },
     },
     verifyCustomFactorRedirectUrl: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._links || !res._links.next || res._links.next.name !== 'redirect' || !res._links.next.href) {
           return null;
         }
@@ -720,7 +720,7 @@ export default Model.extend({
     },
     enrollCustomFactorRedirectUrl: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         if (!res._links || !res._links.next || res._links.next.name !== 'activate' || !res._links.next.href) {
           return null;
         }
@@ -729,13 +729,13 @@ export default Model.extend({
     },
     isFactorResultFailed: {
       deps: ['lastAuthResponse'],
-      fn: function (res) {
+      fn: function(res) {
         return res.factorResult === 'FAILED';
       },
     },
     factorResultErrorMessage: {
       deps: ['lastAuthResponse', 'isFactorResultFailed'],
-      fn: function (res, isFactorResultFailed) {
+      fn: function(res, isFactorResultFailed) {
         if (isFactorResultFailed) {
           return res.factorResultMessage || loc('oform.error.unexpected', 'login');
         }
@@ -744,7 +744,7 @@ export default Model.extend({
     },
   },
 
-  parse: function (options) {
+  parse: function(options) {
     this.settings = options.settings;
     return _.extend(_.omit(options, 'settings'), { 
       languageCode: this.settings.get('languageCode'),

--- a/src/models/BaseLoginModel.js
+++ b/src/models/BaseLoginModel.js
@@ -16,16 +16,16 @@ import Enums from 'util/Enums';
 const KNOWN_ERRORS = ['OAuthError', 'AuthSdkError', 'AuthPollStopError', 'AuthApiError'];
 export default Model.extend({
   // May return either a "standard" promise or a Q promise
-  doTransaction: function (fn, rethrow) {
+  doTransaction: function(fn, rethrow) {
     const self = this;
 
     return fn
       .call(this, this.appState.get('transaction'))
-      .then(function (trans) {
+      .then(function(trans) {
         self.trigger('setTransaction', trans);
         return trans;
       })
-      .catch(function (err) {
+      .catch(function(err) {
         // Q may still consider AuthPollStopError to be unhandled
         if (
           err.name === 'AuthPollStopError' ||
@@ -42,13 +42,13 @@ export default Model.extend({
       });
   },
 
-  manageTransaction: function (fn) {
+  manageTransaction: function(fn) {
     const self = this;
     const res = fn.call(this, this.appState.get('transaction'), _.bind(this.setTransaction, this));
 
     // If it's a promise, listen for failures
     if (Q.isPromiseAlike(res)) {
-      return res.catch(function (err) {
+      return res.catch(function(err) {
         if (
           err.name === 'AuthPollStopError' ||
           err.name === Enums.AUTH_STOP_POLL_INITIATION_ERROR ||
@@ -64,18 +64,18 @@ export default Model.extend({
     return Q.resolve(res);
   },
 
-  startTransaction: function (fn) {
+  startTransaction: function(fn) {
     const self = this;
     const res = fn.call(this, this.settings.getAuthClient());
 
     // If it's a promise, then chain to it
     if (Q.isPromiseAlike(res)) {
       return res
-        .then(function (trans) {
+        .then(function(trans) {
           self.trigger('setTransaction', trans);
           return trans;
         })
-        .catch(function (err) {
+        .catch(function(err) {
           self.trigger('error', self, err.xhr);
           self.trigger('setTransactionError', err);
           throw err;
@@ -85,7 +85,7 @@ export default Model.extend({
     return Q.resolve(res);
   },
 
-  setTransaction: function (trans) {
+  setTransaction: function(trans) {
     this.appState.set('transaction', trans);
   },
 });

--- a/src/models/EnrollUser.js
+++ b/src/models/EnrollUser.js
@@ -13,11 +13,11 @@
 import { _, loc } from 'okta';
 import BaseLoginModel from './BaseLoginModel';
 export default BaseLoginModel.extend({
-  initialize: function (options) {
+  initialize: function(options) {
     this.options = options || {};
     this.appState = this.options.appState;
   },
-  constructPostData: function (profileAttributes) {
+  constructPostData: function(profileAttributes) {
     const postData = {
       registration: {
         profile: profileAttributes,
@@ -30,14 +30,14 @@ export default BaseLoginModel.extend({
     }
     return postData;
   },
-  getEnrollFormData: function () {
-    return this.manageTransaction(function (transaction, setTransaction) {
-      return transaction.enroll().then(function (trans) {
+  getEnrollFormData: function() {
+    return this.manageTransaction(function(transaction, setTransaction) {
+      return transaction.enroll().then(function(trans) {
         setTransaction(trans);
       });
     });
   },
-  save: function () {
+  save: function() {
     let data = BaseLoginModel.prototype.toJSON.apply(this, arguments);
 
     data = _.omit(data, ['appState', 'settings', 'createNewAccount']);
@@ -50,8 +50,8 @@ export default BaseLoginModel.extend({
         responseJSON: error,
       });
     } else {
-      return this.manageTransaction(function (transaction, setTransaction) {
-        transaction.enroll(this.constructPostData(data)).then(function (trans) {
+      return this.manageTransaction(function(transaction, setTransaction) {
+        transaction.enroll(this.constructPostData(data)).then(function(trans) {
           setTransaction(trans);
         });
       });

--- a/src/models/Factor.js
+++ b/src/models/Factor.js
@@ -88,7 +88,7 @@ const FactorFactor = BaseLoginModel.extend({
   derived: {
     isOktaFactor: {
       deps: ['provider'],
-      fn: function (provider) {
+      fn: function(provider) {
         return provider === 'OKTA';
       },
     },
@@ -98,7 +98,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     factorLabel: {
       deps: ['provider', 'factorType', 'vendorName'],
-      fn: function (provider, factorType, vendorName) {
+      fn: function(provider, factorType, vendorName) {
         if (_.contains(['DEL_OATH', 'GENERIC_SAML', 'GENERIC_OIDC', 'CUSTOM'], provider)) {
           return vendorName;
         }
@@ -119,7 +119,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     securityQuestion: {
       deps: ['profile', 'factorType'],
-      fn: function (profile, factorType) {
+      fn: function(profile, factorType) {
         if (factorType !== 'question') {
           return null;
         }
@@ -128,7 +128,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     phoneNumber: {
       deps: ['profile', 'factorType'],
-      fn: function (profile, factorType) {
+      fn: function(profile, factorType) {
         if (_.contains(['sms', 'call'], factorType)) {
           return profile && profile.phoneNumber;
         }
@@ -137,7 +137,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     email: {
       deps: ['profile', 'factorType'],
-      fn: function (profile, factorType) {
+      fn: function(profile, factorType) {
         if (factorType === 'email') {
           return profile && profile.email;
         }
@@ -146,7 +146,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     deviceName: {
       deps: ['profile', 'factorType'],
-      fn: function (profile, factorType) {
+      fn: function(profile, factorType) {
         if (factorType !== 'push') {
           return null;
         }
@@ -155,13 +155,13 @@ const FactorFactor = BaseLoginModel.extend({
     },
     enrolled: {
       deps: ['status'],
-      fn: function (status) {
+      fn: function(status) {
         return status === 'ACTIVE';
       },
     },
     cardinality: {
       deps: ['policy', 'profiles'],
-      fn: function (policy, profiles) {
+      fn: function(policy, profiles) {
         if (profiles && profiles.length > 0) {
           const profile = profiles[0];
           //assume for now we only get one profile (multiple profiles are not supported yet)
@@ -187,7 +187,7 @@ const FactorFactor = BaseLoginModel.extend({
     },
     additionalEnrollment: {
       deps: ['cardinality'],
-      fn: function (cardinality) {
+      fn: function(cardinality) {
         if (cardinality) {
           return cardinality.enrolled !== 0 && cardinality.enrolled < cardinality.maximum;
         } else {
@@ -197,32 +197,32 @@ const FactorFactor = BaseLoginModel.extend({
     },
     required: {
       deps: ['enrollment'],
-      fn: function (enrollment) {
+      fn: function(enrollment) {
         return enrollment === 'REQUIRED';
       },
     },
     canUseResend: {
       deps: ['provider', 'factorType'],
-      fn: function (provider, factorType) {
+      fn: function(provider, factorType) {
         // Only push, sms and call have resend links.
         return provider === 'OKTA' && _.contains(['push', 'sms', 'call', 'email'], factorType);
       },
     },
     isAnswerRequired: {
       deps: ['factorType'],
-      fn: function (factorType) {
+      fn: function(factorType) {
         return _.contains(['sms', 'call', 'email', 'token', 'token:software:totp', 'question'], factorType);
       },
     },
     isFactorTypeVerification: {
       deps: ['provider', 'id'],
-      fn: function (provider, id) {
+      fn: function(provider, id) {
         return provider === undefined && id === undefined;
       },
     },
   },
 
-  parse: function (attributes) {
+  parse: function(attributes) {
     this.settings = attributes.settings;
     this.appState = attributes.appState;
     // set the initial value for remember device.
@@ -233,32 +233,32 @@ const FactorFactor = BaseLoginModel.extend({
     return _.omit(attributes, ['settings', 'appState']);
   },
 
-  validate: function () {
+  validate: function() {
     if (this.get('isAnswerRequired') && !this.get('answer')) {
       return { answer: loc('model.validation.field.blank') };
     } else if (this.get('factorType') === 'password' && !this.get('password')) {
       return { password: loc('error.password.required') };
     }
   },
-  needsPasscode: function () {
+  needsPasscode: function() {
     // we don't need passcode for email with magic link flow
     return !(this.options.appState.get('isIdxStateToken') && this.get('factorType') === 'email');
   },
-  resend: function () {
+  resend: function() {
     this.trigger('form:clear-errors');
-    return this.manageTransaction(function (transaction) {
+    return this.manageTransaction(function(transaction) {
       const firstLink = transaction.data._links.resend[0];
 
       return transaction.resend(firstLink.name);
     });
   },
 
-  save: function () {
+  save: function() {
     const rememberDevice = !!this.get('rememberDevice');
     const self = this;
     // Set/Remove the remember device cookie based on the remember device input.
 
-    return this.manageTransaction(function (transaction, setTransaction) {
+    return this.manageTransaction(function(transaction, setTransaction) {
       const data = {
         rememberDevice: rememberDevice,
       };
@@ -298,7 +298,7 @@ const FactorFactor = BaseLoginModel.extend({
       //to disable the primary button on the factor form
       this.trigger('save');
 
-      return promise.then(function (trans) {
+      return promise.then(function(trans) {
         const options = {
           delay: PUSH_INTERVAL,
           transactionCallBack: transaction => {
@@ -315,18 +315,18 @@ const FactorFactor = BaseLoginModel.extend({
             clearTimeout(initiatePollTimout);
             deferred.reject(new Errors.AuthStopPollInitiationError());
           });
-          return deferred.promise.then(function () {
+          return deferred.promise.then(function() {
             // Stop listening if factor was not switched before poll.
             self.stopListening(self.options.appState, 'factorSwitched');
             if (self.pushFactorHasAutoPush()) {
-              options.autoPush = function () {
+              options.autoPush = function() {
                 return self.get('autoPush');
               };
-              options.rememberDevice = function () {
+              options.rememberDevice = function() {
                 return self.get('rememberDevice');
               };
             }
-            return trans.poll(options).then(function (trans) {
+            return trans.poll(options).then(function(trans) {
               self.options.appState.set('lastAuthResponse', trans.data);
               setTransaction(trans);
             });
@@ -336,7 +336,7 @@ const FactorFactor = BaseLoginModel.extend({
     });
   },
 
-  _findFactor: function (transaction) {
+  _findFactor: function(transaction) {
     let factor;
 
     if (transaction.factorTypes) {
@@ -352,11 +352,11 @@ const FactorFactor = BaseLoginModel.extend({
     return factor;
   },
 
-  pushFactorHasAutoPush: function () {
+  pushFactorHasAutoPush: function() {
     return this.settings.get('features.autoPush') && this.get('factorType') === 'push';
   },
 
-  setCustomHotpVendorName: function (attributes) {
+  setCustomHotpVendorName: function(attributes) {
     // If factor is token:hotp and not enrolled, we assume the first profile is the default.
     // If factor is enrolled, we only support one profile to be enrolled, so find that one
     // and display as enrolled profile. We do this by populating profile name in vendorName.
@@ -382,7 +382,7 @@ const FactorFactors = Collection.extend({
   // there's only one option (Okta Verify), and we show a form with Push
   // with an inline totp option. What we need to do is to add totp
   // as a "backupFactor" for push
-  parse: function (factors) {
+  parse: function(factors) {
     // Keep a track of the last used factor, since
     // we need it to determine the default factor.
     this.lastUsedFactor = factors[0];
@@ -404,7 +404,7 @@ const FactorFactors = Collection.extend({
 
     const parsedFactors = _.reduce(
       factors,
-      function (memo, factor) {
+      function(memo, factor) {
         const isOkta = factor.provider === 'OKTA';
         const isOktaTotp = isOkta && factor.factorType === 'token:software:totp';
         const isOktaPush = isOkta && factor.factorType === 'push';
@@ -439,31 +439,31 @@ const FactorFactors = Collection.extend({
   // However, current code returns last used factor as first factor in list.
   // Also, will need to add priority - i.e. if they do not have a last used
   // factor, should try Okta Verify, then Okta SMS, etc.
-  getDefaultFactor: function () {
+  getDefaultFactor: function() {
     const factor = _.pick(this.lastUsedFactor, 'factorType', 'provider');
 
     return this.findWhere(factor);
   },
 
-  getFirstUnenrolledRequiredFactor: function () {
+  getFirstUnenrolledRequiredFactor: function() {
     return this.findWhere({ required: true, enrolled: false });
   },
 
-  _getFactorsOfType: function (factorType) {
+  _getFactorsOfType: function(factorType) {
     return this.where({ factorType: factorType });
   },
 
-  getFactorIndex: function (factorType, factorId) {
-    return this._getFactorsOfType(factorType).findIndex(function (factor) {
+  getFactorIndex: function(factorType, factorId) {
+    return this._getFactorsOfType(factorType).findIndex(function(factor) {
       return factor.get('id') === factorId;
     });
   },
 
-  hasMultipleFactorsOfSameType: function (factorType) {
+  hasMultipleFactorsOfSameType: function(factorType) {
     return this._getFactorsOfType(factorType).length > 1;
   },
 
-  getFactorByTypeAndIndex: function (factorType, factorIndex) {
+  getFactorByTypeAndIndex: function(factorType, factorIndex) {
     return this._getFactorsOfType(factorType)[factorIndex];
   },
 });

--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -15,7 +15,7 @@ import CookieUtil from 'util/CookieUtil';
 import Enums from 'util/Enums';
 import Util from 'util/Util';
 export default PrimaryAuthModel.extend({
-  props: function () {
+  props: function() {
     const cookieUsername = CookieUtil.getCookieUsername();
     const properties = this.getUsernameAndRemember(cookieUsername);
 
@@ -29,7 +29,7 @@ export default PrimaryAuthModel.extend({
 
   local: {},
 
-  save: function () {
+  save: function() {
     const username = this.settings.transformUsername(this.get('username'), Enums.IDP_DISCOVERY);
     const remember = this.get('remember');
     const lastUsername = this.get('lastUsername');

--- a/src/models/LoginModel.js
+++ b/src/models/LoginModel.js
@@ -13,12 +13,12 @@
 import { Model } from 'okta';
 import BaseLoginModel from './BaseLoginModel';
 export default BaseLoginModel.extend({
-  constructor: function (options) {
+  constructor: function(options) {
     this.settings = options && options.settings;
     Model.apply(this, arguments);
   },
-  loginWithActivationToken: function (activationToken) {
-    return this.startTransaction(function (authClient) {
+  loginWithActivationToken: function(activationToken) {
+    return this.startTransaction(function(authClient) {
       return authClient.signInWithCredentials({ token: activationToken });
     });
   },

--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -17,13 +17,13 @@ import BaseLoginModel from './BaseLoginModel';
 import Util from 'util/Util';
 
 export default BaseLoginModel.extend({
-  props: function () {
+  props: function() {
     const cookieUsername = CookieUtil.getCookieUsername();
     const properties = this.getUsernameAndRemember(cookieUsername);
     const props = {
       username: {
         type: 'string',
-        validate: function (value) {
+        validate: function(value) {
           if (_.isEmpty(value)) {
             return loc('error.username.required', 'login');
           }
@@ -39,7 +39,7 @@ export default BaseLoginModel.extend({
     if (!(this.settings && this.settings.get('features.passwordlessAuth'))) {
       props.password = {
         type: 'string',
-        validate: function (value) {
+        validate: function(value) {
           if (_.isEmpty(value)) {
             return loc('error.password.required', 'login');
           }
@@ -49,7 +49,7 @@ export default BaseLoginModel.extend({
     return props;
   },
 
-  getUsernameAndRemember: function (cookieUsername) {
+  getUsernameAndRemember: function(cookieUsername) {
     const settingsUsername = this.settings && this.settings.get('username');
     const rememberMeEnabled = this.settings && this.settings.get('features.rememberMe');
     let remember = false;
@@ -71,19 +71,19 @@ export default BaseLoginModel.extend({
     };
   },
 
-  constructor: function (options) {
+  constructor: function(options) {
     this.settings = options && options.settings;
     this.appState = options && options.appState;
     Model.apply(this, arguments);
-    this.listenTo(this, 'change:username', function (model, username) {
+    this.listenTo(this, 'change:username', function(model, username) {
       this.set({ remember: username === this.get('lastUsername') });
     });
   },
-  parse: function (options) {
+  parse: function(options) {
     return _.omit(options, ['settings', 'appState']);
   },
 
-  save: function () {
+  save: function() {
     const username = this.settings.transformUsername(this.get('username'), Enums.PRIMARY_AUTH);
     const remember = this.get('remember');
     const lastUsername = this.get('lastUsername');
@@ -105,17 +105,17 @@ export default BaseLoginModel.extend({
       // bootstrapped with stateToken
       if (this.appState.get('isIdxStateToken')) {
         // if its an idx stateToken, we send the parameter as identifier to login API
-        primaryAuthPromise = this.doTransaction(function (transaction) {
+        primaryAuthPromise = this.doTransaction(function(transaction) {
           return this.doPrimaryAuth(authClient, signInArgs, transaction.login);
         });
       } else {
-        primaryAuthPromise = this.doTransaction(function (transaction) {
+        primaryAuthPromise = this.doTransaction(function(transaction) {
           return this.doPrimaryAuth(authClient, signInArgs, transaction.authenticate);
         });
       }
     } else {
       //normal username/password flow without stateToken
-      primaryAuthPromise = this.startTransaction(function (authClient) {
+      primaryAuthPromise = this.startTransaction(function(authClient) {
         return this.doPrimaryAuth(authClient, signInArgs, _.bind(authClient.signInWithCredentials, authClient));
       });
     }
@@ -132,7 +132,7 @@ export default BaseLoginModel.extend({
       });
   },
 
-  getSignInArgs: function (username) {
+  getSignInArgs: function(username) {
     const multiOptionalFactorEnroll = this.get('multiOptionalFactorEnroll');
     const signInArgs = {};
 
@@ -154,7 +154,7 @@ export default BaseLoginModel.extend({
     return signInArgs;
   },
 
-  setUsernameCookie: function (username, remember, lastUsername) {
+  setUsernameCookie: function(username, remember, lastUsername) {
     // Do not modify the cookie when feature is disabled, relevant for SAML ForceAuthn prompts
     if (this.settings.get('features.rememberMe')) {
       // Only delete the cookie if its owner says so. This allows other
@@ -167,7 +167,7 @@ export default BaseLoginModel.extend({
     }
   },
 
-  doPrimaryAuth: function (authClient, signInArgs, func) {
+  doPrimaryAuth: function(authClient, signInArgs, func) {
     const deviceFingerprintEnabled = this.settings.get('features.deviceFingerprinting');
     const typingPatternEnabled = this.settings.get('features.trackTypingPattern');
 
@@ -184,7 +184,7 @@ export default BaseLoginModel.extend({
 
     const self = this;
 
-    return func(signInArgs).finally(function () {
+    return func(signInArgs).finally(function() {
       if (deviceFingerprintEnabled) {
         delete authClient.options.headers['X-Device-Fingerprint'];
         self.appState.unset('deviceFingerprint'); //Fingerprint can only be used once

--- a/src/models/ProfileSchema.js
+++ b/src/models/ProfileSchema.js
@@ -14,13 +14,13 @@ import { _, internal } from 'okta';
 let { BaseSchema } = internal.models;
 export default BaseSchema.Model.extend({
   expand: ['schema'],
-  setFieldPlaceholder: function (formFields) {
-    _.each(formFields, function (formField) {
+  setFieldPlaceholder: function(formFields) {
+    _.each(formFields, function(formField) {
       formField.title = formField.label;
     });
     return formFields;
   },
-  initialize: function (options) {
+  initialize: function(options) {
     let profileAttributes = options.profileSchemaAttributes;
 
     profileAttributes = this.setFieldPlaceholder(profileAttributes);

--- a/src/models/RegistrationSchema.js
+++ b/src/models/RegistrationSchema.js
@@ -13,12 +13,12 @@
 import { _, BaseModel, internal } from 'okta';
 let { BaseSchema, SchemaProperty } = internal.models;
 const RegistrationSchemaRegistrationSchemaPropertyCollection = SchemaProperty.Collection.extend({
-  createModelProperties: function () {
+  createModelProperties: function() {
     const modelProperties = SchemaProperty.Collection.prototype.createModelProperties.apply(this);
 
     _.each(
       modelProperties,
-      function (modelProperty, name) {
+      function(modelProperty, name) {
         modelProperty.required = !!this.get(name).get('required');
       },
       this
@@ -29,19 +29,19 @@ const RegistrationSchemaRegistrationSchemaPropertyCollection = SchemaProperty.Co
 export default BaseSchema.Model.extend({
   expand: ['schema'],
 
-  constructor: function () {
+  constructor: function() {
     this.properties = new RegistrationSchemaRegistrationSchemaPropertyCollection();
     BaseModel.apply(this, arguments);
   },
 
-  parse: function (resp) {
+  parse: function(resp) {
     const parseResponseData = resp => {
       const requireFields = resp.schema.required;
 
       if (_.isArray(requireFields)) {
         _.each(
           requireFields,
-          function (requireField) {
+          function(requireField) {
             const field = this.properties.get(requireField);
 
             if (field) {
@@ -57,7 +57,7 @@ export default BaseSchema.Model.extend({
       if (_.isArray(fieldOrderIds)) {
         _.each(
           fieldOrderIds,
-          function (fieldOrderId, sortOrder) {
+          function(fieldOrderId, sortOrder) {
             const field = this.properties.get(fieldOrderId);
 
             if (field) {
@@ -76,7 +76,7 @@ export default BaseSchema.Model.extend({
     const self = this;
     this.settings.parseRegistrationSchema(
       resp,
-      function (resp) {
+      function(resp) {
         if (resp.profileSchema) {
           resp.schema = resp.profileSchema;
           BaseSchema.Model.prototype.parse.apply(self, [resp]);
@@ -84,7 +84,7 @@ export default BaseSchema.Model.extend({
         }
         self.trigger('parseComplete', { properties: self.properties });
       },
-      function (error) {
+      function(error) {
         self.trigger('parseComplete', { properties: self.properties, error: error });
       }
     );

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -166,7 +166,7 @@ export default Model.extend({
   derived: {
     showPasswordToggle: {
       deps: ['features.showPasswordToggleOnSignInPage'],
-      fn: function () {
+      fn: function() {
         // showPasswordToggle is for OIE only.
         // Used to default showPasswordToggleOnSignInPage to true.
         return this.options?.features?.showPasswordToggleOnSignInPage !== false;
@@ -175,14 +175,14 @@ export default Model.extend({
     },
     redirectUtilFn: {
       deps: ['features.redirectByFormSubmit'],
-      fn: function (redirectByFormSubmit) {
+      fn: function(redirectByFormSubmit) {
         return redirectByFormSubmit ? Util.redirectWithFormGet.bind(Util) : SharedUtil.redirect.bind(SharedUtil);
       },
       cache: true,
     },
     supportedLanguages: {
       deps: ['i18n'],
-      fn: function (i18n) {
+      fn: function(i18n) {
         // Developers can pass in their own languages
         return _.union(config.supportedLanguages, _.keys(i18n));
       },
@@ -190,7 +190,7 @@ export default Model.extend({
     },
     languageCode: {
       deps: ['language', 'supportedLanguages'],
-      fn: function (language, supportedLanguages) {
+      fn: function(language, supportedLanguages) {
         const userLanguages = BrowserFeatures.getUserLanguages();
 
         const preferred = _.clone(userLanguages);
@@ -229,7 +229,7 @@ export default Model.extend({
     },
     countryCode: {
       deps: ['defaultCountryCode'],
-      fn: function (defaultCountryCode) {
+      fn: function(defaultCountryCode) {
         const countries = CountryUtil.getCountries();
         return Object.keys(countries).includes(defaultCountryCode)
           ? defaultCountryCode : 'US';
@@ -237,14 +237,14 @@ export default Model.extend({
     },
     oauth2Enabled: {
       deps: ['clientId', 'authScheme'],
-      fn: function (clientId, authScheme) {
+      fn: function(clientId, authScheme) {
         return (!!clientId) && authScheme.toLowerCase() === 'oauth2';
       },
       cache: true,
     },
     oieEnabled: {
       deps: ['stateToken', 'proxyIdxResponse', 'useInteractionCodeFlow'],
-      fn: function (stateToken, proxyIdxResponse, useInteractionCodeFlow) {
+      fn: function(stateToken, proxyIdxResponse, useInteractionCodeFlow) {
         return stateToken || proxyIdxResponse || useInteractionCodeFlow;
       },
       cache: true,
@@ -252,7 +252,7 @@ export default Model.extend({
     // Redirect Uri to provide in the oauth API
     oauthRedirectUri: {
       deps: ['redirectUri'],
-      fn: function (redirectUri) {
+      fn: function(redirectUri) {
         if (redirectUri) {
           return redirectUri;
         }
@@ -275,8 +275,8 @@ export default Model.extend({
     // Adjusts the idps passed into the widget based on if they get explicit support
     configuredSocialIdps: {
       deps: ['idps'],
-      fn: function (idps) {
-        return _.map(idps, function (idpConfig) {
+      fn: function(idps) {
+        return _.map(idps, function(idpConfig) {
           const idp = _.clone(idpConfig);
 
           let type = idp.type && idp.type.toLowerCase();
@@ -301,7 +301,7 @@ export default Model.extend({
     // Can support piv authentication
     hasPivCard: {
       deps: ['piv'],
-      fn: function (piv) {
+      fn: function(piv) {
         return piv && piv.certAuthUrl;
       },
       cache: true,
@@ -309,21 +309,21 @@ export default Model.extend({
     // social auth buttons order - 'above'/'below' the primary auth form (boolean)
     socialAuthPositionTop: {
       deps: ['configuredSocialIdps', 'hasPivCard', 'idpDisplay'],
-      fn: function (configuredSocialIdps, hasPivCard, idpDisplay) {
+      fn: function(configuredSocialIdps, hasPivCard, idpDisplay) {
         return (!_.isEmpty(configuredSocialIdps) || hasPivCard) && idpDisplay.toUpperCase() === 'PRIMARY';
       },
       cache: true,
     },
     hasConfiguredButtons: {
       deps: ['configuredSocialIdps', 'customButtons', 'hasPivCard'],
-      fn: function (configuredSocialIdps, customButtons, hasPivCard) {
+      fn: function(configuredSocialIdps, customButtons, hasPivCard) {
         return !_.isEmpty(configuredSocialIdps) || !_.isEmpty(customButtons) || hasPivCard;
       },
       cache: true,
     },
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     if (!options.baseUrl) {
       this.callGlobalError(new ConfigError(loc('error.required.baseUrl')));
     } else if (options.colors && _.isString(options.colors.brand) && !options.colors.brand.match(/^#[0-9A-Fa-f]{6}$/)) {
@@ -333,22 +333,22 @@ export default Model.extend({
     }
   },
 
-  setAcceptLanguageHeader: function (authClient) {
+  setAcceptLanguageHeader: function(authClient) {
     if (authClient && authClient.options && authClient.options.headers) {
       authClient.options.headers['Accept-Language'] = this.get('languageCode');
     }
   },
 
-  setAuthClient: function (authClient) {
+  setAuthClient: function(authClient) {
     this.setAcceptLanguageHeader(authClient);
     this.authClient = authClient;
   },
 
-  getAuthClient: function () {
+  getAuthClient: function() {
     return this.authClient;
   },
 
-  set: function () {
+  set: function() {
     try {
       return Model.prototype.set.apply(this, arguments);
     } catch (e) {
@@ -361,7 +361,7 @@ export default Model.extend({
   // Invokes the global success function. This should only be called on a
   // terminal part of the code (i.e. authStatus SUCCESS or after sending
   // a recovery email)
-  callGlobalSuccess: function (status, data) {
+  callGlobalSuccess: function(status, data) {
     const res = _.extend(data, { status: status });
     // Defer this to ensure that our functions have rendered completely
     // before invoking their function
@@ -372,7 +372,7 @@ export default Model.extend({
   // Invokes the global error function. This should only be called on non
   // recoverable errors (i.e. configuration errors, browser unsupported
   // errors, etc)
-  callGlobalError: function (err) {
+  callGlobalError: function(err) {
     const globalErrorFn = this.get('globalErrorFn') || this.options.globalErrorFn;
     // Note: Must use "this.options.globalErrorFn" when they've passed invalid
     // arguments - globalErrorFn will not have been set yet
@@ -386,7 +386,7 @@ export default Model.extend({
   },
 
   // Get the username by applying the transform function if it exists.
-  transformUsername: function (username, operation) {
+  transformUsername: function(username, operation) {
     const transformFn = this.get('transformUsername');
 
     if (transformFn && _.isFunction(transformFn)) {
@@ -395,10 +395,10 @@ export default Model.extend({
     return username;
   },
 
-  processCreds: function (creds) {
+  processCreds: function(creds) {
     const processCreds = this.get('processCreds');
 
-    return Q.Promise(function (resolve) {
+    return Q.Promise(function(resolve) {
       if (!_.isFunction(processCreds)) {
         resolve();
       } else if (processCreds.length === 2) {
@@ -410,17 +410,17 @@ export default Model.extend({
     });
   },
 
-  parseRegistrationSchema: function (schema, onSuccess, onFailure) {
+  parseRegistrationSchema: function(schema, onSuccess, onFailure) {
     const parseSchema = this.get('registration.parseSchema');
 
     //check for parseSchema callback
     if (_.isFunction(parseSchema)) {
       parseSchema(
         schema,
-        function (schema) {
+        function(schema) {
           onSuccess(schema);
         },
-        function (error) {
+        function(error) {
           error = error || { errorSummary: loc('registration.default.callbackhook.error') };
           error['callback'] = 'parseSchema';
           onFailure(error);
@@ -432,17 +432,17 @@ export default Model.extend({
     }
   },
 
-  preRegistrationSubmit: function (postData, onSuccess, onFailure) {
+  preRegistrationSubmit: function(postData, onSuccess, onFailure) {
     const preSubmit = this.get('registration.preSubmit');
 
     //check for preSubmit callback
     if (_.isFunction(preSubmit)) {
       preSubmit(
         postData,
-        function (postData) {
+        function(postData) {
           onSuccess(postData);
         },
-        function (error) {
+        function(error) {
           error = error || { errorSummary: loc('registration.default.callbackhook.error') };
           error['callback'] = 'preSubmit';
           onFailure(error);
@@ -454,17 +454,17 @@ export default Model.extend({
     }
   },
 
-  postRegistrationSubmit: function (response, onSuccess, onFailure) {
+  postRegistrationSubmit: function(response, onSuccess, onFailure) {
     const postSubmit = this.get('registration.postSubmit');
 
     //check for postSubmit callback
     if (_.isFunction(postSubmit)) {
       postSubmit(
         response,
-        function (response) {
+        function(response) {
           onSuccess(response);
         },
-        function (error) {
+        function(error) {
           error = error || { errorSummary: loc('registration.default.callbackhook.error') };
           error['callback'] = 'postSubmit';
           onFailure(error);
@@ -479,18 +479,18 @@ export default Model.extend({
   // Use the parse function to transform config options to the standard
   // settings we currently support. This is a good place to deprecate old
   // option formats.
-  parse: function (options) {
+  parse: function(options) {
     if (options.labels || options.country) {
       Logger.deprecate('Use "i18n" instead of "labels" and "country"');
       const overrides = options.labels || {};
 
-      _.each(options.country, function (val, key) {
+      _.each(options.country, function(val, key) {
         overrides['country.' + key] = val;
       });
       // Old behavior is to treat the override as a global override, so we
       // need to add these overrides to each language
       options.i18n = {};
-      _.each(config.supportedLanguages, function (language) {
+      _.each(config.supportedLanguages, function(language) {
         options.i18n[language] = overrides;
       });
       delete options.labels;
@@ -512,7 +512,7 @@ export default Model.extend({
     return options;
   },
 
-  isDsTheme: function () {
+  isDsTheme: function() {
     return false;
   },
 });

--- a/src/util/Animations.js
+++ b/src/util/Animations.js
@@ -17,7 +17,7 @@ import Enums from './Enums';
 const SWAP_PAGE_TIME = 200;
 const fn = {};
 
-function zoom ($el, start, finish) {
+function zoom($el, start, finish) {
   const deferred = Q.defer();
 
   $el.animate(
@@ -27,12 +27,12 @@ function zoom ($el, start, finish) {
     {
       duration: 200,
       easing: 'swing',
-      step: function (now, fx) {
+      step: function(now, fx) {
         fx.start = start;
         fx.end = finish;
         $el.css('transform', 'scale(' + now + ', ' + now + ')');
       },
-      always: function () {
+      always: function() {
         deferred.resolve($el);
       },
     }
@@ -40,7 +40,7 @@ function zoom ($el, start, finish) {
   return deferred.promise;
 }
 
-function rotate ($el, start, finish) {
+function rotate($el, start, finish) {
   const deferred = Q.defer();
 
   $el.animate(
@@ -50,12 +50,12 @@ function rotate ($el, start, finish) {
     {
       duration: 150,
       easing: 'swing',
-      step: function (now, fx) {
+      step: function(now, fx) {
         fx.start = start;
         fx.end = finish;
         $el.css('transform', 'rotate(' + now + 'deg)');
       },
-      always: function () {
+      always: function() {
         deferred.resolve($el);
       },
     }
@@ -66,7 +66,7 @@ function rotate ($el, start, finish) {
 // Note: It is necessary to pass in a success callback because we must
 // remove the old dom node (and controller) in the same tick of the event
 // loop. Waiting for "then" results in a glitchy animation.
-fn.swapPages = function (options) {
+fn.swapPages = function(options) {
   const deferred = Q.defer();
   const $parent = options.$parent;
   const $oldRoot = options.$oldRoot;
@@ -83,7 +83,7 @@ fn.swapPages = function (options) {
   $parent.append($newRoot);
 
   $parent.addClass('animation-container-overflow');
-  $newRoot.animate({ left: '0px', top: '0px', opacity: 1 }, SWAP_PAGE_TIME, function () {
+  $newRoot.animate({ left: '0px', top: '0px', opacity: 1 }, SWAP_PAGE_TIME, function() {
     $parent.removeClass('animation-container-overflow');
     $newRoot.removeClass(directionClassName);
     $newRoot.removeAttr('style');
@@ -96,43 +96,43 @@ fn.swapPages = function (options) {
   return deferred.promise;
 };
 
-fn.swapBeacons = function (options) {
+fn.swapBeacons = function(options) {
   const $el = options.$el;
   const swap = options.swap;
   const ctx = options.ctx;
 
   return this.implode($el)
-    .then(function () {
+    .then(function() {
       swap.call(ctx);
       return $el;
     })
     .then(this.explode);
 };
 
-fn.explode = function ($el) {
+fn.explode = function($el) {
   return zoom($el, 0, 1); //zoom in
 };
 
-fn.implode = function ($el) {
+fn.implode = function($el) {
   return zoom($el, 1, 0); //zoom out
 };
 
-fn.radialProgressBar = function (options) {
+fn.radialProgressBar = function(options) {
   const radialProgressBar = options.$el;
   const swap = options.swap;
   const circles = radialProgressBar.children();
 
   return rotate(circles, 0, 180)
-    .then(function () {
+    .then(function() {
       radialProgressBar.css({ clip: 'auto' });
     })
-    .then(function () {
+    .then(function() {
       const leftHalf = circles.eq(0);
 
       swap();
       return rotate(leftHalf, 180, 360);
     })
-    .then(function () {
+    .then(function() {
       //reset values to initial state
       radialProgressBar.css({ clip: 'rect(0px, 96px, 96px, 48px)' });
       circles.css({

--- a/src/util/BaseLoginController.js
+++ b/src/util/BaseLoginController.js
@@ -13,8 +13,8 @@
 import { _, Form, Controller } from 'okta';
 import Q from 'q';
 
-function getForm (controller) {
-  return _.find(controller.getChildren(), function (item) {
+function getForm(controller) {
+  return _.find(controller.getChildren(), function(item) {
     return item instanceof Form;
   });
 }
@@ -27,9 +27,9 @@ export default Controller.extend({
   // the constructor doesn't help either (JS errors etc.). This at least guarantees that we
   // are listening to the model events.
   // Note - Figure out a way to call the constructor in the right order.
-  addListeners: function () {
+  addListeners: function() {
     // Events to enable/disable the primary button on the forms
-    this.listenTo(this.model, 'save', function () {
+    this.listenTo(this.model, 'save', function() {
       const form = getForm(this);
       //disable the submit button on forms while making the request
       //to prevent users from hitting rate limiting exceptions of
@@ -43,14 +43,14 @@ export default Controller.extend({
       this.toggleButtonState(true);
     });
 
-    this.listenTo(this.model, 'error', function () {
+    this.listenTo(this.model, 'error', function() {
       this.toggleButtonState(false);
     });
 
     this.addModelListeners(this.model);
   },
 
-  addModelListeners: function (model) {
+  addModelListeners: function(model) {
     const setTransactionHandler = transaction => {
       this.options.appState.set('transaction', transaction);
     };
@@ -79,30 +79,30 @@ export default Controller.extend({
   // promise is resolved. This is useful for cases like enrolling a security
   // question, which requires an additional request to fetch the question
   // list.
-  fetchInitialData: function () {
+  fetchInitialData: function() {
     return Q();
   },
 
   // Override this method to prevent route navigation. This is useful for
   // intermediate status changes that do not trigger a full refresh of the
   // page, like MFA_ENROLL_ACTIVATE and MFA_CHALLENGE.
-  trapAuthResponse: function () {
+  trapAuthResponse: function() {
     return false;
   },
 
-  toJSON: function () {
+  toJSON: function() {
     const data = Controller.prototype.toJSON.apply(this, arguments);
 
     return _.extend(_.pick(this.options, 'appState'), data);
   },
 
-  toggleButtonState: function (state) {
+  toggleButtonState: function(state) {
     const button = this.$el.find('.button');
 
     button.toggleClass('link-button-disabled', state).prop('disabled', state);
   },
 
-  postRenderAnimation: function () {
+  postRenderAnimation: function() {
     // Event triggered after a page is rendered along with the classname to identify the page
     // TODO: Deprecate this event in the next major version in favor of 'afterRender'
     this.trigger('pageRendered', { page: this.className });

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -30,13 +30,13 @@ import Errors from './Errors';
 import RouterUtil from './RouterUtil';
 import Util from './Util';
 
-function isStateLessRouteHandler (router, fn) {
-  return _.find(router.stateLessRouteHandlers, function (routeName) {
+function isStateLessRouteHandler(router, fn) {
+  return _.find(router.stateLessRouteHandlers, function(routeName) {
     return fn === router[routeName];
   });
 }
 
-function beaconIsAvailable (Beacon, settings) {
+function beaconIsAvailable(Beacon, settings) {
   if (!Beacon) {
     return false;
   }
@@ -49,8 +49,8 @@ function beaconIsAvailable (Beacon, settings) {
 /**
  * TODO: deprecated by `util/LanguageUtil.loadLanguage`
  */
-function loadLanguage (appState, i18n, assetBaseUrl, assetRewrite) {
-  const timeout = setTimeout(function () {
+function loadLanguage(appState, i18n, assetBaseUrl, assetRewrite) {
+  const timeout = setTimeout(function() {
     // Trigger a spinner if we're waiting on a request for a new language.
     appState.trigger('loading', true);
   }, 200);
@@ -58,7 +58,7 @@ function loadLanguage (appState, i18n, assetBaseUrl, assetRewrite) {
   return Bundles.loadLanguage(appState.get('languageCode'), i18n, {
     baseUrl: assetBaseUrl,
     rewrite: assetRewrite,
-  }).then(function () {
+  }).then(function() {
     clearTimeout(timeout);
     appState.trigger('loading', false);
   });
@@ -67,14 +67,14 @@ function loadLanguage (appState, i18n, assetBaseUrl, assetRewrite) {
 export default Router.extend({
   Events: Backbone.Events,
 
-  initialize: function (options) {
+  initialize: function(options) {
     // Create a default success and/or error handler if
     // one is not provided.
     if (!options.globalSuccessFn) {
-      options.globalSuccessFn = function () {};
+      options.globalSuccessFn = function() {};
     }
     if (!options.globalErrorFn) {
-      options.globalErrorFn = function (err) {
+      options.globalErrorFn = function(err) {
         Logger.error(err);
       };
     }
@@ -86,7 +86,7 @@ export default Router.extend({
       this.settings.callGlobalError(new Errors.ConfigError(loc('error.required.el')));
     }
 
-    $('body > div').on('click', function () {
+    $('body > div').on('click', function() {
       // OKTA-69769 Tooltip wont close on iPhone/iPad
       // Registering a click handler on the first div
       // allows a tap that falls outside the tooltip
@@ -113,20 +113,20 @@ export default Router.extend({
       settings: this.settings,
     });
 
-    this.listenTo(this.appState, 'change:transactionError', function (appState, err) {
+    this.listenTo(this.appState, 'change:transactionError', function(appState, err) {
       RouterUtil.routeAfterAuthStatusChangeError(this, err);
     });
 
-    this.listenTo(this.appState, 'change:transaction', function (appState, trans) {
+    this.listenTo(this.appState, 'change:transaction', function(appState, trans) {
       RouterUtil.routeAfterAuthStatusChange(this, trans.data);
     });
 
-    this.listenTo(this.appState, 'navigate', function (url) {
+    this.listenTo(this.appState, 'navigate', function(url) {
       this.navigate(url, { trigger: true });
     });
   },
 
-  execute: function (cb, args) {
+  execute: function(cb, args) {
     const recoveryToken = this.settings.get('recoveryToken');
     // Recovery flow with a token passed through widget settings
 
@@ -168,7 +168,7 @@ export default Router.extend({
   // Overriding the default navigate method to allow the widget consumer
   // to "turn off" routing - if features.router is false, the browser
   // location bar will not update when the router navigates
-  navigate: function (fragment, options) {
+  navigate: function(fragment, options) {
     if (this.settings.get('features.router')) {
       return Router.prototype.navigate.apply(this, arguments);
     }
@@ -177,7 +177,7 @@ export default Router.extend({
     }
   },
 
-  render: function (Controller, options) {
+  render: function(Controller, options) {
     options || (options = {});
 
     let Beacon = options.Beacon;
@@ -244,7 +244,7 @@ export default Router.extend({
           $newRoot: this.controller.$el,
           dir: oldController.state.get('navigateDir'),
           ctx: this,
-          success: function () {
+          success: function() {
             const flashError = this.appState.get('flashError');
             const model = this.controller.model;
 
@@ -265,7 +265,7 @@ export default Router.extend({
           },
         });
       })
-      .catch(function () {
+      .catch(function() {
         // OKTA-69665 - if an error occurs in fetchInitialData, we're left in
         // a state with two active controllers. Therefore, we clean up the
         // old one. Note: This explicitly handles the invalid token case -
@@ -279,7 +279,7 @@ export default Router.extend({
       });
   },
 
-  start: function () {
+  start: function() {
     let pushState = false;
 
     // Support for browser's back button.
@@ -296,15 +296,15 @@ export default Router.extend({
     Router.prototype.start.call(this, { pushState: pushState });
   },
 
-  hide: function () {
+  hide: function() {
     this.header.$el.hide();
   },
 
-  show: function () {
+  show: function() {
     this.header.$el.show();
   },
 
-  remove: function () {
+  remove: function() {
     this.controller.remove();
     this.header.$el.remove();
     Bundles.remove();

--- a/src/util/BrowserFeatures.js
+++ b/src/util/BrowserFeatures.js
@@ -14,11 +14,11 @@ const fn = {};
 const hasFullCorsSupport = 'withCredentials' in new window.XMLHttpRequest();
 const hasXDomainRequest = typeof XDomainRequest !== 'undefined';
 
-fn.corsIsNotSupported = function () {
+fn.corsIsNotSupported = function() {
   return !(hasFullCorsSupport || hasXDomainRequest);
 };
 
-fn.corsIsNotEnabled = function (jqXhr) {
+fn.corsIsNotEnabled = function(jqXhr) {
   // Not a definitive check, but it's the best we've got.
   // Note: This will change when OktaAuth is updated
   return jqXhr.status === 0;
@@ -27,7 +27,7 @@ fn.corsIsNotEnabled = function (jqXhr) {
 // This is currently not being used, but we'll keep it around for when we
 // want a fallback mechanism - i.e. use localStorage if it exists, else fall
 // back to cookies.
-fn.localStorageIsNotSupported = function () {
+fn.localStorageIsNotSupported = function() {
   const test = 'test';
 
   try {
@@ -39,25 +39,25 @@ fn.localStorageIsNotSupported = function () {
   }
 };
 
-fn.supportsPushState = function (win) {
+fn.supportsPushState = function(win) {
   win = win || window;
   return !!(win.history && win.history.pushState);
 };
 
-fn.isIE = function () {
+fn.isIE = function() {
   return /(msie|trident)/i.test(navigator.userAgent);
 };
 
-fn.isFirefox = function () {
+fn.isFirefox = function() {
   return navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 };
 
-fn.isEdge = function () {
+fn.isEdge = function() {
   // This is to just check for windows edge. Mac edge - chromium based's UA is 'edg'.
   return navigator.userAgent.toLowerCase().indexOf('edge') > -1;
 };
 
-fn.isSafari = function () {
+fn.isSafari = function() {
   // Chrome has safari in its useragent string so adding this extra check.
   return (
     navigator.userAgent.toLowerCase().indexOf('safari') > -1 &&
@@ -65,25 +65,25 @@ fn.isSafari = function () {
   );
 };
 
-fn.isMac = function () {
+fn.isMac = function() {
   return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 };
 
 
-fn.isAndroid = function () {
+fn.isAndroid = function() {
   // Windows Phone also contains "Android"
   return /android/i.test(navigator.userAgent) &&
     !/windows phone/i.test(navigator.userAgent);
 };
 
-fn.isIOS = function () {
+fn.isIOS = function() {
   // iOS detection from: http://stackoverflow.com/a/9039885/177710
   return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 };
 
 // Returns a list of languages the user has configured for their browser, in
 // order of preference.
-fn.getUserLanguages = function () {
+fn.getUserLanguages = function() {
   var languages, properties;
 
   // Chrome, Firefox
@@ -99,7 +99,7 @@ fn.getUserLanguages = function () {
     'systemLanguage'    // IE
   ];
 
-  properties.forEach(function (property) {
+  properties.forEach(function(property) {
     if (navigator[property]) {
       languages.push(navigator[property]);
     }

--- a/src/util/Bundles.js
+++ b/src/util/Bundles.js
@@ -46,24 +46,24 @@ const STORAGE_KEY = 'osw.languages';
  *  }
  * }
  */
-function parseOverrides (i18n) {
+function parseOverrides(i18n) {
   if (!i18n) {
     return {};
   }
 
   const i18nWithLowerCaseKeys = {};
 
-  _.each(_.keys(i18n), function (key) {
+  _.each(_.keys(i18n), function(key) {
     i18nWithLowerCaseKeys[key.toLowerCase()] = i18n[key];
   });
 
-  return _.mapObject(i18nWithLowerCaseKeys, function (props) {
+  return _.mapObject(i18nWithLowerCaseKeys, function(props) {
     const mapped = { login: {}, country: {} };
 
     if (!_.isObject(props)) {
       throw new Error('Invalid format for "i18n"');
     }
-    _.each(props, function (val, key) {
+    _.each(props, function(val, key) {
       const split = key.split(/^country\./);
 
       if (split.length > 1) {
@@ -80,7 +80,7 @@ function parseOverrides (i18n) {
 // languages are loaded on demand and cached in localStorage. These languages
 // are tied to the version of the widget - when it bumps, we reset the cache.
 
-function getCachedLanguages () {
+function getCachedLanguages() {
   let storage = JSON.parse(localStorage.getItem(STORAGE_KEY));
 
   if (!storage || storage.version !== config.version) {
@@ -91,7 +91,7 @@ function getCachedLanguages () {
   return storage;
 }
 
-function addLanguageToCache (language, loginJson, countryJson) {
+function addLanguageToCache(language, loginJson, countryJson) {
   const current = getCachedLanguages();
 
   current[language] = {
@@ -129,7 +129,7 @@ function addLanguageToCache (language, loginJson, countryJson) {
 // Note: Most developers will not need to use these overrides - the default
 // is to use the Okta CDN and to use the same path + file structure the
 // widget module publishes by default.
-function fetchJson (bundle, language, assets) {
+function fetchJson(bundle, language, assets) {
   let languageCode;
   let path;
 
@@ -155,7 +155,7 @@ function fetchJson (bundle, language, assets) {
     .then(txt => JSON.parse(txt));
 }
 
-function getBundles (language, assets) {
+function getBundles(language, assets) {
   // Two special cases:
   // 1. English is already bundled with the widget
   // 2. If the language is not in our config file, it means that they've
@@ -177,13 +177,13 @@ function getBundles (language, assets) {
   }
 
   return Q.all([fetchJson('login', language, assets), fetchJson('country', language, assets)])
-    .spread(function (loginJson, countryJson) {
+    .spread(function(loginJson, countryJson) {
       if (localStorageIsSupported) {
         addLanguageToCache(language, loginJson, countryJson);
       }
       return { login: loginJson, country: countryJson };
     })
-    .catch(function () {
+    .catch(function() {
       // If there is an error, this will default to the bundled language and
       // we will no longer try to load the language this session.
       Logger.warn('Unable to load language: ' + language);
@@ -201,15 +201,15 @@ export default {
 
   currentLanguage: null,
 
-  isLoaded: function (language) {
+  isLoaded: function(language) {
     return this.currentLanguage === language;
   },
 
-  remove: function () {
+  remove: function() {
     this.currentLanguage = null;
   },
 
-  loadLanguage: function (language, overrides, assets) {
+  loadLanguage: function(language, overrides, assets) {
     const parsedOverrides = parseOverrides(overrides);
     const lowerCaseLanguage = language.toLowerCase();
 

--- a/src/util/ColorsUtil.js
+++ b/src/util/ColorsUtil.js
@@ -13,7 +13,7 @@
 import Enums from 'util/Enums';
 const fn = {};
 
-const template = function (colors) {
+const template = function(colors) {
   return `
 #okta-sign-in.auth-container .button-primary,
 #okta-sign-in.auth-container .button-primary:active,
@@ -27,7 +27,7 @@ const template = function (colors) {
 };
 
 // visible for testing
-fn.lighten = function (hex, lum) {
+fn.lighten = function(hex, lum) {
   lum = lum || 0;
   hex = hex.substr(1);
   let newHex = '#';
@@ -41,7 +41,7 @@ fn.lighten = function (hex, lum) {
   return newHex;
 };
 
-fn.addStyle = function (colors) {
+fn.addStyle = function(colors) {
   const css = template(colors);
   const main = document.getElementById(Enums.WIDGET_CONTAINER_ID);
   const style = document.createElement('style');
@@ -53,7 +53,7 @@ fn.addStyle = function (colors) {
   main.appendChild(style);
 };
 
-fn.isLoaded = function () {
+fn.isLoaded = function() {
   return !!document.getElementById(Enums.WIDGET_CONFIG_COLORS_ID);
 };
 

--- a/src/util/CookieUtil.js
+++ b/src/util/CookieUtil.js
@@ -16,18 +16,18 @@ const LAST_USERNAME_COOKIE_NAME = 'ln';
 const DAYS_SAVE_REMEMBER = 365;
 const fn = {};
 
-fn.getCookieUsername = function () {
+fn.getCookieUsername = function() {
   return Cookie.getCookie(LAST_USERNAME_COOKIE_NAME);
 };
 
-fn.setUsernameCookie = function (username) {
+fn.setUsernameCookie = function(username) {
   Cookie.setCookie(LAST_USERNAME_COOKIE_NAME, username, {
     expires: DAYS_SAVE_REMEMBER,
     path: '/',
   });
 };
 
-fn.removeUsernameCookie = function () {
+fn.removeUsernameCookie = function() {
   Cookie.removeCookie(LAST_USERNAME_COOKIE_NAME, { path: '/' });
 };
 

--- a/src/util/CountryUtil.js
+++ b/src/util/CountryUtil.js
@@ -16,13 +16,13 @@ import countryCallingCodes from './countryCallingCodes';
 const fn = {};
 
 // () => [{ countryCode: countryName }], sorted by countryName
-fn.getCountries = function () {
+fn.getCountries = function() {
   const countries = _.omit(bundles.country, 'HM', 'BV', 'TF');
   // HM, BV, and TF do not have phone prefixes, so don't give the
   // user the option to choose these countries. FYI it appears that these
   // countries do not have calling codes because they are ~~uninhabited~~
 
-  let collection = _.map(countries, function (name, code) {
+  let collection = _.map(countries, function(name, code) {
     return { name: name, code: code };
   });
 
@@ -32,14 +32,14 @@ fn.getCountries = function () {
   collection = _.sortBy(collection, 'name');
   const sorted = {};
 
-  _.each(collection, function (country) {
+  _.each(collection, function(country) {
     sorted[country.code] = country.name;
   });
 
   return sorted;
 };
 
-fn.getCallingCodeForCountry = function (countryCode) {
+fn.getCallingCodeForCountry = function(countryCode) {
   return countryCallingCodes[countryCode];
 };
 

--- a/src/util/CryptoUtil.js
+++ b/src/util/CryptoUtil.js
@@ -22,7 +22,7 @@ const fn = {};
  * @param str the string to be hashed
  * @returns string hash of integer type
  */
-fn.getStringHash = function (str) {
+fn.getStringHash = function(str) {
   let hash = 5381;
   let i = str.length;
 
@@ -37,7 +37,7 @@ fn.getStringHash = function (str) {
  * @param str base64 string that might contain url safe characters
  * @returns base64 formatted string
  */
-fn.base64UrlSafeToBase64 = function (str) {
+fn.base64UrlSafeToBase64 = function(str) {
   return str.replace(new RegExp('_', 'g'), '/').replace(new RegExp('-', 'g'), '+');
 };
 
@@ -46,7 +46,7 @@ fn.base64UrlSafeToBase64 = function (str) {
  * @param bin ArrayBuffer object
  * @returns base64 encoded string
  */
-fn.binToStr = function (bin) {
+fn.binToStr = function(bin) {
   return btoa(new Uint8Array(bin).reduce((s, byte) => s + String.fromCharCode(byte), ''));
 };
 
@@ -55,7 +55,7 @@ fn.binToStr = function (bin) {
  * @param str in base64 or base64UrlSafe format
  * @returns converted Uint8Array view of binary data
  */
-fn.strToBin = function (str) {
+fn.strToBin = function(str) {
   return Uint8Array.from(atob(this.base64UrlSafeToBase64(str)), c => c.charCodeAt(0));
 };
 

--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -13,16 +13,16 @@
 import { $ } from 'okta';
 import Q from 'q';
 export default {
-  getUserAgent: function () {
+  getUserAgent: function() {
     return navigator.userAgent;
   },
-  isAndroid: function () {
+  isAndroid: function() {
     return /Android/i.test(this.getUserAgent());
   },
-  isMessageFromCorrectSource: function ($iframe, event) {
+  isMessageFromCorrectSource: function($iframe, event) {
     return event.source === $iframe[0].contentWindow;
   },
-  generateDeviceFingerprint: function (oktaDomainUrl, element) {
+  generateDeviceFingerprint: function(oktaDomainUrl, element) {
     const userAgent = this.getUserAgent();
 
     if (!userAgent) {
@@ -36,22 +36,22 @@ export default {
     let $iframe;
     let iFrameTimeout;
 
-    function isWindowsPhone (userAgent) {
+    function isWindowsPhone(userAgent) {
       return userAgent.match(/windows phone|iemobile|wpdesktop/i);
     }
 
-    function removeIframe () {
+    function removeIframe() {
       $iframe.off();
       $iframe.remove();
       window.removeEventListener('message', onMessageReceivedFromOkta, false);
     }
 
-    function handleError (reason) {
+    function handleError(reason) {
       removeIframe();
       deferred.reject(reason);
     }
 
-    function onMessageReceivedFromOkta (event) {
+    function onMessageReceivedFromOkta(event) {
       if (!self.isMessageFromCorrectSource($iframe, event)) {
         return;
       }
@@ -77,7 +77,7 @@ export default {
       }
     }
 
-    function sendMessageToOkta (message) {
+    function sendMessageToOkta(message) {
       const win = $iframe[0].contentWindow;
 
       if (win) {

--- a/src/util/Errors.js
+++ b/src/util/Errors.js
@@ -13,44 +13,44 @@
 import { loc } from 'okta';
 import Enums from './Enums';
 
-function ConfigError (message) {
+function ConfigError(message) {
   this.name = Enums.CONFIG_ERROR;
   this.message = message || loc('error.config');
 }
 ConfigError.prototype = new Error();
 
-function UnsupportedBrowserError (message) {
+function UnsupportedBrowserError(message) {
   this.name = Enums.UNSUPPORTED_BROWSER_ERROR;
   this.message = message || loc('error.unsupported.browser');
 }
 UnsupportedBrowserError.prototype = new Error();
 
-function OAuthError (message) {
+function OAuthError(message) {
   this.name = Enums.OAUTH_ERROR;
   this.message = message;
 }
 OAuthError.prototype = new Error();
 
-function RegistrationError (message) {
+function RegistrationError(message) {
   this.name = Enums.REGISTRATION_FAILED;
   this.message = message;
 }
 RegistrationError.prototype = new Error();
 
 // Thrown when initiation of poll was cancelled.
-function AuthStopPollInitiationError () {
+function AuthStopPollInitiationError() {
   this.name = Enums.AUTH_STOP_POLL_INITIATION_ERROR;
 }
 AuthStopPollInitiationError.prototype = new Error();
 
-function U2FError (err) {
+function U2FError(err) {
   this.name = Enums.U2F_ERROR;
   this.message = err.xhr.responseJSON.errorSummary;
   this.xhr = err.xhr;
 }
 U2FError.prototype = new Error();
 
-function WebAuthnError (err) {
+function WebAuthnError(err) {
   this.name = Enums.WEB_AUTHN_ERROR;
   this.message = err.xhr.responseJSON.errorSummary;
   this.xhr = err.xhr;
@@ -58,7 +58,7 @@ function WebAuthnError (err) {
 WebAuthnError.prototype = new Error();
 
 // This is triggered only when code aborts webauthn browser prompt.
-function WebauthnAbortError () {
+function WebauthnAbortError() {
   this.name = Enums.WEBAUTHN_ABORT_ERROR;
 }
 WebauthnAbortError.prototype = new Error();

--- a/src/util/FactorUtil.js
+++ b/src/util/FactorUtil.js
@@ -147,8 +147,8 @@ const factorData = {
   },
 };
 
-const getPasswordComplexityRequirementsAsArray = function (policy, i18nKeys) {
-  const setExcludeAttributes = function (policyComplexity) {
+const getPasswordComplexityRequirementsAsArray = function(policy, i18nKeys) {
+  const setExcludeAttributes = function(policyComplexity) {
     const excludeAttributes = policyComplexity.excludeAttributes;
 
     policyComplexity.excludeFirstName = _.contains(excludeAttributes, 'firstName');
@@ -160,7 +160,7 @@ const getPasswordComplexityRequirementsAsArray = function (policy, i18nKeys) {
     const complexityFields = i18nKeys.complexity;
     const policyComplexity = setExcludeAttributes(policy.complexity);
 
-    const requirements = _.map(policyComplexity, function (complexityValue, complexityType) {
+    const requirements = _.map(policyComplexity, function(complexityValue, complexityType) {
       if (complexityValue <= 0) {
         // to skip 0 and -1
         return;
@@ -176,15 +176,15 @@ const getPasswordComplexityRequirementsAsArray = function (policy, i18nKeys) {
   return [];
 };
 
-const getPasswordHistoryRequirementDescription = function (policy, i18nKeys) {
+const getPasswordHistoryRequirementDescription = function(policy, i18nKeys) {
   if (policy.age && policy.age.historyCount > 0) {
     return loc(i18nKeys.history.i18n, 'login', [policy.age.historyCount]);
   }
   return null;
 };
 
-const getPasswordAgeRequirementDescription = function (policy, i18nKeys) {
-  const getPasswordAgeRequirement = function (displayableTime) {
+const getPasswordAgeRequirementDescription = function(policy, i18nKeys) {
+  const getPasswordAgeRequirement = function(displayableTime) {
     let propertiesString;
 
     switch (displayableTime.unit) {
@@ -208,7 +208,7 @@ const getPasswordAgeRequirementDescription = function (policy, i18nKeys) {
   return null;
 };
 
-const getPasswordRequirements = function (policy, i18nKeys) {
+const getPasswordRequirements = function(policy, i18nKeys) {
   const passwordRequirements = {
     complexity: [],
     history: [],
@@ -232,7 +232,7 @@ const getPasswordRequirements = function (policy, i18nKeys) {
   return passwordRequirements;
 };
 
-fn.getFactorName = function (provider, factorType) {
+fn.getFactorName = function(provider, factorType) {
   if (provider === 'OKTA' && factorType === 'token:software:totp') {
     return 'OKTA_VERIFY';
   }
@@ -281,7 +281,7 @@ fn.getFactorName = function (provider, factorType) {
   return fn.getFactorNameForFactorType.call(this, factorType);
 };
 
-fn.getFactorNameForFactorType = function (factorType) {
+fn.getFactorNameForFactorType = function(factorType) {
   if (factorType === 'u2f') {
     return 'U2F';
   }
@@ -303,17 +303,17 @@ fn.getFactorNameForFactorType = function (factorType) {
   }
 };
 
-fn.isOktaVerify = function (provider, factorType) {
+fn.isOktaVerify = function(provider, factorType) {
   return provider === 'OKTA' && (factorType === 'token:software:totp' || factorType === 'push');
 };
 
-fn.getFactorLabel = function (provider, factorType) {
+fn.getFactorLabel = function(provider, factorType) {
   const key = factorData[fn.getFactorName.apply(this, [provider, factorType])].label;
 
   return loc(key, 'login');
 };
 
-fn.getFactorDescription = function (provider, factorType) {
+fn.getFactorDescription = function(provider, factorType) {
   const descriptionKey = factorData[fn.getFactorName.apply(this, [provider, factorType])].description;
 
   if (_.isFunction(descriptionKey)) {
@@ -326,25 +326,25 @@ fn.getFactorDescription = function (provider, factorType) {
   }
 };
 
-fn.getFactorIconClassName = function (provider, factorType) {
+fn.getFactorIconClassName = function(provider, factorType) {
   return factorData[fn.getFactorName.apply(this, [provider, factorType])].iconClassName;
 };
 
-fn.getFactorSortOrder = function (provider, factorType) {
+fn.getFactorSortOrder = function(provider, factorType) {
   return factorData[fn.getFactorName.apply(this, [provider, factorType])].sortOrder;
 };
 
-fn.getRememberDeviceValue = function (appState) {
+fn.getRememberDeviceValue = function(appState) {
   return appState && appState.get('rememberDeviceByDefault');
 };
 
-fn.getSecurityQuestionLabel = function (questionObj) {
+fn.getSecurityQuestionLabel = function(questionObj) {
   const localizedQuestion = loc('security.' + questionObj.question);
 
   return localizedQuestion.indexOf('L10N_ERROR') < 0 ? localizedQuestion : questionObj.questionText;
 };
 
-fn.removeRequirementsFromError = function (responseJSON, policy) {
+fn.removeRequirementsFromError = function(responseJSON, policy) {
   const passwordRequirementsAsString = this.getPasswordComplexityDescription(policy);
 
   if (
@@ -359,7 +359,7 @@ fn.removeRequirementsFromError = function (responseJSON, policy) {
   return responseJSON;
 };
 
-fn.getPasswordComplexityDescriptionForHtmlList = function (policy) {
+fn.getPasswordComplexityDescriptionForHtmlList = function(policy) {
   const passwordRequirementHtmlI18nKeys = {
     complexity: {
       minLength: { i18n: 'password.complexity.length.description', args: true },
@@ -383,7 +383,7 @@ fn.getPasswordComplexityDescriptionForHtmlList = function (policy) {
   return _.union(passwordRequirements.complexity, passwordRequirements.history, passwordRequirements.age);
 };
 
-fn.getPasswordComplexityDescription = function (policy) {
+fn.getPasswordComplexityDescription = function(policy) {
   const passwordRequirementI18nKeys = {
     complexity: {
       minLength: { i18n: 'password.complexity.length', args: true },
@@ -408,7 +408,7 @@ fn.getPasswordComplexityDescription = function (policy) {
 
   // Generate and add complexity string to result
   if (requirements.length > 0) {
-    requirements = _.reduce(requirements, function (result, requirement) {
+    requirements = _.reduce(requirements, function(result, requirement) {
       return result ? result + loc('password.complexity.list.element', 'login', [requirement]) : requirement;
     });
 
@@ -422,7 +422,7 @@ fn.getPasswordComplexityDescription = function (policy) {
   return _.compact(result).join(' ');
 };
 
-fn.getCardinalityText = function (enrolled, required, cardinality) {
+fn.getCardinalityText = function(enrolled, required, cardinality) {
   if (cardinality) {
     if (enrolled) {
       return cardinality.enrolled === 1 ? '' : loc('enroll.choices.cardinality.setup', 'login', [cardinality.enrolled]);
@@ -433,7 +433,7 @@ fn.getCardinalityText = function (enrolled, required, cardinality) {
   return '';
 };
 
-fn.findFactorInFactorsArray = function (factors, provider, factorType) {
+fn.findFactorInFactorsArray = function(factors, provider, factorType) {
   let factor = factors.findWhere({ provider: provider, factorType: factorType });
 
   if (factor === undefined) {

--- a/src/util/FidoUtil.js
+++ b/src/util/FidoUtil.js
@@ -15,7 +15,7 @@
 import { loc } from 'okta';
 const fn = {};
 
-fn.getU2fEnrollErrorMessageKeyByCode = function (errorCode) {
+fn.getU2fEnrollErrorMessageKeyByCode = function(errorCode) {
   switch (errorCode) {
   default:
   case 1:
@@ -30,7 +30,7 @@ fn.getU2fEnrollErrorMessageKeyByCode = function (errorCode) {
   }
 };
 
-fn.getU2fVerifyErrorMessageKeyByCode = function (errorCode, isOneFactor) {
+fn.getU2fVerifyErrorMessageKeyByCode = function(errorCode, isOneFactor) {
   switch (errorCode) {
   case 1:
     // OTHER_ERROR
@@ -48,19 +48,19 @@ fn.getU2fVerifyErrorMessageKeyByCode = function (errorCode, isOneFactor) {
   }
 };
 
-fn.getU2fEnrollErrorMessageByCode = function (errorCode) {
+fn.getU2fEnrollErrorMessageByCode = function(errorCode) {
   return loc(fn.getU2fEnrollErrorMessageKeyByCode(errorCode), 'login');
 };
 
-fn.getU2fVerifyErrorMessageByCode = function (errorCode, isOneFactor) {
+fn.getU2fVerifyErrorMessageByCode = function(errorCode, isOneFactor) {
   return loc(fn.getU2fVerifyErrorMessageKeyByCode(errorCode, isOneFactor), 'login');
 };
 
-fn.getU2fVersion = function () {
+fn.getU2fVersion = function() {
   return 'U2F_V2';
 };
 
-fn.isU2fAvailable = function () {
+fn.isU2fAvailable = function() {
   return window.hasOwnProperty('u2f');
 };
 

--- a/src/util/FormController.js
+++ b/src/util/FormController.js
@@ -19,11 +19,11 @@ let { FormUtil } = internal.views.forms.helpers;
 const FormControllerSimpleForm = Form.extend({
   layout: 'o-form-theme',
   noCancelButton: true,
-  constructor: function (options) {
+  constructor: function(options) {
     Form.call(this, options);
     _.each(
       _.result(this, 'formChildren') || [],
-      function (child) {
+      function(child) {
         switch (child.type) {
         case FormType.INPUT:
           this.addInput(
@@ -60,10 +60,10 @@ const FormControllerSimpleForm = Form.extend({
   },
 });
 export default BaseLoginController.extend({
-  constructor: function () {
+  constructor: function() {
     const initialize = this.initialize;
 
-    this.initialize = function () {};
+    this.initialize = function() {};
 
     BaseLoginController.apply(this, arguments);
 
@@ -71,7 +71,7 @@ export default BaseLoginController.extend({
       const Model = BaseLoginModel.extend(
         _.extend(
           {
-            parse: function (attributes) {
+            parse: function(attributes) {
               this.settings = attributes.settings;
               this.appState = attributes.appState;
               return _.omit(attributes, ['settings', 'appState']);
@@ -102,18 +102,18 @@ export default BaseLoginController.extend({
     initialize.apply(this, arguments);
   },
 
-  addFooter: function (Footer, args) {
+  addFooter: function(Footer, args) {
     this.footer = new Footer(_.extend(this.toJSON(), args || {}));
     this.add(this.footer);
   },
 
-  toJSON: function () {
+  toJSON: function() {
     const data = BaseLoginController.prototype.toJSON.apply(this, arguments);
 
     return _.extend(_.pick(this.options, 'appState'), data);
   },
 
-  back: function () {
+  back: function() {
     if (this.footer && this.footer.back) {
       this.footer.back();
     }

--- a/src/util/FormType.js
+++ b/src/util/FormType.js
@@ -20,8 +20,8 @@ const DIVIDER = 'DIVIDER';
 const TOOLBAR = 'TOOLBAR';
 const VIEW = 'VIEW';
 
-function wrap (type) {
-  return function (viewOptions, addOptions) {
+function wrap(type) {
+  return function(viewOptions, addOptions) {
     return { type: type, viewOptions: viewOptions, addOptions: addOptions };
   };
 }

--- a/src/util/LanguageUtil.js
+++ b/src/util/LanguageUtil.js
@@ -1,12 +1,12 @@
 import Bundles from 'util/Bundles';
 
-function loadLanguage (appState, settings) {
+function loadLanguage(appState, settings) {
   const languageCode = settings.get('languageCode');
   const i18n = settings.get('i18n');
   const assetBaseUrl = settings.get('assets.baseUrl');
   const assetRewrite = settings.get('assets.rewrite');
 
-  const timeout = setTimeout(function () {
+  const timeout = setTimeout(function() {
     // Trigger a spinner if we're waiting on a request for a new language.
     appState.trigger('loading', true);
   }, 200);
@@ -14,7 +14,7 @@ function loadLanguage (appState, settings) {
   return Bundles.loadLanguage(languageCode, i18n, {
     baseUrl: assetBaseUrl,
     rewrite: assetRewrite,
-  }).then(function () {
+  }).then(function() {
     clearTimeout(timeout);
     appState.trigger('loading', false);
   });

--- a/src/util/Logger.js
+++ b/src/util/Logger.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-function log (level, args) {
+function log(level, args) {
   // Only log statements in development mode or if
   // throwing an error through console.error
   if (DEBUG || level === 'error') {
@@ -22,51 +22,51 @@ function log (level, args) {
  * Utility library of logging functions.
  */
 export default {
-  trace: function () {
+  trace: function() {
     return log('trace', arguments);
   },
 
-  dir: function () {
+  dir: function() {
     return log('dir', arguments);
   },
 
-  time: function () {
+  time: function() {
     return log('time', arguments);
   },
 
-  timeEnd: function () {
+  timeEnd: function() {
     return log('timeEnd', arguments);
   },
 
-  group: function () {
+  group: function() {
     return log('group', arguments);
   },
 
-  groupEnd: function () {
+  groupEnd: function() {
     return log('groupEnd', arguments);
   },
 
-  assert: function () {
+  assert: function() {
     return log('assert', arguments);
   },
 
-  log: function () {
+  log: function() {
     return log('log', arguments);
   },
 
-  info: function () {
+  info: function() {
     return log('info', arguments);
   },
 
-  warn: function () {
+  warn: function() {
     return log('warn', arguments);
   },
 
-  error: function () {
+  error: function() {
     return log('error', arguments);
   },
 
-  deprecate: function (msg) {
+  deprecate: function(msg) {
     return log('warn', ['[okta-signin-widget] DEPRECATED:', msg]);
   },
 };

--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -38,12 +38,12 @@ util.AUTH_PARAMS = AUTH_PARAMS;
  * @param params - {idp: 'xxx'} for social auth
  *                 {sessionToken: 'xxx'} for okta idp
  */
-util.getTokens = function (settings, params, controller) {
-  function success (result) {
+util.getTokens = function(settings, params, controller) {
+  function success(result) {
     settings.callGlobalSuccess(Enums.SUCCESS, result);
   }
 
-  function error (error) {
+  function error(error) {
     let showError = false;
     let responseJSON = error;
   

--- a/src/util/RegistrationFormFactory.js
+++ b/src/util/RegistrationFormFactory.js
@@ -15,14 +15,14 @@ import { _, internal, $ } from 'okta';
 import TextBox from 'views/shared/TextBox';
 let { SchemaFormFactory } = internal.views.forms.helpers;
 
-const getParts = function (username) {
+const getParts = function(username) {
   const usernameArr = username.split('');
   const minPartsLength = 3;
   const userNameParts = [];
   const delimiters = [',', '.', '-', '_', '#', '@'];
   let userNamePart = '';
 
-  _.each(usernameArr, function (part) {
+  _.each(usernameArr, function(part) {
     if (delimiters.indexOf(part) === -1) {
       userNamePart += part;
     } else {
@@ -38,7 +38,7 @@ const getParts = function (username) {
   return userNameParts.filter(Boolean);
 };
 
-const passwordContainsFormField = function (formField, password) {
+const passwordContainsFormField = function(formField, password) {
   if (!formField) {
     return false;
   }
@@ -57,7 +57,7 @@ const passwordContainsFormField = function (formField, password) {
   return false;
 };
 
-const checkSubSchema = function (subSchema, value, model) {
+const checkSubSchema = function(subSchema, value, model) {
   const minLength = subSchema.get('minLength');
   const maxLength = subSchema.get('maxLength');
   const regex = subSchema.get('format');
@@ -97,14 +97,14 @@ const checkSubSchema = function (subSchema, value, model) {
   return true;
 };
 
-const checkSubSchemas = function (fieldName, model, subSchemas, showError) {
+const checkSubSchemas = function(fieldName, model, subSchemas, showError) {
   const value = model.get(fieldName);
 
   if (!_.isString(value)) {
     return;
   }
 
-  subSchemas.each(function (subSchema, index) {
+  subSchemas.each(function(subSchema, index) {
     const ele = $('#subschemas-' + fieldName + ' .subschema-' + index);
 
     //hide password complexity if no password
@@ -128,7 +128,7 @@ const checkSubSchemas = function (fieldName, model, subSchemas, showError) {
   });
 };
 
-const fnCreateInputOptions = function (schemaProperty) {
+const fnCreateInputOptions = function(schemaProperty) {
   let inputOptions = SchemaFormFactory.createInputOptions(schemaProperty);
 
   if (inputOptions.type === 'select') {
@@ -169,22 +169,22 @@ const fnCreateInputOptions = function (schemaProperty) {
 
   if (subSchemas) {
     inputOptions.events = {
-      input: function () {
+      input: function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
-      focusout: function () {
+      focusout: function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
-      'change:userName': function () {
+      'change:userName': function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
-      'change:firstName': function () {
+      'change:firstName': function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
-      'change:lastName': function () {
+      'change:lastName': function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
-      'change:email': function () {
+      'change:email': function() {
         checkSubSchemas(fieldName, this.model, subSchemas, true);
       },
     };

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -33,7 +33,7 @@ const sessionCookieRedirectTpl = hbs(
   '{{baseUrl}}/login/sessionCookieRedirect?checkAccountSetupComplete=true&token={{{token}}}&redirectUrl={{{redirectUrl}}}'
 );
 
-fn.isHostBackgroundChromeTab = function () {
+fn.isHostBackgroundChromeTab = function() {
   // Checks if the SIW is loaded in a chrome webview and
   // it is in an app that is in background.
   if (navigator.userAgent.match(/Android/) && navigator.userAgent.match(/Chrome/) && document.hidden) {
@@ -43,11 +43,11 @@ fn.isHostBackgroundChromeTab = function () {
   }
 };
 
-fn.isDocumentVisible = function () {
+fn.isDocumentVisible = function() {
   return document.visibilityState === 'visible';
 };
 
-fn.createVerifyUrl = function (provider, factorType, factorIndex) {
+fn.createVerifyUrl = function(provider, factorType, factorIndex) {
   if (provider && factorIndex) {
     return verifyUrlMultipleTpl({
       provider: encodeURIComponent(provider.toLowerCase()),
@@ -66,14 +66,14 @@ fn.createVerifyUrl = function (provider, factorType, factorIndex) {
   }
 };
 
-fn.createEnrollFactorUrl = function (provider, factorType) {
+fn.createEnrollFactorUrl = function(provider, factorType) {
   return enrollFactorUrlTpl({
     provider: encodeURIComponent(provider.toLowerCase()),
     factorType: encodeURIComponent(factorType),
   });
 };
 
-fn.createActivateFactorUrl = function (provider, factorType, step) {
+fn.createActivateFactorUrl = function(provider, factorType, step) {
   return activateFactorUrlTpl({
     provider: encodeURIComponent(provider.toLowerCase()),
     factorType: encodeURIComponent(factorType),
@@ -81,19 +81,19 @@ fn.createActivateFactorUrl = function (provider, factorType, step) {
   });
 };
 
-fn.createRecoveryUrl = function (recoveryToken) {
+fn.createRecoveryUrl = function(recoveryToken) {
   return recoveryUrlTpl({
     recoveryToken: encodeURIComponent(recoveryToken),
   });
 };
 
-fn.createRefreshUrl = function (stateToken) {
+fn.createRefreshUrl = function(stateToken) {
   const token = stateToken ? encodeURIComponent(stateToken) : null;
 
   return refreshUrlTpl({ token: token });
 };
 
-fn.routeAfterAuthStatusChangeError = function (router, err) {
+fn.routeAfterAuthStatusChangeError = function(router, err) {
   if (!err) {
     return;
   }
@@ -119,7 +119,7 @@ fn.routeAfterAuthStatusChangeError = function (router, err) {
   Util.triggerAfterError(router.controller, err);
 };
 
-fn.routeAfterAuthStatusChange = function (router, res) {
+fn.routeAfterAuthStatusChange = function(router, res) {
   // Other errors are handled by the function making the authClient request
   if (!res || !res.status) {
     router.appState.clearLastAuthResponse();
@@ -135,7 +135,7 @@ fn.routeAfterAuthStatusChange = function (router, res) {
   fn.handleResponseStatus(router, res);
 };
 
-fn.handleResponseStatus = function (router, res) {
+fn.handleResponseStatus = function(router, res) {
   switch (res.status) {
   case 'SUCCESS': {
     if (res.recoveryType === Enums.RECOVERY_TYPE_UNLOCK) {
@@ -168,12 +168,12 @@ fn.handleResponseStatus = function (router, res) {
 
       successData.stepUp = {
         url: targetUrl,
-        finish: function () {
+        finish: function() {
           redirectFn(targetUrl);
         },
       };
     } else if (nextUrl) {
-      successData.next = function () {
+      successData.next = function() {
         redirectFn(nextUrl);
       };
     } else {
@@ -181,7 +181,7 @@ fn.handleResponseStatus = function (router, res) {
       successData.type = Enums.SESSION_SSO;
       successData.session = {
         token: res.sessionToken,
-        setCookieAndRedirect: function (redirectUri) {
+        setCookieAndRedirect: function(redirectUri) {
           if (redirectUri) {
             Util.debugMessage(`
               Passing a "redirectUri" to "setCookieAndRedirect" is strongly discouraged.
@@ -207,7 +207,7 @@ fn.handleResponseStatus = function (router, res) {
 
     // Check if we need to wait for redirect based on host.
     if (fn.isHostBackgroundChromeTab()) {
-      document.addEventListener('visibilitychange', function checkVisibilityAndCallSuccess () {
+      document.addEventListener('visibilitychange', function checkVisibilityAndCallSuccess() {
         if (fn.isDocumentVisible()) {
           document.removeEventListener('visibilitychange', checkVisibilityAndCallSuccess);
           router.settings.callGlobalSuccess(Enums.SUCCESS, successData);
@@ -258,7 +258,7 @@ fn.handleResponseStatus = function (router, res) {
     if (router.appState.get('isFactorResultFailed')) {
       router.appState.setLastFailedChallengeFactorData();
     }
-    router.appState.get('transaction').prev().then(function (trans) {
+    router.appState.get('transaction').prev().then(function(trans) {
       router.appState.set('transaction', trans);
     });
     // TODO: catch/handle error here?

--- a/src/util/TimeUtil.js
+++ b/src/util/TimeUtil.js
@@ -18,7 +18,7 @@ const MOMENT_UNIT_KEYS = Object.keys(MOMENT_UNIT);
  * @param {String} momentUnit The units that val is in
  * @return {String} The key in the MOMENT_UNIT hash
  */
-const convertMomentUnits = function (momentUnit) {
+const convertMomentUnits = function(momentUnit) {
   const entry = MOMENT_UNIT_KEYS.filter(k => MOMENT_UNIT[k] === momentUnit);
 
   return entry.length === 1 ? entry[0] : momentUnit;
@@ -51,7 +51,7 @@ export default {
    * @param {FlexibleTimeUnit} unit The time unit
    * @return {TimeAndUnit} An object containing the amount of time and the unit
    */
-  getTimeInHighestRelevantUnit: function (val, unit) {
+  getTimeInHighestRelevantUnit: function(val, unit) {
     const defaultTimeObj = {
       days: 0,
       hours: 0,

--- a/src/util/TypingUtil.js
+++ b/src/util/TypingUtil.js
@@ -12,7 +12,7 @@
 import TypingDNA from 'typingdna';
 let tdna;
 export default {
-  track: function (selectorId) {
+  track: function(selectorId) {
     try {
       tdna = new TypingDNA();
       tdna.addTarget(selectorId);
@@ -21,7 +21,7 @@ export default {
       // Issues in typing should not stop Primary auth.
     }
   },
-  getTypingPattern: function () {
+  getTypingPattern: function() {
     try {
       return tdna.getTypingPattern({
         type: 1,

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -17,7 +17,7 @@ import Enums from './Enums';
 import Logger from './Logger';
 const Util = {};
 
-const buildInputForParameter = function (name, value) {
+const buildInputForParameter = function(name, value) {
   const input = document.createElement('input');
 
   input.name = name;
@@ -26,7 +26,7 @@ const buildInputForParameter = function (name, value) {
   return input;
 };
 
-const buildDynamicForm = function (url = '', method) {
+const buildDynamicForm = function(url = '', method) {
   const splitOnFragment = url.split('#');
   const fragment = splitOnFragment[1];
   const splitOnQuery = (splitOnFragment[0] || '').split('?');
@@ -55,7 +55,7 @@ const buildDynamicForm = function (url = '', method) {
   return form;
 };
 
-Util.transformErrorXHR = function (xhr) {
+Util.transformErrorXHR = function(xhr) {
   // Handle network connection error
   if (xhr.status === 0 && _.isEmpty(xhr.responseJSON)) {
     xhr.responseJSON = { errorSummary: loc('error.network.connection', 'login') };
@@ -90,8 +90,8 @@ Util.transformErrorXHR = function (xhr) {
 };
 
 // Simple helper function to lowercase all strings in the given array
-Util.toLower = function (strings) {
-  return _.map(strings, function (str) {
+Util.toLower = function(strings) {
+  return _.map(strings, function(str) {
     return str.toLowerCase();
   });
 };
@@ -105,7 +105,7 @@ Util.toLower = function (strings) {
 // For example:
 // en-US -> [en-US, en]
 // de-DE-bavarian -> [de-DE-bavarian, de-DE, de]
-function expandLanguage (language) {
+function expandLanguage(language) {
   const expanded = [language];
   const parts = language.split('-');
 
@@ -118,23 +118,23 @@ function expandLanguage (language) {
 // Following the rules of expanding one language, this will generate
 // all potential languages in the given order (where higher priority is
 // given to expanded languages over other downstream languages).
-Util.expandLanguages = function (languages) {
+Util.expandLanguages = function(languages) {
   return _.chain(languages).map(expandLanguage).flatten().uniq().value();
 };
 
 //helper to call setTimeout
-Util.callAfterTimeout = function (callback, time) {
+Util.callAfterTimeout = function(callback, time) {
   return setTimeout(callback, time);
 };
 
 // Helper function to provide consistent formatting of template literals
 // that are logged when in development mode.
-Util.debugMessage = function (message) {
+Util.debugMessage = function(message) {
   Logger.warn(`\n${message.replace(/^(\s)+/gm, '')}`);
 };
 
 // Trigger an afterError event
-Util.triggerAfterError = function (controller, err = {}) {
+Util.triggerAfterError = function(controller, err = {}) {
   if (!err.statusCode && err.xhr && err.xhr.status) {
     // Bring the statusCode to the top-level of the Error
     err.statusCode = err.xhr.status;
@@ -149,7 +149,7 @@ Util.triggerAfterError = function (controller, err = {}) {
   Logger.warn('controller: ' + className + ', error: ' + error);
 };
 
-Util.redirect = function (url, win = window) {
+Util.redirect = function(url, win = window) {
   if (!url) {
     Logger.error(`Cannot redirect to empty URL: (${url})`);
     return;
@@ -170,11 +170,11 @@ Util.redirect = function (url, win = window) {
  *
  * Check the commit history for more details.
  */
-Util.redirectWithFormGet = function (url) {
+Util.redirectWithFormGet = function(url) {
   Util.redirectWithForm(url, 'get');
 };
 
-Util.redirectWithForm = function (url, method = 'post') {
+Util.redirectWithForm = function(url, method = 'post') {
   if (!url) {
     Logger.error(`Cannot redirect to empty URL: (${url})`);
     return;
@@ -199,7 +199,7 @@ Util.redirectWithForm = function (url, method = 'post') {
  * okta-signin-widget gives the possibility to customize every i18n, so we cannot
  * know ahead if these two are equal or different, we need to call this function everytime.
  */
-Util.createInputExplain = function (explainKey, labelKey, bundleName, explainParams, labelParams) {
+Util.createInputExplain = function(explainKey, labelKey, bundleName, explainParams, labelParams) {
   const explain = explainParams ? loc(explainKey, bundleName, explainParams) : loc(explainKey, bundleName);
   const label = labelParams ? loc(labelKey, bundleName, labelParams) : loc(labelKey, bundleName);
 
@@ -209,12 +209,12 @@ Util.createInputExplain = function (explainKey, labelKey, bundleName, explainPar
   return explain;
 };
 
-Util.isV1StateToken = function (token) {
+Util.isV1StateToken = function(token) {
   return !!(token && _.isString(token) && token.startsWith('00'));
 };
 
 // TODO: remove when auth-js is updated: OKTA-325445
-Util.removeNils = function removeNils (obj) {
+Util.removeNils = function removeNils(obj) {
   var cleaned = {};
   for (var prop in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, prop)) {

--- a/src/util/ValidationUtil.js
+++ b/src/util/ValidationUtil.js
@@ -14,7 +14,7 @@ import { loc } from 'okta';
 const fn = {};
 
 // Validate the 'username' field on the model.
-fn.validateUsername = function (model) {
+fn.validateUsername = function(model) {
   const username = model.get('username');
 
   if (username && username.length > 256) {
@@ -25,7 +25,7 @@ fn.validateUsername = function (model) {
 };
 
 // Validate that the field1 and field2 fields on the model are a match.
-fn.validateFieldsMatch = function (model, field1, field2, message) {
+fn.validateFieldsMatch = function(model, field1, field2, message) {
   if (model.get(field1) !== model.get(field2)) {
     const ret = {};
 
@@ -35,7 +35,7 @@ fn.validateFieldsMatch = function (model, field1, field2, message) {
 };
 
 // Validate that the 'newPassword' and 'confirmPassword' fields on the model are a match.
-fn.validatePasswordMatch = function (model) {
+fn.validatePasswordMatch = function(model) {
   return fn.validateFieldsMatch(model, 'newPassword', 'confirmPassword', loc('password.error.match', 'login'));
 };
 

--- a/src/util/webauthn.js
+++ b/src/util/webauthn.js
@@ -14,16 +14,16 @@
 import Q from 'q';
 import FidoUtil from 'util/FidoUtil';
 
-function adaptToOkta (promise) {
+function adaptToOkta(promise) {
   return new Q(promise);
 }
 
-function makeCredential (accountInfo, cryptoParams, challenge) {
-  cryptoParams = cryptoParams.map(function (param) {
+function makeCredential(accountInfo, cryptoParams, challenge) {
+  cryptoParams = cryptoParams.map(function(param) {
     return { type: 'FIDO_2_0', algorithm: param.algorithm };
   });
 
-  const promise = window.msCredentials.makeCredential(accountInfo, cryptoParams, challenge).then(function (cred) {
+  const promise = window.msCredentials.makeCredential(accountInfo, cryptoParams, challenge).then(function(cred) {
     return Object.freeze({
       credential: { id: cred.id },
       publicKey: JSON.parse(cred.publicKey),
@@ -34,12 +34,12 @@ function makeCredential (accountInfo, cryptoParams, challenge) {
   return adaptToOkta(promise);
 }
 
-function getAssertion (challenge, allowList) {
-  const accept = allowList.map(function (item) {
+function getAssertion(challenge, allowList) {
+  const accept = allowList.map(function(item) {
     return { type: 'FIDO_2_0', id: item.id };
   });
   const filters = { accept: accept };
-  const promise = window.msCredentials.getAssertion(challenge, filters).then(function (attestation) {
+  const promise = window.msCredentials.getAssertion(challenge, filters).then(function(attestation) {
     const signature = attestation.signature;
 
     return Object.freeze({
@@ -56,13 +56,13 @@ function getAssertion (challenge, allowList) {
 export default {
   makeCredential: makeCredential,
   getAssertion: getAssertion,
-  isAvailable: function () {
+  isAvailable: function() {
     return window.hasOwnProperty('msCredentials');
   },
-  isNewApiAvailable: function () {
+  isNewApiAvailable: function() {
     return navigator && navigator.credentials && navigator.credentials.create;
   },
-  isWebauthnOrU2fAvailable: function () {
+  isWebauthnOrU2fAvailable: function() {
     return this.isNewApiAvailable() || FidoUtil.isU2fAvailable();
   },
 };

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -37,14 +37,14 @@ import IonResponseHelper from './ion/IonResponseHelper';
 export default Router.extend({
   Events: Backbone.Events,
 
-  initialize: function (options) {
+  initialize: function(options) {
     // Create a default success and/or error handler if
     // one is not provided.
     if (!options.globalSuccessFn) {
-      options.globalSuccessFn = function () {};
+      options.globalSuccessFn = function() {};
     }
     if (!options.globalErrorFn) {
-      options.globalErrorFn = function (err) {
+      options.globalErrorFn = function(err) {
         Logger.error(err);
       };
     }
@@ -56,7 +56,7 @@ export default Router.extend({
       this.settings.callGlobalError(new Errors.ConfigError(loc('error.required.el')));
     }
 
-    $('body > div').on('click', function () {
+    $('body > div').on('click', function() {
       // OKTA-69769 Tooltip wont close on iPhone/iPad
       // Registering a click handler on the first div
       // allows a tap that falls outside the tooltip
@@ -80,7 +80,7 @@ export default Router.extend({
     this.listenTo(this.appState, 'remediationError', this.handleIdxResponseFailure);
   },
 
-  handleIdxResponseSuccess (idxResponse) {
+  handleIdxResponseSuccess(idxResponse) {
     if (idxResponse.interactionCode) {
       return interactionCodeFlow(this.settings, idxResponse);
     }
@@ -96,7 +96,7 @@ export default Router.extend({
     this.appState.setIonResponse(ionResponse);
   },
 
-  handleIdxResponseFailure (error = {}) {
+  handleIdxResponseFailure(error = {}) {
     // special case: `useInteractionCodeFlow` is true but the Org does not have OIE enabled
     // The response is not in IDX format. See playground/mocks/data/oauth2/error-feature-not-enabled.json
     if (error?.error === 'access_denied' && error.error_description) {
@@ -160,7 +160,7 @@ export default Router.extend({
     // }
   },
 
-  render: function (Controller, options = {}) {
+  render: function(Controller, options = {}) {
     // Since we have a wrapper view, render our wrapper and use its content
     // element as our new el.
     // Note: Render it here because we know dom is ready at this point
@@ -221,15 +221,15 @@ export default Router.extend({
     this.controller.render();
   },
 
-  hide: function () {
+  hide: function() {
     this.header.$el.hide();
   },
 
-  show: function () {
+  show: function() {
     this.header.$el.show();
   },
 
-  remove: function () {
+  remove: function() {
     this.unload();
     this.header.$el.remove();
     this.stopListening(this.appState);

--- a/src/v2/WidgetRouter.js
+++ b/src/v2/WidgetRouter.js
@@ -19,7 +19,7 @@ module.exports = BaseLoginRouter.extend({
     '*wildcard': 'defaultAuth',
   },
 
-  defaultAuth: function () {
+  defaultAuth: function() {
     this.render(FormController);
   },
 

--- a/src/v2/client/interact.js
+++ b/src/v2/client/interact.js
@@ -19,7 +19,7 @@ import idx from '@okta/okta-idx-js';
 import { getTransactionMeta, saveTransactionMeta } from './transactionMeta';
 
 // Begin or resume a transaction using an interactionHandle
-export async function interact (settings) {
+export async function interact(settings) {
 
   const authClient = settings.getAuthClient();
   let meta;

--- a/src/v2/client/interactionCodeFlow.js
+++ b/src/v2/client/interactionCodeFlow.js
@@ -16,7 +16,7 @@ import { toQueryString } from '@okta/okta-auth-js';
 
 import { clearTransactionMeta } from './transactionMeta';
 
-export async function interactionCodeFlow (settings, idxResponse) {
+export async function interactionCodeFlow(settings, idxResponse) {
   const { interactionCode } = idxResponse;
   const authClient = settings.getAuthClient();
   const transactionMeta = authClient.transactionManager.load();

--- a/src/v2/client/introspect.js
+++ b/src/v2/client/introspect.js
@@ -12,7 +12,7 @@
 
 import idx from '@okta/okta-idx-js';
 
-export async function introspect (settings) {
+export async function introspect(settings) {
   const domain = settings.get('baseUrl');
   const stateHandle = settings.get('stateToken');
   const version = settings.get('apiVersion');

--- a/src/v2/client/startLoginFlow.js
+++ b/src/v2/client/startLoginFlow.js
@@ -23,7 +23,7 @@ const handleProxyIdxResponse = async (settings) => {
   });
 };
 
-export async function startLoginFlow (settings) {
+export async function startLoginFlow(settings) {
   // Return a preset response
   if (settings.get('proxyIdxResponse')) {
     return handleProxyIdxResponse(settings);

--- a/src/v2/client/transactionMeta.js
+++ b/src/v2/client/transactionMeta.js
@@ -12,7 +12,7 @@
 
 import Logger from 'util/Logger';
 
-export async function getTransactionMeta (settings) {
+export async function getTransactionMeta(settings) {
   const authClient = settings.getAuthClient();
 
   // Load existing transaction meta from storage
@@ -32,19 +32,19 @@ export async function getTransactionMeta (settings) {
   return authClient.token.prepareTokenParams();
 }
 
-export function saveTransactionMeta (settings, meta) {
+export function saveTransactionMeta(settings, meta) {
   const authClient = settings.getAuthClient();
   authClient.transactionManager.save(meta);
 }
 
-export function clearTransactionMeta (settings) {
+export function clearTransactionMeta(settings) {
   const authClient = settings.getAuthClient();
   authClient.transactionManager.clear();
 }
 
 // returns true if values in meta match current authClient options
 // this logic can be moved to okta-auth-js OKTA-371584
-export function isTransactionMetaValid (settings, meta) {
+export function isTransactionMetaValid(settings, meta) {
   const keys = ['clientId', 'redirectUri'];
   const authClient = settings.getAuthClient();
   const mismatch = keys.find(key => {

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -29,11 +29,11 @@ export default Controller.extend({
     'switchForm': 'handleSwitchForm',
   },
 
-  preRender () {
+  preRender() {
     this.removeChildren();
   },
 
-  postRender () {
+  postRender() {
     const currentViewState = this.options.appState.getCurrentViewState();
     if (!currentViewState) {
       return;
@@ -59,16 +59,16 @@ export default Controller.extend({
     this.triggerAfterRenderEvent();
   },
 
-  triggerAfterRenderEvent () {
+  triggerAfterRenderEvent() {
     const contextData = this.createAfterEventContext();
     this.trigger('afterRender', contextData);
   },
 
-  handleFormNameChange () {
+  handleFormNameChange() {
     this.render();
   },
 
-  handleAfterError (error = {}) {
+  handleAfterError(error = {}) {
     const contextData = this.createAfterEventContext();
     const errorContextData = {
       xhr: error,
@@ -79,7 +79,7 @@ export default Controller.extend({
     this.trigger('afterError', contextData, errorContextData);
   },
 
-  createAfterEventContext () {
+  createAfterEventContext() {
     const formName = this.options.appState.get('currentFormName');
     const authenticatorKey = this.options.appState.get('authenticatorKey');
     const methodType = this.options.appState.get('authenticatorMethodType');
@@ -107,7 +107,7 @@ export default Controller.extend({
     return eventData;
   },
 
-  handleSwitchForm (formName) {
+  handleSwitchForm(formName) {
     // trigger formName change to change view
     if (this.options.appState.get('messages')) {
       // Clear messages before calling switch form.
@@ -119,7 +119,7 @@ export default Controller.extend({
     this.options.appState.set('currentFormName', formName);
   },
 
-  handleInvokeAction (actionPath = '') {
+  handleInvokeAction(actionPath = '') {
     if(actionPath === 'cancel') {
       clearTransactionMeta(this.options.settings);
     }
@@ -150,7 +150,7 @@ export default Controller.extend({
     }
   },
 
-  handleSaveForm (model) {
+  handleSaveForm(model) {
     const formName = model.get('formName');
 
     const idx = this.options.appState.get('idx');
@@ -217,7 +217,7 @@ export default Controller.extend({
       });
   },
 
-  showFormErrors (model, error) {
+  showFormErrors(model, error) {
     model.trigger('clearFormError');
     if (!error) {
       error = 'FormController - unknown error found';
@@ -235,7 +235,7 @@ export default Controller.extend({
     }
   },
 
-  handleIdxSuccess: function (idxResp) {
+  handleIdxSuccess: function(idxResp) {
     this.options.appState.trigger('remediationSuccess', idxResp);
   },
 
@@ -247,7 +247,7 @@ export default Controller.extend({
    *
    * @param {boolean} disabled whether add extra disable CSS class.
    */
-  toggleFormButtonState: function (disabled) {
+  toggleFormButtonState: function(disabled) {
     const button = this.$el.find('.o-form-button-bar .button');
     button.toggleClass('link-button-disabled', disabled);
   },

--- a/src/v2/ion/transformIdxResponse.js
+++ b/src/v2/ion/transformIdxResponse.js
@@ -16,7 +16,7 @@ import uiSchemaTransformer from './uiSchemaTransformer';
 import i18nTransformer from './i18nTransformer';
 
 // Transforms an IDX response to an ION response
-export default function transformIdxResponse (settings, idxResponse) {
+export default function transformIdxResponse(settings, idxResponse) {
   const ionResponse = _.compose(
     i18nTransformer,
     uiSchemaTransformer.bind({}, settings),

--- a/src/v2/mixins/mixins.js
+++ b/src/v2/mixins/mixins.js
@@ -1,10 +1,10 @@
 import { _ } from 'okta';
 
 _.mixin({
-  nestedOmit: function (obj, iteratee, context) {
+  nestedOmit: function(obj, iteratee, context) {
     var result = _.omit(obj, iteratee, context);
           
-    _.each(result, function (val, key) {
+    _.each(result, function(val, key) {
       if (typeof(val) === 'object') {
         result[key] = _.nestedOmit(val, iteratee, context);
       }

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -34,7 +34,7 @@ export default Model.extend({
   derived: {
     authenticatorProfile: {
       deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment'],
-      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
+      fn(currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
         return currentAuthenticator.profile
           || currentAuthenticatorEnrollment.profile
           || {};
@@ -42,7 +42,7 @@ export default Model.extend({
     },
     authenticatorKey: {
       deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment'],
-      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
+      fn(currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
         return currentAuthenticator.key
           || currentAuthenticatorEnrollment.key
           || '';
@@ -50,7 +50,7 @@ export default Model.extend({
     },
     authenticatorMethodType: {
       deps: ['currentAuthenticator', 'currentAuthenticatorEnrollment',],
-      fn (currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
+      fn(currentAuthenticator = {}, currentAuthenticatorEnrollment = {}) {
         return currentAuthenticator.methods && currentAuthenticator.methods[0].type
           || currentAuthenticatorEnrollment.methods && currentAuthenticatorEnrollment.methods[0].type
           || '';
@@ -58,17 +58,17 @@ export default Model.extend({
     },
     isPasswordRecovery: {
       deps: ['recoveryAuthenticator'],
-      fn: function (recoveryAuthenticator = {}) {
+      fn: function(recoveryAuthenticator = {}) {
         return recoveryAuthenticator?.type === 'password';
       }
     }
   },
 
-  hasRemediationObject (formName) {
+  hasRemediationObject(formName) {
     return this.get('idx').neededToProceed.find((remediation) => remediation.name === formName);
   },
 
-  getActionByPath (actionPath) {
+  getActionByPath(actionPath) {
     const paths = actionPath.split('.');
     let targetObject;
     if (paths.length === 1) {
@@ -86,7 +86,7 @@ export default Model.extend({
     }
   },
 
-  getCurrentViewState () {
+  getCurrentViewState() {
     const currentFormName = this.get('currentFormName');
 
     if (!currentFormName) {
@@ -110,7 +110,7 @@ export default Model.extend({
    * Returns the displayName of the authenticator
    * @returns {string}
    */
-  getAuthenticatorDisplayName () {
+  getAuthenticatorDisplayName() {
     const currentAuthenticator = this.get('currentAuthenticator') || {};
     const currentAuthenticatorEnrollment = this.get('currentAuthenticatorEnrollment') || {};
 
@@ -123,12 +123,12 @@ export default Model.extend({
    * Checks to see if we're in an authenticator challenge flow.
    * @returns {boolean}
    */
-  isAuthenticatorChallenge () {
+  isAuthenticatorChallenge() {
     const currentFormName = this.get('currentFormName');
     return FORMS_FOR_VERIFICATION.includes(currentFormName);
   },
 
-  shouldReRenderView (transformedResponse) {
+  shouldReRenderView(transformedResponse) {
     const previousRawState = this.has('idx') ? this.get('idx').rawIdxState : null;
     const identicalResponse = _.isEqual(
       _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'refresh']),
@@ -172,7 +172,7 @@ export default Model.extend({
   // and form is for identity verification (FORMS_FOR_VERIFICATION)
   // - cancel remediation form is not present in the response
   // - form is part of our list FORMS_WITHOUT_SIGNOUT
-  shouldShowSignOutLinkInCurrentForm (hideSignOutLinkInMFA) {
+  shouldShowSignOutLinkInCurrentForm(hideSignOutLinkInMFA) {
     const idxActions = this.get('idx') && this.get('idx').actions;
     const currentFormName = this.get('currentFormName');
     const hideSignOutConfigOverride = hideSignOutLinkInMFA
@@ -183,7 +183,7 @@ export default Model.extend({
       && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
   },
 
-  containsMessageWithI18nKey (keys) {
+  containsMessageWithI18nKey(keys) {
     if (!Array.isArray(keys)) {
       keys = [ keys ];
     }
@@ -192,13 +192,13 @@ export default Model.extend({
       && messagesObjs.value.some(messagesObj => _.contains(keys, messagesObj.i18n?.key));
   },
 
-  containsMessageStartingWithI18nKey (keySubStr) {
+  containsMessageStartingWithI18nKey(keySubStr) {
     const messagesObjs = this.get('messages');
     return messagesObjs && Array.isArray(messagesObjs.value)
       && messagesObjs.value.some(messagesObj => messagesObj.i18n?.key.startsWith(keySubStr));
   },
 
-  setIonResponse (transformedResponse) {
+  setIonResponse(transformedResponse) {
     if (!this.shouldReRenderView(transformedResponse)){
       return;
     }

--- a/src/v2/view-builder/ViewFactory.js
+++ b/src/v2/view-builder/ViewFactory.js
@@ -209,7 +209,7 @@ const VIEWS_MAPPING = {
 };
 
 module.exports = {
-  create (formName, authenticatorKey = DEFAULT) {
+  create(formName, authenticatorKey = DEFAULT) {
     const config = VIEWS_MAPPING[formName];
     if (!config) {
       Logger.warn(`Cannot find customized View for ${formName}.`);

--- a/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorEnrollOptions.js
@@ -29,18 +29,18 @@ const AuthenticatorRow = View.extend({
           <div class="authenticator-button" {{#if buttonDataSeAttr}}data-se="{{buttonDataSeAttr}}"{{/if}}></div>\
         </div>\
       '),
-  children: function () {
+  children: function() {
     return [[createButton({
       className: 'button select-factor',
-      title: function () {
+      title: function() {
         return loc('oie.enroll.authenticator.button.text', 'login');
       },
-      click: function () {
+      click: function() {
         this.model.trigger('selectAutheticator', this.model.get('value'));
       }
     }), '.authenticator-button']];
   },
-  minimize: function () {
+  minimize: function() {
     this.$el.addClass('authenticator-row-min');
   }
 });
@@ -53,8 +53,8 @@ export default ListView.extend({
 
   itemSelector: '.list-content',
 
-  initialize: function () {
-    this.listenTo(this.collection,'selectAutheticator', function (data) {
+  initialize: function() {
+    this.listenTo(this.collection,'selectAutheticator', function(data) {
       this.model.set(this.options.name, data);
       this.options.appState.trigger('saveForm', this.model);
     });
@@ -66,7 +66,7 @@ export default ListView.extend({
 
   template: hbs`<div class="list-content"> <div class="authenticator-list-title"> {{title}} </div> </div>`,
 
-  getTemplateData () {
+  getTemplateData() {
     // presence of the skip remediation form tells us that the authenticators are all optional
     const title = this.hasOptionalFactors? loc('oie.setup.optional', 'login'):loc('oie.setup.required', 'login');
 

--- a/src/v2/view-builder/components/AuthenticatorFooter.js
+++ b/src/v2/view-builder/components/AuthenticatorFooter.js
@@ -2,7 +2,7 @@ import { BaseFooter } from '../internals';
 import { getSwitchAuthenticatorLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
-  links () {
+  links() {
     return getSwitchAuthenticatorLink(this.options.appState);
   }
 });

--- a/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
+++ b/src/v2/view-builder/components/AuthenticatorVerifyOptions.js
@@ -29,18 +29,18 @@ const AuthenticatorRow = View.extend({
           <div class="authenticator-button" {{#if buttonDataSeAttr}}data-se="{{buttonDataSeAttr}}"{{/if}}></div>\
         </div>\
       '),
-  children: function (){
+  children: function(){
     return [[createButton({
       className: 'button select-factor',
-      title: function () {
+      title: function() {
         return loc('oie.verify.authenticator.button.text', 'login');
       },
-      click: function () {
+      click: function() {
         this.model.trigger('selectAutheticator', this.model.get('value'));
       }
     }), '.authenticator-button']];
   },
-  minimize: function () {
+  minimize: function() {
     this.$el.addClass('authenticator-row-min');
   }
 });
@@ -53,11 +53,11 @@ export default ListView.extend({
 
   itemSelector: '.list-content',
 
-  initialize: function () {
+  initialize: function() {
     this.listenTo(this.collection,'selectAutheticator', this.handleSelect);
   },
 
-  handleSelect (data) {
+  handleSelect(data) {
     //If schema contains a required identifier to fill first then validate the form
     const validationError = this.model.validateField('identifier');
     this.model.trigger('clearFormError');

--- a/src/v2/view-builder/components/BaseAuthenticatorView.js
+++ b/src/v2/view-builder/components/BaseAuthenticatorView.js
@@ -4,7 +4,7 @@ import HeaderBeacon from './HeaderBeacon';
 import { getIconClassNameForBeacon } from '../utils/AuthenticatorUtil';
 
 const HeaderBeaconFactor = HeaderBeacon.extend({
-  getBeaconClassName: function () {
+  getBeaconClassName: function() {
     const authenticatorKey = this.options.appState.get('authenticatorKey');
     return getIconClassNameForBeacon(authenticatorKey);
   },

--- a/src/v2/view-builder/components/HeaderBeacon.js
+++ b/src/v2/view-builder/components/HeaderBeacon.js
@@ -25,10 +25,10 @@ const BeaconView = View.extend({
     </div >\
   '),
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     return { className: this.getBeaconClassName() || '' };
   },
-  getBeaconClassName () {
+  getBeaconClassName() {
     return 'undefined-user';
   }
 });

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -4,7 +4,7 @@ import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { getForgotPasswordLink, getSignUpLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
-  links () {
+  links() {
     let helpLinkHref;
     if (this.options.settings.get('helpLinks.help')) {
       helpLinkHref = this.options.settings.get('helpLinks.help');

--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -19,7 +19,7 @@ const Link = View.extend({
 
   tagName: 'a',
 
-  attributes () {
+  attributes() {
     let href = this.options.href  || '#';
     return {
       'data-se': this.options.name,
@@ -27,7 +27,7 @@ const Link = View.extend({
     };
   },
 
-  className () {
+  className() {
     const names = ['link'];
     if (this.options.name) {
       const nameToClass = this.options.name.replace(/[ ]/g, '-');
@@ -36,7 +36,7 @@ const Link = View.extend({
     return names.join(' ');
   },
 
-  postRender () {
+  postRender() {
     // TODO OKTA-245224
     if (!this.options.href) {
       this.$el.click((event) => {

--- a/src/v2/view-builder/components/MdmOktaVerifyTerminalView.js
+++ b/src/v2/view-builder/components/MdmOktaVerifyTerminalView.js
@@ -19,11 +19,11 @@ export default View.extend({
     </ol>
   `,
 
-  getTemplateData () {
+  getTemplateData() {
     return this.options.appState.get('deviceEnrollment');
   },
 
-  postRender: function () {
+  postRender: function() {
     // Attach each button to the respective 'data-clipboard-text'
     Clipboard.attach('.copy-clipboard-button').done(() => {
       let notification = new Notification({

--- a/src/v2/view-builder/components/OdaOktaVerifyTerminalView.js
+++ b/src/v2/view-builder/components/OdaOktaVerifyTerminalView.js
@@ -22,7 +22,7 @@ export default View.extend({
     </div>
   `,
 
-  getTemplateData () {
+  getTemplateData() {
     const deviceEnrollment = this.options.appState.get('deviceEnrollment');
     const platform = (deviceEnrollment.platform || '').toLowerCase();
     const templateData = {

--- a/src/v2/view-builder/components/SkipOptionalEnrollmentButton.js
+++ b/src/v2/view-builder/components/SkipOptionalEnrollmentButton.js
@@ -3,10 +3,10 @@ import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 
 const skipAll = createButton({
   className: 'button-primary button skip-all',
-  title: function () {
+  title: function() {
     return loc('oie.optional.authenticator.button.title', 'login');
   },
-  click: function () {
+  click: function() {
     this.options.appState.trigger('invokeAction', RemediationForms.SKIP);
   }
 });

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -27,7 +27,7 @@ export default View.extend({
    */
   links: [],
 
-  initialize () {
+  initialize() {
     let links = _.resultCtx(this, 'links', this);
 
     // safe check

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -11,11 +11,11 @@ export default Form.extend({
   autoSave: false,
   noCancelButton: true,
 
-  title () {
+  title() {
     return loc('oform.title.authenticate', 'login');
   },
 
-  save () {
+  save() {
     return loc('oform.next', 'login');
   },
 
@@ -24,7 +24,7 @@ export default Form.extend({
     'error': 'triggerAfterError',
   },
 
-  initialize () {
+  initialize() {
     const uiSchemas = this.getUISchema();
     const inputOptions = uiSchemas.map(FormInputFactory.create);
 
@@ -39,27 +39,27 @@ export default Form.extend({
     this.listenTo(this, 'cancel', this.cancelForm);
   },
 
-  handleClearFormError () {
+  handleClearFormError() {
     if (this.$('.o-form-error-container').hasClass('o-form-has-errors')) {
       this.clearErrors();
     }
   },
 
-  triggerAfterError (model, error) {
+  triggerAfterError(model, error) {
     this.options.appState.trigger('afterError', error);
   },
 
-  saveForm (model) {
+  saveForm(model) {
     //remove any existing warnings or messages before saving form
     this.$el.find('.o-form-error-container').empty();
     this.options.appState.trigger('saveForm', model);
   },
 
-  cancelForm () {
+  cancelForm() {
     this.options.appState.trigger('invokeAction', 'cancel');
   },
 
-  getUISchema () {
+  getUISchema() {
     if (Array.isArray(this.options.currentViewState.uiSchema)) {
       return this.options.currentViewState.uiSchema;
     } else {
@@ -67,7 +67,7 @@ export default Form.extend({
     }
   },
 
-  addInputOrView (input) {
+  addInputOrView(input) {
     if (input.visible === false || input.mutable === false) {
       return;
     }
@@ -89,7 +89,7 @@ export default Form.extend({
     }
   },
 
-  showMessages () {
+  showMessages() {
     // render messages as text
     const messagesObjs = this.options.appState.get('messages');
     if (messagesObjs?.value.length) {

--- a/src/v2/view-builder/internals/BaseFormWithPolling.js
+++ b/src/v2/view-builder/internals/BaseFormWithPolling.js
@@ -3,12 +3,12 @@ import BaseForm from './BaseForm';
 
 export default BaseForm.extend(Object.assign(
   {
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.listenTo(this.options.appState, 'change:dynamicRefreshInterval', this.updateRefreshInterval);
     },
 
-    updateRefreshInterval () {
+    updateRefreshInterval() {
       if (this.polling) {
         this.stopPolling();
         this.startPolling(this.options.appState.get('dynamicRefreshInterval'));

--- a/src/v2/view-builder/internals/BaseHeader.js
+++ b/src/v2/view-builder/internals/BaseHeader.js
@@ -5,13 +5,13 @@ import Enums from 'util/Enums';
 export default View.extend({
   HeaderBeacon: null,
 
-  initialize () {
+  initialize() {
     if (this.HeaderBeacon) {
       this.add(this.HeaderBeacon);
     }
   },
 
-  postRender () {
+  postRender() {
     if (this.HeaderBeacon) {
       $(`#${Enums.WIDGET_CONTAINER_ID}`).removeClass('no-beacon');
 

--- a/src/v2/view-builder/internals/BaseModel.js
+++ b/src/v2/view-builder/internals/BaseModel.js
@@ -27,7 +27,7 @@ const convertUiSchemaFieldToProp = (uiSchemaField) => {
   return { [uiSchemaField.name]: config };
 };
 
-const createPropsAndLocals = function (
+const createPropsAndLocals = function(
   remediation = {},
   optionUiSchemaConfig = {},
   props = {},
@@ -66,7 +66,7 @@ const createPropsAndLocals = function (
   });
 };
 
-const create = function (remediation = {}, optionUiSchemaConfig = {}) {
+const create = function(remediation = {}, optionUiSchemaConfig = {}) {
   const props = {};
   const local = {
     formName: 'string',

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -14,7 +14,7 @@ export default View.extend({
 
   Footer: BaseFooter,
 
-  className () {
+  className() {
     const appState = this.options.appState;
 
     const formName = appState.get('currentFormName');
@@ -39,7 +39,7 @@ export default View.extend({
     <div class="siw-main-footer"></div>
   `,
 
-  preRender () {
+  preRender() {
     View.prototype.preRender.apply(this, arguments);
     // Add Views
     if (this.Header !== null) {
@@ -55,7 +55,7 @@ export default View.extend({
     });
   },
 
-  renderForm () {
+  renderForm() {
     let optionUiSchemaConfig;
 
     if (this.form) {
@@ -101,7 +101,7 @@ export default View.extend({
     });
   },
 
-  createModelClass (currentViewState, optionUiSchemaConfig = {}) {
+  createModelClass(currentViewState, optionUiSchemaConfig = {}) {
     return BaseModel.create(currentViewState, optionUiSchemaConfig);
   },
 

--- a/src/v2/view-builder/internals/FormInputFactory.js
+++ b/src/v2/view-builder/internals/FormInputFactory.js
@@ -71,7 +71,7 @@ const inputCreationStrategy = {
 };
 
 // TODO: move logic to uiSchemaTransformer
-const create = function (uiSchemaObj) {
+const create = function(uiSchemaObj) {
   const strategyFn = inputCreationStrategy[uiSchemaObj.type] || _.identity;
   return strategyFn(uiSchemaObj);
 };

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -15,7 +15,7 @@ import { AUTHENTICATOR_KEY } from '../../ion/RemediationConstants';
 
 const { getPasswordComplexityDescription, getPasswordComplexityDescriptionForHtmlList } = FactorUtil;
 
-const getButtonDataSeAttr = function (authenticator) {
+const getButtonDataSeAttr = function(authenticator) {
   if (authenticator.authenticatorKey) {
     const method = authenticator.value?.methodType ?
       '-' + authenticator.value?.methodType : '';
@@ -25,7 +25,7 @@ const getButtonDataSeAttr = function (authenticator) {
 };
 
 /* eslint complexity: [0, 0] */
-const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
+const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   const authenticatorKey = authenticator.authenticatorKey;
   const key = _.isString(authenticatorKey) ? authenticatorKey.toLowerCase() : '';
   let authenticatorData = {};
@@ -169,19 +169,19 @@ const getAuthenticatorData = function (authenticator, isVerifyAuthenticator) {
   return authenticatorData;
 };
 
-export function getAuthenticatorDataForEnroll (authenticator) {
+export function getAuthenticatorDataForEnroll(authenticator) {
   return getAuthenticatorData(authenticator);
 }
 
-export function getAuthenticatorDataForVerification (authenticator) {
+export function getAuthenticatorDataForVerification(authenticator) {
   return getAuthenticatorData(authenticator, true);
 }
 
-export function getIconClassNameForBeacon (authenticatorKey) {
+export function getIconClassNameForBeacon(authenticatorKey) {
   return getAuthenticatorData({ authenticatorKey }).iconClassName;
 }
 
-export function removeRequirementsFromError (errorJSON, policy) {
+export function removeRequirementsFromError(errorJSON, policy) {
   const passwordRequirementsAsString = getPasswordComplexityDescription(policy);
   if (errorJSON.errorCauses?.length > 0
     && Array.isArray(errorJSON.errorCauses[0].errorSummary)
@@ -200,7 +200,7 @@ export function removeRequirementsFromError (errorJSON, policy) {
  *
  * @param {Object} remediation
  */
-export function getAuthenticatorDisplayName (remediation) {
+export function getAuthenticatorDisplayName(remediation) {
   return remediation.relatesTo?.value?.displayName;
 }
 

--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -3,14 +3,14 @@ import { BaseForm, BaseFooter, BaseView } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return loc('registration.form.title', 'login');
   },
 
-  save () {
+  save() {
     return loc('registration.form.submit', 'login');
   },
-  saveForm () {
+  saveForm() {
     // SIW customization hook for registration
     this.settings.preRegistrationSubmit(this.model.toJSON(),
       (postData) => {
@@ -25,7 +25,7 @@ const Body = BaseForm.extend({
 });
 
 const Footer = BaseFooter.extend({
-  links () {
+  links() {
     const links = [];
     if (this.options.appState.hasRemediationObject(RemediationForms.SELECT_IDENTIFY)) {
       links.push({
@@ -42,7 +42,7 @@ const Footer = BaseFooter.extend({
 export default BaseView.extend({
   Body,
   Footer,
-  createModelClass (currentViewState, optionUiSchemaConfig, settings) {
+  createModelClass(currentViewState, optionUiSchemaConfig, settings) {
     let ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const currentSchema = JSON.parse(JSON.stringify((currentViewState.uiSchema)));
 
@@ -67,7 +67,7 @@ export default BaseView.extend({
     );
     return ModelClass;
   },
-  postRender () {
+  postRender() {
     BaseView.prototype.postRender.apply(this, arguments);
 
     const modelError = this.model.get('parseSchemaError');

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -8,15 +8,15 @@ import signInWithDeviceOption from './signin/SignInWithDeviceOption';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     return loc('primaryauth.title', 'login');
   },
 
-  save () {
+  save() {
     return loc('oform.next', 'login');
   },
 
-  render () {
+  render() {
     BaseForm.prototype.render.apply(this, arguments);
 
     // Launch Device Authenticator
@@ -55,7 +55,7 @@ const Body = BaseForm.extend({
       this.$el.find('.button-primary').hide();
     }
   },
-  showMessages () {
+  showMessages() {
     /**
      * Renders a warning callout for unknown user flow
      * Note: Anytime we get back `messages` object along with identify view
@@ -78,13 +78,13 @@ export default BaseView.extend({
   Body,
   Footer: IdentifierFooter,
 
-  postRender () {
+  postRender() {
     BaseView.prototype.postRender.apply(this, arguments);
 
     // If user enterted identifier is not found, API sends back a message with a link to sign up
     // This is the click handler for that link
     const appState = this.options.appState;
-    this.$el.find('.js-sign-up').click(function () {
+    this.$el.find('.js-sign-up').click(function() {
       appState.trigger('invokeAction', RemediationForms.SELECT_ENROLL_PROFILE);
       return false;
     });

--- a/src/v2/view-builder/views/IdentifyRecoveryView.js
+++ b/src/v2/view-builder/views/IdentifyRecoveryView.js
@@ -3,11 +3,11 @@ import { BaseForm, BaseFooter, BaseView } from '../internals';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     return loc('password.reset.title.generic', 'login');
   },
 
-  save () {
+  save() {
     return loc('oform.next', 'login');
   },
 });

--- a/src/v2/view-builder/views/PollView.js
+++ b/src/v2/view-builder/views/PollView.js
@@ -13,7 +13,7 @@ const PollMessageView = View.extend({
     <div class="okta-waiting-spinner"></div>
     `
   ,
-  getTemplateData () {
+  getTemplateData() {
     const countDownCounterValue = this.options;
     return {
       countDownCounterValue,
@@ -23,30 +23,30 @@ const PollMessageView = View.extend({
 
 const Body = BaseForm.extend(Object.assign(
   {
-    title () {
+    title() {
       return  loc('poll.form.title', 'login');
     },
 
     noButtonBar: true,
     
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.startPolling();
     },
 
-    render () {
+    render() {
       BaseForm.prototype.render.apply(this, arguments);
       this.countDownCounterValue = Math.ceil(this.options.appState.getCurrentViewState().refresh / MS_PER_SEC);
       this.add(new PollMessageView(this.countDownCounterValue));
       this.startCountDown('.ion-messages-container span', MS_PER_SEC);
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
 
-    triggerAfterError () {
+    triggerAfterError() {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
       this.$el.find('.o-form-fieldset-container').empty();

--- a/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorEnrollView.js
@@ -2,10 +2,10 @@ import { BaseForm, BaseView } from '../internals';
 import { loc } from 'okta';
 
 const Body = BaseForm.extend({
-  title: function () {
+  title: function() {
     return loc('oie.select.authenticators.enroll.title', 'login');
   },
-  subtitle: function () {
+  subtitle: function() {
     const subtitle = this.options.settings.get('brandName') ?
       loc('oie.select.authenticators.enroll.subtitle.custom', 'login', [this.options.settings.get('brandName')]):
       loc('oie.select.authenticators.enroll.subtitle', 'login');

--- a/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
@@ -2,19 +2,19 @@ import { BaseForm, BaseView } from '../internals';
 import { loc } from 'okta';
 
 export const Body = BaseForm.extend({
-  title: function () {
+  title: function() {
     if (this.isPasswordRecoveryFlow())  {
       return loc('password.reset.title.generic', 'login');
     }
     return loc('oie.select.authenticators.verify.title', 'login');
   },
-  subtitle: function () {
+  subtitle: function() {
     if (this.isPasswordRecoveryFlow())  {
       return loc('oie.password.reset.verification', 'login');
     }
     return loc('oie.select.authenticators.verify.subtitle', 'login');
   },
-  isPasswordRecoveryFlow () {
+  isPasswordRecoveryFlow() {
     return this.options.appState.get('isPasswordRecovery');
   },
   noButtonBar: true,

--- a/src/v2/view-builder/views/SuccessView.js
+++ b/src/v2/view-builder/views/SuccessView.js
@@ -3,7 +3,7 @@ import { BaseForm, BaseView } from '../internals';
 import Util from '../../../util/Util';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     let titleString = loc('oie.success.text.signingIn', 'login');
     // For more info on the API response available in appState, see IdxResponseBuilder.java
     const app = this.options.appState.get('app');
@@ -27,7 +27,7 @@ const Body = BaseForm.extend({
     return titleString;
   },
   noButtonBar: true,
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     // TODO OKTA-250473
     // Form post for success redirect
@@ -35,7 +35,7 @@ const Body = BaseForm.extend({
     Util.redirectWithFormGet(url);
   },
 
-  render () {
+  render() {
     BaseForm.prototype.render.apply(this, arguments);
     this.add('<div class="okta-waiting-spinner"></div>');
   }

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -23,7 +23,7 @@ const GET_BACK_TO_SIGN_LINK_FLOWS = [
 ];
 
 const HeaderBeaconTerminal = HeaderBeacon.extend({
-  getBeaconClassName: function () {
+  getBeaconClassName: function() {
     return this.options.appState.containsMessageWithI18nKey(EMAIL_AUTHENTICATOR_TERMINAL_KEYS)
       ? getIconClassNameForBeacon(AUTHENTICATOR_KEY.EMAIL)
       : HeaderBeacon.prototype.getBeaconClassName.apply(this, arguments);
@@ -33,12 +33,12 @@ const HeaderBeaconTerminal = HeaderBeacon.extend({
 const Body = BaseForm.extend({
   noButtonBar: true,
 
-  postRender () {
+  postRender() {
     BaseForm.prototype.postRender.apply(this, arguments);
     this.$el.addClass('terminal-state');
   },
 
-  title () {
+  title() {
     if (this.options.appState.containsMessageWithI18nKey(RETURN_LINK_EXPIRED_KEY)) {
       return loc('oie.email.return.link.expired.title', 'login');
     }
@@ -50,7 +50,7 @@ const Body = BaseForm.extend({
     }
   },
 
-  showMessages () {
+  showMessages() {
     const messagesObjs = this.options.appState.get('messages');
     if (messagesObjs && Array.isArray(messagesObjs.value)) {
       this.add('<div class="ion-messages-container"></div>', '.o-form-error-container');
@@ -74,7 +74,7 @@ const Body = BaseForm.extend({
 });
 
 const Footer = BaseFooter.extend({
-  links: function () {
+  links: function() {
     if (this.options.appState.containsMessageWithI18nKey(GET_BACK_TO_SIGN_LINK_FLOWS)) {
       return getBackToSignInLink(this.options.settings);
     }

--- a/src/v2/view-builder/views/authenticator/SelectAuthenticatorUnlockAccountView.js
+++ b/src/v2/view-builder/views/authenticator/SelectAuthenticatorUnlockAccountView.js
@@ -9,7 +9,7 @@ const UnlockAccountView = BaseForm.extend({
 });
 
 export default BaseView.extend({
-  initialize () {
+  initialize() {
     BaseView.prototype.initialize.apply(this, arguments);
     this.Body = UnlockAccountView;
   }

--- a/src/v2/view-builder/views/consent/AdminConsentView.js
+++ b/src/v2/view-builder/views/consent/AdminConsentView.js
@@ -5,14 +5,14 @@ import ConsentViewForm from './ConsentViewForm';
 export default BaseView.extend({
   Header: AdminConsentViewHeader,
   Body: ConsentViewForm,
-  postRender () {
+  postRender() {
     // Move buttons in DOM to match visual hierarchy to fix tab order.
     // TODO https://oktainc.atlassian.net/browse/OKTA-350521
     const buttonContainer = this.$el.find('.o-form-button-bar');
     buttonContainer.find('.button-primary').appendTo(buttonContainer);
 
   },
-  createModelClass (currentViewState) {
+  createModelClass(currentViewState) {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const {scopes} = currentViewState.uiSchema[0];
 
@@ -23,7 +23,7 @@ export default BaseView.extend({
       local: {
         consent: {type: 'boolean', value: false},
       },
-      toJSON: function () {
+      toJSON: function() {
         return {consent: this.get('consent')};
       }
     });

--- a/src/v2/view-builder/views/consent/AdminConsentViewHeader.js
+++ b/src/v2/view-builder/views/consent/AdminConsentViewHeader.js
@@ -27,7 +27,7 @@ const AdminConsentViewHeader = View.extend({
         <div class="issuer"><span>{{issuer}}</span></div>
       {{/if}}
     </h1>`,
-  getTemplateData: function () {
+  getTemplateData: function() {
     const { appState } = this.options;
     const { label, clientUri, logo } =  appState.get('app');
     const { issuer: issuerObj } = appState.get('authentication');

--- a/src/v2/view-builder/views/consent/ConsentViewForm.js
+++ b/src/v2/view-builder/views/consent/ConsentViewForm.js
@@ -9,14 +9,14 @@ export default BaseForm.extend(
     cancel: () => loc('consent.required.cancelButton', 'login'),
     title: false,
     events: {
-      'click input[data-type="save"]': function () {
+      'click input[data-type="save"]': function() {
         this.setConsent(true);
       },
     },
-    setConsent (bool) {
+    setConsent(bool) {
       this.model.set('consent', bool);
     },
-    cancelForm () {
+    cancelForm() {
       // override BaseForm.prototype.cancelForm which cancels auth flow
       this.setConsent(false);
       this.options.appState.trigger('saveForm', this.model);

--- a/src/v2/view-builder/views/consent/EnduserConsentView.js
+++ b/src/v2/view-builder/views/consent/EnduserConsentView.js
@@ -7,7 +7,7 @@ import EnduserConsentAgreementText from './EnduserConsentAgreementText';
 export default AdminConsentView.extend({
   Header: EnduserConsentViewHeader,
   Footer: EnduserConsentViewFooter,
-  postRender () {
+  postRender() {
     const scopeList = this.$el.find('.scope-list');
     const consentAgreementText = new EnduserConsentAgreementText().render().el;
     scopeList.after(consentAgreementText);

--- a/src/v2/view-builder/views/consent/EnduserConsentViewFooter.js
+++ b/src/v2/view-builder/views/consent/EnduserConsentViewFooter.js
@@ -21,7 +21,7 @@ const ConsentViewFooter = View.extend({
       {{/if}}\
     '
   ),
-  getTemplateData: function () {
+  getTemplateData: function() {
     const appState = this.options.appState;
     const app = appState.get('app');
 

--- a/src/v2/view-builder/views/custom-otp/ChallengeCustomOTPAuthenticatorView.js
+++ b/src/v2/view-builder/views/custom-otp/ChallengeCustomOTPAuthenticatorView.js
@@ -6,18 +6,18 @@ const Body = BaseForm.extend(Object.assign(
   {
     className: 'mfa-verify-custom-otp',
 
-    title () {
+    title() {
       const vendorName =
         this.options.appState.getAuthenticatorDisplayName() ||
         loc('oie.custom_otp.authenticator.default.vendorName', 'login');
       return loc('oie.verify.custom_otp.title', 'login', [vendorName]);
     },
 
-    subtitle () {
+    subtitle() {
       return loc('oie.verify.custom_otp.description', 'login');
     },
 
-    save () {
+    save() {
       return loc('mfa.challenge.verify', 'login');
     },
   },

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -27,13 +27,13 @@ const Body = BaseFormWithPolling.extend(
     className: 'ion-form device-challenge-poll',
 
     events: {
-      'click #launch-ov': function (e) {
+      'click #launch-ov': function(e) {
         e.preventDefault();
         this.doCustomURI();
       }
     },
 
-    initialize () {
+    initialize() {
       BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.onPollingFail);
       this.deviceChallengePollRemediation = this.options.currentViewState;
@@ -41,18 +41,18 @@ const Body = BaseFormWithPolling.extend(
       this.startPolling();
     },
 
-    onPollingFail () {
+    onPollingFail() {
       this.$('.spinner').hide();
       this.stopPolling();
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopProbing();
       this.stopPolling();
     },
 
-    doChallenge () {
+    doChallenge() {
       const deviceChallenge = this.deviceChallengePollRemediation.relatesTo.value;
       switch (deviceChallenge.challengeMethod) {
       case Enums.LOOPBACK_CHALLENGE:
@@ -75,7 +75,7 @@ const Body = BaseFormWithPolling.extend(
               {{{i18n code="customUri.required.content.p2" bundle="login" arguments="downloadOVLink"}}}
             </p>
           `,
-          getTemplateData () {
+          getTemplateData() {
             return {
               downloadOVLink: deviceChallenge.downloadHref
             };
@@ -105,7 +105,7 @@ const Body = BaseFormWithPolling.extend(
       }
     },
 
-    doLoopback (authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -172,14 +172,14 @@ const Body = BaseFormWithPolling.extend(
       });
     },
 
-    doCustomURI () {
+    doCustomURI() {
       this.ulDom && this.ulDom.remove();
       this.ulDom = this.add(`
         <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
       `).last();
     },
 
-    stopProbing () {
+    stopProbing() {
       this.checkPortXhr && this.checkPortXhr.abort();
       this.probingXhr && this.probingXhr.abort();
     },
@@ -187,7 +187,7 @@ const Body = BaseFormWithPolling.extend(
 );
 
 const Footer = BaseFooter.extend({
-  initialize () {
+  initialize() {
     const isFallbackApproach = [
       Enums.CUSTOM_URI_CHALLENGE,
       Enums.UNIVERSAL_LINK_CHALLENGE

--- a/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
+++ b/src/v2/view-builder/views/device/DeviceEnrollmentTerminalView.js
@@ -18,13 +18,13 @@ const Body = BaseForm.extend({
 
   className: 'device-enrollment-terminal',
 
-  title () {
+  title() {
     return this.enrollmentType === Enums.ODA
       ? loc('enroll.title.oda', 'login')
       : loc('enroll.title.mdm', 'login');
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     const deviceEnrollment = this.options.appState.get('deviceEnrollment');
     this.enrollmentType = (deviceEnrollment.name || '').toLowerCase(); // oda/mdm
@@ -41,7 +41,7 @@ const Body = BaseForm.extend({
 
 export default BaseView.extend({
   Body,
-  initialize () {
+  initialize() {
     BaseView.prototype.initialize.apply(this, arguments);
     const deviceEnrollment = this.options.appState.get('deviceEnrollment');
     this.enrollmentType = (deviceEnrollment.name || '').toLowerCase(); // oda/mdm

--- a/src/v2/view-builder/views/device/SSOExtensionView.js
+++ b/src/v2/view-builder/views/device/SSOExtensionView.js
@@ -12,11 +12,11 @@ const Body = BaseForm.extend({
 
   className: 'ion-form device-challenge-poll',
 
-  title () {
+  title() {
     return loc('deviceTrust.sso.redirectText', 'login');
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
 
     // TODO: OKTA-286547

--- a/src/v2/view-builder/views/device/SignInDeviceView.js
+++ b/src/v2/view-builder/views/device/SignInDeviceView.js
@@ -6,13 +6,13 @@ import Link from '../../components/Link';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     return loc('primaryauth.title', 'login');
   },
 
   noButtonBar: true,
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     this.add(
       SignInWithDeviceOption,
@@ -28,7 +28,7 @@ const Body = BaseForm.extend({
 // override the footer to add all the supported links except the sign out link
 // no session is granted at this point
 const Footer = IdentifierFooter.extend({
-  initialize () {
+  initialize() {
     let links = _.resultCtx(this, 'links', this);
     if (!Array.isArray(links)) {
       links = [];

--- a/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
+++ b/src/v2/view-builder/views/duo/BaseDuoAuthenticatorForm.js
@@ -6,7 +6,7 @@ export default BaseForm.extend({
 
   noButtonBar: true,
 
-  postRender: function () {
+  postRender: function() {
     const contextualData = this.getContextualData();
     // This is the place to check contextualData.integrationType once we support more types
     // Currently we only support IFRAME
@@ -31,7 +31,7 @@ export default BaseForm.extend({
     }
   },
 
-  getContextualData () {
+  getContextualData() {
     // to be overriden
   }
 });

--- a/src/v2/view-builder/views/duo/ChallengeDuoAuthenticatorView.js
+++ b/src/v2/view-builder/views/duo/ChallengeDuoAuthenticatorView.js
@@ -3,11 +3,11 @@ import BaseDuoAuthenticatorForm from './BaseDuoAuthenticatorForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseDuoAuthenticatorForm.extend({
-  title () {
+  title() {
     return loc('oie.duo.verify.title', 'login');
   },
 
-  getContextualData () {
+  getContextualData() {
     return this.options.appState.get('currentAuthenticatorEnrollment').contextualData;
   },
 });

--- a/src/v2/view-builder/views/duo/EnrollDuoAuthenticatorView.js
+++ b/src/v2/view-builder/views/duo/EnrollDuoAuthenticatorView.js
@@ -3,11 +3,11 @@ import BaseDuoAuthenticatorForm from './BaseDuoAuthenticatorForm';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseDuoAuthenticatorForm.extend({
-  title () {
+  title() {
     return loc('oie.duo.enroll.title', 'login');
   },
 
-  getContextualData () {
+  getContextualData() {
     return this.options.appState.get('currentAuthenticator').contextualData;
   },
 });

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -12,7 +12,7 @@ const ResendView = View.extend(
       'click a.resend-link' : 'handelResendLink'
     },
 
-    initialize () {
+    initialize() {
       this.add(createCallout({
         content: `${loc('email.code.not.received', 'login')}
         <a class='resend-link'>${loc('email.button.resend', 'login')}</a>`,
@@ -20,7 +20,7 @@ const ResendView = View.extend(
       }));
     },
 
-    handelResendLink () {
+    handelResendLink() {
       this.options.appState.trigger('invokeAction', this.options.resendEmailAction);
       // Hide warning, but reinitiate to show warning again after some threshold of polling
       if (!this.$el.hasClass('hide')) {
@@ -29,17 +29,17 @@ const ResendView = View.extend(
       this.showCalloutWithDelay();
     },
 
-    postRender () {
+    postRender() {
       this.showCalloutWithDelay();
     },
 
-    showCalloutWithDelay () {
+    showCalloutWithDelay() {
       this.showMeTimeout = _.delay(() => {
         this.$el.removeClass('hide');
       }, SHOW_RESEND_TIMEOUT);
     },
 
-    remove () {
+    remove() {
       View.prototype.remove.apply(this, arguments);
       clearTimeout(this.showMeTimeout);
     }
@@ -48,10 +48,10 @@ const ResendView = View.extend(
 
 const Body = BaseForm.extend(Object.assign(
   {
-    save () {
+    save() {
       return loc('mfa.challenge.verify', 'login');
     },
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
 
       this.add(ResendView, {
@@ -63,17 +63,17 @@ const Body = BaseForm.extend(Object.assign(
       this.startPolling();
     },
 
-    saveForm () {
+    saveForm() {
       BaseForm.prototype.saveForm.apply(this, arguments);
       this.stopPolling();
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
 
-    triggerAfterError (model, error) {
+    triggerAfterError(model, error) {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
 

--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
@@ -18,7 +18,7 @@ const CheckYourEmailTitle = View.extend({
     {{/if}}
   `,
 
-  getTemplateData () {
+  getTemplateData() {
     const { email } = this.options;
     return {
       email,
@@ -30,7 +30,7 @@ const Body = BaseAuthenticatorEmailForm.extend(Object.assign({
 
   resendEmailAction: 'currentAuthenticatorEnrollment-resend',
 
-  initialize () {
+  initialize() {
     BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
 
     const { email } = this.options.currentViewState.relatesTo?.value?.profile || {};

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -7,7 +7,7 @@ const Body = BaseAuthenticatorEmailForm.extend(Object.assign({
 
   resendEmailAction: 'currentAuthenticator-resend',
 
-  subtitle () {
+  subtitle() {
     return loc('oie.email.enroll.subtitle', 'login');
   },
 }));

--- a/src/v2/view-builder/views/google-authenticator/ChallengeGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/ChallengeGoogleAuthenticatorView.js
@@ -6,15 +6,15 @@ const Body = BaseForm.extend(Object.assign(
   {
     className: 'google-authenticator-challenge',
 
-    title () {
+    title() {
       return loc('oie.verify.google_authenticator.otp.title', 'login');
     },
 
-    subtitle () {
+    subtitle() {
       return loc('oie.verify.google_authenticator.otp.description', 'login');
     },
 
-    save () {
+    save() {
       return loc('mfa.challenge.verify', 'login');
     },
   },

--- a/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollAuthenticatorGoogleAuthenticatorView.js
@@ -13,7 +13,7 @@ const viewToDisplayState = {
 };
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return loc('oie.enroll.google_authenticator.setup.title', 'login');
   },
 
@@ -29,7 +29,7 @@ const Body = BaseForm.extend({
     `,
   }),
 
-  getUISchema () {
+  getUISchema() {
     const schema = BaseForm.prototype.getUISchema.apply(this, arguments);
 
     const nextButton = addCustomButton({
@@ -103,7 +103,7 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
-  createModelClass () {
+  createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const local = Object.assign(
       {

--- a/src/v2/view-builder/views/google-authenticator/EnrollGoogleAuthenticatorBarcodeView.js
+++ b/src/v2/view-builder/views/google-authenticator/EnrollGoogleAuthenticatorBarcodeView.js
@@ -22,13 +22,13 @@ export default View.extend({
       {{/if}}
     `,
 
-  getTemplateData () {
+  getTemplateData() {
     const contextualData = this.options.appState.get('currentAuthenticator').contextualData;
     return { href: contextualData.qrcode?.href };
   },
 
   events: {
-    'click .cannot-scan-link': function (e) {
+    'click .cannot-scan-link': function(e) {
       e.preventDefault();
       this.options.model.set('viewToDisplay', 'manual');
     }

--- a/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
+++ b/src/v2/view-builder/views/idp/AuthenticatorIdPView.js
@@ -4,21 +4,21 @@ import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     const displayName = this.options.appState.getAuthenticatorDisplayName();
     return this.options.isChallenge
       ? loc('oie.idp.challenge.title', 'login', [displayName])
       : loc('oie.idp.enroll.title', 'login', [displayName]);
   },
 
-  subtitle () {
+  subtitle() {
     const displayName = this.options.appState.getAuthenticatorDisplayName();
     return this.options.isChallenge
       ? loc('oie.idp.challenge.description', 'login', [displayName])
       : loc('oie.idp.enroll.description', 'login', [displayName]);
   },
 
-  showMessages () {
+  showMessages() {
     // IdP Authenticator error messages are not form errors
     // Parse and display them here.
     const messages = this.options.appState.get('messages') || {};
@@ -41,7 +41,7 @@ const Body = BaseForm.extend({
     }
   },
 
-  save () {
+  save() {
     return this.options.isChallenge
       ? loc('mfa.challenge.verify', 'login')
       : loc('mfa.enroll', 'login');
@@ -50,7 +50,7 @@ const Body = BaseForm.extend({
 });
 
 export default BaseAuthenticatorView.extend({
-  initialize () {
+  initialize() {
     BaseAuthenticatorView.prototype.initialize.apply(this, arguments);
 
     // The IdP Authenticator doesn't have a traditional enroll/challenge form.

--- a/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
@@ -12,14 +12,14 @@ const Body = BaseForm.extend({
     'error': '_checkTokenChange'
   },
 
-  title () {
+  title() {
     const vendorName =
       this.options.appState.getAuthenticatorDisplayName() ||
       loc('oie.on_prem.authenticator.default.vendorName', 'login');
     return loc('oie.on_prem.verify.title', 'login', [vendorName]);
   },
 
-  _checkTokenChange (model, convertedErrors) {
+  _checkTokenChange(model, convertedErrors) {
     const errorSummaryKeys = convertedErrors?.responseJSON?.errorSummaryKeys;
     if (errorSummaryKeys && errorSummaryKeys.includes(ON_PREM_TOKEN_CHANGE_KEY)) {
       // this means we are in change pin, so we should clear out answer input
@@ -28,7 +28,7 @@ const Body = BaseForm.extend({
     }
   },
 
-  save () {
+  save() {
     return loc('mfa.challenge.verify', 'login');
   },
 });

--- a/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
@@ -12,14 +12,14 @@ const Body = BaseForm.extend({
     'error': '_checkTokenChange'
   },
 
-  title () {
+  title() {
     const vendorName =
       this.options.appState.getAuthenticatorDisplayName() ||
       loc('oie.on_prem.authenticator.default.vendorName', 'login');
     return loc('oie.on_prem.enroll.title', 'login', [vendorName]);
   },
 
-  _checkTokenChange (model, convertedErrors) {
+  _checkTokenChange(model, convertedErrors) {
     const errorSummaryKeys = convertedErrors?.responseJSON?.errorSummaryKeys;
     if (errorSummaryKeys && errorSummaryKeys.includes(ON_PREM_TOKEN_CHANGE_KEY)) {
       // this means we are in change pin, so we should clear out answer input
@@ -28,7 +28,7 @@ const Body = BaseForm.extend({
     }
   },
 
-  save () {
+  save() {
     return loc('mfa.challenge.verify', 'login');
   },
 });

--- a/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
@@ -7,7 +7,7 @@ import { Body as SelectAuthenticatorVerifyViewBody } from '../SelectAuthenticato
 import { AUTHENTICATOR_KEY } from '../../../ion/RemediationConstants';
 
 const Body = SelectAuthenticatorVerifyViewBody.extend({
-  getUISchema () {
+  getUISchema() {
     // Change the UI schema to not display radios here.
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     const methodsSchema = uiSchemas.find(schema => schema.name === 'authenticator.methodType');

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -23,13 +23,13 @@ const Body = BaseForm.extend(Object.assign(
     className: 'ion-form device-challenge-poll',
 
     events: {
-      'click #launch-ov': function (e) {
+      'click #launch-ov': function(e) {
         e.preventDefault();
         this.doCustomURI();
       }
     },
 
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.onPollingFail);
       this.deviceChallengePollRemediation = this.options.currentViewState;
@@ -37,17 +37,17 @@ const Body = BaseForm.extend(Object.assign(
       this.startPolling();
     },
 
-    onPollingFail () {
+    onPollingFail() {
       this.$('.spinner').hide();
       this.stopPolling();
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
 
-    doChallenge () {
+    doChallenge() {
       const deviceChallenge = this.deviceChallengePollRemediation.relatesTo.value.contextualData.challenge.value;
       switch (deviceChallenge.challengeMethod) {
       case Enums.LOOPBACK_CHALLENGE:
@@ -70,7 +70,7 @@ const Body = BaseForm.extend(Object.assign(
               {{{i18n code="customUri.required.content.p2" bundle="login" arguments="downloadOVLink"}}}
             </p>
           `,
-          getTemplateData () {
+          getTemplateData() {
             return {
               downloadOVLink: deviceChallenge.downloadHref
             };
@@ -100,7 +100,7 @@ const Body = BaseForm.extend(Object.assign(
       }
     },
 
-    doLoopback (authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -160,7 +160,7 @@ const Body = BaseForm.extend(Object.assign(
       });
     },
 
-    doCustomURI () {
+    doCustomURI() {
       this.ulDom && this.ulDom.remove();
       this.ulDom = this.add(`
         <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyPushView.js
@@ -18,17 +18,17 @@ const Body = BaseForm.extend(Object.assign(
 
     className: 'okta-verify-push-challenge',
 
-    title () {
+    title() {
       return loc('oie.okta_verify.push.title', 'login');
     },
 
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.stopPoll);
       this.addView();
     },
 
-    addView () {
+    addView() {
       this.add(createButton({
         className: 'button button-wide button-primary send-push link-button-disabled',
         title: loc('oie.okta_verify.push.sent', 'login'),
@@ -41,35 +41,35 @@ const Body = BaseForm.extend(Object.assign(
       );
     },
 
-    postRender () {
+    postRender() {
       this.startPoll();
     },
 
-    startPoll () {
+    startPoll() {
       this.startPolling();
-      this.warningTimeout = setTimeout(_.bind(function () {
+      this.warningTimeout = setTimeout(_.bind(function() {
         this.showWarning(loc('oktaverify.warning', 'login'));
       }, this), WARNING_TIMEOUT);
     },
 
-    stopPoll () {
+    stopPoll() {
       this.stopPolling();
       this.clearWarning();
     },
 
-    showWarning (msg) {
+    showWarning(msg) {
       this.clearWarning();
       this.add(warningTemplate, '.o-form-error-container', {options: {warning: msg}});
     },
 
-    clearWarning () {
+    clearWarning() {
       if (this.$('.o-form-error-container div').hasClass('okta-form-infobox-warning')) {
         this.$('.okta-form-infobox-warning').remove();
       }
       clearTimeout(this.warningTimeout);
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyResendPushView.js
@@ -8,15 +8,15 @@ const Body = BaseForm.extend(Object.assign(
   {
     className: 'okta-verify-resend-push',
 
-    title () {
+    title() {
       return loc('oie.okta_verify.push.title', 'login');
     },
 
-    save () {
+    save() {
       return loc('oie.okta_verify.push.resend', 'login');
     },
 
-    showMessages () {
+    showMessages() {
       // override showMessages to display error in cases like reject push
       // or timeout. Borrowed this logic from TerminalView.
       const messagesObjs = this.options.appState.get('messages');

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
@@ -13,11 +13,11 @@ const Body = BaseForm.extend({
 
   className: 'ion-form device-challenge-poll',
 
-  title () {
+  title() {
     return loc('deviceTrust.sso.redirectText', 'login');
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
 
     // TODO: OKTA-286547

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyTotpView.js
@@ -6,11 +6,11 @@ const Body = BaseForm.extend(Object.assign(
   {
     className: 'okta-verify-totp-challenge',
 
-    title () {
+    title() {
       return loc('oie.okta_verify.totp.title', 'login');
     },
 
-    save () {
+    save() {
       return loc('mfa.challenge.verify', 'login');
     },
   },

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyView.js
@@ -5,7 +5,7 @@ import NumberChallengePushView from './NumberChallengePushView';
 import { AUTHENTICATOR_METHODS } from '../../../ion/RemediationConstants';
 
 export default BaseAuthenticatorView.extend({
-  initialize () {
+  initialize() {
     BaseAuthenticatorView.prototype.initialize.apply(this, arguments);
     const currentAuthenticator = this.options?.appState?.get('currentAuthenticator');
     const selectedMethod = currentAuthenticator?.methods[0];

--- a/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
+++ b/src/v2/view-builder/views/ov/EnrollChannelPollDescriptionView.js
@@ -26,7 +26,7 @@ export default View.extend({
         </ul>
       {{/if}}
     `,
-  getTemplateData () {
+  getTemplateData() {
     const contextualData = this.options.appState.get('currentAuthenticator').contextualData;
     return {
       href: contextualData.qrcode?.href,

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -15,7 +15,7 @@ const OV_FORCE_FIPS_COMPLIANCE_UPGRAGE_KEY_NON_IOS =
 
 const Body = BaseForm.extend(Object.assign(
   {
-    title () {
+    title() {
       const selectedChannel = this.options.appState.get('currentAuthenticator').contextualData.selectedChannel;
       let title;
       switch (selectedChannel) {
@@ -32,7 +32,7 @@ const Body = BaseForm.extend(Object.assign(
     },
     className: 'oie-enroll-ov-poll',
     noButtonBar: true,
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       if ((BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) &
         this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode') {
@@ -41,7 +41,7 @@ const Body = BaseForm.extend(Object.assign(
       this.listenTo(this.model, 'error', this.stopPolling);
       this.startPolling();
     },
-    showMessages () {
+    showMessages() {
       // override showMessages to display error message
       const messagesObjs = this.options.appState.get('messages');
       if (messagesObjs && Array.isArray(messagesObjs.value)) {
@@ -67,7 +67,7 @@ const Body = BaseForm.extend(Object.assign(
 
       }
     },
-    getUISchema () {
+    getUISchema() {
       const schema = [];
       const contextualData = this.options.appState.get('currentAuthenticator').contextualData;
       const selectedChannel = contextualData.selectedChannel;
@@ -89,7 +89,7 @@ const Body = BaseForm.extend(Object.assign(
       }
       return schema;
     },
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },

--- a/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
@@ -6,13 +6,13 @@ import SwitchEnrollChannelLinkView from './SwitchEnrollChannelLinkView';
 
 const Body = BaseForm.extend({
   className: 'oie-enroll-ov-data',
-  title () {
+  title() {
     return this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'email' ?
       loc('oie.enroll.okta_verify.enroll.channel.email.title', 'login'):
       loc('oie.enroll.okta_verify.enroll.channel.sms.title', 'login');
   },
   save: loc('oie.enroll.okta_verify.setupLink', 'login'),
-  getUISchema () {
+  getUISchema() {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     const phoneNumberUISchema = _.find(uiSchemas, ({ name }) => name === 'phoneNumber');
     const phoneNumberUISchemaIndex = _.findIndex(uiSchemas, ({ name }) => name === 'phoneNumber');
@@ -59,12 +59,12 @@ const Body = BaseForm.extend({
     return uiSchemas;
   },
 
-  handlePhoneCodeChange () {
+  handlePhoneCodeChange() {
     const countryCodeField = this.el.querySelector('.country-code-label');
     countryCodeField.innerText = `+${this.model.get('phoneCode')}`;
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     if (this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'sms') {
       this.listenTo(this.model, 'change:phoneCode', this.handlePhoneCodeChange.bind(this));
@@ -74,7 +74,7 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
-  createModelClass () {
+  createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     if (this.options.appState.get('currentAuthenticator').contextualData.selectedChannel !== 'sms') {
       return ModelClass;
@@ -93,7 +93,7 @@ export default BaseAuthenticatorView.extend({
       {
         phoneCode: {
           deps: [ 'country'],
-          fn: function (country) {
+          fn: function(country) {
             return CountryUtil.getCallingCodeForCountry(country);
           },
         },
@@ -103,7 +103,7 @@ export default BaseAuthenticatorView.extend({
     return ModelClass.extend({
       local,
       derived,
-      toJSON: function () {
+      toJSON: function() {
         const modelJSON = Model.prototype.toJSON.call(this, arguments);
         const phoneCode = this.get('phoneCode');
 
@@ -116,7 +116,7 @@ export default BaseAuthenticatorView.extend({
       },
     });
   },
-  postRender () {
+  postRender() {
     this.add(SwitchEnrollChannelLinkView, 'form');
   },
 });

--- a/src/v2/view-builder/views/ov/NumberChallengePhoneView.js
+++ b/src/v2/view-builder/views/ov/NumberChallengePhoneView.js
@@ -20,7 +20,7 @@ const NumberChallengePhoneView = View.extend({
       </div>
     </div>
   `,
-  getTemplateData () {
+  getTemplateData() {
     const correctAnswer = this.options.appState.get('currentAuthenticator')?.contextualData?.correctAnswer;
     return {
       correctAnswer

--- a/src/v2/view-builder/views/ov/NumberChallengePushView.js
+++ b/src/v2/view-builder/views/ov/NumberChallengePushView.js
@@ -14,46 +14,46 @@ const Body = BaseForm.extend(Object.assign(
       'click a.resend-number-challenge': 'handleResendNumberChallenge'
     },
 
-    handleResendNumberChallenge () {
+    handleResendNumberChallenge() {
       this.options.appState.trigger('invokeAction', 'currentAuthenticator-resend');
       // hide the warning
       this.options.appState.trigger('hideNumberChallengeWarning');
     },
 
-    title () {
+    title() {
       return loc('oie.okta_verify.push.sent', 'login');
     },
 
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       this.add(NumberChallengePhoneView);
     },
 
-    triggerAfterError () {
+    triggerAfterError() {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
       this.$el.find('.o-form-fieldset-container').empty();
     },
 
-    postRender () {
+    postRender() {
       this.startPoll();
     },
 
-    startPoll () {
+    startPoll() {
       this.startPolling();
       this.addWarning();
     },
 
-    stopPoll () {
+    stopPoll() {
       this.stopPolling();
     },
 
-    addWarning () {
+    addWarning() {
       this.add(ResendNumberChallengeView, '.o-form-error-container');
       this.options.appState.trigger('showNumberChallengeWarning');
     },
 
-    remove () {
+    remove() {
       BaseForm.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },

--- a/src/v2/view-builder/views/ov/ResendNumberChallengeView.js
+++ b/src/v2/view-builder/views/ov/ResendNumberChallengeView.js
@@ -3,7 +3,7 @@ import hbs from 'handlebars-inline-precompile';
 import { WARNING_TIMEOUT } from '../../utils/Constants';
 
 const ResendNumberChallengeView = View.extend({
-  initialize () {
+  initialize() {
     this.listenTo(this.options.appState, 'showNumberChallengeWarning',  () => {
       this.startWarningTimeout();
     });
@@ -23,16 +23,16 @@ const ResendNumberChallengeView = View.extend({
         </p>
       </div>
   `,
-  showWarning () {
+  showWarning() {
     this.$el.removeClass('hide');
   },
-  clearWarning () {
+  clearWarning() {
     this.$el.addClass('hide');
     clearTimeout(this.warningTimeout);
     this.startWarningTimeout();
   },
-  startWarningTimeout () {
-    this.warningTimeout = setTimeout(_.bind(function () {
+  startWarningTimeout() {
+    this.warningTimeout = setTimeout(_.bind(function() {
       this.showWarning();
     }, this), WARNING_TIMEOUT);
   }

--- a/src/v2/view-builder/views/ov/ResendView.js
+++ b/src/v2/view-builder/views/ov/ResendView.js
@@ -9,7 +9,7 @@ export default View.extend({
     'click a.resend-link' : 'handelResendLink'
   },
 
-  initialize () {
+  initialize() {
     const selectedChannel = this.options.appState.get('currentAuthenticator').contextualData.selectedChannel;
     this.add(createCallout({
       content: selectedChannel === 'email' ?
@@ -19,24 +19,24 @@ export default View.extend({
     }));
   },
 
-  handelResendLink () {
+  handelResendLink() {
     this.options.appState.trigger('invokeAction', 'currentAuthenticator-resend');
     //hide warning, but reinitiate to show warning again after some threshold of polling
     this.$el.addClass('hide');
     this.showCalloutWithDelay();
   },
 
-  postRender () {
+  postRender() {
     this.showCalloutWithDelay();
   },
 
-  showCalloutWithDelay () {
+  showCalloutWithDelay() {
     this.showMeTimeout = _.delay(() => {
       this.$el.removeClass('hide');
     }, SHOW_RESEND_TIMEOUT);
   },
 
-  remove () {
+  remove() {
     View.prototype.remove.apply(this, arguments);
     clearTimeout(this.showMeTimeout);
   }

--- a/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/SelectEnrollmentChannelOktaVerifyView.js
@@ -4,12 +4,12 @@ import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return (BrowserFeatures.isAndroid() || BrowserFeatures.isIOS())
       ? loc('oie.enroll.okta_verify.setup.title', 'login')
       : loc('oie.enroll.okta_verify.select.channel.title', 'login');
   },
-  getUISchema () {
+  getUISchema() {
     const schemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     // filter selected channel
     const channelField = _.find(schemas, (schema) => schema.name === 'authenticator.channel');

--- a/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
+++ b/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
@@ -11,12 +11,12 @@ export default View.extend({
     {{else}}
       {{{i18n code="oie.enroll.okta_verify.switch.channel.link.text" bundle="login"}}}
     {{/if}}`,
-  getTemplateData () {
+  getTemplateData() {
     return {
       isQRcodeChannel: this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode',
     };
   },
-  postRender () {
+  postRender() {
     this.$el.find('.switch-channel-link').on('click', (event) => {
       const appState = this.options.appState;
       event.preventDefault();

--- a/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
@@ -7,17 +7,17 @@ import { getForgotPasswordLink } from '../../utils/LinksUtil';
 
 const Body = BaseForm.extend({
 
-  title: function () {
+  title: function() {
     return loc('oie.password.challenge.title', 'login');
   },
 
-  save: function () {
+  save: function() {
     return loc('mfa.challenge.verify', 'login');
   },
 });
 
 const Footer = AuthenticatorFooter.extend({
-  links: function () {
+  links: function() {
     let links = AuthenticatorFooter.prototype.links.apply(this, arguments);
 
     links = getForgotPasswordLink(this.options.appState, this.options.settings).concat(links);

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -7,20 +7,20 @@ import {
 import hbs from 'handlebars-inline-precompile';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return loc('oie.password.enroll.title', 'login');
   },
-  save () {
+  save() {
     return loc('oform.next', 'login');
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     const policy = this.getPasswordPolicySettings();
     this.displayPasswordPolicy(policy);
   },
 
-  displayPasswordPolicy (policy) {
+  displayPasswordPolicy(policy) {
     if (policy) {
       const rulesList = getPasswordComplexityDescriptionForHtmlList( policy );
       this.add(
@@ -46,13 +46,13 @@ const Body = BaseForm.extend({
     }
   },
 
-  triggerAfterError (model, error) {
+  triggerAfterError(model, error) {
     const policy = this.getPasswordPolicySettings();
     error.responseJSON = removeRequirementsFromError(error.responseJSON, policy);
     this.options.appState.trigger('afterError', error);
   },
 
-  getPasswordPolicySettings () {
+  getPasswordPolicySettings() {
     // This will be overridden by following scenario since the policies could be different for those.
     // - password reset (`ReEnrollAuthenticatorPasswordView.js`)
     //
@@ -60,7 +60,7 @@ const Body = BaseForm.extend({
     return relatesToObject?.value?.settings;
   },
 
-  getUISchema () {
+  getUISchema() {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     return uiSchemas.concat([
       {
@@ -80,7 +80,7 @@ export default BaseAuthenticatorView.extend({
 
   Body,
 
-  createModelClass () {
+  createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const local = Object.assign(
       {
@@ -93,7 +93,7 @@ export default BaseAuthenticatorView.extend({
     );
     return ModelClass.extend({
       local,
-      validate () {
+      validate() {
         if (this.get('credentials.passcode') !== this.get('confirmPassword') &&
             this.get('credential.value') !== this.get('confirmPassword')) {
           const errors = {

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorPasswordView.js
@@ -5,18 +5,18 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
 
   className: 'password-authenticator',
 
-  title () {
+  title() {
     const title = this.options.settings.get('brandName')?
       loc('password.expired.title.specific', 'login', [this.options.settings.get('brandName')]):
       loc('password.expired.title.generic', 'login');
     return title;
   },
 
-  save () {
+  save() {
     return loc('password.expired.submit', 'login');
   },
 
-  getPasswordPolicySettings () {
+  getPasswordPolicySettings() {
     return this.options.appState.get('recoveryAuthenticator')?.settings
       || this.options.appState.get('enrollmentAuthenticator')?.settings;
   },

--- a/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
+++ b/src/v2/view-builder/views/password/ReEnrollAuthenticatorWarningPasswordView.js
@@ -4,12 +4,12 @@ import EnrollAuthenticatorPasswordView from './EnrollAuthenticatorPasswordView';
 
 const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
   className: 'password-authenticator',
-  subtitle () {
+  subtitle() {
     if (this.options.settings.get('brandName')) {
       return loc('password.expiring.subtitle.specific', 'login', [this.options.settings.get('brandName')]);
     }
   },
-  title () {
+  title() {
     const passwordPolicy = this.getPasswordPolicySettings() || {};
     const daysToExpiry = passwordPolicy.daysToExpiry;
 
@@ -22,10 +22,10 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
     }
   },
 
-  save () {
+  save() {
     return loc('password.expired.submit', 'login');
   },
-  showMessages () {
+  showMessages() {
     // if brandName is configured and messages is present, render as subtitle with brandName in context
     if (this.options.settings.get('brandName')) {
       return null;
@@ -36,7 +36,7 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
 });
 
 const Footer = BaseFooter.extend({
-  links () {
+  links() {
     const links = [];
     if (this.options.appState.hasRemediationObject('skip')) {
       links.push({

--- a/src/v2/view-builder/views/password/ResetAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ResetAuthenticatorPasswordView.js
@@ -5,14 +5,14 @@ const Body = EnrollAuthenticatorPasswordView.prototype.Body.extend({
 
   className: 'password-authenticator',
 
-  title () {
+  title() {
     const title = this.options.settings.get('brandName')?
       loc('password.reset.title.specific', 'login', [this.options.settings.get('brandName')]):
       loc('password.reset.title.generic', 'login');
     return title;
   },
 
-  save () {
+  save() {
     return loc('password.reset', 'login');
   },
 

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -9,24 +9,24 @@ const Body = BaseForm.extend(
       'click a.phone-authenticator-challenge__link' : 'handleSecondaryLinkClick'
     },
 
-    title () {
+    title() {
       return loc('oie.phone.verify.title', 'login');
     },
 
-    save () {
+    save() {
       return (this.model.get('primaryMode') === 'sms')
         ? loc('oie.phone.sms.primaryButton', 'login')
         : loc('oie.phone.call.primaryButton', 'login');
     },
 
-    handleSecondaryLinkClick () {
+    handleSecondaryLinkClick() {
       // Call the API to send a code via secondary mode
       const secondaryMode = this.model.get('secondaryMode');
       this.model.set('authenticator.methodType', secondaryMode);
       this.saveForm(this.model);
     },
 
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       const sendText = ( this.model.get('primaryMode') === 'sms' )
         ? loc('oie.phone.verify.sms.sendText', 'login')
@@ -40,13 +40,13 @@ const Body = BaseForm.extend(
       </div>`);
     },
 
-    getUISchema () {
+    getUISchema() {
       // Change the UI schema to not display radios here.
       const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
       return uiSchemas.filter(schema => schema.name !== 'authenticator.methodType');
     },
 
-    render () {
+    render() {
       BaseForm.prototype.render.apply(this, arguments);
       const secondaryMode = this.model.get('secondaryMode');
       if (secondaryMode) {
@@ -66,7 +66,7 @@ const Body = BaseForm.extend(
 export default BaseAuthenticatorView.extend({
   Body,
 
-  createModelClass ({ uiSchema }) {
+  createModelClass({ uiSchema }) {
     // It is important to get methods from here to maintain single source of truth.
     const { options: methods } = _.find(uiSchema, schema => schema.name === 'authenticator.methodType');
     const relatesToObject = this.options.currentViewState.relatesTo;

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -14,7 +14,7 @@ const ResendView = View.extend(
     // Override this to change the resend action location from response
     resendActionKey: 'currentAuthenticatorEnrollment-resend',
 
-    initialize () {
+    initialize() {
       const resendText = (this.model.get('mode') === 'sms')
         ? loc('oie.phone.verify.sms.resendText', 'login')
         : loc('oie.phone.verify.call.resendText', 'login');
@@ -27,7 +27,7 @@ const ResendView = View.extend(
       }));
     },
 
-    handleResendLink () {
+    handleResendLink() {
       this.options.appState.trigger('invokeAction', this.resendActionKey);
       // Hide warning, but start a timeout again..
       if (!this.el.classList.contains('hide')) {
@@ -36,17 +36,17 @@ const ResendView = View.extend(
       this.showCalloutAfterTimeout();
     },
 
-    postRender () {
+    postRender() {
       this.showCalloutAfterTimeout();
     },
 
-    showCalloutAfterTimeout () {
+    showCalloutAfterTimeout() {
       this.showCalloutTimer = setTimeout(() => {
         this.el.classList.remove('hide');
       }, SHOW_RESEND_TIMEOUT);
     },
 
-    remove () {
+    remove() {
       View.prototype.remove.apply(this, arguments);
       clearTimeout(this.showCalloutTimer);
     }
@@ -57,15 +57,15 @@ const Body = BaseForm.extend(Object.assign(
   {
     className: 'phone-authenticator-challenge',
 
-    title () {
+    title() {
       return loc('oie.phone.verify.title', 'login');
     },
 
-    save () {
+    save() {
       return loc('mfa.challenge.verify', 'login');
     },
 
-    initialize () {
+    initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
       const sendText = (this.model.get('mode') === 'sms')
         ? loc('oie.phone.verify.sms.codeSentText', 'login')
@@ -82,7 +82,7 @@ const Body = BaseForm.extend(Object.assign(
       });
     },
 
-    postRender () {
+    postRender() {
       BaseForm.prototype.postRender.apply(this, arguments);
       this.add(ResendView, {
         selector: '.o-form-error-container',
@@ -95,7 +95,7 @@ const Body = BaseForm.extend(Object.assign(
 export default BaseAuthenticatorView.extend({
   Body,
 
-  createModelClass () {
+  createModelClass() {
     const relatesToObject = this.options.currentViewState.relatesTo;
     const { methods, profile } = relatesToObject?.value || {};
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorDataPhoneView.js
@@ -7,15 +7,15 @@ const Body = BaseForm.extend({
 
   className: 'phone-authenticator-enroll',
 
-  title () {
+  title() {
     return loc('oie.phone.enroll.title', 'login');
   },
 
-  subtitle () {
+  subtitle() {
     return loc('oie.phone.enroll.subtitle', 'login');
   },
 
-  render () {
+  render() {
     BaseForm.prototype.render.apply(this, arguments);
     const selectedMethod = this.model.get('authenticator.methodType');
     const phoneField = this.el.querySelector('.phone-authenticator-enroll__phone');
@@ -38,18 +38,18 @@ const Body = BaseForm.extend({
     this.el.querySelector('.phone-authenticator-enroll__phone-code').innerText = `+${this.model.get('phoneCode')}`;
   },
 
-  handlePhoneCodeChange () {
+  handlePhoneCodeChange() {
     const countryCodeField = this.el.querySelector('.phone-authenticator-enroll__phone-code');
     countryCodeField.innerText = `+${this.model.get('phoneCode')}`;
   },
 
-  save () {
+  save() {
     return this.model.get('authenticator.methodType') === 'voice'
       ? loc('oie.phone.call.primaryButton', 'login')
       : loc('oie.phone.sms.primaryButton', 'login');
   },
 
-  getUISchema () {
+  getUISchema() {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
 
     // TODO: Using underscore to support IE, replace with Array.prototype methods (find, findIndex) when IE
@@ -109,7 +109,7 @@ const Body = BaseForm.extend({
     return uiSchemas;
   },
 
-  initialize () {
+  initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
     this.listenTo(this.model, 'change:authenticator.methodType', this.render.bind(this));
     this.listenTo(this.model, 'change:phoneCode', this.handlePhoneCodeChange.bind(this));
@@ -120,7 +120,7 @@ export default BaseAuthenticatorView.extend({
 
   Body,
 
-  createModelClass () {
+  createModelClass() {
     const ModelClass = BaseView.prototype.createModelClass.apply(this, arguments);
     const local = Object.assign(
       {
@@ -139,7 +139,7 @@ export default BaseAuthenticatorView.extend({
       {
         phoneCode: {
           deps: [ 'country' ],
-          fn: function (country) {
+          fn: function(country) {
             return CountryUtil.getCallingCodeForCountry(country);
           },
         },
@@ -149,7 +149,7 @@ export default BaseAuthenticatorView.extend({
     return ModelClass.extend({
       local,
       derived,
-      toJSON: function () {
+      toJSON: function() {
         const modelJSON = Model.prototype.toJSON.call(this, arguments);
         const extension = this.get('extension');
         const phoneCode = this.get('phoneCode');

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
@@ -17,11 +17,11 @@ const Body = ChallengeAuthenticatorPhoneView.prototype.Body.extend(
   {
     className: 'phone-authenticator-enroll',
 
-    title () {
+    title() {
       return loc('oie.phone.enroll.title', 'login');
     },
 
-    postRender () {
+    postRender() {
       BaseForm.prototype.postRender.apply(this, arguments);
       this.add(EnrollResendView, {
         selector: '.o-form-error-container',

--- a/src/v2/view-builder/views/security-question/ChallengeAuthenticatorSecurityQuestion.js
+++ b/src/v2/view-builder/views/security-question/ChallengeAuthenticatorSecurityQuestion.js
@@ -3,15 +3,15 @@ import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return loc('oie.security.question.challenge.title', 'login');
   },
 
-  save () {
+  save() {
     return loc('mfa.challenge.verify', 'login');
   },
 
-  getUISchema () {
+  getUISchema() {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     const questionKey = uiSchemas.filter(s => s.name.indexOf('questionKey') >= 0);
     const answer = uiSchemas.filter(s => s.name.indexOf('answer') >= 0);

--- a/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
+++ b/src/v2/view-builder/views/security-question/EnrollAuthenticatorSecurityQuestionView.js
@@ -3,10 +3,10 @@ import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseForm.extend({
-  title () {
+  title() {
     return loc('oie.security.question.enroll.title', 'login');
   },
-  save () {
+  save() {
     return loc('mfa.challenge.verify', 'login');
   },
 });

--- a/src/v2/view-builder/views/shared/email.js
+++ b/src/v2/view-builder/views/shared/email.js
@@ -1,6 +1,6 @@
 import { loc } from 'okta';
 export default {
-  title () {
+  title() {
     return loc('oie.email.mfa.title', 'login');
   }
 };

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -2,7 +2,7 @@ import { _ } from 'okta';
 import { MS_PER_SEC } from '../../utils/Constants';
 
 export default {
-  startPolling (newRefreshInterval) {
+  startPolling(newRefreshInterval) {
     this.pollingInterval = newRefreshInterval || this.options.currentViewState.refresh;
     this.countDownCounterValue = Math.ceil(this.pollingInterval / MS_PER_SEC);
     // Poll is present in remediation form
@@ -15,7 +15,7 @@ export default {
     }
   },
 
-  _startAuthenticatorPolling () {
+  _startAuthenticatorPolling() {
     // Authenticator won't co-exists hence it's safe to trigger both.
     [
       'currentAuthenticator',
@@ -37,7 +37,7 @@ export default {
     });
   },
 
-  startCountDown (selector , interval) {
+  startCountDown(selector , interval) {
     if(this.countDown) {
       clearInterval(this.countDown);
     }
@@ -53,13 +53,13 @@ export default {
     }, interval, this);
   },
 
-  _stopCountDown () {
+  _stopCountDown() {
     if(this.countDown) {
       clearInterval(this.countDown);
     }
   },
 
-  _startRemediationPolling () {
+  _startRemediationPolling() {
     if (_.isNumber(this.pollingInterval)) {
       this.polling = setInterval(() => {
         this.options.appState.trigger('saveForm', this.model);
@@ -67,7 +67,7 @@ export default {
     }
   },
 
-  stopPolling () {
+  stopPolling() {
     if (this.polling) {
       this._stopCountDown();
       clearInterval(this.polling);

--- a/src/v2/view-builder/views/signin/CustomButtons.js
+++ b/src/v2/view-builder/views/signin/CustomButtons.js
@@ -9,13 +9,13 @@ export default View.extend({
     {{/if}}
     <div class="okta-custom-buttons-container primary-auth-container"></div>
     `,
-  initialize (options) {
+  initialize(options) {
     options.customButtons.forEach((idpButton) => {
       this.add(createButton(idpButton), '.okta-custom-buttons-container');
     });
   },
 
-  getTemplateData () {
+  getTemplateData() {
     const jsonData = View.prototype.getTemplateData.apply(this, arguments);
 
     return Object.assign(jsonData, {

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -20,7 +20,7 @@ export default View.extend({
     </div>
     {{/unless}}
   `,
-  initialize () {
+  initialize() {
     const appState = this.options.appState;
     const deviceChallengePollRemediation = this.options.appState.get('remediations')
       .find(remediation => remediation.name === Enums.LAUNCH_AUTHENTICATOR_REMEDIATION_NAME);
@@ -30,7 +30,7 @@ export default View.extend({
       className: 'button',
       icon: 'okta-verify-authenticator',
       title: loc('oktaVerify.button', 'login'),
-      click () {
+      click() {
         const isUVapproach = deviceChallenge.challengeMethod &&
           deviceChallenge.challengeMethod === Enums.UNIVERSAL_LINK_CHALLENGE;
         if (isUVapproach) {
@@ -56,7 +56,7 @@ export default View.extend({
     }), '.okta-verify-container');
   },
 
-  getTemplateData () {
+  getTemplateData() {
     return {
       signInWithDeviceIsRequired: !!this.options.isRequired,
     };

--- a/src/v2/view-builder/views/signin/SignInWithIdps.js
+++ b/src/v2/view-builder/views/signin/SignInWithIdps.js
@@ -9,13 +9,13 @@ export default View.extend({
     {{/if}}
     <div class="okta-idps-container"></div>
     `,
-  initialize () {
+  initialize() {
     this.options.idpButtons.forEach((idpButton) => {
       this.add(createButton(idpButton), '.okta-idps-container');
     });
   },
 
-  getTemplateData () {
+  getTemplateData() {
     const jsonData = View.prototype.getTemplateData.apply(this, arguments);
 
     return Object.assign(jsonData, {

--- a/src/v2/view-builder/views/symantec/AuthenticatorSymantecView.js
+++ b/src/v2/view-builder/views/symantec/AuthenticatorSymantecView.js
@@ -4,21 +4,21 @@ import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     const displayName = this.options.appState.getAuthenticatorDisplayName();
     return this.options.appState.isAuthenticatorChallenge()
       ? loc('oie.symantecVip.challenge.title', 'login', [displayName])
       : loc('oie.symantecVip.enroll.title', 'login', [displayName]);
   },
 
-  subtitle () {
+  subtitle() {
     const displayName = this.options.appState.getAuthenticatorDisplayName();
     return this.options.appState.isAuthenticatorChallenge()
       ? loc('oie.symantecVip.challenge.description', 'login', [displayName])
       : loc('oie.symantecVip.enroll.description', 'login', [displayName]);
   },
 
-  save () {
+  save() {
     return this.options.appState.isAuthenticatorChallenge()
       ? loc('mfa.challenge.verify', 'login')
       : loc('mfa.enroll', 'login');

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnInfoView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnInfoView.js
@@ -4,7 +4,7 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   // eslint-disable-next-line max-len
   template: hbs`<p class="idx-webauthn-verify-text">{{i18n code="oie.verify.webauthn.instructions" bundle="login"}}</p>`,
-  initialize () {
+  initialize() {
     const relatesToObject = this.options.currentViewState.relatesTo;
     const challengeData = relatesToObject?.value.contextualData.challengeData;
     if (challengeData.userVerification === 'required') {

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -8,13 +8,13 @@ import ChallengeWebauthnInfoView from './ChallengeWebauthnInfoView';
 
 const Body = BaseForm.extend({
 
-  title () {
+  title() {
     return loc('oie.verify.webauth.title', 'login');
   },
 
   className: 'oie-verify-webauthn',
 
-  getUISchema () {
+  getUISchema() {
     const schema = [];
     // Returning custom array so no input fields are displayed for webauthn
     if (webauthn.isNewApiAvailable()) {
@@ -43,7 +43,7 @@ const Body = BaseForm.extend({
     return schema;
   },
 
-  remove () {
+  remove() {
     BaseForm.prototype.remove.apply(this, arguments);
     if (this.webauthnAbortController) {
       this.webauthnAbortController.abort();
@@ -57,7 +57,7 @@ const Body = BaseForm.extend({
     'error': '_stopVerification'
   },
 
-  getCredentialsAndSave () {
+  getCredentialsAndSave() {
     this.clearErrors();
     this._startVerification();
     this.webauthnAbortController = new AbortController();
@@ -102,13 +102,13 @@ const Body = BaseForm.extend({
     });
   },
 
-  _startVerification: function () {
+  _startVerification: function() {
     this.$('.okta-waiting-spinner').show();
     this.$('.retry-webauthn').hide();
     this.$('.retry-webauthn')[0].textContent = loc('retry', 'login');
   },
 
-  _stopVerification: function () {
+  _stopVerification: function() {
     this.$('.okta-waiting-spinner').hide();
     this.$('.retry-webauthn').show();
   }
@@ -116,7 +116,7 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
-  postRender () {
+  postRender() {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
     // Trigger browser prompt automatically for other browsers for better UX.
     if (webauthn.isNewApiAvailable() && !BrowserFeatures.isSafari()) {

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnInfoView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnInfoView.js
@@ -5,7 +5,7 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   // eslint-disable-next-line max-len
   template: hbs`<p class="idx-webauthn-enroll-text">{{i18n code="oie.enroll.webauthn.instructions" bundle="login"}}</p>`,
-  initialize () {
+  initialize() {
     const relatesToObject = this.options.currentViewState.relatesTo;
     const activationData = relatesToObject?.value.contextualData.activationData;
     if (BrowserFeatures.isEdge()) {

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -5,7 +5,7 @@ import webauthn from '../../../../util/webauthn';
 import CryptoUtil from '../../../../util/CryptoUtil';
 import EnrollWebauthnInfoView from './EnrollWebauthnInfoView';
 
-function getExcludeCredentials (authenticatorEnrollments = []) {
+function getExcludeCredentials(authenticatorEnrollments = []) {
   const credentials = [];
   authenticatorEnrollments.forEach((enrollement) => {
     if (enrollement.type === 'security_key') {
@@ -24,7 +24,7 @@ const Body = BaseForm.extend({
   modelEvents: {
     'error': '_stopEnrollment',
   },
-  getUISchema () {
+  getUISchema() {
     const schema = [];
     // Returning custom array so no input fields are displayed for webauthn
     if (webauthn.isNewApiAvailable()) {
@@ -51,7 +51,7 @@ const Body = BaseForm.extend({
     }
     return schema;
   },
-  triggerWebauthnPrompt () {
+  triggerWebauthnPrompt() {
     this.$el.find('.o-form-error-container').empty();
     this._startEnrollment();
     const relatesToObject = this.options.currentViewState.relatesTo;
@@ -86,12 +86,12 @@ const Body = BaseForm.extend({
         });
     }
   },
-  _startEnrollment: function () {
+  _startEnrollment: function() {
     this.$('.okta-waiting-spinner').show();
     this.$('.webauthn-setup').hide();
   },
 
-  _stopEnrollment: function () {
+  _stopEnrollment: function() {
     this.$('.okta-waiting-spinner').hide();
     this.$('.webauthn-setup').show();
   },
@@ -99,7 +99,7 @@ const Body = BaseForm.extend({
 
 export default BaseAuthenticatorView.extend({
   Body,
-  postRender () {
+  postRender() {
     BaseAuthenticatorView.prototype.postRender.apply(this, arguments);
     this.$el.find('.o-form-button-bar [type="submit"]').remove();
   },

--- a/src/views/ResendEmailView.js
+++ b/src/views/ResendEmailView.js
@@ -31,21 +31,21 @@ export default View.extend({
     'click .resend-email-btn': 'resendEmail',
   },
 
-  postRender: function () {
+  postRender: function() {
     this.showResendCallout();
   },
 
-  showResendCallout: function () {
+  showResendCallout: function() {
     _.delay(() => {
       this.$el.removeClass('hide');
     }, Enums.API_RATE_LIMIT);
   },
 
-  hideResendCallout: function () {
+  hideResendCallout: function() {
     this.$el.addClass('hide');
   },
 
-  resendEmail: function (e) {
+  resendEmail: function(e) {
     e.preventDefault();
     this.hideResendCallout();
     this.model.resend().finally(this.showResendCallout.bind(this));

--- a/src/views/admin-consent/ScopeItem.js
+++ b/src/views/admin-consent/ScopeItem.js
@@ -22,7 +22,7 @@ export default View.extend({
     <span class="scope-item-tooltip icon form-help-16" />
     {{/if}}`,
 
-  postRender: function () {
+  postRender: function() {
     this.$('.scope-item-tooltip').qtip({
       content: {
         text: this.options.description

--- a/src/views/admin-consent/ScopeList.js
+++ b/src/views/admin-consent/ScopeList.js
@@ -70,12 +70,12 @@ const ScopeGroupHeaderView = View.extend({
     </span>
     </div>`,
 
-  expandScopes () {
+  expandScopes() {
     this.$el.toggleClass('scope-group--is-expanded');
     this.$('.caret').toggleClass('caret--is-rotated');
   },
 
-  preRender () {
+  preRender() {
     _.chain(this.options.scopes)
       .sortBy(({ name }) => name)
       .each(({ name, displayName, description }) => {
@@ -92,7 +92,7 @@ const ScopeGroupHeaderView = View.extend({
 export default View.extend({
   className: 'scope-list detail-row',
 
-  postRender: function () {
+  postRender: function() {
     const allScopes = this.model.get('scopes');
     const scopesWithGroup = _.groupBy(allScopes, findScopeGroupKey);
 

--- a/src/views/consent/ScopeItem.js
+++ b/src/views/consent/ScopeItem.js
@@ -26,7 +26,7 @@ export default View.extend({
     '
   ),
 
-  postRender: function () {
+  postRender: function() {
     this.$('.scope-item-tooltip').qtip({
       content: {
         text: this.options.description,

--- a/src/views/consent/ScopeList.js
+++ b/src/views/consent/ScopeList.js
@@ -15,7 +15,7 @@ import ScopeItem from './ScopeItem';
 export default View.extend({
   className: 'scope-list detail-row',
 
-  postRender: function () {
+  postRender: function() {
     this.model.get('scopes').forEach(scope => {
       this.add(ScopeItem, {
         options: {

--- a/src/views/enroll-choices/FactorList.js
+++ b/src/views/enroll-choices/FactorList.js
@@ -36,11 +36,11 @@ const FactorListFactorRow = View.extend({
     '
   ),
 
-  attributes: function () {
+  attributes: function() {
     return { 'data-se': this.model.get('factorName') };
   },
 
-  children: function () {
+  children: function() {
     const children = [];
     const enrolled = this.model.get('enrolled');
     const required = this.model.get('required');
@@ -52,7 +52,7 @@ const FactorListFactorRow = View.extend({
           createButton({
             className: 'button',
             title: this.getSetupButtonText(),
-            click: function () {
+            click: function() {
               this.options.appState.trigger(
                 'navigate',
                 RouterUtil.createEnrollFactorUrl(this.model.get('provider'), this.model.get('factorType'))
@@ -76,15 +76,15 @@ const FactorListFactorRow = View.extend({
     return children;
   },
 
-  minimize: function () {
+  minimize: function() {
     this.$el.addClass('enroll-factor-row-min');
   },
 
-  maximize: function () {
+  maximize: function() {
     this.$el.removeClass('enroll-factor-row-min');
   },
 
-  getSetupButtonText: function () {
+  getSetupButtonText: function() {
     return this.model.get('additionalEnrollment')
       ? loc('enroll.choices.setup.another', 'login')
       : loc('enroll.choices.setup', 'login');
@@ -106,14 +106,14 @@ export default ListView.extend({
     '
   ),
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     const json = ListView.prototype.getTemplateData.call(this);
 
     _.extend(json, this);
     return json;
   },
 
-  postRender: function () {
+  postRender: function() {
     if (this.options.minimize) {
       this.invoke('minimize');
     }

--- a/src/views/enroll-choices/Footer.js
+++ b/src/views/enroll-choices/Footer.js
@@ -20,9 +20,9 @@ export default View.extend({
     `,
   className: 'auth-footer clearfix',
   events: {
-    'click .js-skip': function (e) {
+    'click .js-skip': function(e) {
       e.preventDefault();
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         return transaction.skip();
       });
     },

--- a/src/views/enroll-choices/RequiredFactorList.js
+++ b/src/views/enroll-choices/RequiredFactorList.js
@@ -15,17 +15,17 @@ import FactorList from './FactorList';
 export default FactorList.extend({
   listTitle: _.partial(loc, 'enroll.choices.list.setup', 'login'),
 
-  className: function () {
+  className: function() {
     return FactorList.prototype.className + ' enroll-required-factor-list';
   },
 
-  postRender: function () {
+  postRender: function() {
     let currentModel;
     let currentRow;
 
     FactorList.prototype.postRender.apply(this, arguments);
     currentModel = this.options.appState.get('factors').getFirstUnenrolledRequiredFactor();
-    currentRow = this.find(function (view) {
+    currentRow = this.find(function(view) {
       return view.model === currentModel;
     });
     currentRow.maximize();

--- a/src/views/enroll-factors/BarcodeView.js
+++ b/src/views/enroll-factors/BarcodeView.js
@@ -40,7 +40,7 @@ export default View.extend({
   ),
 
   events: {
-    'click [data-type="manual-setup"]': function (e) {
+    'click [data-type="manual-setup"]': function(e) {
       e.preventDefault();
       const url = RouterUtil.createActivateFactorUrl(
         this.model.get('__provider__'),
@@ -50,8 +50,8 @@ export default View.extend({
       if (this.model.get('__factorType__') === 'push') {
         // cancel the poll and navigate to manual setup.
         this.model
-          .doTransaction(function (transaction) {
-            return transaction.prev().then(function (trans) {
+          .doTransaction(function(transaction) {
+            return transaction.prev().then(function(trans) {
               const factor = _.findWhere(trans.factors, {
                 factorType: 'push',
                 provider: 'OKTA',
@@ -67,21 +67,21 @@ export default View.extend({
         this.options.appState.trigger('navigate', url);
       }
     },
-    'click [data-type="refresh-qrcode"]': function (e) {
+    'click [data-type="refresh-qrcode"]': function(e) {
       e.preventDefault();
       this.model.trigger('errors:clear');
 
       const self = this;
 
       this.model
-        .doTransaction(function (transaction) {
+        .doTransaction(function(transaction) {
           if (this.appState.get('isWaitingForActivation')) {
             return transaction.poll();
           } else {
             return transaction.activate();
           }
         })
-        .then(function (trans) {
+        .then(function(trans) {
           const res = trans.data;
 
           if (
@@ -96,22 +96,22 @@ export default View.extend({
     },
   },
 
-  initialize: function () {
-    this.listenTo(this.options.appState, 'change:lastAuthResponse', function () {
+  initialize: function() {
+    this.listenTo(this.options.appState, 'change:lastAuthResponse', function() {
       if (this.options.appState.get('isMfaEnrollActivate')) {
         this.$el.toggleClass('qrcode-expired', !this.options.appState.get('isWaitingForActivation'));
       } else if (this.options.appState.get('isSuccessResponse')) {
         this.$el.addClass('qrcode-success');
       }
     });
-    this.listenTo(this.model, 'error', function () {
+    this.listenTo(this.model, 'error', function() {
       if (this.options.appState.get('isMfaEnrollActivate')) {
         this.$el.toggleClass('qrcode-expired', true);
       }
     });
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
     let instructions;
 

--- a/src/views/enroll-factors/EnterPasscodeForm.js
+++ b/src/views/enroll-factors/EnterPasscodeForm.js
@@ -16,7 +16,7 @@ import FormType from 'util/FormType';
 import Util from 'util/Util';
 import TextBox from 'views/shared/TextBox';
 const form = {
-  title: function () {
+  title: function() {
     const factorName = FactorUtil.getFactorLabel(this.model.get('__provider__'), this.model.get('__factorType__'));
 
     return loc('enroll.totp.title', 'login', [factorName]);
@@ -26,7 +26,7 @@ const form = {
   noButtonBar: true,
   attributes: { 'data-se': 'step-sendcode' },
 
-  formChildren: function () {
+  formChildren: function() {
     return [
       FormType.Input({
         label: loc('mfa.challenge.enterCode.placeholder', 'login'),

--- a/src/views/enroll-factors/Footer.js
+++ b/src/views/enroll-factors/Footer.js
@@ -23,20 +23,20 @@ export default View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.options.appState.trigger('backToFactors');
       this.back();
     },
   },
 
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     if (this.options.appState.get('prevLink')) {
       // Once we are in the MFA_ENROLL_ACTIVATE, we need to reset to the
       // correct state. Fortunately, this means that the router will
       // handle navigation once the request is finished.
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         return transaction.prev();
       });
     } else {

--- a/src/views/enroll-factors/ManualSetupFooter.js
+++ b/src/views/enroll-factors/ManualSetupFooter.js
@@ -27,26 +27,26 @@ export default View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
-    'click .js-goto': function (e) {
+    'click .js-goto': function(e) {
       e.preventDefault();
       // go to a different screen with current auth status:
       // refresh the latest response
-      this.model.startTransaction(function (authClient) {
+      this.model.startTransaction(function(authClient) {
         return authClient.tx.resume();
       });
     },
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     if (this.options.appState.get('prevLink')) {
       // Once we are in the MFA_ENROLL_ACTIVATE, we need to reset to the
       // correct state. Fortunately, this means that the router will
       // handle navigation once the request is finished.
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         return transaction.prev();
       });
     } else {

--- a/src/views/enroll-factors/ManualSetupPushFooter.js
+++ b/src/views/enroll-factors/ManualSetupPushFooter.js
@@ -14,7 +14,7 @@ import { _, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import RouterUtil from 'util/RouterUtil';
 
-function goToFactorActivation (appState) {
+function goToFactorActivation(appState) {
   const url = RouterUtil.createActivateFactorUrl(
     appState.get('activatedFactorProvider'),
     appState.get('activatedFactorType')
@@ -36,19 +36,19 @@ export default View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .js-back': function (e) {
+    'click .js-back': function(e) {
       e.preventDefault();
       this.back();
     },
-    'click .js-goto': function (e) {
+    'click .js-goto': function(e) {
       e.preventDefault();
 
       const goToFactor = _.partial(goToFactorActivation, this.options.appState);
 
       this.options.appState.unset('factorActivationType');
       this.model
-        .doTransaction(function (transaction) {
-          return transaction.prev().then(function (trans) {
+        .doTransaction(function(transaction) {
+          return transaction.prev().then(function(trans) {
             const factor = _.findWhere(trans.factors, {
               factorType: 'push',
               provider: 'OKTA',
@@ -60,16 +60,16 @@ export default View.extend({
         .then(goToFactor);
     },
   },
-  back: function () {
+  back: function() {
     const self = this;
 
     self.options.appState.unset('factorActivationType');
     if (self.options.appState.get('prevLink')) {
       this.model
-        .doTransaction(function (transaction) {
+        .doTransaction(function(transaction) {
           return transaction.prev();
         })
-        .then(function () {
+        .then(function() {
           // we trap 'MFA_ENROLL' response that's why we need to trigger navigation from here
           self.options.appState.trigger('navigate', 'signin/enroll');
         });

--- a/src/views/enroll-factors/PhoneTextBox.js
+++ b/src/views/enroll-factors/PhoneTextBox.js
@@ -24,17 +24,17 @@ export default TextBox.extend({
     '
   ),
 
-  initialize: function () {
-    this.listenTo(this.model, 'change:countryCallingCode', function () {
+  initialize: function() {
+    this.listenTo(this.model, 'change:countryCallingCode', function() {
       this.$('.o-form-label-inline').text(this.model.get('countryCallingCode'));
     });
   },
 
-  preRender: function () {
+  preRender: function() {
     this.options.countryCallingCode = this.model.get('countryCallingCode');
   },
 
-  postRender: function () {
+  postRender: function() {
     // This is a hack - once inputGroups are done, get rid of it!!
     this.$el.removeClass('input-fix o-form-control');
     _.defer(() => {

--- a/src/views/enrollUser/EnrollUserForm.js
+++ b/src/views/enrollUser/EnrollUserForm.js
@@ -19,13 +19,13 @@ export default Form.extend({
   layout: 'o-form-theme',
   autoSave: true,
   noCancelButton: true,
-  title () {
+  title() {
     return loc('registration.form.title', 'login');
   },
-  save () {
+  save() {
     return loc('registration.form.submit', 'login');
   },
-  initialize: function (options) {
+  initialize: function(options) {
     this.options = options || {};
     this.schema = new ProfileSchema({
       profileSchemaAttributes: this.options.appState.get('policy').registration.profile,

--- a/src/views/expired-password/Footer.js
+++ b/src/views/expired-password/Footer.js
@@ -27,15 +27,15 @@ export default View.extend({
   ),
   className: 'auth-footer clearfix',
   events: {
-    'click .js-signout': function (e) {
+    'click .js-signout': function(e) {
       e.preventDefault();
       const self = this;
 
       this.model
-        .doTransaction(function (transaction) {
+        .doTransaction(function(transaction) {
           return transaction.cancel();
         })
-        .then(function () {
+        .then(function() {
           if (self.settings.get('signOutLink')) {
             Util.redirect(self.settings.get('signOutLink'));
           } else {
@@ -44,14 +44,14 @@ export default View.extend({
           }
         });
     },
-    'click .js-skip': function (e) {
+    'click .js-skip': function(e) {
       e.preventDefault();
-      this.model.doTransaction(function (transaction) {
+      this.model.doTransaction(function(transaction) {
         return transaction.skip();
       });
     },
   },
-  getTemplateData: function () {
+  getTemplateData: function() {
     return { passwordWarn: this.options.appState.get('isPwdExpiringSoon') };
   },
 });

--- a/src/views/factor-verify/EmailMagicLinkForm.js
+++ b/src/views/factor-verify/EmailMagicLinkForm.js
@@ -18,7 +18,7 @@ export default Form.extend({
   className: 'factor-verify-magiclink',
   autoSave: true,
   noCancelButton: true,
-  initialize: function () {
+  initialize: function() {
     const form = this;
     // for FACTOR_REQUIRED with email magic link we dont need to show otp code input field and verify button
 
@@ -33,7 +33,7 @@ export default Form.extend({
         attributes: { 'data-se': 'email-send-code' },
         className: 'button email-request-button',
         title: loc('mfa.sendEmail', 'login'),
-        click: function () {
+        click: function() {
           form.clearErrors();
           this.disable();
           this.options.title = loc('mfa.sent', 'login');

--- a/src/views/idp-discovery/IDPDiscoveryForm.js
+++ b/src/views/idp-discovery/IDPDiscoveryForm.js
@@ -14,17 +14,17 @@ import { _, loc } from 'okta';
 import PrimaryAuthForm from 'views/primary-auth/PrimaryAuthForm';
 export default PrimaryAuthForm.extend({
   className: 'idp-discovery-form',
-  save: function () {
+  save: function() {
     return loc('oform.next', 'login');
   },
   saveId: 'idp-discovery-submit',
 
-  initialize: function () {
+  initialize: function() {
     this.listenTo(this, 'save', _.bind(this.model.save, this.model));
     this.stateEnableChange();
   },
 
-  inputs: function () {
+  inputs: function() {
     const inputs = [];
     const usernameProps = {
       className: 'margin-btm-30',
@@ -40,7 +40,7 @@ export default PrimaryAuthForm.extend({
     return inputs;
   },
 
-  focus: function () {
+  focus: function() {
     if (!this.model.get('username')) {
       this.getInputs().first().focus();
     } else if (this.getInputs().toArray()[1]) {

--- a/src/views/mfa-verify/HtmlErrorMessageView.js
+++ b/src/views/mfa-verify/HtmlErrorMessageView.js
@@ -28,13 +28,13 @@ export default View.extend({
 
   message: '',
 
-  initialize: function (options) {
+  initialize: function(options) {
     if (options && options.message) {
       this.message = options.message;
     }
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     return {
       message: this.message,
     };

--- a/src/views/mfa-verify/InlineTOTPForm.js
+++ b/src/views/mfa-verify/InlineTOTPForm.js
@@ -13,7 +13,7 @@
 import { loc, createButton, Form } from 'okta';
 import TextBox from 'views/shared/TextBox';
 
-function addInlineTotp (form) {
+function addInlineTotp(form) {
   form.addDivider();
   form.addInput({
     label: loc('mfa.challenge.enterCode.placeholder', 'login'),
@@ -28,19 +28,19 @@ function addInlineTotp (form) {
       attributes: { 'data-se': 'inline-totp-verify' },
       className: 'button inline-totp-verify margin-top-30',
       title: loc('mfa.challenge.verify', 'login'),
-      click: function () {
+      click: function() {
         form.clearErrors();
         if (!form.isValid()) {
           return;
         }
-        form.model.manageTransaction(function (transaction, setTransaction) {
+        form.model.manageTransaction(function(transaction, setTransaction) {
           // This is the case where we enter the TOTP code and verify while there is an
           // active Push request (or polling) running. We need to invoke previous() on authClient
           // and then call model.save(). If not, we would still be in MFA_CHALLENGE state and
           // verify would result in a wrong request (push verify instead of a TOTP verify).
           if (transaction.status === 'MFA_CHALLENGE' && transaction.prev) {
             form.options.appState.set('trapMfaRequiredResponse', true);
-            return transaction.prev().then(function (trans) {
+            return transaction.prev().then(function(trans) {
               setTransaction(trans);
               form.model.save();
             });
@@ -65,10 +65,10 @@ export default Form.extend({
 
   attributes: { 'data-se': 'factor-inline-totp' },
 
-  initialize: function () {
+  initialize: function() {
     const form = this;
 
-    this.listenTo(this.model, 'error', function () {
+    this.listenTo(this.model, 'error', function() {
       this.clearErrors();
     });
     this.add(
@@ -76,7 +76,7 @@ export default Form.extend({
         className: 'link',
         attributes: { 'data-se': 'inline-totp-add' },
         title: loc('mfa.challenge.orEnterCode', 'login'),
-        click: function () {
+        click: function() {
           this.remove();
           addInlineTotp(form);
         },

--- a/src/views/mfa-verify/NumberChallengeView.js
+++ b/src/views/mfa-verify/NumberChallengeView.js
@@ -28,14 +28,14 @@ export default View.extend({
       </div>
       <p>{{i18n code="oktaverify.numberchallenge.explain"  bundle="login"}}</p>
     `,
-  initialize () {
+  initialize() {
     this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', () => {
       if (this.options.appState.get('lastAuthResponse').status !== 'SUCCESS') {
         this.render();
       }
     });
   },
-  getTemplateData () {
+  getTemplateData() {
     const lastAuthResponse = this.options.appState.get('lastAuthResponse');
     if (!this.options.appState.get('isWaitingForNumberChallenge')) {
       return {

--- a/src/views/mfa-verify/PassCodeForm.js
+++ b/src/views/mfa-verify/PassCodeForm.js
@@ -28,7 +28,7 @@ const PassCodeFormwarningTemplate = View.extend({
     `,
 });
 
-function getFormAndButtonDetails (factorType) {
+function getFormAndButtonDetails(factorType) {
   switch (factorType) {
   case 'sms':
     return {
@@ -78,19 +78,19 @@ export default Form.extend({
   scrollOnError: false,
   layout: 'o-form-theme',
 
-  disableSubmitButton: function () {
+  disableSubmitButton: function() {
     return this.model.appState.get('isMfaChallenge') && this.model.get('answer');
   },
 
-  showWarning: function (msg) {
+  showWarning: function(msg) {
     this.clearWarnings();
     this.add(PassCodeFormwarningTemplate, '.o-form-error-container', { options: { warning: msg } });
   },
-  clearWarnings: function () {
+  clearWarnings: function() {
     this.$('.okta-form-infobox-warning').remove();
   },
 
-  initialize: function () {
+  initialize: function() {
     const form = this;
 
     this.title = this.model.get('factorLabel');
@@ -102,7 +102,7 @@ export default Form.extend({
     this.$el.attr('data-se', 'factor-' + factorType);
 
     this.subtitle = formAndButtonDetails.subtitle;
-    this.listenTo(this.model, 'error', function () {
+    this.listenTo(this.model, 'error', function() {
       this.clearErrors();
     });
     this.addInput({
@@ -118,7 +118,7 @@ export default Form.extend({
         attributes: { 'data-se': formAndButtonDetails.buttonDataSe },
         className: 'button ' + formAndButtonDetails.buttonClassName,
         title: formAndButtonDetails.formSubmit,
-        click: function () {
+        click: function() {
           form.clearErrors();
           this.disable();
           form.clearWarnings();
@@ -129,7 +129,7 @@ export default Form.extend({
           this.model.set('answer', '');
           this.model
             .save()
-            .then(function () {
+            .then(function() {
               // render and focus on the passcode input field.
               form.getInputs().first().render().focus();
               return Q.delay(Enums.API_RATE_LIMIT);

--- a/src/views/mfa-verify/PasswordForm.js
+++ b/src/views/mfa-verify/PasswordForm.js
@@ -20,7 +20,7 @@ export default Form.extend({
   layout: 'o-form-theme',
   attributes: { 'data-se': 'factor-password' },
 
-  initialize: function () {
+  initialize: function() {
     this.title = this.model.get('factorLabel');
 
     this.addInput({

--- a/src/views/mfa-verify/PushForm.js
+++ b/src/views/mfa-verify/PushForm.js
@@ -42,12 +42,12 @@ export default Form.extend({
     submit: 'submit',
   },
 
-  initialize: function () {
+  initialize: function() {
     this.enabled = true;
     this.listenTo(this.options.appState, 'change:isMfaRejected', this.handleRejectStateChange);
 
     this.numberChallengeView = this.add(NumberChallengeView).last();
-    this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', function (
+    this.listenTo(this.options.appState, 'change:isWaitingForNumberChallenge', function(
       state,
       isWaitingForNumberChallenge
     ) {
@@ -60,13 +60,13 @@ export default Form.extend({
         this.$el.find('.button').show();
       }
     });
-    this.listenTo(this.options.appState, 'change:isMfaTimeout', function (state, isMfaTimeout) {
+    this.listenTo(this.options.appState, 'change:isMfaTimeout', function(state, isMfaTimeout) {
       this.setSubmitState(isMfaTimeout);
       if (isMfaTimeout) {
         this.showError(loc('oktaverify.timeout', 'login'));
       }
     });
-    this.listenTo(this.options.appState, 'change:isMfaRequired', function (state, isMfaRequired) {
+    this.listenTo(this.options.appState, 'change:isMfaRequired', function(state, isMfaRequired) {
       if (isMfaRequired) {
         this.clearErrors();
         this.clearWarnings();
@@ -77,7 +77,7 @@ export default Form.extend({
       deviceName: this.model.get('deviceName'),
     });
   },
-  setSubmitState: function (ableToSubmit) {
+  setSubmitState: function(ableToSubmit) {
     const button = this.$el.find('.button');
     const a11ySpan = this.$el.find('.accessibility-text');
     this.enabled = ableToSubmit;
@@ -97,7 +97,7 @@ export default Form.extend({
       );
     }
   },
-  submit: function (e) {
+  submit: function(e) {
     if (e !== undefined) {
       e.preventDefault();
     }
@@ -106,7 +106,7 @@ export default Form.extend({
       this.doSave();
     }
   },
-  postRender: function () {
+  postRender: function() {
     const factorsPolicyInfo = this.options.appState.get('factorsPolicyInfo');
     const id = this.model.get('id');
     const isAutoPushEnabled = this.settings.get('features.autoPush') && factorsPolicyInfo && factorsPolicyInfo[id]
@@ -119,13 +119,13 @@ export default Form.extend({
       _.defer(_.bind(this.submit, this));
     }
   },
-  doSave: function () {
+  doSave: function() {
     let warningTimeout;
 
     this.clearErrors();
     this.clearWarnings();
     if (this.model.isValid()) {
-      this.listenToOnce(this.model, 'error', function () {
+      this.listenToOnce(this.model, 'error', function() {
         this.setSubmitState(true);
         this.clearWarnings();
         clearTimeout(warningTimeout);
@@ -138,24 +138,24 @@ export default Form.extend({
       }, WARNING_TIMEOUT);
     }
   },
-  showError: function (msg) {
+  showError: function(msg) {
     this.clearWarnings();
     this.model.trigger('error', this.model, { responseJSON: { errorSummary: msg } });
   },
-  showWarning: function (msg) {
+  showWarning: function(msg) {
     this.clearWarnings();
     this.add(PushFormwarningTemplate, '.o-form-error-container', { options: { warning: msg } });
   },
-  clearWarnings: function () {
+  clearWarnings: function() {
     this.$('.okta-form-infobox-warning').remove();
   },
-  handleRejectStateChange: function (state, isMfaRejected) {
+  handleRejectStateChange: function(state, isMfaRejected) {
     if (isMfaRejected) {
       this.setSubmitState(isMfaRejected);
       this.setRejectedErrorMessage();
     }
   },
-  setRejectedErrorMessage: function () {
+  setRejectedErrorMessage: function() {
     // If rejection is due to outdated app, show error message per platform
     // else show user rejected message.
     if (this.options.appState.get('lastAuthResponse').factorResultMessage === 'OKTA_VERIFY_UPGRADE_REQUIRED') {

--- a/src/views/mfa-verify/SecurityQuestionForm.js
+++ b/src/views/mfa-verify/SecurityQuestionForm.js
@@ -20,7 +20,7 @@ export default Form.extend({
   layout: 'o-form-theme',
   attributes: { 'data-se': 'factor-question' },
 
-  initialize: function () {
+  initialize: function() {
     this.title = this.model.get('factorLabel');
 
     this.addInput({

--- a/src/views/mfa-verify/SendEmailAndVerifyCodeForm.js
+++ b/src/views/mfa-verify/SendEmailAndVerifyCodeForm.js
@@ -15,7 +15,7 @@ import hbs from 'handlebars-inline-precompile';
 import ResendEmailView from 'views/ResendEmailView';
 import TextBox from 'views/shared/TextBox';
 
-const createEmailMaskElement = function () {
+const createEmailMaskElement = function() {
   const email = this.model.get('email');
   const emailTpl = hbs('<span class="mask-email">{{email}}</span>');
   return { factorEmail: emailTpl({ email }) };
@@ -31,20 +31,20 @@ const SendEmailAndVerifyCodeFormVerifyEmailCodeForm = Form.extend({
   attributes: {
     'data-se': 'factor-email',
   },
-  save: function () {
+  save: function() {
     return this.options.appState.get('isMfaChallenge')
       ? loc('mfa.challenge.verify', 'login')
       : loc('email.button.send', 'login');
   },
 
   events: Object.assign({}, Form.prototype.events, {
-    submit: function (e) {
+    submit: function(e) {
       e.preventDefault();
       this.handleSubmit();
     },
   }),
 
-  handleSubmit () {
+  handleSubmit() {
     this.clearErrors();
     if (this.options.appState.get('isMfaChallenge')) {
       if (this.isValid()) {
@@ -57,7 +57,7 @@ const SendEmailAndVerifyCodeFormVerifyEmailCodeForm = Form.extend({
     }
   },
 
-  initialize: function () {
+  initialize: function() {
     Form.prototype.initialize.apply(this, arguments);
 
     // render 'Send Email' page at first place
@@ -73,7 +73,7 @@ const SendEmailAndVerifyCodeFormVerifyEmailCodeForm = Form.extend({
     );
   },
 
-  renderChallengView: function () {
+  renderChallengView: function() {
     this.removeChildren();
     this.add(
       View.extend({

--- a/src/views/mfa-verify/TOTPForm.js
+++ b/src/views/mfa-verify/TOTPForm.js
@@ -21,7 +21,7 @@ export default Form.extend({
   layout: 'o-form-theme',
   attributes: { 'data-se': 'factor-totp' },
 
-  initialize: function () {
+  initialize: function() {
     const factorName = this.model.get('factorLabel');
     const maskPasswordField = this.model.get('provider') === 'RSA' || this.model.get('provider') === 'DEL_OATH';
 

--- a/src/views/mfa-verify/YubikeyForm.js
+++ b/src/views/mfa-verify/YubikeyForm.js
@@ -21,7 +21,7 @@ export default Form.extend({
   layout: 'o-form-theme',
   attributes: { 'data-se': 'factor-yubikey' },
 
-  initialize: function () {
+  initialize: function() {
     const factorName = this.model.get('factorLabel');
 
     this.title = factorName;

--- a/src/views/mfa-verify/dropdown/FactorsDropDown.js
+++ b/src/views/mfa-verify/dropdown/FactorsDropDown.js
@@ -16,7 +16,7 @@ import Factor from '../../../models/Factor';
 import FactorsDropDownOptions from './FactorsDropDownOptions';
 const { BaseDropDown } = internal.views.components;
 
-$(document).click(function (e) {
+$(document).click(function(e) {
   const $target = $(e.target);
   const isDropdown = $target.closest('.option-selected').length > 0 && $target.closest('.dropdown').length > 0;
 
@@ -28,7 +28,7 @@ $(document).click(function (e) {
 
 export default BaseDropDown.extend({
   className: 'bg-helper icon-button',
-  screenReaderText: function () {
+  screenReaderText: function() {
     const factors = this.options.appState.get('factors');
     let factor;
     let factorLabel;
@@ -42,7 +42,7 @@ export default BaseDropDown.extend({
     return loc('mfa.factors.dropdown.sr.text', 'login', [factorLabel]);
   },
   events: {
-    'click a.option-selected': function (e) {
+    'click a.option-selected': function(e) {
       e.preventDefault();
       if (_.result(this, 'disabled')) {
         e.stopPropagation();
@@ -55,21 +55,21 @@ export default BaseDropDown.extend({
         }
       }
     },
-    'click .dropdown-disabled': function (e) {
+    'click .dropdown-disabled': function(e) {
       e.preventDefault();
       e.stopPropagation();
     },
   },
-  initialize: function () {
+  initialize: function() {
     this.addOption(FactorsDropDownOptions.getDropdownOption('TITLE'));
     const factorsList = this.options.appState.get('factors');
     const multiplePushFactors = factorsList.hasMultipleFactorsOfSameType('push');
 
-    factorsList.each(function (factor) {
+    factorsList.each(function(factor) {
       // Do not add okta totp if there are multiple okta push (each push will have an inline totp)
       if (!(factor.get('factorType') === 'token:software:totp' && multiplePushFactors)) {
         this.addOption(FactorsDropDownOptions.getDropdownOption(factor.get('factorName')), { model: factor });
-        this.listenTo(this.last(), 'options:toggle', function () {
+        this.listenTo(this.last(), 'options:toggle', function() {
           this.$('.options').hide();
           this.$('a.option-selected').attr('aria-expanded', false);
         });

--- a/src/views/mfa-verify/dropdown/FactorsDropDownOptions.js
+++ b/src/views/mfa-verify/dropdown/FactorsDropDownOptions.js
@@ -18,7 +18,7 @@ const pushTitleTpl = hbs('{{factorName}} ({{{deviceName}}})');
 
 // deviceName is escaped on BaseForm (see BaseForm's template)
 
-const action = function (model) {
+const action = function(model) {
   let factorIndex;
   const factorType = model.get('factorType');
   const factorsList = this.options.appState.get('factors');
@@ -30,14 +30,14 @@ const action = function (model) {
   const self = this;
 
   this.options.appState.trigger('factorSwitched');
-  this.model.manageTransaction(function (transaction, setTransaction) {
+  this.model.manageTransaction(function(transaction, setTransaction) {
     // FACTOR_CHALLENGE does not have a prev link
     if (transaction.status === 'FACTOR_CHALLENGE') {
       this.options.appState.set('trapMfaRequiredResponse', true);
     }
     if (transaction.status === 'MFA_CHALLENGE' && transaction.prev) {
       this.options.appState.set('trapMfaRequiredResponse', true);
-      return transaction.prev().then(function (trans) {
+      return transaction.prev().then(function(trans) {
         self.trigger('options:toggle');
         setTransaction(trans);
         self.options.appState.trigger('navigate', url);
@@ -59,10 +59,10 @@ const dropdownOptions = {
   OKTA_VERIFY: {
     icon: 'factor-icon mfa-okta-verify-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -70,13 +70,13 @@ const dropdownOptions = {
   OKTA_VERIFY_PUSH: {
     icon: 'factor-icon mfa-okta-verify-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return pushTitleTpl({
         factorName: this.model.get('factorLabel'),
         deviceName: this.model.get('deviceName'),
       });
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -84,10 +84,10 @@ const dropdownOptions = {
   GOOGLE_AUTH: {
     icon: 'factor-icon mfa-google-auth-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -95,10 +95,10 @@ const dropdownOptions = {
   CUSTOM_HOTP: {
     icon: 'factor-icon mfa-hotp-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -106,10 +106,10 @@ const dropdownOptions = {
   SYMANTEC_VIP: {
     icon: 'factor-icon mfa-symantec-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -118,7 +118,7 @@ const dropdownOptions = {
     icon: 'factor-icon mfa-rsa-30',
     className: 'factor-option',
     title: _.partial(loc, 'factor.totpHard.rsaSecurId', 'login'),
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -126,10 +126,10 @@ const dropdownOptions = {
   ON_PREM: {
     icon: 'factor-icon mfa-onprem-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -137,10 +137,10 @@ const dropdownOptions = {
   DUO: {
     icon: 'factor-icon mfa-duo-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -169,10 +169,10 @@ const dropdownOptions = {
   YUBIKEY: {
     icon: 'factor-icon mfa-yubikey-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -180,10 +180,10 @@ const dropdownOptions = {
   SMS: {
     icon: 'factor-icon mfa-sms-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -191,10 +191,10 @@ const dropdownOptions = {
   CALL: {
     icon: 'factor-icon mfa-call-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -202,10 +202,10 @@ const dropdownOptions = {
   QUESTION: {
     icon: 'factor-icon mfa-question-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -213,10 +213,10 @@ const dropdownOptions = {
   PASSWORD: {
     icon: 'factor-icon mfa-password-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -224,10 +224,10 @@ const dropdownOptions = {
   WINDOWS_HELLO: {
     icon: 'factor-icon mfa-windows-hello-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -235,10 +235,10 @@ const dropdownOptions = {
   U2F: {
     icon: 'factor-icon mfa-u2f-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -246,10 +246,10 @@ const dropdownOptions = {
   WEBAUTHN: {
     icon: 'factor-icon mfa-webauthn-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -257,10 +257,10 @@ const dropdownOptions = {
   EMAIL: {
     icon: 'factor-icon mfa-email-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -268,10 +268,10 @@ const dropdownOptions = {
   GENERIC_SAML: {
     icon: 'factor-icon mfa-custom-factor-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -279,10 +279,10 @@ const dropdownOptions = {
   GENERIC_OIDC: {
     icon: 'factor-icon mfa-custom-factor-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
@@ -290,16 +290,16 @@ const dropdownOptions = {
   CUSTOM_CLAIMS: {
     icon: 'factor-icon mfa-custom-factor-30',
     className: 'factor-option',
-    title: function () {
+    title: function() {
       return this.model.get('factorLabel');
     },
-    action: function () {
+    action: function() {
       action.call(this, this.model);
     },
   },
 };
 export default {
-  getDropdownOption: function (factorName) {
+  getDropdownOption: function(factorName) {
     return dropdownOptions[factorName];
   },
 };

--- a/src/views/primary-auth/CustomButtons.js
+++ b/src/views/primary-auth/CustomButtons.js
@@ -21,7 +21,7 @@ const formTitleTpl = hbs('<h2 data-se="o-form-head" class="okta-form-title o-for
 export default View.extend({
   className: 'primary-auth-container',
 
-  children: function () {
+  children: function() {
     const children = [];
     const socialIdpButtons = this.settings.get('configuredSocialIdps');
     const pivButton = this.settings.get('piv');
@@ -34,7 +34,7 @@ export default View.extend({
 
     _.each(
       socialIdpButtons,
-      function (button) {
+      function(button) {
         children.push(this._createSocialIdpButton(button));
       },
       this
@@ -42,7 +42,7 @@ export default View.extend({
 
     _.each(
       customButtons,
-      function (button) {
+      function(button) {
         children.push(this._createCustomButton(button));
       },
       this
@@ -64,16 +64,16 @@ export default View.extend({
     return children;
   },
 
-  _createSocialIdpButton: function (options) {
+  _createSocialIdpButton: function(options) {
     return createButton({
       attributes: {
         'data-se': options.dataAttr,
       },
       className: options.className,
-      title: function () {
+      title: function() {
         return options.text || loc(options.i18nKey);
       },
-      click: function (e) {
+      click: function(e) {
         e.preventDefault();
         if (this.settings.get('oauth2Enabled')) {
           OAuth2Util.getTokens(this.settings, { idp: options.id }, this.options.currentController);
@@ -89,7 +89,7 @@ export default View.extend({
     });
   },
 
-  _createPivButton: function (options) {
+  _createPivButton: function(options) {
     let className = options.className || '';
     return createButton({
       attributes: {
@@ -97,20 +97,20 @@ export default View.extend({
       },
       className: className + ' piv-button',
       title: options.text || loc('piv.cac.card', 'login'),
-      click: function (e) {
+      click: function(e) {
         e.preventDefault();
         this.options.appState.trigger('navigate', 'signin/verify/piv');
       },
     });
   },
 
-  _createCustomButton: function (options) {
+  _createCustomButton: function(options) {
     return createButton({
       attributes: {
         'data-se': options.dataAttr,
       },
       className: options.className + ' default-custom-button',
-      title: function () {
+      title: function() {
         return options.title || loc(options.i18nKey);
       },
       click: options.click,

--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -19,7 +19,7 @@ export default Form.extend({
   className: 'primary-auth-form',
   noCancelButton: true,
   attributes: { novalidate: 'novalidate' },
-  save: function () {
+  save: function() {
     if (this.settings.get('features.passwordlessAuth')) {
       return loc('oform.next', 'login');
     }
@@ -30,7 +30,7 @@ export default Form.extend({
 
   // If socialAuth is configured, the title moves from the form to
   // the top of the container (and is rendered in socialAuth).
-  title: function () {
+  title: function() {
     let formTitle = loc('primaryauth.title', 'login');
 
     if (this.settings.get('socialAuthPositionTop')) {
@@ -39,10 +39,10 @@ export default Form.extend({
     return formTitle;
   },
 
-  initialize: function () {
+  initialize: function() {
     const trackTypingPattern = this.settings.get('features.trackTypingPattern');
 
-    this.listenTo(this, 'save', function () {
+    this.listenTo(this, 'save', function() {
       if (trackTypingPattern) {
         const typingPattern = TypingUtil.getTypingPattern();
 
@@ -58,20 +58,20 @@ export default Form.extend({
       }
       this.settings
         .processCreds(creds)
-        .then(function () {
+        .then(function() {
           if (!self.settings.get('features.deviceFingerprinting')) {
             return;
           }
           self.options.appState.trigger('loading', true);
           self.state.trigger('togglePrimaryAuthButton', true);
           return DeviceFingerprint.generateDeviceFingerprint(self.settings.get('baseUrl'), self.$el)
-            .then(function (fingerprint) {
+            .then(function(fingerprint) {
               self.options.appState.set('deviceFingerprint', fingerprint);
             })
-            .catch(function () {
+            .catch(function() {
               // Keep going even if device fingerprint fails
             })
-            .finally(function () {
+            .finally(function() {
               self.options.appState.trigger('loading', false);
               self.state.trigger('togglePrimaryAuthButton', false);
             });
@@ -82,8 +82,8 @@ export default Form.extend({
     this.stateEnableChange();
   },
 
-  stateEnableChange: function () {
-    this.listenTo(this.state, 'change:enabled', function (model, enable) {
+  stateEnableChange: function() {
+    this.listenTo(this.state, 'change:enabled', function(model, enable) {
       if (enable) {
         this.enable();
       } else {
@@ -92,7 +92,7 @@ export default Form.extend({
     });
   },
 
-  inputs: function () {
+  inputs: function() {
     const inputs = [];
 
     inputs.push(this.getUsernameField());
@@ -105,7 +105,7 @@ export default Form.extend({
     return inputs;
   },
 
-  getUsernameField: function () {
+  getUsernameField: function() {
     const userNameFieldObject = {
       className: 'margin-btm-5',
       label: loc('primaryauth.username.placeholder', 'login'),
@@ -125,7 +125,7 @@ export default Form.extend({
       disabled: this.options.appState.get('disableUsername'),
       autoComplete: 'username',
       // TODO: support a11y attrs in Courage - OKTA-279025
-      render: function () {
+      render: function() {
         this.$(`input[name=${this.options.name}]`).prop('required', true);
       },
     };
@@ -133,7 +133,7 @@ export default Form.extend({
     return userNameFieldObject;
   },
 
-  getPasswordField: function () {
+  getPasswordField: function() {
     const passwordFieldObject = {
       className: 'margin-btm-30',
       label: loc('primaryauth.password.placeholder', 'login'),
@@ -152,7 +152,7 @@ export default Form.extend({
       type: 'password',
       autoComplete: 'current-password',
       // TODO: support a11y attrs in Courage - OKTA-279025
-      render: function () {
+      render: function() {
         this.$(`input[name=${this.options.name}]`).prop('required', true);
       },
     };
@@ -164,7 +164,7 @@ export default Form.extend({
     return passwordFieldObject;
   },
 
-  isCustomized: function (property) {
+  isCustomized: function(property) {
     const language = this.settings.get('language');
     const i18n = this.settings.get('i18n');
     const customizedProperty = i18n && i18n[language] && i18n[language][property];
@@ -172,7 +172,7 @@ export default Form.extend({
     return !!customizedProperty;
   },
 
-  getRemeberMeCheckbox: function () {
+  getRemeberMeCheckbox: function() {
     return {
       label: false,
       placeholder: loc('remember', 'login'),
@@ -180,8 +180,8 @@ export default Form.extend({
       type: 'checkbox',
       'label-top': true,
       className: 'margin-btm-0',
-      initialize: function () {
-        this.listenTo(this.model, 'change:remember', function (model, val) {
+      initialize: function() {
+        this.listenTo(this.model, 'change:remember', function(model, val) {
           // OKTA-98946: We normally re-render on changes to model values,
           // but in this case we will manually update the checkbox due to
           // iOS Safari and how it handles autofill - it will autofill the
@@ -193,7 +193,7 @@ export default Form.extend({
     };
   },
 
-  focus: function () {
+  focus: function() {
     if (!this.model.get('username')) {
       this.getInputs().first().focus();
     } else if (!this.settings.get('features.passwordlessAuth')) {

--- a/src/views/registration/SubSchema.js
+++ b/src/views/registration/SubSchema.js
@@ -15,10 +15,10 @@ import hbs from 'handlebars-inline-precompile';
 const SubSchemaSubSchema = View.extend({
   index: '',
   message: '',
-  class: function () {
+  class: function() {
     return;
   },
-  className: function () {
+  className: function() {
     return 'subschema-unsatisfied subschema-' + this.index;
   },
   template: hbs(
@@ -29,7 +29,7 @@ const SubSchemaSubSchema = View.extend({
       </p>\
     '
   ),
-  getTemplateData: function () {
+  getTemplateData: function() {
     return {
       message: this.message,
     };
@@ -38,8 +38,8 @@ const SubSchemaSubSchema = View.extend({
 export default View.extend({
   className: 'subschema',
 
-  children: function () {
-    return this.subSchemas.map(function (subSchema, index) {
+  children: function() {
+    return this.subSchemas.map(function(subSchema, index) {
       const description = subSchema.get('description');
       const message = description;
       // TODO API should send translated strings instead of i18n code inside description

--- a/src/views/shared/AuthContainer.js
+++ b/src/views/shared/AuthContainer.js
@@ -18,8 +18,8 @@ export default View.extend({
   className: 'auth-container main-container',
   id: Enums.WIDGET_CONTAINER_ID,
   attributes: { 'data-se': 'auth-container', tabindex: '-1' },
-  initialize: function (options) {
-    this.listenTo(options.appState, 'change:beaconType', function (model, type) {
+  initialize: function(options) {
+    this.listenTo(options.appState, 'change:beaconType', function(model, type) {
       this.$el.toggleClass(CAN_REMOVE_BEACON_CLS, type === 'security');
     });
   },

--- a/src/views/shared/ContactSupport.js
+++ b/src/views/shared/ContactSupport.js
@@ -22,7 +22,7 @@ export default View.extend({
   ),
   className: 'contact-support',
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     return this.settings.pick('helpSupportNumber');
   },
 });

--- a/src/views/shared/FactorBeacon.js
+++ b/src/views/shared/FactorBeacon.js
@@ -31,7 +31,7 @@ export default View.extend({
   ),
 
   events: {
-    'click .auth-beacon-factor': function (e) {
+    'click .auth-beacon-factor': function(e) {
       e.preventDefault();
       e.stopPropagation();
       const expanded = this.$('.dropdown .options').toggle().is(':visible');
@@ -43,11 +43,11 @@ export default View.extend({
     },
   },
 
-  initialize: function () {
+  initialize: function() {
     this.options.appState.set('beaconType', 'factor');
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     const factors = this.options.appState.get('factors');
     let factor;
     let className;
@@ -61,7 +61,7 @@ export default View.extend({
     return { className: className || '' };
   },
 
-  postRender: function () {
+  postRender: function() {
     if (this.options.animate) {
       this.$('.auth-beacon-factor').fadeIn(200);
     }
@@ -72,16 +72,16 @@ export default View.extend({
     }
   },
 
-  fadeOut: function () {
+  fadeOut: function() {
     const deferred = Q.defer();
 
-    this.$('.auth-beacon-factor').fadeOut(200, function () {
+    this.$('.auth-beacon-factor').fadeOut(200, function() {
       deferred.resolve();
     });
     return deferred.promise;
   },
 
-  equals: function (Beacon, options) {
+  equals: function(Beacon, options) {
     return (
       Beacon &&
       this instanceof Beacon &&

--- a/src/views/shared/Footer.js
+++ b/src/views/shared/Footer.js
@@ -50,13 +50,13 @@ export default View.extend({
   ),
   className: 'auth-footer',
 
-  initialize: function () {
-    this.listenTo(this.state, 'change:enabled', function (model, enable) {
+  initialize: function() {
+    this.listenTo(this.state, 'change:enabled', function(model, enable) {
       this.$('.link').toggleClass('o-form-disabled', !enable);
     });
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     let helpLinkUrl;
     const customHelpPage = this.settings.get('helpLinks.help');
 
@@ -67,10 +67,10 @@ export default View.extend({
     }
     return _.extend(this.settings.toJSON({ verbose: true }), { helpLinkUrl: helpLinkUrl });
   },
-  postRender: function () {
+  postRender: function() {
     this.$('.js-help-links').hide();
   },
-  toggleLinks: function (e) {
+  toggleLinks: function(e) {
     e.preventDefault();
 
     this.$('.js-help-links').slideToggle(200, () => {
@@ -78,7 +78,7 @@ export default View.extend({
     });
   },
   events: {
-    'click .js-help': function (e) {
+    'click .js-help': function(e) {
       e.preventDefault();
       if (!this.state.get('enabled')) {
         return;
@@ -86,7 +86,7 @@ export default View.extend({
 
       this.toggleLinks(e);
     },
-    'click .js-forgot-password': function (e) {
+    'click .js-forgot-password': function(e) {
       e.preventDefault();
       if (!this.state.get('enabled')) {
         return;
@@ -100,7 +100,7 @@ export default View.extend({
         this.options.appState.trigger('navigate', 'signin/forgot-password');
       }
     },
-    'click .js-unlock': function (e) {
+    'click .js-unlock': function(e) {
       e.preventDefault();
       if (!this.state.get('enabled')) {
         return;

--- a/src/views/shared/FooterMFA.js
+++ b/src/views/shared/FooterMFA.js
@@ -31,7 +31,7 @@ export default FooterSignout.extend({
     '
   ),
   className: 'auth-footer clearfix',
-  getTemplateData: function () {
+  getTemplateData: function() {
     const signoutTemplateData = FooterSignout.prototype.getTemplateData.apply(this, arguments);
     const factorPageCustomLinkHref = this.settings.get('helpLinks.factorPage.href');
     const factorPageCustomLinkText = this.settings.get('helpLinks.factorPage.text');

--- a/src/views/shared/FooterRegistration.js
+++ b/src/views/shared/FooterRegistration.js
@@ -27,7 +27,7 @@ export default View.extend({
     'click a.registration-link': 'handleClickEvent',
   },
 
-  handleClickEvent: function (e) {
+  handleClickEvent: function(e) {
     e.preventDefault();
     const clickHandler = this.settings.get('registration.click');
 
@@ -40,7 +40,7 @@ export default View.extend({
     }
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     const templateData = {
       label: loc('registration.signup.label', 'login'),
       text: loc('registration.signup.text', 'login'),

--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -26,16 +26,16 @@ export default View.extend({
   events: {
     'click a[data-se="signout-link"]': 'handleSignout',
   },
-  handleSignout: function (e) {
+  handleSignout: function(e) {
     e.preventDefault();
     this.options.appState.trigger('signOut');
     const self = this;
 
     this.model
-      .doTransaction(function (transaction) {
+      .doTransaction(function(transaction) {
         return transaction.cancel();
       })
-      .then(function () {
+      .then(function() {
         if (self.settings.get('signOutLink')) {
           Util.redirect(self.settings.get('signOutLink'));
         } else {
@@ -44,7 +44,7 @@ export default View.extend({
         }
       });
   },
-  getTemplateData: function () {
+  getTemplateData: function() {
     return {
       linkClassName: _.isUndefined(this.options.linkClassName) ? 'goto' : this.options.linkClassName,
       linkText: this.options.linkText || loc('signout', 'login'),

--- a/src/views/shared/FooterWithBackLink.js
+++ b/src/views/shared/FooterWithBackLink.js
@@ -23,12 +23,12 @@ export default View.extend({
   ),
   className: 'auth-footer',
   events: {
-    'click .help': function (e) {
+    'click .help': function(e) {
       e.preventDefault();
       this.back();
     },
   },
-  back: function () {
+  back: function() {
     this.state.set('navigateDir', Enums.DIRECTION_BACK);
     this.options.appState.trigger('navigate', '');
   },

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -17,11 +17,11 @@ import LoadingBeacon from 'views/shared/LoadingBeacon';
 const NO_BEACON_CLS = 'no-beacon';
 const LOADING_BEACON_CLS = 'beacon-small beacon-loading';
 
-function isLoadingBeacon (beacon) {
+function isLoadingBeacon(beacon) {
   return beacon && beacon.equals(LoadingBeacon);
 }
 
-function removeBeacon (view) {
+function removeBeacon(view) {
   // There are some timing issues with removing beacons (i.e. the case of
   // transitioning from loadingBeacon -> loadingBeacon)
   if (!view.currentBeacon) {
@@ -31,7 +31,7 @@ function removeBeacon (view) {
   view.currentBeacon = null;
 }
 
-function addBeacon (view, NextBeacon, selector, options) {
+function addBeacon(view, NextBeacon, selector, options) {
   view.add(NextBeacon, {
     selector: selector,
     options: options,
@@ -39,7 +39,7 @@ function addBeacon (view, NextBeacon, selector, options) {
   view.currentBeacon = view.first();
 }
 
-function typeOfTransition (currentBeacon, NextBeacon, options) {
+function typeOfTransition(currentBeacon, NextBeacon, options) {
   if (!currentBeacon && !NextBeacon) {
     return 'none';
   }
@@ -86,7 +86,7 @@ export default View.extend({
 
   // Attach a 'no-beacon' class if the security image feature
   // is not passed in to prevent the beacon from jumping.
-  initialize: function (options) {
+  initialize: function(options) {
     if (!options.settings.get('features.securityImage')) {
       this.$el.addClass(NO_BEACON_CLS);
       // To show/hide the spinner when there is no security image,
@@ -97,7 +97,7 @@ export default View.extend({
   },
 
   /* eslint complexity: 0 */
-  setBeacon: function (NextBeacon, options) {
+  setBeacon: function(NextBeacon, options) {
     const selector = '[data-type="beacon-container"]';
     const container = this.$(selector);
     const transition = typeOfTransition(this.currentBeacon, NextBeacon, options);
@@ -116,7 +116,7 @@ export default View.extend({
     case 'remove':
       this.$el.addClass(NO_BEACON_CLS);
       return Animations.implode(container)
-        .then(function () {
+        .then(function() {
           removeBeacon(self);
         })
         .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
@@ -134,7 +134,7 @@ export default View.extend({
       options.animate = true;
       return this.currentBeacon
         .fadeOut()
-        .then(function () {
+        .then(function() {
           removeBeacon(self);
           addBeacon(self, NextBeacon, selector, options);
         })
@@ -142,7 +142,7 @@ export default View.extend({
     case 'swap':
       return Animations.swapBeacons({
         $el: container,
-        swap: function () {
+        swap: function() {
           const isLoading = isLoadingBeacon(self.currentBeacon);
 
           // Order of these calls is important for -
@@ -170,7 +170,7 @@ export default View.extend({
   },
 
   // Show the loading beacon when the security image feature is not enabled.
-  setLoadingBeacon: function (isLoading) {
+  setLoadingBeacon: function(isLoading) {
     if (!isLoading || isLoadingBeacon(this.currentBeacon)) {
       return;
     }
@@ -178,23 +178,23 @@ export default View.extend({
   },
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.
-  removeLoadingBeacon: function () {
+  removeLoadingBeacon: function() {
     const self = this;
     const container = this.$('[data-type="beacon-container"]');
 
     return Animations.implode(container)
-      .then(function () {
+      .then(function() {
         removeBeacon(self);
         container.removeClass(LOADING_BEACON_CLS);
       })
       .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     return this.settings.toJSON({ verbose: true });
   },
 
-  getContentEl: function () {
+  getContentEl: function() {
     return this.$('.auth-content-inner');
   },
 });

--- a/src/views/shared/LoadingBeacon.js
+++ b/src/views/shared/LoadingBeacon.js
@@ -22,7 +22,7 @@ export default View.extend({
     '
   ),
 
-  equals: function (Beacon) {
+  equals: function(Beacon) {
     return Beacon && this instanceof Beacon;
   },
 });

--- a/src/views/shared/PIVBeacon.js
+++ b/src/views/shared/PIVBeacon.js
@@ -25,7 +25,7 @@ export default View.extend({
     '
   ),
 
-  equals: function (Beacon) {
+  equals: function(Beacon) {
     return Beacon && this instanceof Beacon;
   },
 });

--- a/src/views/shared/PasswordRequirements.js
+++ b/src/views/shared/PasswordRequirements.js
@@ -29,7 +29,7 @@ export default View.extend({
 
   allRequirements: [],
 
-  initialize: function (options) {
+  initialize: function(options) {
     const policy = options.policy;
 
     if (!policy) {
@@ -39,7 +39,7 @@ export default View.extend({
     this.allRequirements = FactorUtil.getPasswordComplexityDescriptionForHtmlList(policy);
   },
 
-  getTemplateData: function () {
+  getTemplateData: function() {
     return {
       requirements: this.allRequirements,
     };

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -14,7 +14,7 @@ import { _, $, loc, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import Animations from 'util/Animations';
 
-function setBackgroundImage (el, appState) {
+function setBackgroundImage(el, appState) {
   const imgSrc = appState.get('securityImage');
   const imgDescription = appState.get('securityImageDescription');
   const isUndefinedUser = appState.get('isUndefinedUser');
@@ -44,10 +44,10 @@ function setBackgroundImage (el, appState) {
   }
 }
 
-function antiPhishingMessage (image, host) {
+function antiPhishingMessage(image, host) {
   $(window).on(
     'resize.securityBeaconQtip',
-    _.debounce(function () {
+    _.debounce(function() {
       if (image.is(':visible')) {
         image.qtip('show');
       }
@@ -75,7 +75,7 @@ function antiPhishingMessage (image, host) {
     hide: { event: false, fixed: true },
     show: { event: false, delay: 200 },
     events: {
-      move: function (event, api) {
+      move: function(event, api) {
         if (!api.elements.target.is(':visible')) {
           // Have to hide it immediately, with no effect
           api.set('hide.effect', false);
@@ -89,12 +89,12 @@ function antiPhishingMessage (image, host) {
   image.qtip('toggle', image.is(':visible'));
 }
 
-function destroyAntiPhishingMessage (image) {
+function destroyAntiPhishingMessage(image) {
   image.qtip('destroy');
   $(window).off('resize.securityBeaconQtip');
 }
 
-async function updateSecurityImage ($el, appState, animate) {
+async function updateSecurityImage($el, appState, animate) {
   const image = $el.find('.auth-beacon-security');
   const border = $el.find('.js-auth-beacon-border');
   const hasBorder = !appState.get('isUndefinedUser');
@@ -117,7 +117,7 @@ async function updateSecurityImage ($el, appState, animate) {
   if (!hasBorder) {
     // This occurrs when appState username is blank
     // we do not yet know if the user is recognized
-    image.fadeOut(duration, function () {
+    image.fadeOut(duration, function() {
       setBackgroundImage(image, appState);
       border.removeClass('auth-beacon-border');
       image.fadeIn(duration);
@@ -128,7 +128,7 @@ async function updateSecurityImage ($el, appState, animate) {
     border.removeClass('auth-beacon-border');
     await Animations.radialProgressBar({
       $el: radialProgressBar,
-      swap () {
+      swap() {
         image.fadeOut(duration, () => {
           setBackgroundImage(image, appState);
           image.fadeIn(duration);
@@ -160,10 +160,10 @@ export default View.extend({
   ),
   className: 'js-security-beacon',
 
-  initialize: function (options) {
+  initialize: function(options) {
     this.update = _.partial(updateSecurityImage, this.$el, options.appState);
     this.listenTo(options.appState, 'change:securityImage', this.update);
-    this.listenTo(options.appState, 'loading', function (isLoading) {
+    this.listenTo(options.appState, 'loading', function(isLoading) {
       this.$el.toggleClass('beacon-loading', isLoading);
       this.removeAntiPhishingMessage();
     });
@@ -172,15 +172,15 @@ export default View.extend({
     this.listenTo(options.appState, 'navigate', this.removeAntiPhishingMessage);
   },
 
-  postRender: function () {
+  postRender: function() {
     this.update(false);
   },
 
-  equals: function (Beacon) {
+  equals: function(Beacon) {
     return Beacon && this instanceof Beacon;
   },
 
-  removeAntiPhishingMessage: function () {
+  removeAntiPhishingMessage: function() {
     const image = this.$el.find('.auth-beacon-security');
 
     image.qtip('destroy');

--- a/src/views/shared/SkipLink.js
+++ b/src/views/shared/SkipLink.js
@@ -5,7 +5,7 @@ export default View.extend({
   tagName: 'a',
   className: 'skip-to-content-link',
   attributes: { href: `#${Enums.WIDGET_CONTAINER_ID}` },
-  initialize: function initialize () {
+  initialize: function initialize() {
     this.$el.append(loc('skip.to.main.content', 'login'));
   }
 });

--- a/src/views/shared/Spinner.js
+++ b/src/views/shared/Spinner.js
@@ -21,17 +21,17 @@ export default View.extend({
     'spinner:hide': 'hide',
   },
 
-  initialize: function (options) {
+  initialize: function(options) {
     if (options && options.visible === false) {
       this.hide();
     }
   },
 
-  show: function () {
+  show: function() {
     this.$el.removeClass('hide');
   },
 
-  hide: function () {
+  hide: function() {
     this.$el.addClass('hide');
   },
 });

--- a/src/views/shared/TextBox.js
+++ b/src/views/shared/TextBox.js
@@ -19,7 +19,7 @@ import 'qtip';
 import BrowserFeatures from 'util/BrowserFeatures';
 const { TextBox } = internal.views.forms.inputs;
 export default TextBox.extend({
-  postRender: function () {
+  postRender: function() {
     if (this.options.type === 'number') {
       const input = this.$('input');
 
@@ -32,7 +32,7 @@ export default TextBox.extend({
   },
   // Override the focus() to ignore focus in IE. IE (8-11) has a known bug where
   // the placeholder text disappears when the input field is focused.
-  focus: function () {
+  focus: function() {
     if (BrowserFeatures.isIE()) {
       return;
     }

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -8,13 +8,13 @@ import createRouter from 'widget/createRouter';
 import V1Router from 'LoginRouter';
 import V2Router from 'v2/WidgetRouter';
 
-var OktaSignIn = (function () {
+var OktaSignIn = (function() {
 
   var router;
 
-  function getProperties (authClient, Router, widgetOptions = {}) {
+  function getProperties(authClient, Router, widgetOptions = {}) {
     // Returns a promise that will resolve on success or reject on error
-    function render (renderOptions, successFn, errorFn) {
+    function render(renderOptions, successFn, errorFn) {
       if (router) {
         throw new Error('An instance of the widget has already been rendered. Call remove() first.');
       }
@@ -24,19 +24,19 @@ var OktaSignIn = (function () {
       return res.promise;
     }
 
-    function hide () {
+    function hide() {
       if (router) {
         router.hide();
       }
     }
 
-    function show () {
+    function show() {
       if (router) {
         router.show();
       }
     }
 
-    function remove () {
+    function remove() {
       if (router) {
         router.remove();
         router = undefined;
@@ -47,7 +47,7 @@ var OktaSignIn = (function () {
      * Renders the Widget and returns a promise that resolves to OAuth tokens
      * @param options - options for the signin widget
      */
-    function showSignInToGetTokens (options = {}) {
+    function showSignInToGetTokens(options = {}) {
       const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options), {
         redirect: 'never'
       });
@@ -66,7 +66,7 @@ var OktaSignIn = (function () {
      * Renders the widget and redirects to the OAuth callback
      * @param options - options for the signin widget
      */
-    function showSignInAndRedirect (options = {}) {
+    function showSignInAndRedirect(options = {}) {
       const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options), {
         redirect: 'always'
       });
@@ -77,7 +77,7 @@ var OktaSignIn = (function () {
      * Renders the widget. Either resolves the returned promise, or redirects.
      * @param options - options for the signin widget
      */
-    function showSignIn (options = {}) {
+    function showSignIn(options = {}) {
       const renderOptions = Object.assign(buildRenderOptions(widgetOptions, options));
       return this.renderEl(renderOptions);
     }
@@ -102,7 +102,7 @@ var OktaSignIn = (function () {
    * @param success - success callback function
    * @param error - error callback function
    */
-  function OktaSignIn (options) {
+  function OktaSignIn(options) {
     Util.debugMessage(`
         The Okta Sign-In Widget is running in development mode.
         When you are ready to publish your app, embed the minified version to turn on production mode.
@@ -147,7 +147,7 @@ var OktaSignIn = (function () {
     this.listenTo(Router.prototype, 'all', this.trigger);
 
     // On the first afterRender event (usually when the Widget is ready) - emit a 'ready' event
-    this.once('afterRender', function (context) {
+    this.once('afterRender', function(context) {
       this.trigger('ready', context);
     });
   }

--- a/src/widget/buildRenderOptions.js
+++ b/src/widget/buildRenderOptions.js
@@ -2,7 +2,7 @@ import { _, $ } from 'okta';
 import Errors from 'util/Errors';
 import OAuth2Util from 'util/OAuth2Util';
 
-export default function buildRenderOptions (widgetOptions = {}, options = {}) {
+export default function buildRenderOptions(widgetOptions = {}, options = {}) {
   const authParams = $.extend(true, {}, widgetOptions.authParams, _.pick(options, OAuth2Util.AUTH_PARAMS));
   const { el, clientId, redirectUri } = Object.assign({}, widgetOptions, options);
   const renderOptions = Object.assign({}, { el, clientId, redirectUri, authParams });

--- a/src/widget/createAuthClient.js
+++ b/src/widget/createAuthClient.js
@@ -3,7 +3,7 @@ import Util from 'util/Util';
 import config from 'config/config.json';
 import _ from 'underscore';
 
-export default function (options) {
+export default function(options) {
   var authParams = _.extend({
     transformErrorXHR: Util.transformErrorXHR,
     headers: {

--- a/src/widget/createRouter.js
+++ b/src/widget/createRouter.js
@@ -1,7 +1,7 @@
 import { $ } from 'okta';
 import Enums from 'util/Enums';
 
-export default function createRouter (Router, widgetOptions, renderOptions, authClient, successFn, errorFn) {
+export default function createRouter(Router, widgetOptions, renderOptions, authClient, successFn, errorFn) {
   let router;
   let routerOptions;
   const promise = new Promise((resolve, reject) => {

--- a/test/e2e/app/app-using-osw-entry.js
+++ b/test/e2e/app/app-using-osw-entry.js
@@ -20,7 +20,7 @@ var signIn = new OktaSignIn({
   baseUrl: '{{{WIDGET_TEST_SERVER}}}'
 });
 
-signIn.renderEl({el: '#okta-login-container'}, function (res) {
+signIn.renderEl({el: '#okta-login-container'}, function(res) {
   if (res.status !== 'SUCCESS') {
     return;
   }

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -19,7 +19,7 @@ var config = {
   framework: 'jasmine2',
   specs: ['specs/*.js'],
   restartBrowserBetweenTests: false,
-  onPrepare: function () {
+  onPrepare: function() {
     jasmine.getEnv().addReporter(new jasmineReporters.JUnitXmlReporter({
       savePath: 'build2/reports/junit',
       filePrefix: 'e2e-results',

--- a/test/e2e/env.js
+++ b/test/e2e/env.js
@@ -6,7 +6,7 @@ const dotenv = require('dotenv');
 var DEFAULTS = require('./env.defaults');
 var VALUES = {};
 
-function config () {
+function config() {
 
   // Read environment variables from "testenv". Override environment vars if they are already set.
   const TESTENV = path.resolve(__dirname, '../..', 'testenv');
@@ -18,7 +18,7 @@ function config () {
   }
 
   // Set defaults, populate VALUES
-  Object.keys(DEFAULTS).forEach(function (key) {
+  Object.keys(DEFAULTS).forEach(function(key) {
     if (!process.env[key]) {
       // Allow use of default value
       process.env[key] = DEFAULTS[key];
@@ -27,21 +27,21 @@ function config () {
   });
 }
 
-function checkValues () {
-  Object.keys(DEFAULTS).forEach(function (key) {
+function checkValues() {
+  Object.keys(DEFAULTS).forEach(function(key) {
     if (!VALUES[key]) {
       console.error('ERROR: no value set for environment variable: ' + key);
     }
   });
 }
 
-function printValues () {
-  Object.keys(VALUES).forEach(function (key) {
+function printValues() {
+  Object.keys(VALUES).forEach(function(key) {
     console.log(key + ' = ', VALUES[key]);
   });
 }
 
-function getValues () {
+function getValues() {
   return VALUES;
 }
 

--- a/test/e2e/page-objects/FacebookPage.js
+++ b/test/e2e/page-objects/FacebookPage.js
@@ -14,14 +14,14 @@
 const EC = protractor.ExpectedConditions;
 
 class FacebookPage {
-  login (username, password) {
+  login(username, password) {
     $('#email').clear();
     $('#email').sendKeys(username);
     $('#pass').sendKeys(password);
     $('[name=login]').click();
   }
 
-  logout () {
+  logout() {
     const bookmarkElemId = '#bookmarks_jewel';
     browser.get('https://m.facebook.com/');
     browser.wait(EC.presenceOf($(bookmarkElemId)), 5000);

--- a/test/e2e/page-objects/FormPage.js
+++ b/test/e2e/page-objects/FormPage.js
@@ -17,15 +17,15 @@ const EC = protractor.ExpectedConditions;
  * Helper functions to compose css selectors
  */
 
-function dataSe (val) {
+function dataSe(val) {
   return '[data-se="' + val + '"]';
 }
 
-function dataType (val) {
+function dataType(val) {
   return '[data-type="' + val + '"]';
 }
 
-function inputWrap (field) {
+function inputWrap(field) {
   return dataSe('o-form-input-' + field);
 }
 
@@ -38,7 +38,7 @@ class FormPage {
    * Abstract methods
    */
 
-  getFormClass () {
+  getFormClass() {
     throw new Error('Class name not defined!');
   }
 
@@ -46,15 +46,15 @@ class FormPage {
    * Concrete selectors/methods that are shared by all forms
    */
 
-  submitButton () {
+  submitButton() {
     return this.$(dataType('save'));
   }
 
-  submit () {
+  submit() {
     return this.submitButton().click();
   }
 
-  getErrorMessage () {
+  getErrorMessage() {
     const errorEl = this.$('.okta-form-infobox-error.infobox.infobox-error p');
     browser.wait(EC.presenceOf(errorEl));
     return errorEl.getText();
@@ -65,19 +65,19 @@ class FormPage {
    * methods.
    */
 
-  input (field) {
+  input(field) {
     return this.$(inputWrap(field) + ' input');
   }
 
-  inputWrap (field) {
+  inputWrap(field) {
     return this.$(inputWrap(field));
   }
 
-  $ (selector) {
+  $(selector) {
     return $('.' + this.getFormClass() + ' ' + selector);
   }
 
-  $dataSe (val) {
+  $dataSe(val) {
     return this.$(dataSe(val));
   }
 

--- a/test/e2e/page-objects/OIDCAppPage.js
+++ b/test/e2e/page-objects/OIDCAppPage.js
@@ -15,7 +15,7 @@ const EC = protractor.ExpectedConditions;
 
 class AppPage {
 
-  constructor () {
+  constructor() {
     this.pageEl = $('#page');
     this.idTokenUserEl = $('#idtoken_user');
     this.accessTokenTypeEl = $('#accesstoken_type');
@@ -23,27 +23,27 @@ class AppPage {
     this.locationHash = $('#location_hash');
   }
 
-  getIdTokenUser () {
+  getIdTokenUser() {
     browser.wait(EC.presenceOf(this.idTokenUserEl));
     return this.idTokenUserEl.getText();
   }
 
-  getAccessTokenType () {
+  getAccessTokenType() {
     browser.wait(EC.presenceOf(this.accessTokenTypeEl));
     return this.accessTokenTypeEl.getText();
   }
 
-  getCodeFromQuery () {
+  getCodeFromQuery() {
     browser.wait(EC.presenceOf(this.locationSearch));
-    return this.locationSearch.getText().then(function (search) {
+    return this.locationSearch.getText().then(function(search) {
       const matches = search.match(/code=([^&]+)/i);
       return matches && matches[1];
     });
   }
 
-  getCodeFromHash () {
+  getCodeFromHash() {
     browser.wait(EC.presenceOf(this.locationHash));
-    return this.locationHash.getText().then(function (hash) {
+    return this.locationHash.getText().then(function(hash) {
       const matches = hash.match(/code=([^&]+)/i);
       return matches && matches[1];
     });

--- a/test/e2e/page-objects/OktaHomePage.js
+++ b/test/e2e/page-objects/OktaHomePage.js
@@ -15,17 +15,17 @@ const EC = protractor.ExpectedConditions;
 
 class OktaHomePage {
 
-  constructor () {
+  constructor() {
     this.mainContentEl = $('.main-content');
     this.usernameEl = $('[data-se=user-menu] .option-selected-text');
   }
 
-  waitForPageLoad () {
+  waitForPageLoad() {
     browser.wait(EC.presenceOf(this.mainContentEl));
     expect(browser.getCurrentUrl()).toMatch('/app/UserHome');
   }
 
-  getLoggedInUser () {
+  getLoggedInUser() {
     browser.wait(EC.presenceOf(this.usernameEl));
     return this.usernameEl.getText();
   }

--- a/test/e2e/page-objects/PrimaryAuthPage.js
+++ b/test/e2e/page-objects/PrimaryAuthPage.js
@@ -14,7 +14,7 @@
 const FormPage = require('./FormPage'),
     FacebookPage = require('./FacebookPage');
 
-function getSocialIdpPage (idp) {
+function getSocialIdpPage(idp) {
   switch (idp) {
   case 'facebook':
     return new FacebookPage();
@@ -25,25 +25,25 @@ function getSocialIdpPage (idp) {
 
 class PrimaryAuthPage extends FormPage {
 
-  constructor () {
+  constructor() {
     super();
     this.usernameInput = this.input('username');
     this.passwordInput = this.input('password');
   }
 
-  getFormClass () {
+  getFormClass() {
     return 'primary-auth';
   }
 
-  loginToForm (username, password) {
+  loginToForm(username, password) {
     this.usernameInput.sendKeys(username);
     this.passwordInput.sendKeys(password);
     this.submit();
   }
 
-  loginToSocialIdpPopup (idp, username, password) {
+  loginToSocialIdpPopup(idp, username, password) {
     this.socialAuthButton(idp).click();
-    browser.getAllWindowHandles().then(function (handles) {
+    browser.getAllWindowHandles().then(function(handles) {
       const parent = handles[0],
           popup = handles[1];
       browser.switchTo().window(popup);
@@ -52,12 +52,12 @@ class PrimaryAuthPage extends FormPage {
     });
   }
 
-  loginToSocialIdpRedirect (idp, username, password) {
+  loginToSocialIdpRedirect(idp, username, password) {
     this.socialAuthButton(idp).click();
     getSocialIdpPage(idp).login(username, password);
   }
 
-  socialAuthButton (idp) {
+  socialAuthButton(idp) {
     return this.$dataSe('social-auth-' + idp + '-button');
   }
 

--- a/test/e2e/partials/shared-functions.js
+++ b/test/e2e/partials/shared-functions.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-unused-vars */
-function addMessageToPage (id, msg) {
+function addMessageToPage(id, msg) {
   var appNode = document.createElement('div');
   appNode.setAttribute('id', id);
   appNode.innerHTML = msg;
   document.body.appendChild(appNode);
 }
 
-function addTokensToPage (tokens) {
+function addTokensToPage(tokens) {
   var idToken = tokens.idToken;
   if (idToken) {
     addMessageToPage('idtoken_user', idToken.claims.name);

--- a/test/e2e/specs/OIDC_spec.js
+++ b/test/e2e/specs/OIDC_spec.js
@@ -16,13 +16,13 @@ const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage'),
     util = require('../util/util'),
     Expect = require('../util/Expect');
 
-function setup (options) {
+function setup(options) {
   browser.executeScript('initialize(' + JSON.stringify(options) + ')');
 }
 
 const clientIds = ['{{{WIDGET_WEB_CLIENT_ID}}}', '{{{WIDGET_SPA_CLIENT_ID}}}'];
 
-describe('OIDC flows', function () {
+describe('OIDC flows', function() {
   // TODO: Enable after fixing OKTA-244878
   if (process.env.SAUCE_PLATFORM_NAME === 'android') {
     return 0;
@@ -32,21 +32,21 @@ describe('OIDC flows', function () {
       oidcApp = new OIDCAppPage(),
       facebook = new FacebookPage();
 
-  beforeEach(function () {
+  beforeEach(function() {
     browser.driver.get('about:blank');
     browser.ignoreSynchronization = true;
     util.loadTestPage('oidc');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     // Logout of Okta session
     browser.get('{{{WIDGET_TEST_SERVER}}}/login/signout');
   });
 
-  describe('Okta as IDP', function () {
+  describe('Okta as IDP', function() {
 
     clientIds.forEach(clientId => {
-      it('can login and exchange a sessionToken for an id_token', function () {
+      it('can login and exchange a sessionToken for an id_token', function() {
         setup({
           baseUrl: '{{{WIDGET_TEST_SERVER}}}',
           clientId,
@@ -68,7 +68,7 @@ describe('OIDC flows', function () {
         expect(oidcApp.getIdTokenUser()).toBe('{{{WIDGET_BASIC_NAME}}}');
       });
 
-      it('throws form error if auth client returns with OAuth error', function () {
+      it('throws form error if auth client returns with OAuth error', function() {
         // TODO - Enable after https://oktainc.atlassian.net/browse/OKTA-375434
         if (process.env.ORG_OIE_ENABLED) {
           return;
@@ -88,7 +88,7 @@ describe('OIDC flows', function () {
         expect(primaryAuth.getErrorMessage()).toBe('User is not assigned to the client application.');
       });
 
-      it('can login and get a token and id_token', function () {
+      it('can login and get a token and id_token', function() {
         setup({
           baseUrl: '{{{WIDGET_TEST_SERVER}}}',
           clientId,
@@ -113,7 +113,7 @@ describe('OIDC flows', function () {
   
     });
 
-    it('logs in and uses the redirect flow for responseType "code"', function () {
+    it('logs in and uses the redirect flow for responseType "code"', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_WEB_CLIENT_ID}}}',
@@ -129,7 +129,7 @@ describe('OIDC flows', function () {
       expect(oidcApp.getCodeFromQuery()).not.toBeNull();
     });
 
-    it('PKCE login flow', function () {
+    it('PKCE login flow', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_SPA_CLIENT_ID}}}',
@@ -146,7 +146,7 @@ describe('OIDC flows', function () {
       expect(oidcApp.getAccessTokenType()).toBe('Bearer');
     });
 
-    it('PKCE login flow (fragment)', function () {
+    it('PKCE login flow (fragment)', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_SPA_CLIENT_ID}}}',
@@ -167,13 +167,13 @@ describe('OIDC flows', function () {
   });
 
   // https://oktainc.atlassian.net/browse/OKTA-197861
-  xdescribe('Social IDP', function () {
+  xdescribe('Social IDP', function() {
 
-    afterEach(function () {
+    afterEach(function() {
       facebook.logout();
     });
 
-    it('can login and get an idToken in the popup flow', function () {
+    it('can login and get an idToken in the popup flow', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_WEB_CLIENT_ID}}}',
@@ -193,7 +193,7 @@ describe('OIDC flows', function () {
       expect(oidcApp.getIdTokenUser()).toBe('{{{WIDGET_FB_NAME}}}');
     });
 
-    it('can login and get an idToken in the redirect flow', function () {
+    it('can login and get an idToken in the redirect flow', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_WEB_CLIENT_ID}}}',
@@ -214,7 +214,7 @@ describe('OIDC flows', function () {
       expect(oidcApp.getIdTokenUser()).toBe('{{{WIDGET_FB_NAME_2}}}');
     });
 
-    it('can login and get a "code" using the redirect flow', function () {
+    it('can login and get a "code" using the redirect flow', function() {
       setup({
         baseUrl: '{{{WIDGET_TEST_SERVER}}}',
         clientId: '{{{WIDGET_WEB_CLIENT_ID}}}',

--- a/test/e2e/specs/angular_spec.js
+++ b/test/e2e/specs/angular_spec.js
@@ -14,8 +14,8 @@
 const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage');
 const until = protractor.ExpectedConditions;
 
-describe('Angular flows', function () {
-  it('should allow logging in with the widget', function () {
+describe('Angular flows', function() {
+  it('should allow logging in with the widget', function() {
     // open browser to a protected route
     browser.ignoreSynchronization = true;
     browser.driver.get('http://localhost:4200/protected');

--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -14,16 +14,16 @@ const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage'),
     OktaHomePage = require('../page-objects/OktaHomePage'),
     util = require('../util/util');
 
-describe('Basic flows', function () {
+describe('Basic flows', function() {
   const primaryAuth = new PrimaryAuthPage();
 
-  beforeEach(function () {
+  beforeEach(function() {
     browser.driver.get('about:blank');
     browser.ignoreSynchronization = true;
     util.loadTestPage('basic');
   });
 
-  it('can hide, show, remove, and start a widget', function () {
+  it('can hide, show, remove, and start a widget', function() {
     // Ensure the widget exists
     const el = element(by.css('#okta-sign-in'));
     const signInTitle = element(by.css('[data-se="o-form-head"]'));
@@ -43,7 +43,7 @@ describe('Basic flows', function () {
     expect(el.isPresent()).toBe(false);
 
     // Ensure a new widget can be created
-    function createWidget () {
+    function createWidget() {
       options.i18n = {
         en: {
           'primaryauth.title': 'Sign In to Acme'
@@ -53,14 +53,14 @@ describe('Basic flows', function () {
       oktaSignIn = new OktaSignIn(options);
       oktaSignIn.renderEl({
         el: '#okta-login-container'
-      }, function () {});
+      }, function() {});
     }
     browser.executeScript(createWidget);
     expect(el.isDisplayed()).toBe(true);
     expect(signInTitle.getText()).toBe('Sign In to Acme');
   });
 
-  it('modifies the error banner using an afterError event', function () {
+  it('modifies the error banner using an afterError event', function() {
     // Ensure the widget exists
     const el = element(by.css('#okta-sign-in'));
     expect(el.isDisplayed()).toBe(true);
@@ -71,7 +71,7 @@ describe('Basic flows', function () {
     expect(errorBox.getText()).toBe('Custom Error!');
   });
 
-  it('has the style from config.colors', function () {
+  it('has the style from config.colors', function() {
     /*global browserName*/
     // In IE, primaryButton.getCssValue('background') is empty. Expectation on line 97 fails
     if (browserName === 'internet explorer') {
@@ -80,7 +80,7 @@ describe('Basic flows', function () {
 
     // Create new widget with colors.brand
     browser.executeScript('oktaSignIn.remove()');
-    function createWidget () {
+    function createWidget() {
       options.colors = {
         brand: '#008000'
       };
@@ -88,7 +88,7 @@ describe('Basic flows', function () {
       oktaSignIn = new OktaSignIn(options);
       oktaSignIn.renderEl({
         el: '#okta-login-container'
-      }, function () {});
+      }, function() {});
     }
     browser.executeScript(createWidget);
 
@@ -97,9 +97,9 @@ describe('Basic flows', function () {
     expect(primaryButton.getCssValue('background')).toContain(('rgb(0, 128, 0)')); // #008000 in rgb
   });
 
-  it('redircts to successful page when features.redirectByFormSubmit is on', function () {
+  it('redircts to successful page when features.redirectByFormSubmit is on', function() {
     browser.executeScript('oktaSignIn.remove()');
-    function createWidget () {
+    function createWidget() {
       options.features = {
         redirectByFormSubmit: true,
       };
@@ -107,7 +107,7 @@ describe('Basic flows', function () {
       oktaSignIn = new OktaSignIn(options);
       oktaSignIn.renderEl({
         el: '#okta-login-container'
-      }, function (res) {
+      }, function(res) {
         if (res.status === 'SUCCESS') {
           res.session.setCookieAndRedirect(options.baseUrl + '/app/UserHome');
         }

--- a/test/e2e/specs/dev_spec.js
+++ b/test/e2e/specs/dev_spec.js
@@ -17,13 +17,13 @@ const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage'),
 
 const clientIds = ['{{{WIDGET_WEB_CLIENT_ID}}}', '{{{WIDGET_SPA_CLIENT_ID}}}'];
 
-describe('Dev Mode flows', function () {
+describe('Dev Mode flows', function() {
 
-  function renderWidget () {
-    function renderAndRedirect () {
+  function renderWidget() {
+    function renderAndRedirect() {
       oktaSignIn.renderEl(
         {},
-        function (res) {
+        function(res) {
           if (res.status === 'SUCCESS') {
             res.session.setCookieAndRedirect('{{{WIDGET_TEST_SERVER}}}' + '/app/UserHome');
           }
@@ -33,20 +33,20 @@ describe('Dev Mode flows', function () {
     browser.executeScript(renderAndRedirect);
   }
 
-  beforeEach(function () {
+  beforeEach(function() {
     browser.driver.get('about:blank');
     browser.ignoreSynchronization = true;
     util.loadTestPage('basic-dev');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     // Logout of Okta session
     browser.get('{{{WIDGET_TEST_SERVER}}}/login/signout');
     const el = element(by.css('#okta-sign-in'));
     expect(el.isDisplayed()).toBe(true);
   });
 
-  it('can hide, show, remove, and start a widget', function () {
+  it('can hide, show, remove, and start a widget', function() {
     renderWidget();
     // Ensure the widget exists
     const el = element(by.css('#okta-sign-in'));
@@ -65,15 +65,15 @@ describe('Dev Mode flows', function () {
     expect(el.isPresent()).toBe(false);
 
     // Ensure a new widget can be created
-    function createWidget () {
-      oktaSignIn.renderEl({}, function () {});
+    function createWidget() {
+      oktaSignIn.renderEl({}, function() {});
     }
     browser.executeScript(createWidget);
     expect(el.isDisplayed()).toBe(true);
   });
 
   clientIds.forEach(clientId => {
-    it('can login and return tokens using the showSignInToGetTokens method', function () {
+    it('can login and return tokens using the showSignInToGetTokens method', function() {
       const options = {
         clientId,
         redirectUri: 'http://localhost:3000/done',
@@ -93,7 +93,7 @@ describe('Dev Mode flows', function () {
       expect(oidcApp.getIdTokenUser()).toBe('{{{WIDGET_BASIC_NAME}}}');
     });
   
-    it('can login and receive tokens on a callback using the showSignInAndRedirect method', function () {
+    it('can login and receive tokens on a callback using the showSignInAndRedirect method', function() {
       const options = {
         clientId,
         redirectUri: 'http://localhost:3000/done',

--- a/test/e2e/specs/npm_spec.js
+++ b/test/e2e/specs/npm_spec.js
@@ -16,22 +16,22 @@ const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage'),
     util = require('../util/util'),
     Expect = require('../util/Expect');
 
-describe('OIDC flows', function () {
+describe('OIDC flows', function() {
   const primaryAuth = new PrimaryAuthPage(),
       oktaHome = new OktaHomePage();
 
-  beforeEach(function () {
+  beforeEach(function() {
     browser.driver.get('about:blank');
     browser.ignoreSynchronization = true;
     util.loadTestPage('npm');
   });
 
-  afterEach(function () {
+  afterEach(function() {
     // Logout of Okta session
     browser.get('{{{WIDGET_TEST_SERVER}}}/login/signout');
   });
 
-  it('can login and auth in a basic flow', function () {
+  it('can login and auth in a basic flow', function() {
     Expect.toBeA11yCompliant();
     primaryAuth.loginToForm('{{{WIDGET_BASIC_USER_3}}}', '{{{WIDGET_BASIC_PASSWORD_3}}}');
     oktaHome.waitForPageLoad();

--- a/test/e2e/specs/react_spec.js
+++ b/test/e2e/specs/react_spec.js
@@ -14,8 +14,8 @@
 const PrimaryAuthPage = require('../page-objects/PrimaryAuthPage');
 const until = protractor.ExpectedConditions;
 
-describe('React flows', function () {
-  it('should allow logging in with the widget', function () {
+describe('React flows', function() {
+  it('should allow logging in with the widget', function() {
     // open browser to a protected route
     browser.ignoreSynchronization = true;
     browser.driver.get('http://localhost:3001/protected');

--- a/test/e2e/util/Expect.js
+++ b/test/e2e/util/Expect.js
@@ -13,7 +13,7 @@ var _ = require('lodash'),
     JUNIT_FOLDER = ROOT_FOLDER + 'junit/',
     TEXT_FOLDER = ROOT_FOLDER + 'text/';
 
-function makeFileName (url) {
+function makeFileName(url) {
   return JUNIT_FOLDER + url.split('://').pop().replace(/[.:/]/g, '-') + _.uniqueId('_') + '.xml';
 }
 
@@ -23,11 +23,11 @@ fs.mkdirsSync(JUNIT_FOLDER);
 
 var textWriter = fs.createWriteStream(TEXT_FOLDER + 'report.txt');
 
-Expect.toBeA11yCompliant = function () {
+Expect.toBeA11yCompliant = function() {
   var deferred = protractor.promise.defer();
   if ('{{{CHECK_A11Y}}}' === 'true') {
     axe(browser.driver)
-      .analyze(function (result) {
+      .analyze(function(result) {
         textReporter(result, -1, textWriter);
         junitReporter(result, makeFileName(result.url));
         deferred.fulfill();

--- a/test/e2e/util/junit-reporter.js
+++ b/test/e2e/util/junit-reporter.js
@@ -1,12 +1,12 @@
 /* global module */
 var junitReportBuilder = require('junit-report-builder');
 
-function checkMessages (checks) {
-  return checks.reduce(function (messages, check) {
+function checkMessages(checks) {
+  return checks.reduce(function(messages, check) {
     messages += '    \u2022 ' + check.message + '\n';
     if (check.relatedNodes && check.relatedNodes.length) {
       messages += '    Related Nodes:\n';
-      check.relatedNodes.forEach(function (relatedNode) {
+      check.relatedNodes.forEach(function(relatedNode) {
         messages += '        \u25E6 ' + relatedNode.target[0];
       });
     }
@@ -14,7 +14,7 @@ function checkMessages (checks) {
   }, '');
 }
 
-module.exports = function (result, outFile) {
+module.exports = function(result, outFile) {
   var suite = junitReportBuilder.testSuite()
     .name(result.url)
     .timestamp(new Date().getTime())
@@ -22,9 +22,9 @@ module.exports = function (result, outFile) {
 
   var packageName = result.url;
 
-  result.violations.forEach(function (ruleResult) {
+  result.violations.forEach(function(ruleResult) {
 
-    ruleResult.nodes.forEach(function (violation) {
+    ruleResult.nodes.forEach(function(violation) {
       var failure = ruleResult.help + ' (' + ruleResult.helpUrl + ')\n';
       var stacktrace = 'Target: ' + violation.target + '\n\n' +
         'HTML: ' + violation.html + '\n\n' +
@@ -49,8 +49,8 @@ module.exports = function (result, outFile) {
     });
   });
 
-  result.passes.forEach(function (ruleResult) {
-    ruleResult.nodes.forEach(function (pass) {
+  result.passes.forEach(function(ruleResult) {
+    ruleResult.nodes.forEach(function(pass) {
       suite.testCase()
         .className(packageName + '.' + ruleResult.id)
         .name(pass.target);

--- a/test/e2e/util/text-reporter.js
+++ b/test/e2e/util/text-reporter.js
@@ -1,10 +1,10 @@
 /* global module */
 var grunt = require('grunt');
 
-module.exports = function (result, threshold, writer) {
+module.exports = function(result, threshold, writer) {
   var pass = true;
 
-  function log (text, method) {
+  function log(text, method) {
     grunt.log[method](text);
     writer.write(('' + text) + '\n');
   }
@@ -22,15 +22,15 @@ module.exports = function (result, threshold, writer) {
     }
     log('', 'ok');
 
-    violations.forEach(function (ruleResult) {
+    violations.forEach(function(ruleResult) {
       log(ruleResult.help, 'subhead');
 
-      ruleResult.nodes.forEach(function (violation, index) {
+      ruleResult.nodes.forEach(function(violation, index) {
         log('   ' + (index + 1) + '. ' + JSON.stringify(violation.target), 'writeln');
 
         if (violation.any.length) {
           log('       Fix any of the following:', 'writeln');
-          violation.any.forEach(function (check) {
+          violation.any.forEach(function(check) {
             log('        \u2022 ' + check.message, 'writeln');
           });
         }
@@ -38,7 +38,7 @@ module.exports = function (result, threshold, writer) {
         var alls = violation.all.concat(violation.none);
         if (alls.length) {
           log('       Fix all of the following:', 'writeln');
-          alls.forEach(function (check) {
+          alls.forEach(function(check) {
             log('        \u2022 ' + check.message, 'writeln');
           });
         }

--- a/test/e2e/util/util.js
+++ b/test/e2e/util/util.js
@@ -15,10 +15,10 @@ var util = module.exports = {};
 
 var EC = protractor.ExpectedConditions;
 
-util.loadTestPage = function (pageName) {
+util.loadTestPage = function(pageName) {
   browser.get('http://localhost:3000/' + pageName + '.html');
 };
 
-util.waitForElement = function (el) {
+util.waitForElement = function(el) {
   browser.wait(EC.visibilityOf(el));
 };

--- a/test/testcafe/.eslintrc.js
+++ b/test/testcafe/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
     'es6': true,
   },
   'rules': {
-    'space-before-function-paren': 0, // remove me after clear up root eslintrc.
     'new-cap': 0, // for testcafe functions like RequestLogger, RequestMock
     'semi': 2,
     'max-len': 0,

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -35,7 +35,7 @@ export default class BasePageObject {
     return Selector(selector).innerText;
   }
 
-  getIonMessages () {
+  getIonMessages() {
     return this.form.getElement(ionMessagesSelector).innerText;
   }
 

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -1,7 +1,7 @@
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
 export default class ChallengeEmailPageObject extends ChallengeFactorPageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOktaVerifyPushPageObject.js
@@ -10,15 +10,15 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
     super(t);
   }
 
-  getPushButton () {
+  getPushButton() {
     return this.form.getElement('.send-push');
   }
 
-  getA11ySpan () {
+  getA11ySpan() {
     return this.form.getElement('.accessibility-text');
   }
 
-  getResendPushButton () {
+  getResendPushButton() {
     return this.form.getElement('.button-primary');
   }
 
@@ -34,7 +34,7 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
     await this.form.el.find(FORM_INFOBOX_ERROR).exists;
   }
 
-  getErrorBox () {
+  getErrorBox() {
     return this.form.getElement(FORM_INFOBOX_ERROR);
   }
 
@@ -42,7 +42,7 @@ export default class ChallengeOktaVerifyPushPageObject extends ChallengeFactorPa
     return this.form.getElement(FORM_INFOBOX_ERROR_TITLE);
   }
 
-  getWarningBox () {
+  getWarningBox() {
     return this.form.getElement(FORM_INFOBOX_WARNING);
   }
 

--- a/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengePhonePageObject.js
@@ -1,7 +1,7 @@
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
 export default class ChallengePhonePageObject extends ChallengeFactorPageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -42,7 +42,7 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     await this.footer.click('[data-se="cancel-authenticator-challenge"]');
   }
 
-  async clickSwitchAuthenticatorButton () {
+  async clickSwitchAuthenticatorButton() {
     await this.t.click(this.getFooterSwitchAuthenticatorLink());
   }
 

--- a/test/testcafe/framework/page-objects/DuoPageObject.js
+++ b/test/testcafe/framework/page-objects/DuoPageObject.js
@@ -1,7 +1,7 @@
 import BasePageObject from './BasePageObject';
 
 export default class DuoPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
@@ -5,7 +5,7 @@ const CODE_FIELD_NAME = 'credentials.passcode';
 
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
-  constructor (t) {
+  constructor(t) {
     super(t);
     this.resendEmail = new ResendEmailObject(t, this.form.el);
   }

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -5,28 +5,28 @@ const CODE_FIELD_NAME = 'credentials.passcode';
 
 export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject {
 
-  constructor (t) {
+  constructor(t) {
     super(t);
     this.resendEmail = new ResendEmailObject(t, this.form.el);
   }
 
-  getBarcodeSubtitle () {
+  getBarcodeSubtitle() {
     return this.getTextContent('.barcode-setup-title');
   }
 
-  getmanualSetupSubtitle () {
+  getmanualSetupSubtitle() {
     return this.getTextContent('.manual-setup-title');
   }
 
-  getSetUpDescription () {
+  getSetUpDescription() {
     return this.getTextContent('.google-authenticator-setup-info');
   }
 
-  hasQRcode () {
+  hasQRcode() {
     return this.form.elementExist('.qrcode');
   }
 
-  getSharedSecret () {
+  getSharedSecret() {
     return this.form.getElement('.shared-secret input').getAttribute('placeholder');
   }
 

--- a/test/testcafe/framework/page-objects/EnrollOVViaEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOVViaEmailPageObject.js
@@ -4,7 +4,7 @@ const EMAIL_FIELD = 'email';
 const SWITCH_CHANNEL_TEXT = '.switch-channel-text';
 
 export default class EnrollOVViaEmailPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 
@@ -16,7 +16,7 @@ export default class EnrollOVViaEmailPageObject extends BasePageObject {
     return this.form.clickSaveButton();
   }
 
-  hasSwitchChannelText () {
+  hasSwitchChannelText() {
     return this.form.getElement(SWITCH_CHANNEL_TEXT).visible;
   }
 }

--- a/test/testcafe/framework/page-objects/EnrollOVViaSMSPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOVViaSMSPageObject.js
@@ -6,7 +6,7 @@ const COUNTRY_CODE_LABEL = '.country-code-label';
 const SWITCH_CHANNEL_TEXT = '.switch-channel-text';
 
 export default class EnrollOVViaEmailPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 
@@ -26,7 +26,7 @@ export default class EnrollOVViaEmailPageObject extends BasePageObject {
     return this.form.clickSaveButton();
   }
 
-  hasSwitchChannelText () {
+  hasSwitchChannelText() {
     return this.form.getElement(SWITCH_CHANNEL_TEXT).visible;
   }
 }

--- a/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOktaVerifyPageObject.js
@@ -4,7 +4,7 @@ const FORM_INFOBOX_ERROR = '[data-se="o-form-error-container"] [data-se="callout
 const FORM_INFOBOX_ERROR_TITLE = '[data-se="o-form-error-container"] [data-se="callout"] > h3';
 
 export default class EnrollOktaVerifyPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 
@@ -16,11 +16,11 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
     return this.form.elementExist('.qrcode');
   }
 
-  hasEnrollViaEmailInstruction () {
+  hasEnrollViaEmailInstruction() {
     return this.form.elementExist('.email-info');
   }
 
-  hasEnrollViaSmsInstruction () {
+  hasEnrollViaSmsInstruction() {
     return this.form.elementExist('.sms-info');
   }
 
@@ -36,11 +36,11 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
     return this.getTextContent('.sms-info');
   }
 
-  getSwitchChannelText () {
+  getSwitchChannelText() {
     return this.getTextContent('.switch-channel-link');
   }
 
-  async clickSwitchChannel () {
+  async clickSwitchChannel() {
     await this.form.clickElement('.switch-channel-link');
   }
 
@@ -52,7 +52,7 @@ export default class EnrollOktaVerifyPageObject extends BasePageObject {
     await this.form.clickElement('.resend-ov-link-view a.resend-link');
   }
 
-  getErrorBox () {
+  getErrorBox() {
     return this.form.getElement(FORM_INFOBOX_ERROR);
   }
 

--- a/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
@@ -5,7 +5,7 @@ const USER_NAME_FIELD_NAME = 'credentials.clientData';
 const FORM_INFOBOX_ERROR = '.o-form-error-container .infobox-error';
 
 export default class EnrollOnPremPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 
@@ -37,7 +37,7 @@ export default class EnrollOnPremPageObject extends BasePageObject {
     await this.form.el.find(FORM_INFOBOX_ERROR).exists;
   }
 
-  getErrorBox () {
+  getErrorBox() {
     return this.form.getElement(FORM_INFOBOX_ERROR);
   }
 

--- a/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollPhonePageObject.js
@@ -7,39 +7,39 @@ const RESEND_VIEW_SELECTOR = '.phone-authenticator-enroll--warning';
 
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
-  constructor (t) {
+  constructor(t) {
     super (t);
   }
 
-  clickRadio (methodType = 'voice') {
+  clickRadio(methodType = 'voice') {
     return this.form.selectRadioButtonOptionByValue('authenticator\\.methodType', methodType);
   }
 
-  extensionIsHidden () {
+  extensionIsHidden() {
     return this.form.getElement(PHONE_NUMBER_EXTENSION_SELECTOR).hasClass('hide');
   }
 
-  getElement (selector) {
+  getElement(selector) {
     return this.form.getElement(selector);
   }
 
-  hasPhoneNumberError () {
+  hasPhoneNumberError() {
     return this.form.hasTextBoxError(phoneFieldName);
   }
 
-  clickSaveButton () {
+  clickSaveButton() {
     return this.form.clickSaveButton();
   }
 
-  waitForError () {
+  waitForError() {
     return this.form.waitForErrorBox();
   }
 
-  fillPhoneNumber (value) {
+  fillPhoneNumber(value) {
     return this.form.setTextBoxValue(phoneFieldName, value);
   }
 
-  phoneNumberFieldIsSmall () {
+  phoneNumberFieldIsSmall() {
     return this.form.getElement(PHONE_NUMBER_SELECTOR)
       .hasClass('phone-authenticator-enroll__phone--small');
   }

--- a/test/testcafe/framework/page-objects/EnrollWebauthnPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollWebauthnPageObject.js
@@ -1,7 +1,7 @@
 import BasePageObject from './BasePageObject';
 
 export default class EnrollWebauthnPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/FactorEnrollPasswordPageObject.js
@@ -14,7 +14,7 @@ const requirementsSelector = '[data-se="password-authenticator--rules"]';
  * TODO: Rename this to have AuthenticatorPasswordPageObject when Factor is cleaned up.
  */
 export default class EnrollPasswordPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 
@@ -59,11 +59,11 @@ export default class EnrollPasswordPageObject extends BasePageObject {
   }
 
   // This will be used by any password page that has requirements on it.
-  getRequirements () {
+  getRequirements() {
     return this.form.getElement(requirementsSelector).innerText;
   }
 
-  requirementsExist () {
+  requirementsExist() {
     return this.form.elementExist(requirementsSelector);
   }
 }

--- a/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
@@ -2,7 +2,7 @@ import { ClientFunction } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class IdPAuthenticatorPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -13,7 +13,7 @@ const CUSTOM_BUTTON = '.custom-buttons .okta-custom-buttons-container .default-c
 const UNLOCK_ACCOUNT = '.auth-footer .js-unlock';
 
 export default class IdentityPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/PollingPageObject.js
+++ b/test/testcafe/framework/page-objects/PollingPageObject.js
@@ -3,7 +3,7 @@ import BasePageObject from './BasePageObject';
 
 export default class PollingPageObject extends BasePageObject {
 
-  constructor (t) {
+  constructor(t) {
     super(t);
     this.spinner = new Selector('.okta-waiting-spinner');
   }

--- a/test/testcafe/framework/page-objects/SuccessPageObject.js
+++ b/test/testcafe/framework/page-objects/SuccessPageObject.js
@@ -2,7 +2,7 @@ import { Selector, ClientFunction } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class SuccessPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
   async getPageUrl() {

--- a/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
+++ b/test/testcafe/framework/page-objects/SwitchOVEnrollChannelPageObject.js
@@ -4,7 +4,7 @@ const optionLabelSelector = '.radio-label';
 const channelOptionFieldName = 'authenticator.channel';
 
 export default class SwitchOVEnrollPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
@@ -2,7 +2,7 @@ import { ClientFunction } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class SymantecAuthenticatorPageObject extends BasePageObject {
-  constructor (t) {
+  constructor(t) {
     super(t);
   }
 

--- a/test/testcafe/framework/page-objects/TerminalPageObject.js
+++ b/test/testcafe/framework/page-objects/TerminalPageObject.js
@@ -4,7 +4,7 @@ import CalloutObject from './components/CalloutObject';
 
 export default class TerminalPageObject extends BasePageObject {
 
-  constructor (t) {
+  constructor(t) {
     super(t);
     this.beacon = new Selector('.beacon-container');
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -14,7 +14,7 @@ const focusOnSubmitButton = () => {
 };
 
 export default class BaseFormObject {
-  constructor (t, index) {
+  constructor(t, index) {
     this.t = t;
     this.el = new Selector('.o-form').nth(index || 0);
   }

--- a/test/testcafe/framework/page-objects/components/CalloutObject.js
+++ b/test/testcafe/framework/page-objects/components/CalloutObject.js
@@ -4,7 +4,7 @@ const DATA_SE_CALLOUT = '[data-se="callout"]';
 
 export default class CalloutObject {
 
-  constructor (parent /* Selector */, index = 0) {
+  constructor(parent /* Selector */, index = 0) {
     if (parent) {
       this.el = parent.find(DATA_SE_CALLOUT).nth(index);
     } else {

--- a/test/testcafe/framework/page-objects/components/FooterLinkObject.js
+++ b/test/testcafe/framework/page-objects/components/FooterLinkObject.js
@@ -2,21 +2,21 @@ import { Selector } from 'testcafe';
 
 export default class FooterLinkObject {
 
-  constructor (t, selector) {
+  constructor(t, selector) {
     this.t = t;
     this.el = new Selector(`.siw-main-footer ${selector}`);
   }
 
-  getLabel () {
+  getLabel() {
     return this.el.textContent;
   }
 
-  async exists () {
+  async exists() {
     const count = await this.el.count;
     return count === 1;
   }
 
-  async click () {
+  async click() {
     return this.t.click(this.el);
   }
 

--- a/test/testcafe/framework/page-objects/components/ResendEmailObject.js
+++ b/test/testcafe/framework/page-objects/components/ResendEmailObject.js
@@ -4,7 +4,7 @@ const RESEND_EMAIL = '.resend-email-view';
 
 export default class ResendEmailObject {
 
-  constructor (t, parent /* Selector */) {
+  constructor(t, parent /* Selector */) {
     this.t = t;
     if (parent) {
       this.el = parent.find(RESEND_EMAIL);

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -37,15 +37,15 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
 
   await rerenderWidget({
     registration: {
-      parseSchema: function (resp, onSuccess) {
+      parseSchema: function(resp, onSuccess) {
         resp.find(({name}) => name === 'userProfile.firstName').required = false;
         onSuccess(resp);
       },
-      preSubmit: function (postData, onSuccess) {
+      preSubmit: function(postData, onSuccess) {
         postData.userProfile.extra = 'stuff';
         onSuccess(postData);
       },
-      postSubmit: function (postData, onSuccess) {
+      postSubmit: function(postData, onSuccess) {
         // eslint-disable-next-line
         console.log(`made it to postSubmit ${postData}`);
         onSuccess(postData);
@@ -80,19 +80,19 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onFailu
 
   await rerenderWidget({
     registration: {
-      parseSchema: function (resp, onSuccess, onFailure) {
+      parseSchema: function(resp, onSuccess, onFailure) {
         const error = {
           'errorSummary': 'My parseSchema message'
         };
         onFailure(error);
       },
-      preSubmit: function (postData, onSuccess, onFailure) {
+      preSubmit: function(postData, onSuccess, onFailure) {
         const error = {
           'errorSummary': 'My preSubmit message'
         };
         onFailure(error);
       },
-      postSubmit: function (postData, onSuccess, onFailure) {
+      postSubmit: function(postData, onSuccess, onFailure) {
         const error = {
           'errorSummary': 'My postSubmit message'
         };
@@ -119,7 +119,7 @@ test.requestHooks(logger, mock)('should call settings.registration.postSubmit ho
 
   await rerenderWidget({
     registration: {
-      postSubmit: function (postData, onSuccess, onFailure) {
+      postSubmit: function(postData, onSuccess, onFailure) {
         const error = {
           'errorSummary': 'My postSubmit message'
         };

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -157,7 +157,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should transform identif
   const identityPage = await setup(t);
 
   await rerenderWidget({
-    transformUsername: function (username, operation) {
+    transformUsername: function(username, operation) {
       if (operation === 'PRIMARY_AUTH') {
         return `${username}@okta.com`;
       }

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -38,7 +38,7 @@ const mockCrypto = ClientFunction(() => {
 
   if (typeof window.crypto.subtle === 'undefined') {
     window.crypto.subtle = {
-      digest: function () { 
+      digest: function() { 
         return Promise.resolve(65);
       }
     };
@@ -87,7 +87,7 @@ const requestLogger = RequestLogger(
 
 fixture('Interact');
 
-function decodeUrlEncodedRequestBody (body) {
+function decodeUrlEncodedRequestBody(body) {
   const params = {};
   const pairs = body.split('&');
   pairs.forEach(pair => {

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -24,7 +24,7 @@ const terminalRegistrationEmailMock = RequestMock()
 
 fixture('Terminal view');
 
-async function setup (t) {
+async function setup(t) {
   const terminalPageObject = new TerminalPageObject(t);
   await terminalPageObject.navigateToPage();
   return terminalPageObject;

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -122,14 +122,14 @@ test.requestHooks(identifyMock)('should show custom buttons links', async t => {
     'customButtons' : [{
       'title': 'Custom Button 1',
       'className': 'btn-customAuth-1',
-      'click': function () {
+      'click': function() {
         window.location.href = 'https://www.example.com/';
       }
     },
     {
       'title': 'Custom Button 2',
       'className': 'btn-customAuth-1',
-      'click': function () {
+      'click': function() {
         window.location.href = 'https://www.example2.com/';
       }
     }]

--- a/test/unit/helpers/dom/AccountRecoveryForm.js
+++ b/test/unit/helpers/dom/AccountRecoveryForm.js
@@ -10,124 +10,124 @@ const EMAIL_SENT_BACK_BTN = 'back-button';
 const SEND_EMAIL_LINK_SELECTOR = '.send-email-link';
 const EMAIL_BUTTON_SELECTOR = '.email-button';
 export default Form.extend({
-  usernameField: function () {
+  usernameField: function() {
     return this.input(USERNAME_FIELD);
   },
 
-  usernameLabel: function () {
+  usernameLabel: function() {
     return this.$(USERNAME_LABEL);
   },
 
-  usernameExplain: function () {
+  usernameExplain: function() {
     return this.explain(USERNAME_FIELD);
   },
 
-  getUsernameAutocomplete: function () {
+  getUsernameAutocomplete: function() {
     return this.autocomplete(USERNAME_FIELD);
   },
 
-  usernameErrorField: function () {
+  usernameErrorField: function() {
     return this.error(USERNAME_FIELD);
   },
 
-  usernameTooltipText: function () {
+  usernameTooltipText: function() {
     return this.tooltipText(USERNAME_FIELD);
   },
 
-  setUsername: function (val) {
+  setUsername: function(val) {
     const field = this.usernameField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  hasSmsButton: function () {
+  hasSmsButton: function() {
     return this.button(SMS_BUTTON_SELECTOR).length > 0;
   },
 
-  smsHintText: function () {
+  smsHintText: function() {
     return this.$(SMS_HINT_SELECTOR).trimmedText();
   },
 
-  hasSmsHint: function () {
+  hasSmsHint: function() {
     return Form.isVisible(this.$(SMS_HINT_SELECTOR));
   },
 
-  sendSms: function () {
+  sendSms: function() {
     this.button(SMS_BUTTON_SELECTOR).click();
   },
 
-  mobileRecoveryHintText: function () {
+  mobileRecoveryHintText: function() {
     return this.$(MOBILE_RECOVERY_HINT_SELECTOR).trimmedText();
   },
 
-  hasMobileRecoveryHint: function () {
+  hasMobileRecoveryHint: function() {
     return Form.isVisible(this.$(MOBILE_RECOVERY_HINT_SELECTOR));
   },
 
-  hasCallButton: function () {
+  hasCallButton: function() {
     return this.button(CALL_BUTTON_SELECTOR).length > 0;
   },
 
-  makeCall: function () {
+  makeCall: function() {
     this.button(CALL_BUTTON_SELECTOR).click();
   },
 
-  hasEmailButton: function () {
+  hasEmailButton: function() {
     return this.button(EMAIL_BUTTON_SELECTOR).length > 0;
   },
 
-  sendEmail: function () {
+  sendEmail: function() {
     return this.button(EMAIL_BUTTON_SELECTOR).click();
   },
 
-  goBack: function () {
+  goBack: function() {
     this.$('.js-back').click();
   },
 
   // Email Send Confirmation view
 
-  getEmailSentConfirmationText: function () {
+  getEmailSentConfirmationText: function() {
     return this.$('p').text();
   },
 
-  backToLoginButton: function () {
+  backToLoginButton: function() {
     return this.el(EMAIL_SENT_BACK_BTN);
   },
 
-  goBackToLogin: function () {
+  goBackToLogin: function() {
     this.backToLoginButton().click();
   },
 
-  hasCantAccessEmailLink: function () {
+  hasCantAccessEmailLink: function() {
     return Form.isVisible(this.$(CANT_ACCESS_EMAIL_SELECTOR));
   },
 
-  clickCantAccessEmail: function () {
+  clickCantAccessEmail: function() {
     this.$(CANT_ACCESS_EMAIL_SELECTOR).click();
   },
 
-  contactSupport: function () {
+  contactSupport: function() {
     return this.$('.contact-support');
   },
 
-  contactSupportText: function () {
+  contactSupportText: function() {
     return this.contactSupport().trimmedText();
   },
 
-  sendEmailLink: function () {
+  sendEmailLink: function() {
     return this.$(SEND_EMAIL_LINK_SELECTOR);
   },
 
-  hasSendEmailLink: function () {
+  hasSendEmailLink: function() {
     return this.sendEmailLink().css('visibility') === 'visible';
   },
 
-  clickSendEmailLink: function () {
+  clickSendEmailLink: function() {
     this.sendEmailLink().click();
   },
 
-  pressEnter: function () {
+  pressEnter: function() {
     this.$('form.o-form').submit();
   },
 });

--- a/test/unit/helpers/dom/AdminConsentRequiredForm.js
+++ b/test/unit/helpers/dom/AdminConsentRequiredForm.js
@@ -3,55 +3,55 @@ import Form from './Form';
 
 export default Form.extend({
 
-  consentTitle: function () {
+  consentTitle: function() {
     return this.$('.consent-title');
   },
 
-  consentTitleText: function () {
+  consentTitleText: function() {
     return this.consentTitle().find('.title-text').text().trim();
   },
 
-  consentIssuer: function () {
+  consentIssuer: function() {
     return this.consentTitle().find('.issuer');
   },
 
-  clientLogo: function () {
+  clientLogo: function() {
     return this.consentTitle().find('.client-logo');
   },
 
-  clientLogoLink: function () {
+  clientLogoLink: function() {
     return this.consentTitle().find('.client-logo-link');
   },
 
-  scopeGroupList: function () {
+  scopeGroupList: function() {
     return this.$('.scope-group');
   },
 
-  scopeGroupListRow: function (index) {
+  scopeGroupListRow: function(index) {
     return this.$(`.scope-group:eq(${index})`);
   },
 
-  scopeGroupName: function (index) {
+  scopeGroupName: function(index) {
     return this.scopeGroupListRow(index).find('.scope-group--header h3').text();
   },
 
-  scopeNames: function (index) {
+  scopeNames: function(index) {
     return this.scopeGroupListRow(index).find('.scope-item-text')
-      .map(function () {
+      .map(function() {
         return this.innerText;
       })
       .get();
   },
 
-  consentDescription: function () {
+  consentDescription: function() {
     return this.$('.o-form-content .consent-description');
   },
 
-  consentButton: function () {
+  consentButton: function() {
     return this.$('.admin-consent-required input[data-type="save"]');
   },
 
-  cancelButton: function () {
+  cancelButton: function() {
     return this.$('.admin-consent-required input[data-type="cancel"]');
   }
 });

--- a/test/unit/helpers/dom/AuthContainer.js
+++ b/test/unit/helpers/dom/AuthContainer.js
@@ -1,10 +1,10 @@
 import Dom from './Dom';
 export default Dom.extend({
-  authContainer: function () {
+  authContainer: function() {
     return this.el('auth-container');
   },
 
-  canBeMinimized: function () {
+  canBeMinimized: function() {
     return this.authContainer().hasClass('can-remove-beacon');
   },
 });

--- a/test/unit/helpers/dom/Beacon.js
+++ b/test/unit/helpers/dom/Beacon.js
@@ -1,7 +1,7 @@
 import { _, $ } from 'okta';
 import Dom from './Dom';
 export default Dom.extend({
-  beacon: function () {
+  beacon: function() {
     let beacon = this.securityBeacon();
 
     if (!beacon.length) {
@@ -16,66 +16,66 @@ export default Dom.extend({
     return beacon;
   },
 
-  loadingBeacon: function () {
+  loadingBeacon: function() {
     return this.el('loading-beacon');
   },
 
-  isLoadingBeacon: function () {
+  isLoadingBeacon: function() {
     return this.loadingBeacon().length === 1;
   },
 
-  securityBeacon: function () {
+  securityBeacon: function() {
     return this.el('security-beacon');
   },
 
-  isSecurityBeacon: function () {
+  isSecurityBeacon: function() {
     return this.securityBeacon().length === 1;
   },
 
-  factorBeacon: function () {
+  factorBeacon: function() {
     return this.el('factor-beacon');
   },
 
-  isFactorBeacon: function () {
+  isFactorBeacon: function() {
     return this.factorBeacon().length === 1;
   },
 
-  pivBeacon: function () {
+  pivBeacon: function() {
     return this.el('piv-beacon');
   },
 
-  isPIVBeacon: function () {
+  isPIVBeacon: function() {
     return this.pivBeacon().length === 1;
   },
 
-  getBeaconImage: function () {
+  getBeaconImage: function() {
     return this.beacon().css('background-image');
   },
 
-  hasClass: function (className) {
+  hasClass: function(className) {
     return this.beacon().hasClass(className);
   },
 
-  getOptionsContainer: function () {
+  getOptionsContainer: function() {
     return this.$('[data-type="factor-types-dropdown"]');
   },
 
-  getOptionsList: function () {
+  getOptionsList: function() {
     return this.getOptionsContainer().find('div.options');
   },
 
-  getOptionsLinks: function () {
+  getOptionsLinks: function() {
     // first one is explain text
     return this.getOptionsContainer().find('a:gt(1)');
   },
 
-  getOptionsLinksText: function () {
-    return _.map(this.getOptionsLinks(), function (link) {
+  getOptionsLinksText: function() {
+    return _.map(this.getOptionsLinks(), function(link) {
       return $(link).trimmedText();
     });
   },
 
-  dropDownButton: function () {
+  dropDownButton: function() {
     return this.getOptionsContainer().find('.link-button');
   },
 });

--- a/test/unit/helpers/dom/ConsentRequiredForm.js
+++ b/test/unit/helpers/dom/ConsentRequiredForm.js
@@ -1,38 +1,38 @@
 import Form from './Form';
 export default Form.extend({
-  consentTitle: function () {
+  consentTitle: function() {
     return this.$('.consent-title');
   },
 
-  clientLogo: function () {
+  clientLogo: function() {
     return this.consentTitle().find('.client-logo');
   },
 
-  clientLogoLink: function () {
+  clientLogoLink: function() {
     return this.consentTitle().find('.client-logo-link');
   },
 
-  scopeList: function () {
+  scopeList: function() {
     return this.$('.scope-list');
   },
 
-  consentDescription: function () {
+  consentDescription: function() {
     return this.$('.o-form-content .consent-description');
   },
 
-  termsOfService: function () {
+  termsOfService: function() {
     return this.$('.consent-footer .terms-of-service');
   },
 
-  privacyPolicy: function () {
+  privacyPolicy: function() {
     return this.$('.consent-footer .privacy-policy');
   },
 
-  consentButton: function () {
+  consentButton: function() {
     return this.$('.consent-required input[data-type="save"]');
   },
 
-  cancelButton: function () {
+  cancelButton: function() {
     return this.$('.consent-required input[data-type="cancel"]');
   },
 });

--- a/test/unit/helpers/dom/Dom.js
+++ b/test/unit/helpers/dom/Dom.js
@@ -2,11 +2,11 @@ import { internal } from 'okta';
 import 'helpers/util/jquery.okta';
 let { Class } = internal.util;
 const Dom = Class.extend({
-  initialize: function ($root) {
+  initialize: function($root) {
     this.$root = $root;
   },
 
-  el: function (dataSe) {
+  el: function(dataSe) {
     const sel = '[data-se="' + dataSe + '"]';
 
     if (this.$root.is(sel)) {
@@ -15,12 +15,12 @@ const Dom = Class.extend({
     return this.$root.find(sel);
   },
 
-  $: function (selector) {
+  $: function(selector) {
     return this.$root.find(selector);
   },
 });
 
-Dom.isVisible = function ($el) {
+Dom.isVisible = function($el) {
   // non-jquery method
   // return $el.css('visibility') === 'visible' && $el.css('display') !== 'none' && $el.html() !== '';
 

--- a/test/unit/helpers/dom/EnrollActivateEmailForm.js
+++ b/test/unit/helpers/dom/EnrollActivateEmailForm.js
@@ -1,29 +1,29 @@
 import Form from './Form';
 export default Form.extend({
-  enrollEmailActivateContent: function () {
+  enrollEmailActivateContent: function() {
     return this.el('enroll-activate-email-content').trimmedText();
   },
 
-  setVerificationCode: function (val) {
+  setVerificationCode: function(val) {
     const field = this.input('passCode');
 
     field.val(val);
     field.trigger('change');
   },
 
-  getResendEmailView: function () {
+  getResendEmailView: function() {
     return this.$('.resend-email-infobox');
   },
 
-  getResendEmailMessage: function () {
+  getResendEmailMessage: function() {
     return this.$('.resend-email-infobox:not(.hide) .infobox p');
   },
 
-  getResendButton: function () {
+  getResendButton: function() {
     return this.$('.resend-email-infobox:not(.hide) a.resend-email-btn');
   },
 
-  clickResend: function () {
+  clickResend: function() {
     const resendLinkBtn = this.getResendButton();
 
     resendLinkBtn.click();

--- a/test/unit/helpers/dom/EnrollCallForm.js
+++ b/test/unit/helpers/dom/EnrollCallForm.js
@@ -2,15 +2,15 @@ import SmsForm from './EnrollSmsForm';
 const PHONE_EXTENSION_FIELD = 'phoneExtension';
 export default SmsForm.extend({
   //Override
-  sendCodeButton: function () {
+  sendCodeButton: function() {
     return this.el('call-request-button').filter(':visible');
   },
 
-  phoneExtensionField: function () {
+  phoneExtensionField: function() {
     return this.input(PHONE_EXTENSION_FIELD);
   },
 
-  setPhoneExtension: function (val) {
+  setPhoneExtension: function(val) {
     const field = this.phoneExtensionField();
 
     field.val(val);

--- a/test/unit/helpers/dom/EnrollChoicesForm.js
+++ b/test/unit/helpers/dom/EnrollChoicesForm.js
@@ -1,30 +1,30 @@
 import { _, $ } from 'okta';
 import Form from './Form';
 export default Form.extend({
-  factorRow: function (factorName) {
+  factorRow: function(factorName) {
     return this.el(factorName);
   },
 
-  factorDescription: function (factorName) {
+  factorDescription: function(factorName) {
     return this.factorRow(factorName).find('.enroll-factor-description');
   },
 
-  factorIconClass: function (factorName) {
+  factorIconClass: function(factorName) {
     const $el = this.factorRow(factorName).find('.enroll-factor-icon');
     const className = $el.attr('class').replace('enroll-factor-icon', '').replace(/\s\s+/g, ' ');
 
     return $.trim(className);
   },
 
-  factorTitle: function (factorName) {
+  factorTitle: function(factorName) {
     return this.factorDescription(factorName).find('h3').trimmedText();
   },
 
-  factorSubtitle: function (factorName) {
+  factorSubtitle: function(factorName) {
     return this.factorDescription(factorName).find('p').trimmedText();
   },
 
-  factorButton: function (factorName, factorsRow) {
+  factorButton: function(factorName, factorsRow) {
     if (factorName) {
       return this.factorRow(factorName).find('.button');
     } else {
@@ -32,7 +32,7 @@ export default Form.extend({
     }
   },
 
-  factorButtonText: function (factorName, factorsRow) {
+  factorButtonText: function(factorName, factorsRow) {
     if (factorName) {
       return this.factorButton(factorName).trimmedText();
     } else {
@@ -40,7 +40,7 @@ export default Form.extend({
     }
   },
 
-  factorCardinalityText: function (factorName, factorsRow) {
+  factorCardinalityText: function(factorName, factorsRow) {
     if (factorName) {
       return this.factorRow(factorName).find('.factor-cardinality').trimmedText();
     } else {
@@ -48,11 +48,11 @@ export default Form.extend({
     }
   },
 
-  isFactorMinimized: function (factorName) {
+  isFactorMinimized: function(factorName) {
     return this.factorRow(factorName).hasClass('enroll-factor-row-min');
   },
 
-  factorHasSuccessCheck: function (factorName, factorsRow) {
+  factorHasSuccessCheck: function(factorName, factorsRow) {
     if (factorName) {
       return this.factorRow(factorName).find('.success-16-green').length > 0;
     } else {
@@ -60,46 +60,46 @@ export default Form.extend({
     }
   },
 
-  factorHasPendingCheck: function (factorName) {
+  factorHasPendingCheck: function(factorName) {
     return this.factorRow(factorName).find('.success-16-gray').length > 0;
   },
 
-  requiredFactorList: function () {
+  requiredFactorList: function() {
     return this.$('.enroll-required-factor-list');
   },
 
-  requiredFactorListTitle: function () {
+  requiredFactorListTitle: function() {
     return this.requiredFactorList().find('.list-title').trimmedText();
   },
 
-  skipSetUpLink: function () {
+  skipSetUpLink: function() {
     return this.$('.enroll-choices').find('.auth-footer .js-skip');
   },
 
-  enrolledFactorList: function () {
+  enrolledFactorList: function() {
     const lists = this.$('.enroll-factor-list');
 
     return lists.length === 2 ? lists.eq(0) : $();
   },
 
-  enrolledFactorListTitle: function () {
+  enrolledFactorListTitle: function() {
     return this.enrolledFactorList().find('.list-title').trimmedText();
   },
 
-  optionalFactorList: function () {
+  optionalFactorList: function() {
     const lists = this.$('.enroll-factor-list').not('.enroll-required-factor-list');
 
     return lists.length === 2 ? lists.eq(1) : lists.eq(0);
   },
 
-  optionalFactorListTitle: function () {
+  optionalFactorListTitle: function() {
     return this.optionalFactorList().find('.list-title').trimmedText();
   },
 
-  getFactorList: function () {
+  getFactorList: function() {
     const factorRows = this.$('.enroll-factor-list .enroll-factor-row');
 
-    return _.map(factorRows, function (row) {
+    return _.map(factorRows, function(row) {
       return $(row).attr('data-se');
     });
   },

--- a/test/unit/helpers/dom/EnrollCustomFactorForm.js
+++ b/test/unit/helpers/dom/EnrollCustomFactorForm.js
@@ -1,18 +1,18 @@
 import Form from './Form';
 export default Form.extend({
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  buttonBar: function () {
+  buttonBar: function() {
     return this.$('.o-form-button-bar');
   },
 
-  hasErrorBox: function () {
+  hasErrorBox: function() {
     return this.el('o-form-error-container').find('.infobox-error').length > 0;
   },
 
-  errorBoxMessage: function () {
+  errorBoxMessage: function() {
     return this.$('.o-form-error-container .infobox-error h4').text().trim();
   },
 });

--- a/test/unit/helpers/dom/EnrollDuoForm.js
+++ b/test/unit/helpers/dom/EnrollDuoForm.js
@@ -1,10 +1,10 @@
 import Form from './Form';
 export default Form.extend({
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  iframe: function () {
+  iframe: function() {
     return this.$('iframe');
   },
 });

--- a/test/unit/helpers/dom/EnrollEmailForm.js
+++ b/test/unit/helpers/dom/EnrollEmailForm.js
@@ -1,6 +1,6 @@
 import Form from './Form';
 export default Form.extend({
-  enrollEmailContent: function () {
+  enrollEmailContent: function() {
     return this.el('enroll-email-content').trimmedText();
   },
 });

--- a/test/unit/helpers/dom/EnrollHotpForm.js
+++ b/test/unit/helpers/dom/EnrollHotpForm.js
@@ -1,14 +1,14 @@
 import Form from './Form';
 export default Form.extend({
-  title: function () {
+  title: function() {
     return this.$('[data-se="o-form-head"]');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  errorHtml: function () {
+  errorHtml: function() {
     return this.el('o-form-error-html').find('strong');
   },
 });

--- a/test/unit/helpers/dom/EnrollPasswordForm.js
+++ b/test/unit/helpers/dom/EnrollPasswordForm.js
@@ -2,53 +2,53 @@ import Form from './Form';
 const PASSWORD_FIELD = 'password';
 const CONFIRM_PASSWORD_FIELD = 'confirmPassword';
 export default Form.extend({
-  passwordField: function () {
+  passwordField: function() {
     return this.input(PASSWORD_FIELD);
   },
 
-  confirmPasswordField: function () {
+  confirmPasswordField: function() {
     return this.input(CONFIRM_PASSWORD_FIELD);
   },
 
-  setPassword: function (val) {
+  setPassword: function(val) {
     const field = this.passwordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setConfirmPassword: function (val) {
+  setConfirmPassword: function(val) {
     const field = this.confirmPasswordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  getPasswordAutocomplete: function () {
+  getPasswordAutocomplete: function() {
     return this.autocomplete(PASSWORD_FIELD);
   },
 
-  getConfirmPasswordAutocomplete: function () {
+  getConfirmPasswordAutocomplete: function() {
     return this.autocomplete(CONFIRM_PASSWORD_FIELD);
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  hasPasswordFieldErrors: function () {
+  hasPasswordFieldErrors: function() {
     return this.hasFieldErrors(PASSWORD_FIELD);
   },
 
-  passwordFieldErrorMessage: function () {
+  passwordFieldErrorMessage: function() {
     return this.fieldErrorMessage(PASSWORD_FIELD);
   },
 
-  hasConfirmPasswordFieldErrors: function () {
+  hasConfirmPasswordFieldErrors: function() {
     return this.hasFieldErrors(CONFIRM_PASSWORD_FIELD);
   },
 
-  confirmPasswordFieldErrorMessage: function () {
+  confirmPasswordFieldErrorMessage: function() {
     return this.fieldErrorMessage(CONFIRM_PASSWORD_FIELD);
   },
 });

--- a/test/unit/helpers/dom/EnrollPushLinkSentForm.js
+++ b/test/unit/helpers/dom/EnrollPushLinkSentForm.js
@@ -2,19 +2,19 @@ import Form from './Form';
 const SMS_LINK_SENT_VIEW = 'sent-sms-activation-link';
 const EMAIL_LINK_SENT_VIEW = 'sent-email-activation-link';
 export default Form.extend({
-  smsSentMsg: function () {
+  smsSentMsg: function() {
     return this.el(SMS_LINK_SENT_VIEW);
   },
 
-  emailSentMsg: function () {
+  emailSentMsg: function() {
     return this.el(EMAIL_LINK_SENT_VIEW);
   },
 
-  getMsgText: function () {
+  getMsgText: function() {
     return this.$('p').text();
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 });

--- a/test/unit/helpers/dom/EnrollQuestionsForm.js
+++ b/test/unit/helpers/dom/EnrollQuestionsForm.js
@@ -2,30 +2,30 @@ import Form from './Form';
 const ANSWER_FIELD = 'answer';
 const QUESTIONS_FIELD = 'question';
 export default Form.extend({
-  answerField: function () {
+  answerField: function() {
     return this.input(ANSWER_FIELD);
   },
 
-  setAnswer: function (val) {
+  setAnswer: function(val) {
     const field = this.answerField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  getAnswerAutocomplete: function () {
+  getAnswerAutocomplete: function() {
     return this.autocomplete(ANSWER_FIELD);
   },
 
-  questionList: function () {
+  questionList: function() {
     return this.selectOptions(QUESTIONS_FIELD);
   },
 
-  selectQuestion: function (question) {
+  selectQuestion: function(question) {
     return this.selectOption(QUESTIONS_FIELD, question);
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 });

--- a/test/unit/helpers/dom/EnrollSmsForm.js
+++ b/test/unit/helpers/dom/EnrollSmsForm.js
@@ -3,62 +3,62 @@ const PHONE_FIELD = 'phoneNumber';
 const CODE_FIELD = 'passCode';
 const COUNTRIES_FIELD = 'countryCode';
 export default Form.extend({
-  countriesList: function () {
+  countriesList: function() {
     return this.selectOptions(COUNTRIES_FIELD);
   },
 
-  selectedCountry: function () {
+  selectedCountry: function() {
     return this.selectedOption(COUNTRIES_FIELD);
   },
 
-  selectCountry: function (countryCode) {
+  selectCountry: function(countryCode) {
     return this.selectOption(COUNTRIES_FIELD, countryCode);
   },
 
-  hasCountriesList: function () {
+  hasCountriesList: function() {
     return this.inputWrap(COUNTRIES_FIELD).find('.chzn-container').length > 0;
   },
 
-  phoneNumberField: function () {
+  phoneNumberField: function() {
     return this.input(PHONE_FIELD);
   },
 
-  getPhoneNumberAutocomplete: function () {
+  getPhoneNumberAutocomplete: function() {
     return this.autocomplete(PHONE_FIELD);
   },
 
-  phonePrefixText: function () {
+  phonePrefixText: function() {
     return this.inlineLabel(PHONE_FIELD).trimmedText();
   },
 
-  sendCodeButton: function () {
+  sendCodeButton: function() {
     return this.el('sms-request-button').filter(':visible');
   },
 
-  divider: function () {
+  divider: function() {
     return this.$('.form-divider');
   },
 
-  codeField: function () {
+  codeField: function() {
     return this.input(CODE_FIELD);
   },
 
-  getCodeFieldAutocomplete: function () {
+  getCodeFieldAutocomplete: function() {
     return this.autocomplete(CODE_FIELD);
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  setPhoneNumber: function (val) {
+  setPhoneNumber: function(val) {
     const field = this.phoneNumberField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setCode: function (val) {
+  setCode: function(val) {
     const field = this.codeField();
 
     field.val(val);

--- a/test/unit/helpers/dom/EnrollTokenFactorForm.js
+++ b/test/unit/helpers/dom/EnrollTokenFactorForm.js
@@ -3,58 +3,58 @@ const CRED_ID_FIELD = 'credentialId';
 const CODE_FIELD = 'passCode';
 const SECOND_CODE_FIELD = 'nextPassCode';
 export default Form.extend({
-  credentialIdField: function () {
+  credentialIdField: function() {
     return this.input(CRED_ID_FIELD);
   },
 
-  codeField: function () {
+  codeField: function() {
     return this.input(CODE_FIELD);
   },
 
-  getCodeFieldAutocomplete: function () {
+  getCodeFieldAutocomplete: function() {
     return this.autocomplete(CODE_FIELD);
   },
 
-  secondCodeField: function () {
+  secondCodeField: function() {
     return this.input(SECOND_CODE_FIELD);
   },
 
-  setCredentialId: function (val) {
+  setCredentialId: function(val) {
     const field = this.credentialIdField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  getCredentialId: function () {
+  getCredentialId: function() {
     const field = this.credentialIdField();
 
     return field.val();
   },
 
-  setCode: function (val) {
+  setCode: function(val) {
     const field = this.codeField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setSecondCode: function (val) {
+  setSecondCode: function(val) {
     const field = this.secondCodeField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  credIdExplain: function () {
+  credIdExplain: function() {
     return this.explain(CRED_ID_FIELD);
   },
 
-  codeExplain: function () {
+  codeExplain: function() {
     return this.explain(CODE_FIELD);
   },
 });

--- a/test/unit/helpers/dom/EnrollTotpBarcodeForm.js
+++ b/test/unit/helpers/dom/EnrollTotpBarcodeForm.js
@@ -7,69 +7,69 @@ const REFRESH_QRCODE_LINK = 'refresh-qrcode';
 const SCAN_FORM = 'step-scan';
 const REFRESH_LINK = 'refresh-qrcode';
 export default Form.extend({
-  isEnrollTotpBarcodeForm: function () {
+  isEnrollTotpBarcodeForm: function() {
     return this.container().length === 1;
   },
 
-  form: function () {
+  form: function() {
     return this.el(SCAN_FORM);
   },
 
-  container: function () {
+  container: function() {
     return this.$(CLASS_SELECTOR);
   },
 
-  qrcodeImg: function () {
+  qrcodeImg: function() {
     return this.el(QRCODE);
   },
 
-  manualSetupLink: function () {
+  manualSetupLink: function() {
     return this.el(MANUAL_SETUP_LINK);
   },
 
-  clickManualSetupLink: function () {
+  clickManualSetupLink: function() {
     this.manualSetupLink().click();
   },
 
-  refreshQrcodeLink: function () {
+  refreshQrcodeLink: function() {
     return this.el(REFRESH_QRCODE_LINK);
   },
 
-  scanInstructions: function () {
+  scanInstructions: function() {
     return this.$('.scan-instructions');
   },
 
-  hasRefreshQrcodeLink: function () {
+  hasRefreshQrcodeLink: function() {
     return this.scanInstructions().hasClass('qrcode-expired');
   },
 
-  hasManualSetupLink: function () {
+  hasManualSetupLink: function() {
     const instructions = this.scanInstructions();
 
     return !instructions.hasClass('qrcode-expired') && !instructions.hasClass('qrcode-success');
   },
 
-  clickrefreshQrcodeLink: function () {
+  clickrefreshQrcodeLink: function() {
     this.refreshQrcodeLink().click();
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  clickBackLink: function () {
+  clickBackLink: function() {
     this.backLink().click();
   },
 
-  refreshLink: function () {
+  refreshLink: function() {
     return this.el(REFRESH_LINK);
   },
 
-  clickRefreshLink: function () {
+  clickRefreshLink: function() {
     return this.refreshLink().click();
   },
 
-  waitForRefreshQrcodeLink: function (resolveValue) {
+  waitForRefreshQrcodeLink: function(resolveValue) {
     return Expect.wait(this.hasRefreshQrcodeLink.bind(this), resolveValue);
   },
 });

--- a/test/unit/helpers/dom/EnrollTotpDeviceTypeForm.js
+++ b/test/unit/helpers/dom/EnrollTotpDeviceTypeForm.js
@@ -2,33 +2,33 @@ import Form from './Form';
 const DEVICE_TYPE = '__deviceType__';
 const APP_DOWNLOAD_INSTRUCTIONS = 'app-download-instructions';
 export default Form.extend({
-  deviceTypeOptions: function () {
+  deviceTypeOptions: function() {
     return this.input(DEVICE_TYPE);
   },
 
-  deviceTypeOptionLabel: function (val) {
+  deviceTypeOptionLabel: function(val) {
     return this.$('[data-se-name="' + DEVICE_TYPE + '"][value="' + val + '"] + label');
   },
 
-  appDownloadInstructions: function () {
+  appDownloadInstructions: function() {
     return this.el(APP_DOWNLOAD_INSTRUCTIONS);
   },
 
-  appDownloadInstructionsAppLogo: function (selector) {
+  appDownloadInstructionsAppLogo: function(selector) {
     return this.appDownloadInstructions().find(selector);
   },
 
-  appDownloadInstructionsLinkText: function () {
+  appDownloadInstructionsLinkText: function() {
     return this.appDownloadInstructions().find('a').text().trim();
   },
 
-  selectDeviceType: function (val) {
+  selectDeviceType: function(val) {
     const options = this.deviceTypeOptions();
 
     options.filter('[value="' + val + '"]').click();
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 });

--- a/test/unit/helpers/dom/EnrollTotpManualSetupForm.js
+++ b/test/unit/helpers/dom/EnrollTotpManualSetupForm.js
@@ -11,105 +11,105 @@ const COUNTRY_CODE_SELECTOR = 'countryCode';
 const PHONE_INPUT = 'phoneNumber';
 const NEXT_BUTTON = 'next-button';
 export default Form.extend({
-  form: function () {
+  form: function() {
     return this.el(MANUAL_SETUP_FORM);
   },
 
-  sharedSecretField: function () {
+  sharedSecretField: function() {
     return this.input(SHARED_SECRET_FIELD);
   },
 
-  sharedSecretFieldValue: function () {
+  sharedSecretFieldValue: function() {
     return this.sharedSecretField().val();
   },
 
-  hasSharedSecret: function () {
+  hasSharedSecret: function() {
     return this.sharedSecretFieldValue() !== '';
   },
 
-  countryCodeSelect: function () {
+  countryCodeSelect: function() {
     return this.inputWrap(COUNTRY_CODE_SELECTOR).find('.chzn-container');
   },
 
-  waitForCountryCodeSelect: function (resolveValue) {
+  waitForCountryCodeSelect: function(resolveValue) {
     return Expect.wait(
-      function () {
+      function() {
         return this.countryCodeSelect().length > 0;
       }.bind(this),
       resolveValue
     );
   },
 
-  phoneNumberField: function () {
+  phoneNumberField: function() {
     return this.input(PHONE_INPUT);
   },
 
-  setPhoneNumber: function (val) {
+  setPhoneNumber: function(val) {
     const field = this.phoneNumberField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  dropdownElement: function () {
+  dropdownElement: function() {
     return this.inputWrap(DROPDOWN).find('.chzn-container');
   },
 
-  waitForDropdownElement: function (resolveValue) {
+  waitForDropdownElement: function(resolveValue) {
     return Expect.wait(
-      function () {
+      function() {
         return this.dropdownElement().length > 0;
       }.bind(this),
       resolveValue
     );
   },
 
-  dropdownOptions: function () {
+  dropdownOptions: function() {
     this.selectOptions(DROPDOWN);
   },
 
-  selectDropdownOption: function (val) {
+  selectDropdownOption: function(val) {
     this.selectOption(DROPDOWN, val);
   },
 
-  selectSmsOption: function () {
+  selectSmsOption: function() {
     this.selectDropdownOption(SMS_OPTION);
   },
 
-  selectEmailOption: function () {
+  selectEmailOption: function() {
     this.selectDropdownOption(EMAIL_OPTION);
   },
 
-  selectManualOption: function () {
+  selectManualOption: function() {
     this.selectDropdownOption(MANUAL_OPTION);
   },
 
-  nextButton: function () {
+  nextButton: function() {
     return this.el(NEXT_BUTTON);
   },
 
-  nextButtonClick: function () {
+  nextButtonClick: function() {
     return this.nextButton().click();
   },
 
-  gotoScanBarcodeLink: function () {
+  gotoScanBarcodeLink: function() {
     return this.el(SCAN_BARCODE_LINK);
   },
 
-  gotoScanBarcode: function () {
+  gotoScanBarcode: function() {
     this.gotoScanBarcodeLink().click();
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  waitForManual: function (resolveValue) {
+  waitForManual: function(resolveValue) {
     return Expect.wait(this.hasSharedSecret.bind(this), resolveValue);
   },
 
-  waitForSms: function (resolveValue) {
-    const condition = function () {
+  waitForSms: function(resolveValue) {
+    const condition = function() {
       const field = this.phoneNumberField();
 
       return !this.hasSharedSecret() && field.length === 1 && Form.isVisible(field);
@@ -118,8 +118,8 @@ export default Form.extend({
     return Expect.wait(condition, resolveValue);
   },
 
-  waitForEmail: function (resolveValue) {
-    const condition = function () {
+  waitForEmail: function(resolveValue) {
+    const condition = function() {
       return !this.hasSharedSecret() && this.phoneNumberField().is(':not(:visible)');
     }.bind(this);
 

--- a/test/unit/helpers/dom/EnrollTotpPassCodeForm.js
+++ b/test/unit/helpers/dom/EnrollTotpPassCodeForm.js
@@ -2,22 +2,22 @@ import Form from './Form';
 const CODE_FIELD = 'passCode';
 const PASSCODE_FORM = 'step-sendcode';
 export default Form.extend({
-  form: function () {
+  form: function() {
     return this.el(PASSCODE_FORM);
   },
 
-  codeField: function () {
+  codeField: function() {
     return this.input(CODE_FIELD);
   },
 
-  setCode: function (val) {
+  setCode: function(val) {
     const field = this.codeField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 });

--- a/test/unit/helpers/dom/EnrollU2FForm.js
+++ b/test/unit/helpers/dom/EnrollU2FForm.js
@@ -1,26 +1,26 @@
 import Form from './Form';
 export default Form.extend({
-  enrollInstructions: function () {
+  enrollInstructions: function() {
     return this.$('.u2f-instructions ol');
   },
 
-  enrollWaitingText: function () {
+  enrollWaitingText: function() {
     return this.$('.u2f-enroll-text');
   },
 
-  enrollDeviceImages: function () {
+  enrollDeviceImages: function() {
     return this.el('u2f-devices');
   },
 
-  enrollSpinningIcon: function () {
+  enrollSpinningIcon: function() {
     return this.el('u2f-waiting');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  errorHtml: function () {
+  errorHtml: function() {
     return this.el('o-form-error-html').find('strong');
   },
 });

--- a/test/unit/helpers/dom/EnrollUserForm.js
+++ b/test/unit/helpers/dom/EnrollUserForm.js
@@ -1,12 +1,12 @@
 import Form from './Form';
 export default Form.extend({
-  formTitle: function () {
+  formTitle: function() {
     return this.$('.enroll-user .okta-form-title');
   },
-  formButton: function () {
+  formButton: function() {
     return this.$('.enroll-user .button-primary');
   },
-  formInputs: function (field) {
+  formInputs: function(field) {
     return this.inputWrap(field);
   },
 });

--- a/test/unit/helpers/dom/EnrollWebauthnForm.js
+++ b/test/unit/helpers/dom/EnrollWebauthnForm.js
@@ -1,26 +1,26 @@
 import Form from './Form';
 export default Form.extend({
-  enrollInstructions: function () {
+  enrollInstructions: function() {
     return this.$('.webauthn-enroll-instructions p');
   },
 
-  enrollEdgeInstructions: function () {
+  enrollEdgeInstructions: function() {
     return this.$('.webauthn-edge-text p');
   },
 
-  enrollRestrictions: function () {
+  enrollRestrictions: function() {
     return this.$('.webauthn-restrictions-text p');
   },
 
-  enrollSpinningIcon: function () {
+  enrollSpinningIcon: function() {
     return this.el('webauthn-waiting');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  errorHtml: function () {
+  errorHtml: function() {
     return this.el('o-form-error-html').find('strong');
   },
 });

--- a/test/unit/helpers/dom/EnrollWindowsHelloForm.js
+++ b/test/unit/helpers/dom/EnrollWindowsHelloForm.js
@@ -1,18 +1,18 @@
 import Form from './Form';
 export default Form.extend({
-  hasErrorHtml: function () {
+  hasErrorHtml: function() {
     return this.el('o-form-error-html').length === 1;
   },
 
-  spinner: function () {
+  spinner: function() {
     return this.el('o-form-okta-waiting-spinner');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 
-  buttonBar: function () {
+  buttonBar: function() {
     return this.$('.o-form-button-bar');
   },
 });

--- a/test/unit/helpers/dom/ErrorStateForm.js
+++ b/test/unit/helpers/dom/ErrorStateForm.js
@@ -1,7 +1,7 @@
 import Form from './Form';
 const CLASS_SELECTOR = '.error-state';
 export default Form.extend({
-  isErrorStateView: function () {
+  isErrorStateView: function() {
     return this.$(CLASS_SELECTOR).length === 1;
   },
 });

--- a/test/unit/helpers/dom/Form.js
+++ b/test/unit/helpers/dom/Form.js
@@ -1,40 +1,40 @@
 import { _, $ } from 'okta';
 import Dom from './Dom';
 export default Dom.extend({
-  titleText: function () {
+  titleText: function() {
     return this.el('o-form-head').trimmedText();
   },
 
-  subtitleText: function () {
+  subtitleText: function() {
     return this.el('o-form-explain').trimmedText();
   },
 
-  subtitle: function () {
+  subtitle: function() {
     return this.el('o-form-explain');
   },
 
-  inputWrap: function (field) {
+  inputWrap: function(field) {
     return this.el('o-form-input-' + field);
   },
 
-  input: function (field) {
+  input: function(field) {
     return this.inputWrap(field).find('input');
   },
 
-  inlineLabel: function (field) {
+  inlineLabel: function(field) {
     return this.inputWrap(field).find('.o-form-label-inline');
   },
 
-  select: function (field) {
+  select: function(field) {
     return this.inputWrap(field).find('select');
   },
 
-  autocomplete: function (field) {
+  autocomplete: function(field) {
     return this.input(field).attr('autocomplete');
   },
 
-  selectOptions: function (field) {
-    return _.map(this.select(field).find('option'), function (el) {
+  selectOptions: function(field) {
+    return _.map(this.select(field).find('option'), function(el) {
       return {
         val: el.value,
         text: $.trim(el.innerHTML),
@@ -42,11 +42,11 @@ export default Dom.extend({
     });
   },
 
-  selectedOption: function (field) {
+  selectedOption: function(field) {
     return this.inputWrap(field).find('.chzn-single span').trimmedText();
   },
 
-  selectOption: function (field, val) {
+  selectOption: function(field, val) {
     const $select = this.select(field);
 
     $select.val(val);
@@ -54,14 +54,14 @@ export default Dom.extend({
     $select.trigger('change');
   },
 
-  explain: function (field) {
+  explain: function(field) {
     const $container = this.inputWrap(field).parent();
     const $explain = $container.find('.o-form-explain');
 
     return $explain;
   },
 
-  error: function (field) {
+  error: function(field) {
     const $container = this.inputWrap(field).parent();
     // container holds input and error description
 
@@ -118,23 +118,23 @@ export default Dom.extend({
     return $error;
   },
 
-  checkbox: function (field) {
+  checkbox: function(field) {
     return this.inputWrap(field).find(':checkbox');
   },
 
-  checkboxLabel: function (field) {
+  checkboxLabel: function(field) {
     return this.inputWrap(field).find('label');
   },
 
-  checkboxLabelText: function (field) {
+  checkboxLabelText: function(field) {
     return this.checkboxLabel(field).trimmedText();
   },
 
-  labelText: function (field) {
+  labelText: function(field) {
     return this.inputWrap(field).closest('[data-se="o-form-fieldset"]').find('label').trimmedText();
   },
 
-  tooltipApi: function (field) {
+  tooltipApi: function(field) {
     let element;
     const formInput = this.inputWrap(field);
 
@@ -147,7 +147,7 @@ export default Dom.extend({
     return $(element).qtip('api');
   },
 
-  tooltipText: function (field) {
+  tooltipText: function(field) {
     let api;
     let tooltipText;
 
@@ -161,55 +161,55 @@ export default Dom.extend({
     return tooltipText;
   },
 
-  button: function (selector) {
+  button: function(selector) {
     return this.$(selector + '.button');
   },
 
-  submitButton: function () {
+  submitButton: function() {
     return $('[data-type="save"]');
   },
 
-  submitButtonText: function () {
+  submitButtonText: function() {
     return this.submitButton().val();
   },
 
-  submit: function () {
+  submit: function() {
     this.submitButton().click();
   },
 
-  getErrors: function () {
+  getErrors: function() {
     return this.$('.okta-form-infobox-error');
   },
 
-  hasErrors: function () {
+  hasErrors: function() {
     return this.getErrors().length > 0;
   },
 
-  errorBox: function () {
+  errorBox: function() {
     return this.el('o-form-error-container').find('.infobox-error');
   },
 
-  errorMessage: function () {
+  errorMessage: function() {
     return this.$('.okta-form-infobox-error p').text().trim();
   },
 
-  hasFieldErrors: function (field) {
+  hasFieldErrors: function(field) {
     return this.inputWrap(field).next('.okta-form-input-error').length > 0;
   },
 
-  fieldErrorMessage: function (field) {
+  fieldErrorMessage: function(field) {
     return this.inputWrap(field).next('.okta-form-input-error').text().trim();
   },
 
-  accessibilityText: function () {
+  accessibilityText: function() {
     return this.$('.accessibility-text').text().trim();
   },
 
-  warningMessage: function () {
+  warningMessage: function() {
     return this.$('.okta-form-infobox-warning p').text().trim();
   },
 
-  hasWarningMessage: function () {
+  hasWarningMessage: function() {
     return this.$('.okta-form-infobox-warning').length > 0;
   },
 });

--- a/test/unit/helpers/dom/IDPDiscoveryForm.js
+++ b/test/unit/helpers/dom/IDPDiscoveryForm.js
@@ -3,23 +3,23 @@ const IDP_DISCOVERY_USERNAME_LABEL = 'label[for="idp-discovery-username"]';
 const CLASS_SELECTOR = '.idp-discovery';
 const NEXT_BUTTON = '.button.button-primary';
 export default PrimaryAuthForm.extend({
-  isIDPDiscovery: function () {
+  isIDPDiscovery: function() {
     return this.$(CLASS_SELECTOR).length === 1;
   },
 
-  idpDiscoveryForm: function () {
+  idpDiscoveryForm: function() {
     return this.$(CLASS_SELECTOR + ' form');
   },
 
-  idpDiscoveryUsernameLabel: function () {
+  idpDiscoveryUsernameLabel: function() {
     return this.$(IDP_DISCOVERY_USERNAME_LABEL);
   },
 
-  nextButton: function () {
+  nextButton: function() {
     return this.$(NEXT_BUTTON);
   },
 
-  inputsDisabled: function () {
+  inputsDisabled: function() {
     return this.usernameField().is(':disabled') && this.rememberMeCheckbox().is(':disabled');
   },
 });

--- a/test/unit/helpers/dom/MfaVerifyForm.js
+++ b/test/unit/helpers/dom/MfaVerifyForm.js
@@ -8,221 +8,221 @@ const AUTO_PUSH = 'autoPush';
 const FACTOR_PUSH = 'factor-push';
 const NUMBER_CHALLENGE_VIEW_CLASS = '.number-challenge-view';
 export default Form.extend({
-  isDuo: function () {
+  isDuo: function() {
     return this.el('factor-duo').length === 1;
   },
 
-  isPush: function () {
+  isPush: function() {
     return this.el(FACTOR_PUSH).length === 1;
   },
 
-  isSecurityQuestion: function () {
+  isSecurityQuestion: function() {
     return this.el('factor-question').length === 1;
   },
 
-  isTOTP: function () {
+  isTOTP: function() {
     return this.el('factor-totp').length === 1;
   },
 
-  isSMS: function () {
+  isSMS: function() {
     return this.el('factor-sms').length === 1;
   },
 
-  isCall: function () {
+  isCall: function() {
     return this.el('factor-call').length === 1;
   },
 
-  isEmail: function () {
+  isEmail: function() {
     return this.el('factor-email').length === 1;
   },
 
-  isInlineTOTP: function () {
+  isInlineTOTP: function() {
     return this.el('factor-inline-totp').length === 1;
   },
 
-  isPassword: function () {
+  isPassword: function() {
     return this.el('factor-password').length === 1;
   },
 
-  isCustomFactor: function () {
+  isCustomFactor: function() {
     return this.el('factor-custom').length === 1;
   },
 
-  accessibilityText: function () {
+  accessibilityText: function() {
     return this.$('.accessibility-text').trimmedText();
   },
 
-  answerField: function () {
+  answerField: function() {
     return this.input(ANSWER_FIELD);
   },
 
-  answerLabel: function () {
+  answerLabel: function() {
     return this.$(ANSWER_LABEL);
   },
 
-  setAnswer: function (val) {
+  setAnswer: function(val) {
     const field = this.answerField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  showAnswerLabelText: function () {
+  showAnswerLabelText: function() {
     return this.checkboxLabelText(SHOW_ANSWER_FIELD);
   },
 
-  answerButtonsContainer: function () {
+  answerButtonsContainer: function() {
     return this.el('o-form-input-answer').find('.password-toggle');
   },
 
-  showAnswerButton: function () {
+  showAnswerButton: function() {
     return this.el('o-form-input-answer').find('.button-show');
   },
 
-  hideAnswerButton: function () {
+  hideAnswerButton: function() {
     return this.el('o-form-input-answer').find('.button-hide');
   },
 
-  passwordField: function () {
+  passwordField: function() {
     return this.input(PASSWORD_FIELD);
   },
 
-  setPassword: function (val) {
+  setPassword: function(val) {
     const field = this.passwordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  showPasswordLabelText: function () {
+  showPasswordLabelText: function() {
     return this.checkboxLabelText(SHOW_ANSWER_FIELD);
   },
 
-  passwordButtonsContainer: function () {
+  passwordButtonsContainer: function() {
     return this.el('o-form-input-password').find('.password-toggle');
   },
 
-  showPasswordButton: function () {
+  showPasswordButton: function() {
     return this.el('o-form-input-password').find('.button-show');
   },
 
-  hidePasswordButton: function () {
+  hidePasswordButton: function() {
     return this.el('o-form-input-password').find('.button-hide');
   },
 
-  rememberDeviceCheckbox: function () {
+  rememberDeviceCheckbox: function() {
     return this.checkbox(REMEMBER_DEVICE);
   },
 
-  rememberDeviceLabelText: function () {
+  rememberDeviceLabelText: function() {
     return this.checkboxLabelText(REMEMBER_DEVICE);
   },
 
-  isRememberDeviceChecked: function () {
+  isRememberDeviceChecked: function() {
     return this.checkbox(REMEMBER_DEVICE).prop('checked');
   },
 
-  setRememberDevice: function (val) {
+  setRememberDevice: function(val) {
     const rememberDevice = this.rememberDeviceCheckbox();
 
     rememberDevice.prop('checked', val);
     rememberDevice.trigger('change');
   },
 
-  autoPushCheckbox: function () {
+  autoPushCheckbox: function() {
     return this.checkbox(AUTO_PUSH);
   },
 
-  autoPushLabelText: function () {
+  autoPushLabelText: function() {
     return this.checkboxLabelText(AUTO_PUSH);
   },
 
-  isAutoPushChecked: function () {
+  isAutoPushChecked: function() {
     return this.checkbox(AUTO_PUSH).prop('checked');
   },
 
-  setAutoPush: function (val) {
+  setAutoPush: function(val) {
     const autoPush = this.autoPushCheckbox();
 
     autoPush.prop('checked', val);
     autoPush.trigger('change');
   },
 
-  isPushSent: function () {
+  isPushSent: function() {
     const buttonText = 'Push sent!';
     return this.button('.mfa-verify ').val() === buttonText
       && this.accessibilityText() === buttonText;
   },
 
-  numberChallengeView: function () {
+  numberChallengeView: function() {
     return this.el(FACTOR_PUSH).find(NUMBER_CHALLENGE_VIEW_CLASS);
   },
 
-  getChallengeNumber: function () {
+  getChallengeNumber: function() {
     return this.el('challenge-number').text().trim();
   },
 
-  smsSendCode: function () {
+  smsSendCode: function() {
     return this.el('sms-send-code');
   },
 
-  makeCall: function () {
+  makeCall: function() {
     return this.el('make-call');
   },
 
-  inlineTOTPVerify: function () {
+  inlineTOTPVerify: function() {
     return this.el('inline-totp-verify');
   },
 
-  inlineTOTPVerifyText: function () {
+  inlineTOTPVerifyText: function() {
     return this.inlineTOTPVerify().trimmedText();
   },
 
-  inlineTOTPAdd: function () {
+  inlineTOTPAdd: function() {
     return this.el('inline-totp-add');
   },
 
-  inlineTOTPAddText: function () {
+  inlineTOTPAddText: function() {
     return this.inlineTOTPAdd().trimmedText();
   },
 
-  iframe: function () {
+  iframe: function() {
     return this.$('iframe');
   },
 
-  passCodeErrorField: function () {
+  passCodeErrorField: function() {
     return this.error('answer');
   },
 
-  passwordErrorField: function () {
+  passwordErrorField: function() {
     return this.error('password');
   },
 
-  getAutocomplete: function () {
+  getAutocomplete: function() {
     return this.autocomplete(ANSWER_FIELD);
   },
 
-  signoutLink: function ($sandbox) {
+  signoutLink: function($sandbox) {
     return $sandbox.find('[data-se=signout-link]');
   },
 
-  passwordToggleShowContainer: function () {
+  passwordToggleShowContainer: function() {
     return this.$('.password-toggle span.button-show');
   },
 
-  passwordToggleHideContainer: function () {
+  passwordToggleHideContainer: function() {
     return this.$('.password-toggle span.button-hide');
   },
 
-  factorPageCustomLink: function ($sandbox) {
+  factorPageCustomLink: function($sandbox) {
     return $sandbox.find('.js-factor-page-custom-link');
   },
 
-  factorPageCustomLinkLabel: function ($sandbox) {
+  factorPageCustomLinkLabel: function($sandbox) {
     return this.factorPageCustomLink($sandbox).text();
   },
 
-  factorPageCustomLinkHref: function ($sandbox) {
+  factorPageCustomLinkHref: function($sandbox) {
     return this.factorPageCustomLink($sandbox).attr('href');
   },
 });

--- a/test/unit/helpers/dom/PasswordExpiredForm.js
+++ b/test/unit/helpers/dom/PasswordExpiredForm.js
@@ -3,88 +3,88 @@ const OLD_PASS_FIELD = 'oldPassword';
 const NEW_PASS_FIELD = 'newPassword';
 const CONFIRM_PASS_FIELD = 'confirmPassword';
 export default Form.extend({
-  passwordRequirementsHtmlList: function () {
+  passwordRequirementsHtmlList: function() {
     return this.el('password-requirements-html');
   },
 
-  passwordRequirementsHtmlHeader: function () {
+  passwordRequirementsHtmlHeader: function() {
     return this.passwordRequirementsHtmlList().find('.password-requirements--header');
   },
 
-  passwordRequirementsHtmlListItems: function () {
+  passwordRequirementsHtmlListItems: function() {
     return this.passwordRequirementsHtmlList().find('.password-requirements--list-item');
   },
 
-  oldPassField: function () {
+  oldPassField: function() {
     return this.input(OLD_PASS_FIELD);
   },
 
-  oldPassFieldError: function () {
+  oldPassFieldError: function() {
     return this.error(OLD_PASS_FIELD);
   },
 
-  setOldPass: function (val) {
+  setOldPass: function(val) {
     const field = this.oldPassField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  newPassField: function () {
+  newPassField: function() {
     return this.input(NEW_PASS_FIELD);
   },
 
-  newPassFieldError: function () {
+  newPassFieldError: function() {
     return this.error(NEW_PASS_FIELD);
   },
 
-  setNewPass: function (val) {
+  setNewPass: function(val) {
     const field = this.newPassField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  confirmPassField: function () {
+  confirmPassField: function() {
     return this.input(CONFIRM_PASS_FIELD);
   },
 
-  confirmPassFieldError: function () {
+  confirmPassFieldError: function() {
     return this.error(CONFIRM_PASS_FIELD);
   },
 
-  setConfirmPass: function (val) {
+  setConfirmPass: function(val) {
     const field = this.confirmPassField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  skipLink: function () {
+  skipLink: function() {
     return this.el('skip-link');
   },
 
-  skip: function () {
+  skip: function() {
     return this.skipLink().click();
   },
 
-  signoutLink: function () {
+  signoutLink: function() {
     return this.el('signout-link');
   },
 
-  signout: function () {
+  signout: function() {
     return this.signoutLink().click();
   },
 
-  customButton: function () {
+  customButton: function() {
     return this.el('custom-button');
   },
 
-  customButtonText: function () {
+  customButtonText: function() {
     return this.el('custom-button').trimmedText();
   },
 
-  clickCustomButton: function () {
+  clickCustomButton: function() {
     this.el('custom-button').click();
   },
 });

--- a/test/unit/helpers/dom/PasswordResetForm.js
+++ b/test/unit/helpers/dom/PasswordResetForm.js
@@ -2,57 +2,57 @@ import Form from './Form';
 const NEW_PASSWORD_FIELD = 'newPassword';
 const CONFIRM_PASSWORD_FIELD = 'confirmPassword';
 export default Form.extend({
-  passwordRequirementsHtmlList: function () {
+  passwordRequirementsHtmlList: function() {
     return this.el('password-requirements-html');
   },
 
-  passwordRequirementsHtmlHeader: function () {
+  passwordRequirementsHtmlHeader: function() {
     return this.passwordRequirementsHtmlList().find('.password-requirements--header');
   },
 
-  passwordRequirementsHtmlListItems: function () {
+  passwordRequirementsHtmlListItems: function() {
     return this.passwordRequirementsHtmlList().find('.password-requirements--list-item');
   },
 
-  newPasswordField: function () {
+  newPasswordField: function() {
     return this.input(NEW_PASSWORD_FIELD);
   },
 
-  getNewPasswordAutocomplete: function () {
+  getNewPasswordAutocomplete: function() {
     return this.autocomplete(NEW_PASSWORD_FIELD);
   },
 
-  confirmPasswordField: function () {
+  confirmPasswordField: function() {
     return this.input(CONFIRM_PASSWORD_FIELD);
   },
 
-  getConfirmPasswordAutocomplete: function () {
+  getConfirmPasswordAutocomplete: function() {
     return this.autocomplete(CONFIRM_PASSWORD_FIELD);
   },
 
-  setNewPassword: function (val) {
+  setNewPassword: function(val) {
     const field = this.newPasswordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setConfirmPassword: function (val) {
+  setConfirmPassword: function(val) {
     const field = this.confirmPasswordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  newPassFieldError: function () {
+  newPassFieldError: function() {
     return this.error(NEW_PASSWORD_FIELD);
   },
 
-  confirmPassFieldError: function () {
+  confirmPassFieldError: function() {
     return this.error(CONFIRM_PASSWORD_FIELD);
   },
 
-  signoutLink: function () {
+  signoutLink: function() {
     return this.el('signout-link');
   },
 });

--- a/test/unit/helpers/dom/PivForm.js
+++ b/test/unit/helpers/dom/PivForm.js
@@ -1,14 +1,14 @@
 import Form from './Form';
 export default Form.extend({
-  instructions: function () {
+  instructions: function() {
     return this.$('.piv-verify-text p').trimmedText();
   },
 
-  spinningIcon: function () {
+  spinningIcon: function() {
     return this.el('piv-waiting');
   },
 
-  backLink: function () {
+  backLink: function() {
     return this.el('back-link');
   },
 });

--- a/test/unit/helpers/dom/PollingForm.js
+++ b/test/unit/helpers/dom/PollingForm.js
@@ -1,9 +1,9 @@
 import Form from './Form';
 export default Form.extend({
-  pageTitle: function () {
+  pageTitle: function() {
     return this.$('.poll-controller .okta-form-title');
   },
-  cancelButton: function () {
+  cancelButton: function() {
     return this.$('.poll-controller .o-form-button-bar input');
   },
 });

--- a/test/unit/helpers/dom/PrimaryAuthForm.js
+++ b/test/unit/helpers/dom/PrimaryAuthForm.js
@@ -10,99 +10,99 @@ const SECURITY_BEACON = 'security-beacon';
 const CLASS_SELECTOR = '.primary-auth';
 const SIGN_IN_BUTTON = '.button.button-primary';
 export default Form.extend({
-  isPrimaryAuth: function () {
+  isPrimaryAuth: function() {
     return this.$(CLASS_SELECTOR).length === 1;
   },
 
-  primaryAuthForm: function () {
+  primaryAuthForm: function() {
     return this.$(CLASS_SELECTOR + ' form');
   },
 
-  usernameField: function () {
+  usernameField: function() {
     return this.input(USERNAME_FIELD);
   },
 
-  usernameLabel: function () {
+  usernameLabel: function() {
     return this.$(USERNAME_LABEL);
   },
 
-  usernameExplain: function () {
+  usernameExplain: function() {
     return this.explain(USERNAME_FIELD);
   },
 
-  usernameErrorField: function () {
+  usernameErrorField: function() {
     return this.error(USERNAME_FIELD);
   },
 
-  getUsernameFieldAutocomplete: function () {
+  getUsernameFieldAutocomplete: function() {
     return this.autocomplete(USERNAME_FIELD);
   },
 
-  passwordField: function () {
+  passwordField: function() {
     return this.input(PASSWORD_FIELD);
   },
 
-  passwordLabel: function () {
+  passwordLabel: function() {
     return this.$(PASSWORD_LABEL);
   },
 
-  passwordExplain: function () {
+  passwordExplain: function() {
     return this.explain(PASSWORD_FIELD);
   },
 
-  passwordErrorField: function () {
+  passwordErrorField: function() {
     return this.error(PASSWORD_FIELD);
   },
 
-  getPasswordFieldAutocomplete: function () {
+  getPasswordFieldAutocomplete: function() {
     return this.autocomplete(PASSWORD_FIELD);
   },
 
-  signInButton: function () {
+  signInButton: function() {
     return this.$(SIGN_IN_BUTTON);
   },
 
-  rememberMeCheckbox: function () {
+  rememberMeCheckbox: function() {
     return this.checkbox(REMEMBER_ME_FIELD);
   },
 
-  rememberMeLabelText: function () {
+  rememberMeLabelText: function() {
     return this.checkboxLabelText(REMEMBER_ME_FIELD);
   },
 
-  rememberMeCheckboxStatus: function () {
+  rememberMeCheckboxStatus: function() {
     const isChecked = this.$(REMEMBER_ME_LABEL).hasClass('checked');
 
     return isChecked ? 'checked' : 'unchecked';
   },
 
-  usernameTooltipText: function () {
+  usernameTooltipText: function() {
     return this.tooltipText(USERNAME_FIELD);
   },
 
-  passwordTooltipText: function () {
+  passwordTooltipText: function() {
     return this.tooltipText(PASSWORD_FIELD);
   },
 
-  securityImageTooltipText: function () {
+  securityImageTooltipText: function() {
     return this.tooltipText(SECURITY_BEACON);
   },
 
-  isSecurityImageTooltipDestroyed: function () {
+  isSecurityImageTooltipDestroyed: function() {
     const api = this.tooltipApi(SECURITY_BEACON);
 
     return api ? api.destroyed : true;
   },
 
-  securityBeacon: function () {
+  securityBeacon: function() {
     return this.el(SECURITY_BEACON);
   },
 
-  securityBeaconContainer: function () {
+  securityBeaconContainer: function() {
     return this.$('.beacon-container');
   },
 
-  editingUsername: function (val) {
+  editingUsername: function(val) {
     const field = this.usernameField();
 
     field.val(val);
@@ -110,70 +110,70 @@ export default Form.extend({
     return field;
   },
 
-  setUsername: function (val) {
+  setUsername: function(val) {
     this.editingUsername(val).trigger('focusout');
   },
 
-  setPassword: function (val) {
+  setPassword: function(val) {
     const field = this.passwordField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setRememberMe: function (val) {
+  setRememberMe: function(val) {
     const field = this.rememberMeCheckbox();
 
     field.prop('checked', val);
     field.trigger('change');
   },
 
-  helpFooter: function () {
+  helpFooter: function() {
     return this.$('.js-help');
   },
 
-  helpFooterLabel: function () {
+  helpFooterLabel: function() {
     return this.helpFooter().text();
   },
 
-  helpLink: function () {
+  helpLink: function() {
     return this.$('.js-help-link');
   },
 
-  helpLinkLabel: function () {
+  helpLinkLabel: function() {
     return this.helpLink().text();
   },
 
-  helpLinkHref: function () {
+  helpLinkHref: function() {
     return this.helpLink().attr('href');
   },
 
-  forgotPasswordLink: function () {
+  forgotPasswordLink: function() {
     return this.$('.js-forgot-password');
   },
 
-  forgotPasswordLabel: function () {
+  forgotPasswordLabel: function() {
     return this.forgotPasswordLink().text();
   },
 
-  forgotPasswordLinkVisible: function () {
+  forgotPasswordLinkVisible: function() {
     return this.forgotPasswordLink().is(':visible');
   },
 
-  unlockLink: function () {
+  unlockLink: function() {
     return this.$('.js-unlock');
   },
 
-  unlockLabel: function () {
+  unlockLabel: function() {
     return this.unlockLink().text();
   },
 
-  unlockLinkVisible: function () {
+  unlockLinkVisible: function() {
     return this.unlockLink().is(':visible');
   },
 
-  customLinks: function () {
-    return _.map(this.$('a.js-custom'), function (el) {
+  customLinks: function() {
+    return _.map(this.$('a.js-custom'), function(el) {
       const $el = $(el);
       const link = {
         text: $el.text(),
@@ -188,47 +188,47 @@ export default Form.extend({
     });
   },
 
-  primaryAuthContainer: function () {
+  primaryAuthContainer: function() {
     return this.$('.primary-auth-container');
   },
 
-  hasSocialAuthDivider: function () {
+  hasSocialAuthDivider: function() {
     return this.$('.auth-divider').length === 1;
   },
 
-  socialAuthButton: function (idp) {
+  socialAuthButton: function(idp) {
     return this.el('social-auth-' + idp + '-button');
   },
 
-  facebookButton: function () {
+  facebookButton: function() {
     return this.socialAuthButton('facebook');
   },
 
-  googleButton: function () {
+  googleButton: function() {
     return this.socialAuthButton('google');
   },
 
-  appleButton: function () {
+  appleButton: function() {
     return this.socialAuthButton('apple');
   },
 
-  linkedInButton: function () {
+  linkedInButton: function() {
     return this.socialAuthButton('linkedin');
   },
 
-  microsoftButton: function () {
+  microsoftButton: function() {
     return this.socialAuthButton('microsoft');
   },
 
-  socialAuthButtons: function () {
+  socialAuthButtons: function() {
     return this.$('.social-auth-button');
   },
 
-  linksAppearDisabled: function () {
+  linksAppearDisabled: function() {
     return this.$('a.link.o-form-disabled').length === this.$('a.link').length;
   },
 
-  inputsDisabled: function () {
+  inputsDisabled: function() {
     return (
       this.usernameField().is(':disabled') &&
       this.passwordField().is(':disabled') &&
@@ -236,43 +236,43 @@ export default Form.extend({
     );
   },
 
-  isDisabled: function () {
+  isDisabled: function() {
     return this.inputsDisabled() && this.linksAppearDisabled();
   },
 
-  additionalAuthButton: function () {
+  additionalAuthButton: function() {
     return this.$('.default-custom-button');
   },
 
-  pivButton: function () {
+  pivButton: function() {
     return this.$('.piv-button');
   },
 
-  authDivider: function () {
+  authDivider: function() {
     return this.$('.auth-divider');
   },
 
-  registrationContainer: function () {
+  registrationContainer: function() {
     return this.$('.registration-container');
   },
 
-  registrationLabel: function () {
+  registrationLabel: function() {
     return this.$('.registration-container .content-container .registration-label');
   },
 
-  registrationLink: function () {
+  registrationLink: function() {
     return this.$('.registration-container .content-container .registration-link');
   },
 
-  passwordToggleContainer: function () {
+  passwordToggleContainer: function() {
     return this.$('.password-toggle');
   },
 
-  passwordToggleShowContainer: function () {
+  passwordToggleShowContainer: function() {
     return this.$('.password-toggle span.button-show');
   },
 
-  passwordToggleHideContainer: function () {
+  passwordToggleHideContainer: function() {
     return this.$('.password-toggle span.button-hide');
   },
 });

--- a/test/unit/helpers/dom/RecoveryChallengeForm.js
+++ b/test/unit/helpers/dom/RecoveryChallengeForm.js
@@ -1,26 +1,26 @@
 import Form from './Form';
 const CODE_FIELD = 'passCode';
 export default Form.extend({
-  codeField: function () {
+  codeField: function() {
     return this.input(CODE_FIELD);
   },
 
-  getAutocompleteCodeField: function () {
+  getAutocompleteCodeField: function() {
     return this.autocomplete(CODE_FIELD);
   },
 
-  setCode: function (val) {
+  setCode: function(val) {
     const field = this.codeField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  resendButton: function () {
+  resendButton: function() {
     return this.el('resend-button');
   },
 
-  signoutLink: function () {
+  signoutLink: function() {
     return this.el('signout-link');
   },
 });

--- a/test/unit/helpers/dom/RecoveryQuestionForm.js
+++ b/test/unit/helpers/dom/RecoveryQuestionForm.js
@@ -4,53 +4,53 @@ const SHOW_ANSWER_FIELD = 'showAnswer';
 const CLASS_SELECTOR = '.recovery-question';
 const BACK_TO_LOGIN_BTN = 'back-button';
 export default Form.extend({
-  isRecoveryQuestion: function () {
+  isRecoveryQuestion: function() {
     return this.$(CLASS_SELECTOR).length === 1;
   },
 
-  answerField: function () {
+  answerField: function() {
     return this.input(ANSWER_FIELD);
   },
 
-  setAnswer: function (val) {
+  setAnswer: function(val) {
     const field = this.answerField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  showAnswerCheckbox: function () {
+  showAnswerCheckbox: function() {
     return this.checkbox(SHOW_ANSWER_FIELD);
   },
 
-  showAnswerLabelText: function () {
+  showAnswerLabelText: function() {
     return this.checkboxLabelText(SHOW_ANSWER_FIELD);
   },
 
-  showAnswerCheckboxStatus: function () {
+  showAnswerCheckboxStatus: function() {
     const isChecked = this.showAnswerCheckbox().prop('checked');
 
     return isChecked ? 'checked' : 'unchecked';
   },
 
-  setShowAnswer: function (val) {
+  setShowAnswer: function(val) {
     const showAnswer = this.showAnswerCheckbox();
 
     showAnswer.prop('checked', val);
     showAnswer.trigger('change');
   },
 
-  signoutLink: function () {
+  signoutLink: function() {
     return this.el('signout-link');
   },
 
   // unlock confirmation form
 
-  backToLoginButton: function () {
+  backToLoginButton: function() {
     return this.el(BACK_TO_LOGIN_BTN);
   },
 
-  goBackToLogin: function () {
+  goBackToLogin: function() {
     this.backToLoginButton().click();
   },
 });

--- a/test/unit/helpers/dom/RegistrationForm.js
+++ b/test/unit/helpers/dom/RegistrationForm.js
@@ -6,102 +6,102 @@ const EMAIL_FIELD = 'email';
 const PASSWORD_FIELD = 'password';
 const REFERRER_FIELD = 'referrer';
 export default Form.extend({
-  firstnameField: function () {
+  firstnameField: function() {
     return this.input(FIRSTNAME_FIELD);
   },
 
-  firstnameErrorField: function () {
+  firstnameErrorField: function() {
     return this.error(FIRSTNAME_FIELD);
   },
 
-  setFirstname: function (val) {
+  setFirstname: function(val) {
     const field = this.firstnameField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  lastnameField: function () {
+  lastnameField: function() {
     return this.input(LASTNAME_FIELD);
   },
 
-  lastnameErrorField: function () {
+  lastnameErrorField: function() {
     return this.error(LASTNAME_FIELD);
   },
 
-  setLastname: function (val) {
+  setLastname: function(val) {
     const field = this.lastnameField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  referrerField: function () {
+  referrerField: function() {
     return this.input(REFERRER_FIELD);
   },
 
-  referrerErrorField: function () {
+  referrerErrorField: function() {
     return this.error(REFERRER_FIELD);
   },
 
-  setReferrer: function (val) {
+  setReferrer: function(val) {
     const field = this.referrerField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  userNameField: function () {
+  userNameField: function() {
     return this.input(USERNAME_FIELD);
   },
 
-  userNameErrorField: function () {
+  userNameErrorField: function() {
     return this.error(USERNAME_FIELD);
   },
 
-  emailField: function () {
+  emailField: function() {
     return this.input(EMAIL_FIELD);
   },
 
-  emailErrorField: function () {
+  emailErrorField: function() {
     return this.error(EMAIL_FIELD);
   },
 
-  setUserName: function (val) {
+  setUserName: function(val) {
     const field = this.userNameField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  setEmail: function (val) {
+  setEmail: function(val) {
     const field = this.emailField();
 
     field.val(val);
     field.trigger('change');
   },
 
-  passwordField: function () {
+  passwordField: function() {
     return this.input(PASSWORD_FIELD);
   },
 
-  passwordErrorField: function () {
+  passwordErrorField: function() {
     return this.error(PASSWORD_FIELD);
   },
 
-  requiredFieldLabel: function () {
+  requiredFieldLabel: function() {
     return this.$('.required-fields-label').text();
   },
 
-  fieldPlaceholder: function (fieldName) {
+  fieldPlaceholder: function(fieldName) {
     return this.$('.okta-form-input-field input[name="' + fieldName + '"]').attr('placeholder');
   },
 
-  getFieldByName: function (fieldName) {
+  getFieldByName: function(fieldName) {
     return this.$('.okta-form-input-field input[name="' + fieldName + '"]');
   },
 
-  setPassword: function (val) {
+  setPassword: function(val) {
     const field = this.passwordField();
 
     field.val(val);
@@ -109,13 +109,13 @@ export default Form.extend({
     field.trigger('input');
   },
 
-  focusOutPassword: function () {
+  focusOutPassword: function() {
     const field = this.passwordField();
 
     field.trigger('focusout');
   },
 
-  hasPasswordComplexityUnsatisfied: function (index) {
+  hasPasswordComplexityUnsatisfied: function(index) {
     return (
       this.$('.subschema-' + index).hasClass('subschema-unsatisfied') &&
       !this.$('.subschema-' + index).hasClass('subschema-satisfied') &&
@@ -123,7 +123,7 @@ export default Form.extend({
     );
   },
 
-  hasPasswordComplexitySatisfied: function (index) {
+  hasPasswordComplexitySatisfied: function(index) {
     return (
       this.$('.subschema-' + index).hasClass('subschema-satisfied') &&
       !this.$('.subschema-' + index).hasClass('subschema-unsatisfied') &&
@@ -131,11 +131,11 @@ export default Form.extend({
     );
   },
 
-  isPasswordComplexitySectionHidden: function (index) {
+  isPasswordComplexitySectionHidden: function(index) {
     return this.$('.subschema-' + index + '>p').hasClass('default-schema');
   },
 
-  passwordContainsUsernameError: function () {
+  passwordContainsUsernameError: function() {
     return this.$('.subschema-4').hasClass('subschema-error');
   },
 });

--- a/test/unit/helpers/dom/v2/IdentifierForm.js
+++ b/test/unit/helpers/dom/v2/IdentifierForm.js
@@ -1,14 +1,14 @@
 import Form from '../Form';
 export default Form.extend({
-  getTitle: function () {
+  getTitle: function() {
     return this.$('.siw-main-body .okta-form-title').text();
   },
 
-  getIdentifierInput: function () {
+  getIdentifierInput: function() {
     return this.$('.siw-main-body .o-form-fieldset-container input[type="text"]');
   },
 
-  getFormSaveButton: function () {
+  getFormSaveButton: function() {
     return this.$('.siw-main-body .o-form-button-bar .button-primary');
   },
 });

--- a/test/unit/helpers/dom/v2/TerminalView.js
+++ b/test/unit/helpers/dom/v2/TerminalView.js
@@ -1,10 +1,10 @@
 import Form from '../Form';
 export default Form.extend({
-  getTitle: function () {
+  getTitle: function() {
     return this.$('.siw-main-body .okta-form-title').text();
   },
 
-  getErrorMessages: function () {
+  getErrorMessages: function() {
     return this.$('.siw-main-body .o-form-error-container').text();
   }
 

--- a/test/unit/helpers/mocks/AuthClient.js
+++ b/test/unit/helpers/mocks/AuthClient.js
@@ -1,12 +1,12 @@
 import Q from 'q';
 
-function addMethodSpy (mock, methodName) {
-  const spy = jasmine.createSpy(methodName + 'Spy').and.callFake(function () {
+function addMethodSpy(mock, methodName) {
+  const spy = jasmine.createSpy(methodName + 'Spy').and.callFake(function() {
     if (!mock.__nextRes) {
       return Q.resolve({});
     }
     if (mock.__nextRes.isFulfilled() && mock.__globalSubscribeFn) {
-      mock.__nextRes.then(function (res) {
+      mock.__nextRes.then(function(res) {
         // Very specific to behavior in OktaAuth. Will remove when we remove
         // this logic
         if (res.status === 'MFA_CHALLENGE') {
@@ -15,7 +15,7 @@ function addMethodSpy (mock, methodName) {
         mock.__globalSubscribeFn(null, res);
       });
     } else if (mock.__nextRes.isRejected() && mock.__globalSubscribeFn) {
-      mock.__nextRes.catch(function (err) {
+      mock.__nextRes.catch(function(err) {
         mock.__globalSubscribeFn(err, null);
       });
     }
@@ -25,10 +25,10 @@ function addMethodSpy (mock, methodName) {
   mock[methodName] = spy;
 }
 
-function Mock () {
+function Mock() {
   const self = this;
 
-  this.subscribe = jasmine.createSpy('subscribeSpy').and.callFake(function (fn) {
+  this.subscribe = jasmine.createSpy('subscribeSpy').and.callFake(function(fn) {
     self.__globalSubscribeFn = fn;
   });
   addMethodSpy(this, 'primaryAuth');
@@ -49,13 +49,13 @@ function Mock () {
   addMethodSpy(this, 'getLastResponse');
 }
 
-Mock.prototype.__setNextResponse = function (res) {
+Mock.prototype.__setNextResponse = function(res) {
   const isError = res.responseJSON && res.responseJSON.errorCode;
 
   this.__nextRes = isError ? Q.reject(res) : Q.resolve(res);
 };
 
-Mock.prototype.__invokeResponse = function (res) {
+Mock.prototype.__invokeResponse = function(res) {
   this.__globalSubscribeFn(null, res);
 };
 

--- a/test/unit/helpers/mocks/Util.js
+++ b/test/unit/helpers/mocks/Util.js
@@ -25,31 +25,31 @@ fn.LoremIpsum =
   'ut tempor eros gravida egestas. Curabitur tempus dignissim justo et pellentesque. ' +
   'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.';
 
-fn.mockGetCookie = function (name, value) {
-  spyOn(Cookie, 'getCookie').and.callFake(function (nameGiven) {
+fn.mockGetCookie = function(name, value) {
+  spyOn(Cookie, 'getCookie').and.callFake(function(nameGiven) {
     return name === nameGiven ? value : undefined;
   });
   return Cookie.getCookie;
 };
 
-fn.mockSetCookie = function () {
+fn.mockSetCookie = function() {
   spyOn(Cookie, 'setCookie');
   return Cookie.setCookie;
 };
 
-fn.mockSDKCookie = function (authClient, key, value) {
+fn.mockSDKCookie = function(authClient, key, value) {
   key = key || 'oktaStateToken';
   value = value || 'testStateToken';
   spyOn(authClient.tx.exists, '_get').and.returnValue(value);
 };
 
-fn.mockRemoveCookie = function () {
+fn.mockRemoveCookie = function() {
   spyOn(Cookie, 'removeCookie');
   return Cookie.removeCookie;
 };
 
-fn.mockRouterNavigate = function (router, start) {
-  spyOn(router, 'navigate').and.callFake(function (fragment) {
+fn.mockRouterNavigate = function(router, start) {
+  spyOn(router, 'navigate').and.callFake(function(fragment) {
     Backbone.history.root = '/';
     Backbone.history.loadUrl(fragment);
   });
@@ -60,11 +60,11 @@ fn.mockRouterNavigate = function (router, start) {
   }
 };
 
-fn.mockDuo = function () {
+fn.mockDuo = function() {
   spyOn(Duo, 'init');
 };
 
-fn.mockAjax = function (responses) {
+fn.mockAjax = function(responses) {
   globalFetch = window.fetch;
   window.fetch = null;
   jasmine.Ajax.install();
@@ -76,7 +76,7 @@ fn.mockAjax = function (responses) {
     allResponses = allResponses.concat(responses);
   }
 
-  function respond (request, xhr) {
+  function respond(request, xhr) {
     request.respondWith({
       status: xhr.status,
       responseText: typeof xhr.response === 'string' ? xhr.response : JSON.stringify(xhr.response),
@@ -100,7 +100,7 @@ fn.mockAjax = function (responses) {
     respond(request, xhr);
   });
 
-  function setNextResponse (response, responseTextOnly) {
+  function setNextResponse(response, responseTextOnly) {
     expect(responseTextOnly).toBe(undefined);
 
     if (_.isArray(response)) {
@@ -113,33 +113,33 @@ fn.mockAjax = function (responses) {
   return setNextResponse;
 };
 
-fn.numAjaxRequests = function () {
+fn.numAjaxRequests = function() {
   return jasmine.Ajax.requests.count();
 };
 
-fn.resetAjaxRequests = function () {
+fn.resetAjaxRequests = function() {
   jasmine.Ajax.requests.reset();
 };
 
-fn.lastAjaxRequest = function () {
+fn.lastAjaxRequest = function() {
   return jasmine.Ajax.requests.mostRecent();
 };
 
-fn.getAjaxRequest = function (index) {
+fn.getAjaxRequest = function(index) {
   return jasmine.Ajax.requests.at(index);
 };
 
-fn.unmockAjax = function () {
+fn.unmockAjax = function() {
   window.fetch = globalFetch;
   jasmine.Ajax.uninstall();
 };
 
 // Useful for overriding setting of security image (which tries to load
 // a file that does not exist in our tests)
-fn.mockJqueryCss = function () {
+fn.mockJqueryCss = function() {
   const original = $.fn.css;
 
-  spyOn($.fn, 'css').and.callFake(function () {
+  spyOn($.fn, 'css').and.callFake(function() {
     const data = arguments[0];
 
     switch (data['background-image']) {
@@ -152,37 +152,37 @@ fn.mockJqueryCss = function () {
   });
 };
 
-fn.mockQDelay = function () {
+fn.mockQDelay = function() {
   const original = Q.delay;
 
-  spyOn(Q, 'delay').and.callFake(function () {
+  spyOn(Q, 'delay').and.callFake(function() {
     return original.call(this, 0);
   });
 };
 
-fn.mockRateLimiting = function () {
+fn.mockRateLimiting = function() {
   const deferred = Q.defer();
 
-  spyOn(Q, 'delay').and.callFake(function () {
+  spyOn(Q, 'delay').and.callFake(function() {
     return deferred.promise;
   });
   return deferred;
 };
 
-fn.speedUpDelay = function () {
+fn.speedUpDelay = function() {
   const delay = _.delay;
 
-  spyOn(_, 'delay').and.callFake(function (func, wait, args) {
+  spyOn(_, 'delay').and.callFake(function(func, wait, args) {
     return delay(func, 0, args);
   });
 };
 
 // Random 'state' generator in Auth SDK for OIDC
-fn.mockOIDCStateGenerator = function () {
+fn.mockOIDCStateGenerator = function() {
   spyOn(Math, 'random').and.returnValue(0.1);
 };
 
-fn.loadWellKnownAndKeysCache = function () {
+fn.loadWellKnownAndKeysCache = function() {
   const expirationTime = 2449786329;
   // add /.well-known/openid-configuration and /oauth2/v1/keys to cache
   // so we don't make unnecessary requests
@@ -210,13 +210,13 @@ fn.loadWellKnownAndKeysCache = function () {
   );
 };
 
-fn.stallEnrollFactorPoll = function (authClient, originalAjax) {
+fn.stallEnrollFactorPoll = function(authClient, originalAjax) {
   // Needed in order to reset the mock. Jasmine spies don't have restore()
   if (authClient.options.httpRequestClient.calls) {
     authClient.options.httpRequestClient = originalAjax;
   }
   originalAjax = authClient.options.httpRequestClient;
-  spyOn(authClient.options, 'httpRequestClient').and.callFake(function (method, uri) {
+  spyOn(authClient.options, 'httpRequestClient').and.callFake(function(method, uri) {
     const isPollFn = uri.indexOf('/lifecycle/activate') !== -1;
 
     if (isPollFn) {
@@ -236,7 +236,7 @@ fn.stallEnrollFactorPoll = function (authClient, originalAjax) {
   return originalAjax;
 };
 
-fn.resumeEnrollFactorPoll = function (authClient, originalAjax, response) {
+fn.resumeEnrollFactorPoll = function(authClient, originalAjax, response) {
   if (authClient.options.httpRequestClient.calls) {
     authClient.options.httpRequestClient = originalAjax;
   }
@@ -244,7 +244,7 @@ fn.resumeEnrollFactorPoll = function (authClient, originalAjax, response) {
     response.responseText = JSON.stringify(response.response);
   }
   originalAjax = authClient.options.httpRequestClient;
-  spyOn(authClient.options, 'httpRequestClient').and.callFake(function (method, uri) {
+  spyOn(authClient.options, 'httpRequestClient').and.callFake(function(method, uri) {
     const isPollFn = uri.indexOf('/activate') !== -1;
 
     if (isPollFn) {
@@ -256,28 +256,28 @@ fn.resumeEnrollFactorPoll = function (authClient, originalAjax, response) {
   return originalAjax;
 };
 
-fn.stopRouter = function () {
+fn.stopRouter = function() {
   Backbone.history.stop();
 };
 
 // Needs to be preceded by a call to mockRouterNavigate() with startRouter as true.
-fn.triggerBrowserBackButton = function () {
+fn.triggerBrowserBackButton = function() {
   const args = window.addEventListener.calls.argsFor(0);
 
   expect(args[0]).toBe('popstate');
   const callback = args[1];
 
   callback.call(null, {
-    preventDefault: function () {},
-    stopImmediatePropagation: function () {},
+    preventDefault: function() {},
+    stopImmediatePropagation: function() {},
   });
 };
 
-function isMock (fn) {
+function isMock(fn) {
   return fn._isMock;
 }
 
-function createMock (fn) {
+function createMock(fn) {
   fn._isMock = true;
   return fn;
 }
@@ -290,14 +290,14 @@ function createMock (fn) {
 const timeouts = [];
 let originalSetTimeout;
 
-fn.mockSetTimeout = function () {
+fn.mockSetTimeout = function() {
   if (setTimeout !== window.setTimeout) {
     // eslint-disable-next-line no-console
     console.error('setTimeout !== window.setTimeout. Tests will probably fail. This may be caused by babel polyfill.');
   }
   if (!isMock(window.setTimeout)) {
     originalSetTimeout = window.setTimeout;
-    window.setTimeout = createMock(function (fn, delay) {
+    window.setTimeout = createMock(function(fn, delay) {
       const entry = {
         fn,
         delay,
@@ -312,13 +312,13 @@ fn.mockSetTimeout = function () {
   }
 };
 
-fn.clearAllTimeouts = function () {
+fn.clearAllTimeouts = function() {
   while (timeouts.length) {
     clearTimeout(timeouts.pop().id);
   }
 };
 
-fn.callAllTimeouts = function () {
+fn.callAllTimeouts = function() {
   while (timeouts.length) {
     const entry = timeouts.pop();
     clearTimeout(entry.id);
@@ -329,10 +329,10 @@ fn.callAllTimeouts = function () {
 const intervals = [];
 let originalSetInterval;
 
-fn.mockSetInterval = function () {
+fn.mockSetInterval = function() {
   if (!isMock(window.setInterval)) {
     originalSetInterval = window.setInterval;
-    window.setInterval = createMock(function () {
+    window.setInterval = createMock(function() {
       const id = originalSetInterval.apply(this, arguments);
 
       timeouts.push(id);
@@ -341,7 +341,7 @@ fn.mockSetInterval = function () {
   }
 };
 
-fn.clearAllIntervals = function () {
+fn.clearAllIntervals = function() {
   while (intervals.length) {
     clearTimeout(intervals.pop());
   }
@@ -351,11 +351,11 @@ const registeredRouters = [];
 
 // Call this method in each setup function so that we can do cleanup
 // after the test has run
-fn.registerRouter = function (router) {
+fn.registerRouter = function(router) {
   registeredRouters.push(router);
 };
 
-fn.cleanupRouter = function () {
+fn.cleanupRouter = function() {
   let current;
 
   while (registeredRouters.length) {
@@ -368,11 +368,11 @@ fn.cleanupRouter = function () {
   }
 };
 
-fn.deepCopy = function (res) {
+fn.deepCopy = function(res) {
   return JSON.parse(JSON.stringify(res));
 };
 
-fn.getAutoPushResponse = function (response, autoPushVal) {
+fn.getAutoPushResponse = function(response, autoPushVal) {
   const responseCopy = fn.deepCopy(response);
   const embeddedResponse = responseCopy['response']['_embedded'];
   const factors = embeddedResponse['factors'];

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -12,15 +12,15 @@ const fn = {};
 const WAIT_MAX_TIME = 2000;
 const WAIT_INTERVAL = 20;
 
-const unhandledRejectionListener = function (event) {
+const unhandledRejectionListener = function(event) {
   // We've thrown an unexpected error in the test - setup a fake
   // expectation to expose it to the developer
   expect('Unhandled promise rejection').toEqual(event.reason);
 };
 
-function runTest (jasmineFn, desc, testFn) {
-  jasmineFn(desc, function () {
-    const errListener = function (err) {
+function runTest(jasmineFn, desc, testFn) {
+  jasmineFn(desc, function() {
+    const errListener = function(err) {
       // We've thrown an unexpected error in the test - setup a fake
       // expectation to expose it to the developer
       expect('Unexpected error thrown').toEqual(err.message);
@@ -29,7 +29,7 @@ function runTest (jasmineFn, desc, testFn) {
     window.addEventListener('error', errListener);
     window.addEventListener('unhandledrejection', unhandledRejectionListener);
 
-    return testFn.call(this).then(function () {
+    return testFn.call(this).then(function() {
       const unhandledFailures = Q.getUnhandledReasons();
       if (unhandledFailures.length) {
         // eslint-disable-next-line no-console
@@ -49,18 +49,18 @@ function runTest (jasmineFn, desc, testFn) {
   });
 }
 
-fn.allowUnhandledPromiseRejection = function () {
+fn.allowUnhandledPromiseRejection = function() {
   window.removeEventListener('unhandledrejection', unhandledRejectionListener);
 };
 
-function wrapDescribe (_describe, desc, fn) {
-  return _describe(desc, function () {
-    beforeAll(function () {
+function wrapDescribe(_describe, desc, fn) {
+  return _describe(desc, function() {
+    beforeAll(function() {
       Util.mockSetTimeout();
       Util.mockSetInterval();
     });
 
-    beforeEach(function () {
+    beforeEach(function() {
       this._origDeprecate = Logger.deprecate;
       Logger.deprecate = jasmine.createSpy('deprecate');
 
@@ -71,7 +71,7 @@ function wrapDescribe (_describe, desc, fn) {
       localStorage.clear();
     });
 
-    afterEach(function () {
+    afterEach(function() {
       Logger.deprecate = this._origDeprecate;
       config.version = this._origVersion;
       Util.clearAllTimeouts();
@@ -100,16 +100,16 @@ fn.fitp = runTest.bind({}, fit);
  * @deprecated This function is non deterministic and can affect the output of the tests
  *             Instead use any of the Expect.wait* functions.
  */
-fn.tick = function (returnVal) {
+fn.tick = function(returnVal) {
   const deferred = Q.defer();
 
   // Using four setTimeouts to remove flakiness (some tests need an extra
   // cycle when transitioning/setting up, and the new tick in OktaAuth makes
   // for three)
-  setTimeout(function () {
-    setTimeout(function () {
-      setTimeout(function () {
-        setTimeout(function () {
+  setTimeout(function() {
+    setTimeout(function() {
+      setTimeout(function() {
+        setTimeout(function() {
           deferred.resolve(returnVal);
         });
       });
@@ -118,8 +118,8 @@ fn.tick = function (returnVal) {
   return deferred.promise;
 };
 
-fn.waitForController = function (pageClass, resolveValue) {
-  const condition = function () {
+fn.waitForController = function(pageClass, resolveValue) {
+  const condition = function() {
     const pages = $('.auth-content-inner', $sandbox).children();
 
     return pages.length === 1 && pages.eq(0).hasClass(pageClass);
@@ -128,8 +128,8 @@ fn.waitForController = function (pageClass, resolveValue) {
   return fn.wait(condition, resolveValue);
 };
 
-fn.waitForVerifyView = function (verifyClass, resolveValue) {
-  const condition = function () {
+fn.waitForVerifyView = function(verifyClass, resolveValue) {
+  const condition = function() {
     const pages = $('.auth-content-inner', $sandbox).children();
     const txSettled = pages.length === 1 && pages.eq(0).hasClass('mfa-verify');
 
@@ -139,32 +139,32 @@ fn.waitForVerifyView = function (verifyClass, resolveValue) {
   return fn.wait(condition, resolveValue);
 };
 
-fn.waitForCss = function (css, resolveValue) {
-  const condition = function () {
+fn.waitForCss = function(css, resolveValue) {
+  const condition = function() {
     return $(css, $sandbox).length > 0;
   };
 
   return fn.wait(condition, resolveValue);
 };
 
-fn.waitForSpyCall = function (spy, resolveValue) {
-  const condition = function () {
+fn.waitForSpyCall = function(spy, resolveValue) {
+  const condition = function() {
     return spy.calls.count() > 0;
   };
 
   return fn.wait(condition, resolveValue);
 };
 
-fn.waitForAjaxRequest = function (resolveValue) {
-  const condition = function () {
+fn.waitForAjaxRequest = function(resolveValue) {
+  const condition = function() {
     return jasmine.Ajax.requests.count() > 0;
   };
 
   return fn.wait(condition, resolveValue);
 };
 
-fn.waitForAjaxRequests = function (numRequests, resolveValue, timeout) {
-  const condition = function () {
+fn.waitForAjaxRequests = function(numRequests, resolveValue, timeout) {
+  const condition = function() {
     return jasmine.Ajax.requests.count() === numRequests;
   };
 
@@ -174,8 +174,8 @@ fn.waitForAjaxRequests = function (numRequests, resolveValue, timeout) {
 /**
  * Use this function to wait for an error view which has top level class '.okta-form-infobox-error'.
  */
-fn.waitForFormError = function (form, resolveValue) {
-  const condition = function () {
+fn.waitForFormError = function(form, resolveValue) {
+  const condition = function() {
     return form.hasErrors();
   };
 
@@ -185,8 +185,8 @@ fn.waitForFormError = function (form, resolveValue) {
 /**
  * Use this function to wait for an error view which has top level class '.okta-infobox-error'.
  */
-fn.waitForFormErrorBox = function (form, resolveValue) {
-  const condition = function () {
+fn.waitForFormErrorBox = function(form, resolveValue) {
+  const condition = function() {
     return form.errorBox().length > 0;
   };
 
@@ -196,8 +196,8 @@ fn.waitForFormErrorBox = function (form, resolveValue) {
 /**
  * Wait for a window event handler to be added
  */
-fn.waitForWindowListener = function (eventName, resolveValue) {
-  const condition = function () {
+fn.waitForWindowListener = function(eventName, resolveValue) {
+  const condition = function() {
     const calls = window.addEventListener.calls;
     const count = calls.count();
     if (count) {
@@ -212,8 +212,8 @@ fn.waitForWindowListener = function (eventName, resolveValue) {
 };
 
 
-fn.wait = function (condition, resolveValue, timeout) {
-  function check (success, fail, triesLeft) {
+fn.wait = function(condition, resolveValue, timeout) {
+  function check(success, fail, triesLeft) {
     if (condition()) {
       success(resolveValue);
     } else if (triesLeft <= 0) {
@@ -222,56 +222,56 @@ fn.wait = function (condition, resolveValue, timeout) {
       setTimeout(check.bind(null, success, fail, triesLeft - 1), WAIT_INTERVAL);
     }
   }
-  return Q.Promise(function (resolve, reject) {
+  return Q.Promise(function(resolve, reject) {
     const numTries = (timeout || WAIT_MAX_TIME) / WAIT_INTERVAL;
 
     check(resolve, reject, numTries);
   });
 };
 
-fn.isTextField = function ($input) {
+fn.isTextField = function($input) {
   expect($input.length).toBe(1);
   expect($input.attr('type')).toEqual('text');
 };
 
-fn.isPasswordField = function ($input) {
+fn.isPasswordField = function($input) {
   expect($input.length).toBe(1);
   expect($input.attr('type')).toEqual('password');
 };
 
-fn.isLink = function ($el) {
+fn.isLink = function($el) {
   expect($el.length).toBe(1);
   expect($el.is('a')).toBe(true);
 };
 
-fn.isEmptyFieldError = function ($errorField) {
+fn.isEmptyFieldError = function($errorField) {
   expect($errorField.length).toBe(1);
   expect($errorField.text()).toBe('This field cannot be left blank');
 };
 
-fn.isNotVisible = function ($input) {
+fn.isNotVisible = function($input) {
   expect($input.length).toBe(1);
   expect(Dom.isVisible($input)).toBe(false);
 };
 
-fn.isVisible = function ($input) {
+fn.isVisible = function($input) {
   expect($input.length).toBe(1);
   expect(Dom.isVisible($input)).toBe(true);
 };
 
-fn.isController = function (className, controller) {
+fn.isController = function(className, controller) {
   expect(controller.className).toBe(className);
   fn.isVisible(controller.$el);
 };
 
-fn.deprecated = function (msg) {
+fn.deprecated = function(msg) {
   expect(Logger.deprecate).toHaveBeenCalledWith(msg);
 };
 
 // Convenience function to test a json post - pass in url and data, and it
 // will test the rest. Note: We JSON.stringify data here so you don't have to
 // JSON posts are done using fetch
-fn.isJsonPost = function (args, expected) {
+fn.isJsonPost = function(args, expected) {
   // Jasmine times out if args doesn't exist when we try to retrieve
   // its properties. This makes it fail faster.
   if (!args) {
@@ -291,7 +291,7 @@ fn.isJsonPost = function (args, expected) {
 };
 
 // Form post is done using $.post
-fn.isFormPost = function (args, expected) {
+fn.isFormPost = function(args, expected) {
   if (!args) {
     expect(args).not.toBeUndefined();
     return;
@@ -309,7 +309,7 @@ fn.isFormPost = function (args, expected) {
 };
 
 // For JSON assets such as language files
-fn.isJsonAssetRequest = function (args, expected) {
+fn.isJsonAssetRequest = function(args, expected) {
   // Jasmine times out if args doesn't exist when we try to retrieve
   // its properties. This makes it fail faster.
   if (!args) {
@@ -385,7 +385,7 @@ const controllerClasses = {
   ErrorState: 'error-state',
 };
 
-_.each(controllerClasses, function (className, controller) {
+_.each(controllerClasses, function(className, controller) {
   fn['waitFor' + controller] = _.partial(fn.waitForController, className);
   fn['is' + controller] = _.partial(fn.isController, className);
 });
@@ -404,7 +404,7 @@ const verifyClasses = {
   VerifyPush: 'mfa-verify-push',
 };
 
-_.each(verifyClasses, function (className, verifyView) {
+_.each(verifyClasses, function(className, verifyView) {
   fn['waitFor' + verifyView] = _.partial(fn.waitForVerifyView, className);
 });
 

--- a/test/unit/helpers/util/jquery.okta.js
+++ b/test/unit/helpers/util/jquery.okta.js
@@ -1,5 +1,5 @@
 import { $ } from 'okta';
 
-$.fn.trimmedText = function () {
+$.fn.trimmedText = function() {
   return $.trim(this.text());
 };

--- a/test/unit/jest/jest-setup-global.js
+++ b/test/unit/jest/jest-setup-global.js
@@ -4,18 +4,18 @@ import jasmine from 'jasmine';
 
 global.$ = global.jQuery = $;
 global.DEBUG = false;
-global.getJasmineRequireObj = function jestSetupGlobalJasmine () {
+global.getJasmineRequireObj = function jestSetupGlobalJasmine() {
   return jasmine;
 };
 global.jasmine = jasmine;
 
 navigator.credentials = {
-  create: function () {
+  create: function() {
     return Promise.resolve({
       response: {}
     });
   },
-  get: function () {
+  get: function() {
     return Promise.resolve({
       response: {}
     });

--- a/test/unit/karma/karma-enforce-precompile.js
+++ b/test/unit/karma/karma-enforce-precompile.js
@@ -2,11 +2,11 @@
 import { FrameworkView, _ } from 'okta';
 
 const _viewAdd = FrameworkView.prototype.add;
-FrameworkView.prototype.add = function (view) {
+FrameworkView.prototype.add = function(view) {
   if (_.isString(view) && view.indexOf('{{') >= 0) {
     const msg = 'Attempt to add an uncompiled template as a string: ' + view;
     console.error(msg);
-    setImmediate(function () {
+    setImmediate(function() {
       throw new Error(msg); // fail test
     });
   }
@@ -14,11 +14,11 @@ FrameworkView.prototype.add = function (view) {
 };
 
 const _viewCompileTemplate = FrameworkView.prototype.compileTemplate;
-FrameworkView.prototype.compileTemplate = function (str) {
+FrameworkView.prototype.compileTemplate = function(str) {
   if (str.indexOf('{{') >= 0) {
     const msg = 'attempt to compile template: ' + str;
     console.error(msg);
-    setImmediate(function () {
+    setImmediate(function() {
       throw new Error(msg); // fail test
     });
   }

--- a/test/unit/karma/karma-onload.js
+++ b/test/unit/karma/karma-onload.js
@@ -6,10 +6,10 @@ const karma = window.__karma__; /* eslint-env browser */
 
 const originalStart = karma.start;
 
-karma.start = function () {
+karma.start = function() {
   const args = arguments;
 
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener('DOMContentLoaded', function() {
     originalStart.apply(this, args);
   });
 };

--- a/test/unit/karma/karma-overrides.js
+++ b/test/unit/karma/karma-overrides.js
@@ -2,11 +2,11 @@
 
 const path = require('path');
 
-const createPattern = function (pattern) {
+const createPattern = function(pattern) {
   return { pattern, included: true, served: true, watched: false };
 };
 
-const initKarmaOverrides = function (files) {
+const initKarmaOverrides = function(files) {
   files.unshift(createPattern(path.join(__dirname, 'karma-onload.js')));
 };
 

--- a/test/unit/spec/AdminConsentRequired_spec.js
+++ b/test/unit/spec/AdminConsentRequired_spec.js
@@ -12,11 +12,11 @@ import LoginUtil from 'util/Util';
 
 const itp = Expect.itp;
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-function setup (settings, res = resAdminConsentRequired) {
+function setup(settings, res = resAdminConsentRequired) {
   settings || (settings = {});
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
@@ -49,7 +49,7 @@ function setup (settings, res = resAdminConsentRequired) {
   return Expect.waitForAdminConsentRequired(settings);
 }
 
-function setupClientLogo () {
+function setupClientLogo() {
   const resConsentRequiredClientLogo = deepClone(resAdminConsentRequired);
   const customLogo = {
     href: '/base/test/unit/assets/logo.svg',
@@ -59,7 +59,7 @@ function setupClientLogo () {
   return setup(undefined, resConsentRequiredClientLogo);
 }
 
-function setupClientUri () {
+function setupClientUri() {
   const resConsentRequiredClientUri = deepClone(resAdminConsentRequired);
   resConsentRequiredClientUri.response._embedded.target._links['client-uri'] = {
     href: `${window.location.origin}/client-uri.html`,
@@ -68,15 +68,15 @@ function setupClientUri () {
   return setup(undefined, resConsentRequiredClientUri);
 }
 
-function setupLessScopes () {
+function setupLessScopes() {
   const resp = deepClone(resAdminConsentRequired);
   resp.response._embedded.scopes = resp.response._embedded.scopes.slice(0, 2);
   return setup(undefined, resp);
 }
 
-Expect.describe('AdminConsentRequired', function () {
-  itp('has the correct number of scopes - all groups and scopes', function () {
-    return setup().then(function ({ form }) {
+Expect.describe('AdminConsentRequired', function() {
+  itp('has the correct number of scopes - all groups and scopes', function() {
+    return setup().then(function({ form }) {
       expect(form.scopeGroupList().length).toBe(4);
 
       expect(form.scopeGroupName(0)).toBe('User and groups');
@@ -93,8 +93,8 @@ Expect.describe('AdminConsentRequired', function () {
     });
   });
 
-  itp('has the correct number of scopes - one group and scopes', function () {
-    return setupLessScopes().then(function ({ form }) {
+  itp('has the correct number of scopes - one group and scopes', function() {
+    return setupLessScopes().then(function({ form }) {
       expect(form.scopeGroupList().length).toBe(1);
 
       expect(form.scopeGroupName(0)).toBe('User and groups');
@@ -102,11 +102,11 @@ Expect.describe('AdminConsentRequired', function () {
     });
   });
 
-  itp('toggle scope list', function () {
-    return setup().then(function ({ form }) {
+  itp('toggle scope list', function() {
+    return setup().then(function({ form }) {
       expect(form.scopeGroupList().length).toBe(4);
 
-      form.scopeGroupList().each(function () {
+      form.scopeGroupList().each(function() {
         expect(this.getAttribute('class')).toBe('scope-group');
       });
 
@@ -117,7 +117,7 @@ Expect.describe('AdminConsentRequired', function () {
       expect(form.scopeGroupListRow(3).attr('class')).toBe('scope-group');
 
       form.scopeGroupListRow(0).click();
-      form.scopeGroupList().each(function () {
+      form.scopeGroupList().each(function() {
         expect(this.getAttribute('class')).toBe('scope-group');
       });
 
@@ -129,46 +129,46 @@ Expect.describe('AdminConsentRequired', function () {
     });
   });
 
-  itp('has the default logo if client logo is not provided', function () {
-    return setup().then(function (test) {
+  itp('has the default logo if client logo is not provided', function() {
+    return setup().then(function(test) {
       expect(test.form.clientLogoLink()).toHaveLength(0);
       expect(test.form.clientLogo().attr('src')).toBe(`${window.location.origin}/img/logos/default.png`);
     });
   });
 
-  itp('has the client uri', function () {
-    return setupClientUri().then(function (test) {
+  itp('has the client uri', function() {
+    return setupClientUri().then(function(test) {
       expect(test.form.clientLogoLink().attr('href')).toBe(`${window.location.origin}/client-uri.html`);
       expect(test.form.clientLogo().attr('src')).toBe(`${window.location.origin}/img/logos/default.png`);
     });
   });
-  itp('has the correct client logo', function () {
-    return setupClientLogo().then(function (test) {
+  itp('has the correct client logo', function() {
+    return setupClientLogo().then(function(test) {
       expect(test.form.clientLogo().attr('src')).toBe('/base/test/unit/assets/logo.svg');
     });
   });
-  itp('has the correct app name in the title', function () {
-    return setup().then(function (test) {
+  itp('has the correct app name in the title', function() {
+    return setup().then(function(test) {
       expect(test.form.consentTitleText()).toBe('OAuth Service - Foo App 1 would like to access:');
     });
   });
 
-  itp('has the consent button', function () {
-    return setup().then(function (test) {
+  itp('has the consent button', function() {
+    return setup().then(function(test) {
       expect(test.form.consentButton()).toHaveLength(1);
       expect(test.form.consentButton().attr('value')).toBe('Allow Access');
       expect(test.form.consentButton().attr('class')).toBe('button button-primary');
     });
   });
-  itp('consent button click makes the correct consent post', function () {
+  itp('consent button click makes the correct consent post', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.consentButton().click();
         return Expect.waitForAjaxRequest();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.lastAjaxRequest(), {
           url: 'http://localhost:3000/api/v1/authn/consent',
@@ -191,25 +191,25 @@ Expect.describe('AdminConsentRequired', function () {
       });
   });
 
-  itp('has the cancel button', function () {
-    return setup().then(function (test) {
+  itp('has the cancel button', function() {
+    return setup().then(function(test) {
       expect(test.form.cancelButton()).toHaveLength(1);
       expect(test.form.cancelButton().attr('value')).toBe('Don\'t Allow');
       expect(test.form.cancelButton().attr('class')).toBe('button button-clear');
     });
   });
 
-  itp('cancel button click cancels the current stateToken and calls the cancel function', function () {
+  itp('cancel button click cancels the current stateToken and calls the cancel function', function() {
     const cancel = jasmine.createSpy('cancel');
     return setup({ consent: { cancel } })
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         Util.resetAjaxRequests();
         test.setNextResponse(resCancel);
         test.form.cancelButton().click();
         return Expect.waitForAjaxRequest(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.lastAjaxRequest(), {
           url: 'http://localhost:3000/api/v1/authn/cancel',
@@ -217,11 +217,11 @@ Expect.describe('AdminConsentRequired', function () {
             stateToken: '00eL1hS274lCJnfPCifGwB-jNgwNeKlviamZhdloF1',
           },
         });
-        return Expect.wait(function () {
+        return Expect.wait(function() {
           return test.router.controller.options.appState.clearLastAuthResponse.calls.count() > 0;
         }, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
         expect(cancel).toHaveBeenCalled();
       });

--- a/test/unit/spec/ColorsUtil_spec.js
+++ b/test/unit/spec/ColorsUtil_spec.js
@@ -2,20 +2,20 @@ import { $ } from 'okta';
 import ColorsUtil from 'util/ColorsUtil';
 import Enums from 'util/Enums';
 
-const normalize = function (text) {
+const normalize = function(text) {
   return text.replace(/\s+/g, ' ');
 };
 
-describe('ColorsUtil', function () {
-  beforeEach(function () {
+describe('ColorsUtil', function() {
+  beforeEach(function() {
     $('body').append(`<div id="${Enums.WIDGET_CONTAINER_ID}" />`);
   });
-  afterEach(function () {
+  afterEach(function() {
     $(`#${Enums.WIDGET_CONTAINER_ID}`).remove();
   });
 
-  describe('addStyle', function () {
-    it('appends the correct style to head', function () {
+  describe('addStyle', function() {
+    it('appends the correct style to head', function() {
       const colors = {
         brand: '#008000',
       };
@@ -36,11 +36,11 @@ describe('ColorsUtil', function () {
     });
   });
 
-  describe('isLoaded', function () {
-    it('returns false if no okta-sign-in-config-colors style was added', function () {
+  describe('isLoaded', function() {
+    it('returns false if no okta-sign-in-config-colors style was added', function() {
       expect(ColorsUtil.isLoaded()).toBe(false);
     });
-    it('returns true if okta-sign-in-config-colors style was added', function () {
+    it('returns true if okta-sign-in-config-colors style was added', function() {
       const colors = {
         brand: '#008000',
       };
@@ -50,13 +50,13 @@ describe('ColorsUtil', function () {
     });
   });
 
-  describe('lighten', function () {
-    it('returns a lighter color if a lum parameter is passed', function () {
+  describe('lighten', function() {
+    it('returns a lighter color if a lum parameter is passed', function() {
       expect(ColorsUtil.lighten('#008000', 0.3)).toBe('#00a600');
       expect(ColorsUtil.lighten('#C0C0C0', 0.1)).toBe('#d3d3d3');
       expect(ColorsUtil.lighten('#0000EE', 0.05)).toBe('#0000fa');
     });
-    it('returns the same color if no lum parameter is passed', function () {
+    it('returns the same color if no lum parameter is passed', function() {
       expect(ColorsUtil.lighten('#008000')).toBe('#008000');
     });
   });

--- a/test/unit/spec/ConsentRequired_spec.js
+++ b/test/unit/spec/ConsentRequired_spec.js
@@ -12,11 +12,11 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-function setup (settings, res) {
+function setup(settings, res) {
   settings || (settings = {});
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
@@ -51,7 +51,7 @@ function setup (settings, res) {
   return Expect.waitForConsentRequired(settings);
 }
 
-function setupClientLogo () {
+function setupClientLogo() {
   const resConsentRequiredClientLogo = deepClone(resConsentRequired);
   const customLogo = {
     href: '/base/test/unit/assets/logo.svg',
@@ -62,7 +62,7 @@ function setupClientLogo () {
   return setup(undefined, resConsentRequiredClientLogo);
 }
 
-function setupClientUri () {
+function setupClientUri() {
   const resConsentRequiredClientUri = deepClone(resConsentRequired);
 
   resConsentRequiredClientUri.response._embedded.target._links['client-uri'] = {
@@ -72,26 +72,26 @@ function setupClientUri () {
   return setup(undefined, resConsentRequiredClientUri);
 }
 
-Expect.describe('ConsentRequired', function () {
-  describe('ScopeList', function () {
-    itp('has the correct number of scopes', function () {
-      return setup().then(function (test) {
+Expect.describe('ConsentRequired', function() {
+  describe('ScopeList', function() {
+    itp('has the correct number of scopes', function() {
+      return setup().then(function(test) {
         expect(test.form.scopeList().children()).toHaveLength(2);
       });
     });
-    itp('scope item show displayName instead of name if the first is available', function () {
-      return setup().then(function (test) {
+    itp('scope item show displayName instead of name if the first is available', function() {
+      return setup().then(function(test) {
         expect(test.form.scopeList().children()[0].textContent).toEqual(expect.stringContaining('Ability to read protected data'));
         expect(test.form.scopeList().children()[0].textContent).toEqual(expect.not.stringContaining('api:read'));
       });
     });
-    itp('scope item show name if displayName is not available', function () {
-      return setup().then(function (test) {
+    itp('scope item show name if displayName is not available', function() {
+      return setup().then(function(test) {
         expect(test.form.scopeList().children()[1].textContent).toEqual(expect.stringContaining('api:write'));
       });
     });
-    itp('scope item has a tooltip if description is available', function () {
-      return setup().then(function (test) {
+    itp('scope item has a tooltip if description is available', function() {
+      return setup().then(function(test) {
         expect(test.form.scopeList().children().eq(0).find('span.scope-item-tooltip')).toHaveLength(1);
         expect(test.form.scopeList().html()).toMatch(new RegExp(
           '<div class="scope-item"><div class="scope-item-text"><p>Ability to read protected data</p></div>' + 
@@ -100,69 +100,69 @@ Expect.describe('ConsentRequired', function () {
         ));
       });
     });
-    itp('scope item does not have a tooltip if description is not available', function () {
-      return setup().then(function (test) {
+    itp('scope item does not have a tooltip if description is not available', function() {
+      return setup().then(function(test) {
         expect(test.form.scopeList().children().eq(1).find('span.scope-item-tooltip')).toHaveLength(0);
       });
     });
   });
 
-  describe('ConsentForm', function () {
-    itp('has the default logo if client logo is not provided', function () {
-      return setup().then(function (test) {
+  describe('ConsentForm', function() {
+    itp('has the default logo if client logo is not provided', function() {
+      return setup().then(function(test) {
         expect(test.form.clientLogoLink()).toHaveLength(0);
         expect(test.form.clientLogo().attr('src')).toBe(`${window.location.origin}/img/logos/default.png`);
       });
     });
-    itp('has the client uri', function () {
-      return setupClientUri().then(function (test) {
+    itp('has the client uri', function() {
+      return setupClientUri().then(function(test) {
         expect(test.form.clientLogoLink().attr('href')).toBe(`${window.location.origin}/client-uri.html`);
         expect(test.form.clientLogo().attr('src')).toBe(`${window.location.origin}/img/logos/default.png`);
       });
     });
-    itp('has the correct client logo', function () {
-      return setupClientLogo().then(function (test) {
+    itp('has the correct client logo', function() {
+      return setupClientLogo().then(function(test) {
         expect(test.form.clientLogo().attr('src')).toBe('/base/test/unit/assets/logo.svg');
       });
     });
-    itp('has the correct app name in the title', function () {
-      return setup().then(function (test) {
+    itp('has the correct app name in the title', function() {
+      return setup().then(function(test) {
         expect(test.form.consentTitle().text().trim()).toBe('Janky App would like to access:');
       });
     });
-    itp('has the correct consent description', function () {
-      return setup().then(function (test) {
+    itp('has the correct consent description', function() {
+      return setup().then(function(test) {
         expect(test.form.consentDescription().text().trim()).toBe(
           'By clicking Allow Access, you allow the actions listed above.'
         );
       });
     });
-    itp('has the correct term of services link', function () {
-      return setup().then(function (test) {
+    itp('has the correct term of services link', function() {
+      return setup().then(function(test) {
         expect(test.form.termsOfService().attr('href')).toBe('https://example.okta.com/tos.html');
       });
     });
-    itp('has the correct privacy policy link', function () {
-      return setup().then(function (test) {
+    itp('has the correct privacy policy link', function() {
+      return setup().then(function(test) {
         expect(test.form.privacyPolicy().attr('href')).toBe('https://example.okta.com/policy.html');
       });
     });
-    itp('has the consent button', function () {
-      return setup().then(function (test) {
+    itp('has the consent button', function() {
+      return setup().then(function(test) {
         expect(test.form.consentButton()).toHaveLength(1);
         expect(test.form.consentButton().attr('value')).toBe('Allow Access');
         expect(test.form.consentButton().attr('class')).toBe('button');
       });
     });
-    itp('consent button click makes the correct consent post', function () {
+    itp('consent button click makes the correct consent post', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.consentButton().click();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.lastAjaxRequest(), {
             url: 'https://example.okta.com/api/v1/authn/consent',
@@ -176,25 +176,25 @@ Expect.describe('ConsentRequired', function () {
           });
         });
     });
-    itp('has the cancel button', function () {
-      return setup().then(function (test) {
+    itp('has the cancel button', function() {
+      return setup().then(function(test) {
         expect(test.form.cancelButton()).toHaveLength(1);
         expect(test.form.cancelButton().attr('value')).toBe('Don\'t Allow');
         expect(test.form.cancelButton().attr('class')).toBe('button button-clear');
       });
     });
-    itp('cancel button click cancels the current stateToken and calls the cancel function', function () {
+    itp('cancel button click cancels the current stateToken and calls the cancel function', function() {
       const cancel = jasmine.createSpy('cancel');
 
       return setup({ consent: { cancel } })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           Util.resetAjaxRequests();
           test.setNextResponse(resCancel);
           test.form.cancelButton().click();
           return Expect.waitForAjaxRequest(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.lastAjaxRequest(), {
             url: 'https://example.okta.com/api/v1/authn/cancel',
@@ -202,11 +202,11 @@ Expect.describe('ConsentRequired', function () {
               stateToken: 'testStateToken',
             },
           });
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.router.controller.options.appState.clearLastAuthResponse.calls.count() > 0;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           expect(cancel).toHaveBeenCalled();
         });

--- a/test/unit/spec/CryptoUtil_spec.js
+++ b/test/unit/spec/CryptoUtil_spec.js
@@ -3,8 +3,8 @@
 import Expect from 'helpers/util/Expect';
 import CryptoUtil from 'util/CryptoUtil';
 
-Expect.describe('CryptoUtil', function () {
-  it('hash string to unique integer', function () {
+Expect.describe('CryptoUtil', function() {
+  it('hash string to unique integer', function() {
     const original = {};
     const hashed = {};
     let name;
@@ -17,17 +17,17 @@ Expect.describe('CryptoUtil', function () {
     expect(Object.keys(original).length).toEqual(Object.keys(hashed).length);
   });
 
-  it('converts Base64 str to binary array', function () {
+  it('converts Base64 str to binary array', function() {
     expect(CryptoUtil.strToBin('WXVtaW5nIENhbw==')).toEqual(
       Uint8Array.from([89, 117, 109, 105, 110, 103, 32, 67, 97, 111])
     );
   });
 
-  it('supports Base64UrlSafe str', function () {
+  it('supports Base64UrlSafe str', function() {
     expect(CryptoUtil.strToBin('WXVtaW5_IE-hbw==')).toEqual(CryptoUtil.strToBin('WXVtaW5/IE+hbw=='));
   });
 
-  it('converts binary array to Base64 str', function () {
+  it('converts binary array to Base64 str', function() {
     expect(CryptoUtil.binToStr([89, 117, 109, 105, 110, 103, 32, 67, 97, 111])).toEqual('WXVtaW5nIENhbw==');
   });
 });

--- a/test/unit/spec/DeviceFingerprint_spec.js
+++ b/test/unit/spec/DeviceFingerprint_spec.js
@@ -2,8 +2,8 @@ import Expect from 'helpers/util/Expect';
 import $sandbox from 'sandbox';
 import DeviceFingerprint from 'util/DeviceFingerprint';
 
-Expect.describe('DeviceFingerprint', function () {
-  function mockIFrameMessages (success, errorMessage) {
+Expect.describe('DeviceFingerprint', function() {
+  function mockIFrameMessages(success, errorMessage) {
     const message = success
       ? {
         type: 'FingerprintAvailable',
@@ -15,23 +15,23 @@ Expect.describe('DeviceFingerprint', function () {
     window.postMessage(JSON.stringify(message), '*');
   }
 
-  function mockUserAgent (userAgent) {
-    spyOn(DeviceFingerprint, 'getUserAgent').and.callFake(function () {
+  function mockUserAgent(userAgent) {
+    spyOn(DeviceFingerprint, 'getUserAgent').and.callFake(function() {
       return userAgent;
     });
   }
 
-  function bypassMessageSourceCheck () {
+  function bypassMessageSourceCheck() {
     // since we mock the Iframe messages the check to see if the message
     // sent from right iframe would fail.
-    spyOn(DeviceFingerprint, 'isMessageFromCorrectSource').and.callFake(function () {
+    spyOn(DeviceFingerprint, 'isMessageFromCorrectSource').and.callFake(function() {
       return true;
     });
   }
 
   const baseUrl = window.origin || 'file://';
 
-  it('iframe is created with the right src and it is hidden', function () {
+  it('iframe is created with the right src and it is hidden', function() {
     spyOn(window, 'addEventListener');
     DeviceFingerprint.generateDeviceFingerprint('baseUrl', $sandbox);
     const $iFrame = $sandbox.find('iframe');
@@ -42,20 +42,20 @@ Expect.describe('DeviceFingerprint', function () {
     expect(window.addEventListener).toHaveBeenCalledWith('message', jasmine.any(Function), false);
   });
 
-  it('returns a fingerprint if the communication with the iframe is successfull', function () {
+  it('returns a fingerprint if the communication with the iframe is successfull', function() {
     mockIFrameMessages(true);
     bypassMessageSourceCheck();
-    return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox).then(function (fingerprint) {
+    return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox).then(function(fingerprint) {
       expect(fingerprint).toBe('thisIsTheFingerprint');
     });
   });
 
-  it('fails if the iframe does not load', function (done) {
+  it('fails if the iframe does not load', function(done) {
     DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
-      .then(function () {
+      .then(function() {
         done.fail('Fingerprint promise should have been rejected');
       })
-      .catch(function (reason) {
+      .catch(function(reason) {
         expect(reason).toBe('service not available');
         const $iFrame = $sandbox.find('iframe');
 
@@ -64,27 +64,27 @@ Expect.describe('DeviceFingerprint', function () {
       });
   });
 
-  it('clears iframe timeout once the iframe loads', function () {
+  it('clears iframe timeout once the iframe loads', function() {
     mockIFrameMessages(true);
     bypassMessageSourceCheck();
     const originalClearTimeout = window.clearTimeout;
 
     window.clearTimeout = jasmine.createSpy('clearTimeout');
-    return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox).then(function (fingerprint) {
+    return DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox).then(function(fingerprint) {
       expect(fingerprint).toBe('thisIsTheFingerprint');
       expect(window.clearTimeout).toHaveBeenCalled();
       window.clearTimeout = originalClearTimeout;
     });
   });
 
-  it('fails if there is a problem with communicating with the iframe', function (done) {
+  it('fails if there is a problem with communicating with the iframe', function(done) {
     mockIFrameMessages(false);
     bypassMessageSourceCheck();
     DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
-      .then(function () {
+      .then(function() {
         done.fail('Fingerprint promise should have been rejected');
       })
-      .catch(function (reason) {
+      .catch(function(reason) {
         expect(reason).toBe('no data');
         const $iFrame = $sandbox.find('iframe');
 
@@ -93,14 +93,14 @@ Expect.describe('DeviceFingerprint', function () {
       });
   });
 
-  it('fails if there iframe sends and invalid message content', function (done) {
+  it('fails if there iframe sends and invalid message content', function(done) {
     mockIFrameMessages(false, { type: 'InvalidMessageType' });
     bypassMessageSourceCheck();
     DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
-      .then(function () {
+      .then(function() {
         done.fail('Fingerprint promise should have been rejected');
       })
-      .catch(function (reason) {
+      .catch(function(reason) {
         expect(reason).toBe('no data');
         const $iFrame = $sandbox.find('iframe');
 
@@ -109,14 +109,14 @@ Expect.describe('DeviceFingerprint', function () {
       });
   });
 
-  it('fails if user agent is not defined', function (done) {
+  it('fails if user agent is not defined', function(done) {
     mockUserAgent();
     mockIFrameMessages(true);
     DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
-      .then(function () {
+      .then(function() {
         done.fail('Fingerprint promise should have been rejected');
       })
-      .catch(function (reason) {
+      .catch(function(reason) {
         const $iFrame = $sandbox.find('iframe');
 
         expect($iFrame.length).toBe(0);
@@ -125,14 +125,14 @@ Expect.describe('DeviceFingerprint', function () {
       });
   });
 
-  it('fails if it is called from a Windows phone', function (done) {
+  it('fails if it is called from a Windows phone', function(done) {
     mockUserAgent('Windows Phone');
     mockIFrameMessages(true);
     DeviceFingerprint.generateDeviceFingerprint(baseUrl, $sandbox)
-      .then(function () {
+      .then(function() {
         done.fail('Fingerprint promise should have been rejected');
       })
-      .catch(function (reason) {
+      .catch(function(reason) {
         expect(reason).toBe('device fingerprint is not supported on Windows phones');
         const $iFrame = $sandbox.find('iframe');
 
@@ -141,7 +141,7 @@ Expect.describe('DeviceFingerprint', function () {
       });
   });
 
-  it('ignores if message is not from right iframe', function (done) {
+  it('ignores if message is not from right iframe', function(done) {
     spyOn(DeviceFingerprint, 'isMessageFromCorrectSource').and.callFake(() => {
       return false;
     });

--- a/test/unit/spec/EnrollActivateClaimsFactor_spec.js
+++ b/test/unit/spec/EnrollActivateClaimsFactor_spec.js
@@ -13,8 +13,8 @@ import LoginUtil from 'util/Util';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-Expect.describe('EnrollActivateCustomFactor', function () {
-  function setup (options) {
+Expect.describe('EnrollActivateCustomFactor', function() {
+  function setup(options) {
     const initResponse = getInitialResponse(options);
     const setNextResponse = Util.mockAjax([initResponse]);
     const baseUrl = 'https://foo.com';
@@ -43,7 +43,7 @@ Expect.describe('EnrollActivateCustomFactor', function () {
     });
   }
 
-  function getInitialResponse (options) {
+  function getInitialResponse(options) {
     const initResponse = JSON.parse(JSON.stringify(responseMfaEnrollActivateClaimsProvider));
 
     if (options && options.setFactorResult) {
@@ -53,100 +53,100 @@ Expect.describe('EnrollActivateCustomFactor', function () {
     return initResponse;
   }
 
-  describe('Enroll Activate CUSTOM_CLAIMS', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  describe('Enroll Activate CUSTOM_CLAIMS', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-custom-factor')).toBe(true);
       });
     });
 
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
 
-    itp('displays correct title', function () {
-      return setup().then(function (test) {
+    itp('displays correct title', function() {
+      return setup().then(function(test) {
         test.setNextResponse(responseSuccess);
         expect(test.form.titleText()).toBe('IDP factor');
         expect(test.form.buttonBar().hasClass('hide')).toBe(false);
       });
     });
 
-    itp('displays correct subtitle', function () {
-      return setup().then(function (test) {
+    itp('displays correct subtitle', function() {
+      return setup().then(function(test) {
         test.setNextResponse(responseSuccess);
         expect(test.form.subtitleText()).toBe('Clicking below will redirect to MFA enrollment with IDP factor');
         expect(test.form.buttonBar().hasClass('hide')).toBe(false);
       });
     });
 
-    itp('redirects to third party when Enroll button is clicked', function () {
+    itp('redirects to third party when Enroll button is clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(responseSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://rain.okta1.com:1802/sso/idps/idpId?stateToken=testStateToken'
           );
         });
     });
 
-    itp('does not display error for normal setup', function () {
-      return setup().then(function (test) {
+    itp('does not display error for normal setup', function() {
+      return setup().then(function(test) {
         expect(test.form.hasErrorBox()).toBe(false);
       });
     });
 
-    itp('displays error when factorResult is FAILED', function () {
+    itp('displays error when factorResult is FAILED', function() {
       const options = {
         setFactorResult: true,
         factorResult: 'FAILED',
         factorResultMessage: 'Enroll failed.',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.hasErrorBox()).toBe(true);
         expect(test.form.errorBoxMessage()).toBe('Enroll failed.');
       });
     });
 
-    itp('does not display error when factorResult is WAITING', function () {
+    itp('does not display error when factorResult is WAITING', function() {
       const options = {
         setFactorResult: true,
         factorResult: 'WAITING',
         factorResultMessage: 'Enroll failed.',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.hasErrorBox()).toBe(false);
       });
     });
 
-    itp('does not display error when factorResult is undefined', function () {
+    itp('does not display error when factorResult is undefined', function() {
       const options = {
         setFactorResult: true,
         factorResultMessage: 'Enroll failed.',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.hasErrorBox()).toBe(false);
       });
     });
 
-    itp('displays default error when factorResultMessage is undefined', function () {
+    itp('displays default error when factorResultMessage is undefined', function() {
       const options = {
         setFactorResult: true,
         factorResult: 'FAILED',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.hasErrorBox()).toBe(true);
         expect(test.form.errorBoxMessage()).toBe('There was an unexpected internal error. Please try again.');
       });

--- a/test/unit/spec/EnrollCall_spec.js
+++ b/test/unit/spec/EnrollCall_spec.js
@@ -18,8 +18,8 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-Expect.describe('EnrollCall', function () {
-  function setup (resp, startRouter, routerOptions = {}) {
+Expect.describe('EnrollCall', function() {
+  function setup(resp, startRouter, routerOptions = {}) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -49,7 +49,7 @@ Expect.describe('EnrollCall', function () {
       setNextResponse(resp || resAllFactors);
       router.refreshAuthState('dummy-token');
       return Expect.waitForEnrollChoices(test)
-        .then(function (test) {
+        .then(function(test) {
           test.router.enrollCall();
           return Expect.waitForEnrollCall(test);
         })
@@ -66,25 +66,25 @@ Expect.describe('EnrollCall', function () {
     }
   }
 
-  function waitForEnrollActivateSuccess (test) {
+  function waitForEnrollActivateSuccess(test) {
     test.router.controller.trapAuthResponse.calls.reset();
     return Expect.waitForSpyCall(test.router.controller.trapAuthResponse, test);
   }
 
-  function enterPhone (test, countryCode, phoneNumber, phoneExtension) {
+  function enterPhone(test, countryCode, phoneNumber, phoneExtension) {
     test.form.selectCountry(countryCode);
     test.form.setPhoneNumber(phoneNumber);
     test.form.setPhoneExtension(phoneExtension);
   }
 
-  function sendCode (test, res, countryCode, phoneNumber, phoneExtension) {
+  function sendCode(test, res, countryCode, phoneNumber, phoneExtension) {
     test.setNextResponse(res);
     enterPhone(test, countryCode, phoneNumber, phoneExtension);
     test.form.sendCodeButton().click();
     return test;
   }
 
-  function sendCodeOnEnter (test, res, countryCode, phoneNumber, phoneExtension) {
+  function sendCodeOnEnter(test, res, countryCode, phoneNumber, phoneExtension) {
     test.setNextResponse(res);
     enterPhone(test, countryCode, phoneNumber, phoneExtension);
     const keydown = $.Event('keydown');
@@ -98,34 +98,34 @@ Expect.describe('EnrollCall', function () {
     return test;
   }
 
-  function setupAndSendCode (res, countryCode, phoneNumber, phoneExtension) {
-    return setup().then(function (test) {
+  function setupAndSendCode(res, countryCode, phoneNumber, phoneExtension) {
+    return setup().then(function(test) {
       return sendCode(test, res, countryCode, phoneNumber, phoneExtension);
     });
   }
 
-  function setupAndSendValidCode (phoneExtension) {
-    return setup().then(function (test) {
+  function setupAndSendValidCode(phoneExtension) {
+    return setup().then(function(test) {
       sendCode(test, resEnrollSuccess, 'US', '6501231234', phoneExtension);
       return waitForEnrollActivateSuccess(test);
     });
   }
 
-  function setupAndSendInvalidCode (phoneExtension) {
-    return setup().then(function (test) {
+  function setupAndSendInvalidCode(phoneExtension) {
+    return setup().then(function(test) {
       sendCode(test, resEnrollError, 'US', '650', phoneExtension);
       return Expect.waitForFormError(test.form, test);
     });
   }
 
-  function expectRedialButton (test) {
+  function expectRedialButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Redial');
     expect(button.hasClass('button-primary')).toBe(false);
   }
 
-  function expectCallingButton (test) {
+  function expectCallingButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Calling');
@@ -133,14 +133,14 @@ Expect.describe('EnrollCall', function () {
     expect(button.attr('class')).toMatch('link-button-disabled');
   }
 
-  function expectCallButton (test) {
+  function expectCallButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Call');
     expect(button.hasClass('button-primary')).toBe(true);
   }
 
-  function expectAlphabeticalCountryList (test) {
+  function expectAlphabeticalCountryList(test) {
     const countries = test.form.countriesList();
 
     expect(countries[0]).toEqual({ val: 'AF', text: 'Afghanistan' });
@@ -148,7 +148,7 @@ Expect.describe('EnrollCall', function () {
     expect(countries[239]).toEqual({ val: 'ZW', text: 'Zimbabwe' });
   }
 
-  function expectCountriesWithNoCallingCodes (test) {
+  function expectCountriesWithNoCallingCodes(test) {
     const countries = test.form.countriesList();
 
     expect(_.findWhere(countries, { val: 'HM' })).toBe(undefined);
@@ -156,99 +156,99 @@ Expect.describe('EnrollCall', function () {
     expect(_.findWhere(countries, { val: 'TF' })).toBe(undefined);
   }
 
-  function expectCountryCallingCodeUpdates (test) {
+  function expectCountryCallingCodeUpdates(test) {
     expect(test.form.phonePrefixText()).toBe('+1');
     test.form.selectCountry('AQ');
     expect(test.form.phonePrefixText()).toBe('+672');
   }
 
-  function testEnrollPhoneNumber (setupFn, enrollSuccess) {
-    it('has a list of countries in alphabetical order', function () {
-      return setupFn().then(function (test) {
+  function testEnrollPhoneNumber(setupFn, enrollSuccess) {
+    it('has a list of countries in alphabetical order', function() {
+      return setupFn().then(function(test) {
         expectAlphabeticalCountryList(test);
       });
     });
-    itp('does not include countries with no calling codes', function () {
-      return setupFn().then(function (test) {
+    itp('does not include countries with no calling codes', function() {
+      return setupFn().then(function(test) {
         expectCountriesWithNoCallingCodes(test);
       });
     });
-    itp('has autocomplete set to false', function () {
-      return setupFn().then(function (test) {
+    itp('has autocomplete set to false', function() {
+      return setupFn().then(function(test) {
         expect(test.form.getCodeFieldAutocomplete()).toBe('off');
       });
     });
-    itp('defaults to United States for the country', function () {
-      return setupFn().then(function (test) {
+    itp('defaults to United States for the country', function() {
+      return setupFn().then(function(test) {
         expect(test.form.selectedCountry()).toBe('United States');
       });
     });
-    itp('selects country based on defaultCountryCode from settings', function () {
+    itp('selects country based on defaultCountryCode from settings', function() {
       return setupFn(undefined, undefined, { defaultCountryCode: 'GB' })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.selectedCountry()).toBe('United Kingdom');
         });
     });
-    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function () {
+    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function() {
       return setupFn(undefined, undefined, { defaultCountryCode: 'FAKECODE' })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.selectedCountry()).toBe('United States');
         });
     });
-    itp('updates the phone number country calling code when country is changed', function () {
-      return setupFn().then(function (test) {
+    itp('updates the phone number country calling code when country is changed', function() {
+      return setupFn().then(function(test) {
         expectCountryCallingCodeUpdates(test);
       });
     });
-    itp('has a phone number text field', function () {
-      return setupFn().then(function (test) {
+    itp('has a phone number text field', function() {
+      return setupFn().then(function(test) {
         Expect.isTextField(test.form.phoneNumberField());
       });
     });
-    itp('has a phone extension text field', function () {
-      return setupFn().then(function (test) {
+    itp('has a phone extension text field', function() {
+      return setupFn().then(function(test) {
         Expect.isTextField(test.form.phoneExtensionField());
       });
     });
-    itp('has a button with primary class and text "Call"', function () {
-      return setup().then(function (test) {
+    itp('has a button with primary class and text "Call"', function() {
+      return setup().then(function(test) {
         expectCallButton(test);
       });
     });
-    itp('does not show divider', function () {
-      return setupFn().then(function (test) {
+    itp('does not show divider', function() {
+      return setupFn().then(function(test) {
         Expect.isNotVisible(test.form.divider());
       });
     });
-    itp('does not show enter code input', function () {
-      return setupFn().then(function (test) {
+    itp('does not show enter code input', function() {
+      return setupFn().then(function(test) {
         Expect.isNotVisible(test.form.codeField());
       });
     });
-    itp('does not show verify button', function () {
-      return setupFn().then(function (test) {
+    itp('does not show verify button', function() {
+      return setupFn().then(function(test) {
         Expect.isNotVisible(test.form.submitButton());
       });
     });
-    itp('validation error if phone number field is blank', function () {
-      return setupAndSendCode(enrollSuccess, 'US', '').then(function (test) {
+    itp('validation error if phone number field is blank', function() {
+      return setupAndSendCode(enrollSuccess, 'US', '').then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
       });
     });
-    itp('clears previous errors in form when redial', function () {
+    itp('clears previous errors in form when redial', function() {
       return setupAndSendInvalidCode()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Invalid Phone Number.');
           sendCodeOnEnter(test, enrollSuccess, 'US', '4151111111');
           return waitForEnrollActivateSuccess(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
         });
     });
-    itp('enrolls with correct info when call button is clicked', function () {
-      return setupAndSendCode(enrollSuccess, 'AQ', '12345678900').then(function () {
+    itp('enrolls with correct info when call button is clicked', function() {
+      return setupAndSendCode(enrollSuccess, 'AQ', '12345678900').then(function() {
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isJsonPost(Util.getAjaxRequest(1), {
           url: 'https://foo.com/api/v1/authn/factors',
@@ -264,8 +264,8 @@ Expect.describe('EnrollCall', function () {
         });
       });
     });
-    itp('shows error and does not go to next step if error response', function () {
-      return setupAndSendInvalidCode().then(function (test) {
+    itp('shows error and does not go to next step if error response', function() {
+      return setupAndSendInvalidCode().then(function(test) {
         expectCallButton(test);
         Expect.isNotVisible(test.form.divider());
         Expect.isNotVisible(test.form.codeField());
@@ -303,21 +303,21 @@ Expect.describe('EnrollCall', function () {
     });
   }
 
-  function testVerifyPhoneNumber (setupFn, setupAndSendCodeFn, enrollSuccess, expectedStateToken) {
-    itp('replaces button text from "call" to "calling", disables it and with no primary class', function () {
-      return setupAndSendCodeFn().then(function (test) {
+  function testVerifyPhoneNumber(setupFn, setupAndSendCodeFn, enrollSuccess, expectedStateToken) {
+    itp('replaces button text from "call" to "calling", disables it and with no primary class', function() {
+      return setupAndSendCodeFn().then(function(test) {
         expectCallingButton(test);
       });
     });
 
-    itp('uses send code button with validatePhone:false if user has retried with invalid phone number', function () {
+    itp('uses send code button with validatePhone:false if user has retried with invalid phone number', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -341,7 +341,7 @@ Expect.describe('EnrollCall', function () {
           sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -358,14 +358,14 @@ Expect.describe('EnrollCall', function () {
           });
         });
     });
-    itp('does not set validatePhone:false if the error is not a validation error (E0000098).', function () {
+    itp('does not set validatePhone:false if the error is not a validation error (E0000098).', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           sendCode(test, resEnrollError, 'PF', '12345678');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -387,7 +387,7 @@ Expect.describe('EnrollCall', function () {
           sendCode(test, resEnrollError, 'PF', '12345678');
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -403,16 +403,16 @@ Expect.describe('EnrollCall', function () {
           });
         });
     });
-    itp('uses resend and not enrollFactor when redial is clicked', function () {
+    itp('uses resend and not enrollFactor when redial is clicked', function() {
       Util.speedUpDelay();
       return setupAndSendCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(enrollSuccess);
           test.form.sendCodeButton().click();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
@@ -424,25 +424,25 @@ Expect.describe('EnrollCall', function () {
     });
     itp(
       'submitting a number, then changing it, and then changing it back ' + 'will still use the resend endpoint',
-      function () {
+      function() {
         // The call button is normally disabled for several seconds
         // to prevent too many calls to the API, but for testing
         // we mock out the delay function to wait 0 seconds.
         Util.speedUpDelay();
         return setupAndSendCodeFn()
-          .then(function (test) {
+          .then(function(test) {
             // change the number from 'US' to 'AQ'
             enterPhone(test, 'AQ', '6501231234');
             expectCallButton(test);
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // change the number back to 'US'
             enterPhone(test, 'US', '6501231234');
             expectRedialButton(test);
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // resubmit the 'US' number
             Util.resetAjaxRequests();
             test.setNextResponse(enrollSuccess);
@@ -450,7 +450,7 @@ Expect.describe('EnrollCall', function () {
             expectCallingButton(test);
             return Expect.waitForAjaxRequest();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
@@ -461,40 +461,40 @@ Expect.describe('EnrollCall', function () {
           });
       }
     );
-    itp('shows divider', function () {
-      return setupAndSendCodeFn().then(function (test) {
+    itp('shows divider', function() {
+      return setupAndSendCodeFn().then(function(test) {
         Expect.isVisible(test.form.divider());
       });
     });
-    itp('shows enter code input', function () {
-      return setupAndSendCodeFn().then(function (test) {
+    itp('shows enter code input', function() {
+      return setupAndSendCodeFn().then(function(test) {
         Expect.isVisible(test.form.codeField());
         expect(test.form.codeField().attr('type')).toBe('tel');
       });
     });
-    itp('shows verify button when enrolled', function () {
-      return setupAndSendCodeFn().then(function (test) {
+    itp('shows verify button when enrolled', function() {
+      return setupAndSendCodeFn().then(function(test) {
         Expect.isVisible(test.form.submitButton());
       });
     });
-    itp('does not send request and shows error if code is not entered', function () {
-      return setupAndSendCodeFn().then(function (test) {
+    itp('does not send request and shows error if code is not entered', function() {
+      return setupAndSendCodeFn().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.hasErrors()).toBe(true);
       });
     });
-    itp('calls activate with the right params if passes validation', function () {
+    itp('calls activate with the right params if passes validation', function() {
       return setupAndSendCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setCode(123456);
           test.setNextResponse(enrollSuccess);
           test.form.submit();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/activate',
@@ -505,16 +505,16 @@ Expect.describe('EnrollCall', function () {
           });
         });
     });
-    itp('shows error if error response on verification', function () {
+    itp('shows error if error response on verification', function() {
       return setupAndSendCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Q.stopUnhandledRejectionTracking();
           test.setNextResponse(resActivateError);
           test.form.setCode(123);
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Your token doesn\'t match our records. Please try again.');
           expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
@@ -548,39 +548,39 @@ Expect.describe('EnrollCall', function () {
     });
   }
 
-  describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-okta-call')).toBe(true);
       });
     });
-    itp('links back to factors directly if phone has not been enrolled', function () {
-      return setup().then(function (test) {
+    itp('links back to factors directly if phone has not been enrolled', function() {
+      return setup().then(function(test) {
         test.form.backLink().click();
         expect(test.router.navigate.calls.mostRecent().args).toEqual(['signin/enroll', { trigger: true }]);
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setup(null, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('visits previous link if phone is enrolled, but not activated', function () {
+    itp('visits previous link if phone is enrolled, but not activated', function() {
       return setupAndSendValidCode()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resAllFactors);
           test.form.backLink().click();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/previous',
@@ -593,19 +593,19 @@ Expect.describe('EnrollCall', function () {
     });
   });
 
-  describe('Enroll phone number', function () {
+  describe('Enroll phone number', function() {
     testEnrollPhoneNumber(setup, resEnrollSuccess);
   });
 
-  describe('Verify phone number', function () {
+  describe('Verify phone number', function() {
     testVerifyPhoneNumber(setup, setupAndSendValidCode, resEnrollSuccess, 'testStateToken');
-    itp('appends updatePhone=true to the request if user has an existing phone', function () {
+    itp('appends updatePhone=true to the request if user has an existing phone', function() {
       return setup(resExistingPhone)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           return sendCode(test, resEnrollSuccess, 'US', '6501231234');
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors?updatePhone=true',
@@ -622,22 +622,22 @@ Expect.describe('EnrollCall', function () {
         });
     });
 
-    itp('shows warning message to click "Redial" after 30s', function () {
+    itp('shows warning message to click "Redial" after 30s', function() {
       Util.speedUpDelay();
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resFactorEnrollActivateCall);
           enterPhone(test, 'AQ', '6501231234');
           test.form.sendCodeButton().click();
           return waitForEnrollActivateSuccess(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectRedialButton(test);
           expect(test.form.hasWarningMessage()).toBe(true);
           expect(test.form.warningMessage()).toContain('Haven\'t received a voice call? To try again, click Redial.');
           return test;
         })
-        .then(function (test) {
+        .then(function(test) {
           // redial will clear the warning
           Util.resetAjaxRequests();
           test.setNextResponse(resFactorEnrollActivateCall);
@@ -646,7 +646,7 @@ Expect.describe('EnrollCall', function () {
           expect(test.form.hasWarningMessage()).toBe(false);
           return waitForEnrollActivateSuccess(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Re-send after 30s wil show the warning again
           expectRedialButton(test);
           expect(test.form.warningMessage()).toContain('Haven\'t received a voice call? To try again, click Redial.');
@@ -656,9 +656,9 @@ Expect.describe('EnrollCall', function () {
     itp(
       'if phone number is changed after enroll, resets the status to MFA_Enroll ' +
         'and then enrolls with updatePhone=true',
-      function () {
+      function() {
         return setupAndSendValidCode()
-          .then(function (test) {
+          .then(function(test) {
             expectCallingButton(test);
             Expect.isVisible(test.form.codeField());
             enterPhone(test, 'US', '4151112222');
@@ -668,7 +668,7 @@ Expect.describe('EnrollCall', function () {
             test.form.sendCodeButton().click();
             return waitForEnrollActivateSuccess(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(Util.numAjaxRequests()).toBe(2);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/previous',
@@ -688,7 +688,7 @@ Expect.describe('EnrollCall', function () {
             });
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // form wasn't rerendered
             expect(test.form.phoneNumberField().val()).toEqual('4151112222');
             expectCallingButton(test);

--- a/test/unit/spec/EnrollChoices_spec.js
+++ b/test/unit/spec/EnrollChoices_spec.js
@@ -91,8 +91,8 @@ const enrolledWebauthnFactor = {
   vendorName: 'FIDO',
 };
 
-Expect.describe('EnrollChoices', function () {
-  function setup (res, showSecurityImage, webauthnEnabled, brandName) {
+Expect.describe('EnrollChoices', function() {
+  function setup(res, showSecurityImage, webauthnEnabled, brandName) {
     const settings = {};
 
     if (webauthnEnabled) {
@@ -134,11 +134,11 @@ Expect.describe('EnrollChoices', function () {
   }
 
   // Poor man's deep clone since we don't use lodash
-  function deepClone (res) {
+  function deepClone(res) {
     return JSON.parse(JSON.stringify(res));
   }
 
-  function setGracePeriodEndDate (res, endDate) {
+  function setGracePeriodEndDate(res, endDate) {
     const policy = res.response._embedded.policy || {};
 
     res.response._embedded.policy = _.extend(policy, {
@@ -148,7 +148,7 @@ Expect.describe('EnrollChoices', function () {
     });
   }
 
-  function setupWithRequiredNoneEnrolled (brandName, endDate) {
+  function setupWithRequiredNoneEnrolled(brandName, endDate) {
     const res = deepClone(resAllFactors);
 
     res.response._embedded.factors[0].enrollment = 'REQUIRED';
@@ -161,7 +161,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res, false, false, brandName);
   }
 
-  function setupWithRequiredNoneEnrolledOnPrem () {
+  function setupWithRequiredNoneEnrolledOnPrem() {
     const res = deepClone(resAllFactorsOnPrem);
 
     res.response._embedded.factors[0].enrollment = 'REQUIRED';
@@ -172,7 +172,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res);
   }
 
-  function setupWithRequiredSomeRequiredEnrolled (endDate) {
+  function setupWithRequiredSomeRequiredEnrolled(endDate) {
     const res = deepClone(resAllFactors);
 
     res.response._embedded.factors[0].enrollment = 'REQUIRED';
@@ -185,7 +185,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res);
   }
 
-  function setupWithRequiredAllRequiredEnrolled (includeOnPrem, endDate) {
+  function setupWithRequiredAllRequiredEnrolled(includeOnPrem, endDate) {
     const response = includeOnPrem ? resAllFactorsOnPrem : resAllFactors;
     const res = deepClone(response);
 
@@ -199,7 +199,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res);
   }
 
-  function setupWithAllOptionalNoneEnrolled (brandName, endDate) {
+  function setupWithAllOptionalNoneEnrolled(brandName, endDate) {
     const res = deepClone(resAllFactors);
 
     if (endDate) {
@@ -208,7 +208,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res, false, false, brandName);
   }
 
-  function setupWithAllOptionalSomeEnrolled (includeOnPrem, endDate) {
+  function setupWithAllOptionalSomeEnrolled(includeOnPrem, endDate) {
     const response = includeOnPrem ? resAllFactorsOnPrem : resAllFactors;
     const res = deepClone(response);
 
@@ -219,14 +219,14 @@ Expect.describe('EnrollChoices', function () {
     return setup(res);
   }
 
-  function setupWithOktaVerifyPushWithSofttokenEnrolled () {
+  function setupWithOktaVerifyPushWithSofttokenEnrolled() {
     const res = deepClone(resPush);
 
     res.response._embedded.factors[0].status = 'ACTIVE';
     return setup(res);
   }
 
-  function setupWithAllEnrolledButOktaVerifyPushWithSofttokenEnrolled () {
+  function setupWithAllEnrolledButOktaVerifyPushWithSofttokenEnrolled() {
     const res = deepClone(resPush);
 
     res.response._embedded.factors[0].status = 'ACTIVE';
@@ -234,7 +234,7 @@ Expect.describe('EnrollChoices', function () {
     return setup([res, deepClone(resSuccess)]);
   }
 
-  function setupWithOktaVerifyPushWithPushEnrolled () {
+  function setupWithOktaVerifyPushWithPushEnrolled() {
     const res = deepClone(resPush);
 
     res.response._embedded.factors[0].status = 'ACTIVE';
@@ -242,7 +242,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res);
   }
 
-  function setupMultipleFactorEnrollments (options) {
+  function setupMultipleFactorEnrollments(options) {
     const res = options.singleFactorRes
       ? deepClone(options.singleFactorRes)
       : options.useProfiles ? deepClone(resAllFactorsProfile) : deepClone(resAllFactors);
@@ -259,7 +259,7 @@ Expect.describe('EnrollChoices', function () {
     return setup(res, false, options.webauthnEnabled);
   }
 
-  function setProfileData (profile, cardinality, enrolledFactor) {
+  function setProfileData(profile, cardinality, enrolledFactor) {
     const cardinalityData = {
       min: cardinality.minimum,
       max: cardinality.maximum,
@@ -271,7 +271,7 @@ Expect.describe('EnrollChoices', function () {
     }
   }
 
-  function setupMultipleRequiredActiveEnrollmentsForFactorAndAnotherFactorRequired (options) {
+  function setupMultipleRequiredActiveEnrollmentsForFactorAndAnotherFactorRequired(options) {
     const index = factorEnrollList[options.factorName].index;
     const res = deepClone(resAllFactors);
 
@@ -283,68 +283,68 @@ Expect.describe('EnrollChoices', function () {
     return setup(res, false, options.webauthnEnabled);
   }
 
-  function itHasIconAndText (factorName, iconClass, title, subtitle, res, webauthnEnabled, brandName) {
-    itp('has right icon', function () {
-      return setup(res, false, webauthnEnabled, brandName).then(function (test) {
+  function itHasIconAndText(factorName, iconClass, title, subtitle, res, webauthnEnabled, brandName) {
+    itp('has right icon', function() {
+      return setup(res, false, webauthnEnabled, brandName).then(function(test) {
         expect(test.form.factorIconClass(factorName)).toBe('factor-icon ' + iconClass);
       });
     });
-    itp('has right title', function () {
-      return setup(res, false, webauthnEnabled, brandName).then(function (test) {
+    itp('has right title', function() {
+      return setup(res, false, webauthnEnabled, brandName).then(function(test) {
         expect(test.form.factorTitle(factorName)).toBe(title);
       });
     });
-    itp('has right subtitle', function () {
-      return setup(res, false, webauthnEnabled, brandName).then(function (test) {
+    itp('has right subtitle', function() {
+      return setup(res, false, webauthnEnabled, brandName).then(function(test) {
         expect(test.form.factorSubtitle(factorName)).toBe(subtitle);
       });
     });
   }
 
-  describe('General', function () {
-    itp('has correct title', function () {
-      return setup(resAllFactors).then(function (test) {
+  describe('General', function() {
+    itp('has correct title', function() {
+      return setup(resAllFactors).then(function(test) {
         expect(test.form.titleText()).toBe('Set up multifactor authentication');
       });
     });
-    itp('shows security beacon with saved security image if security image is enabled', function () {
-      return setup(resAllFactors, true).then(function (test) {
+    itp('shows security beacon with saved security image if security image is enabled', function() {
+      return setup(resAllFactors, true).then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
   });
 
-  describe('Wizard', function () {
-    describe('Required', function () {
-      itp('has the correct subtitle text', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+  describe('Wizard', function() {
+    describe('Required', function() {
+      itp('has the correct subtitle text', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           expect(test.form.subtitleText()).toBe(
             'Your company requires multifactor authentication to add an ' +
               'additional layer of security when signing in to your account'
           );
         });
       });
-      itp('has the correct subtitle text if config has a brandName', function () {
-        return setupWithRequiredNoneEnrolled('Spaghett Inc.').then(function (test) {
+      itp('has the correct subtitle text if config has a brandName', function() {
+        return setupWithRequiredNoneEnrolled('Spaghett Inc.').then(function(test) {
           expect(test.form.subtitleText()).toBe(
             'Your company requires multifactor authentication to add an ' +
               'additional layer of security when signing in to your Spaghett Inc. account'
           );
         });
       });
-      itp('has the correct list title of "Setup required"', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+      itp('has the correct list title of "Setup required"', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           expect(test.form.requiredFactorListTitle()).toBe('Setup required');
         });
       });
-      itp('chooses the first unenrolled required factor as the current factor', function () {
-        return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+      itp('chooses the first unenrolled required factor as the current factor', function() {
+        return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
           // GOOGLE_AUTH is the current factor in this test
           expect(test.form.isFactorMinimized('GOOGLE_AUTH')).toBe(false);
         });
       });
-      itp('minimizes factors that are not current', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+      itp('minimizes factors that are not current', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           // OKTA_VERIFY is the current factor, and GOOGLE_AUTH, QUESTION, and RSA are
           // the other required factors in this test
           expect(test.form.isFactorMinimized('OKTA_VERIFY')).toBe(false);
@@ -353,8 +353,8 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.isFactorMinimized('RSA_SECURID')).toBe(true);
         });
       });
-      itp('minimizes factors that are not current (On-Prem)', function () {
-        return setupWithRequiredNoneEnrolledOnPrem().then(function (test) {
+      itp('minimizes factors that are not current (On-Prem)', function() {
+        return setupWithRequiredNoneEnrolledOnPrem().then(function(test) {
           // OKTA_VERIFY is the current factor, and GOOGLE_AUTH, QUESTION, and ON_PREM are
           // the other required factors in this test
           expect(test.form.isFactorMinimized('OKTA_VERIFY_PUSH')).toBe(false);
@@ -363,8 +363,8 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.isFactorMinimized('ON_PREM')).toBe(true);
         });
       });
-      itp('does not show optional factors', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+      itp('does not show optional factors', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           expect(test.form.optionalFactorList().length).toBe(0);
           expect(test.form.factorRow('SYMANTEC_VIP').length).toBe(0);
           expect(test.form.factorRow('DUO').length).toBe(0);
@@ -375,37 +375,37 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorRow('CUSTOM_CLAIMS').length).toBe(0);
         });
       });
-      itp('has the button text "Configure factor" if no required factors have been enrolled', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+      itp('has the button text "Configure factor" if no required factors have been enrolled', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           expect(test.form.submitButtonText()).toBe('Configure factor');
         });
       });
-      itp('does not have skip set up link when all factors are required', function () {
-        return setupWithRequiredNoneEnrolled().then(function (test) {
+      itp('does not have skip set up link when all factors are required', function() {
+        return setupWithRequiredNoneEnrolled().then(function(test) {
           expect(test.form.skipSetUpLink().length).toBe(0);
         });
       });
-      itp('has the button text "Configure next factor if a required factor has already been enrolled"', function () {
-        return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+      itp('has the button text "Configure next factor if a required factor has already been enrolled"', function() {
+        return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
           expect(test.form.submitButtonText()).toBe('Configure next factor');
         });
       });
-      itp('shows a green checkmark next to factors that have been enrolled', function () {
-        return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+      itp('shows a green checkmark next to factors that have been enrolled', function() {
+        return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
           expect(test.form.factorHasSuccessCheck('OKTA_VERIFY')).toBe(true);
           expect(test.form.factorHasSuccessCheck('GOOGLE_AUTH')).toBe(false);
           expect(test.form.factorHasSuccessCheck('QUESTION')).toBe(false);
         });
       });
-      itp('shows a gray checkmark next to factors that have been enrolled', function () {
-        return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+      itp('shows a gray checkmark next to factors that have been enrolled', function() {
+        return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
           expect(test.form.factorHasPendingCheck('OKTA_VERIFY')).toBe(false);
           expect(test.form.factorHasPendingCheck('GOOGLE_AUTH')).toBe(true);
           expect(test.form.factorHasPendingCheck('QUESTION')).toBe(true);
         });
       });
-      itp('navigates to the current factor on save', function () {
-        return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+      itp('navigates to the current factor on save', function() {
+        return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
           test.form.submit();
           expect(test.router.navigate).toHaveBeenCalledWith('signin/enroll/google/token%3Asoftware%3Atotp', {
             trigger: true,
@@ -414,17 +414,17 @@ Expect.describe('EnrollChoices', function () {
       });
       itp(
         'has skip set up link when it is in the response and at least 1 required factor is enrolled but all required are not enrolled yet',
-        function () {
-          return setupWithRequiredSomeRequiredEnrolled().then(function (test) {
+        function() {
+          return setupWithRequiredSomeRequiredEnrolled().then(function(test) {
             expect(test.form.skipSetUpLink().length).toBe(1);
           });
         }
       );
     });
 
-    describe('Optional/Finish', function () {
-      itp('displays the general subtitle if there are only optional factors and none are enrolled', function () {
-        return setupWithAllOptionalNoneEnrolled().then(function (test) {
+    describe('Optional/Finish', function() {
+      itp('displays the general subtitle if there are only optional factors and none are enrolled', function() {
+        return setupWithAllOptionalNoneEnrolled().then(function(test) {
           expect(test.form.subtitleText()).toBe(
             'Your company requires multifactor authentication to add an ' +
               'additional layer of security when signing in to your account'
@@ -433,8 +433,8 @@ Expect.describe('EnrollChoices', function () {
       });
       itp(
         'displays the specific subtitle if there are only optional factors and none are enrolled if config has a brandName',
-        function () {
-          return setupWithAllOptionalNoneEnrolled('Spaghetti Inc.').then(function (test) {
+        function() {
+          return setupWithAllOptionalNoneEnrolled('Spaghetti Inc.').then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company requires multifactor authentication to add an ' +
                 'additional layer of security when signing in to your Spaghetti Inc. account'
@@ -442,62 +442,62 @@ Expect.describe('EnrollChoices', function () {
           });
         }
       );
-      itp('displays add optional subtitle if there are only optional factors and some are enrolled', function () {
-        return setupWithAllOptionalSomeEnrolled().then(function (test) {
+      itp('displays add optional subtitle if there are only optional factors and some are enrolled', function() {
+        return setupWithAllOptionalSomeEnrolled().then(function(test) {
           expect(test.form.subtitleText()).toBe('You can configure any additional optional factor or click finish');
         });
       });
-      itp('displays add optional subtitle if all required factors have been enrolled', function () {
-        return setupWithRequiredAllRequiredEnrolled().then(function (test) {
+      itp('displays add optional subtitle if all required factors have been enrolled', function() {
+        return setupWithRequiredAllRequiredEnrolled().then(function(test) {
           expect(test.form.subtitleText()).toBe('You can configure any additional optional factor or click finish');
         });
       });
-      itp('does not have skip set up link when all factors are optional none enrolled', function () {
-        return setupWithAllOptionalNoneEnrolled().then(function (test) {
+      itp('does not have skip set up link when all factors are optional none enrolled', function() {
+        return setupWithAllOptionalNoneEnrolled().then(function(test) {
           expect(test.form.skipSetUpLink().length).toBe(0);
         });
       });
-      itp('does not have skip set up link when all factors are optional some enrolled', function () {
-        return setupWithAllOptionalSomeEnrolled().then(function (test) {
+      itp('does not have skip set up link when all factors are optional some enrolled', function() {
+        return setupWithAllOptionalSomeEnrolled().then(function(test) {
           expect(test.form.skipSetUpLink().length).toBe(0);
         });
       });
-      itp('does not have skip set up link when all required factors are enrolled', function () {
-        return setupWithRequiredAllRequiredEnrolled().then(function (test) {
+      itp('does not have skip set up link when all required factors are enrolled', function() {
+        return setupWithRequiredAllRequiredEnrolled().then(function(test) {
           expect(test.form.skipSetUpLink().length).toBe(0);
         });
       });
-      itp('does not show the enrolled list if no factors have been enrolled', function () {
-        return setupWithAllOptionalNoneEnrolled().then(function (test) {
+      itp('does not show the enrolled list if no factors have been enrolled', function() {
+        return setupWithAllOptionalNoneEnrolled().then(function(test) {
           expect(test.form.enrolledFactorList().length).toBe(0);
         });
       });
-      itp('does not have a list title if there are no enrolled factors', function () {
-        return setupWithAllOptionalNoneEnrolled().then(function (test) {
+      itp('does not have a list title if there are no enrolled factors', function() {
+        return setupWithAllOptionalNoneEnrolled().then(function(test) {
           expect(test.form.optionalFactorListTitle()).toBe('');
         });
       });
-      itp('has a list title of "Enrolled factors" for factors that have been enrolled', function () {
-        return setupWithAllOptionalSomeEnrolled().then(function (test) {
+      itp('has a list title of "Enrolled factors" for factors that have been enrolled', function() {
+        return setupWithAllOptionalSomeEnrolled().then(function(test) {
           expect(test.form.enrolledFactorListTitle()).toBe('Enrolled factors');
         });
       });
       itp(
         'has a list title of "Additional optional factors" for the optional list if ' + 'there are enrolled factors',
-        function () {
-          return setupWithAllOptionalSomeEnrolled().then(function (test) {
+        function() {
+          return setupWithAllOptionalSomeEnrolled().then(function(test) {
             expect(test.form.optionalFactorListTitle()).toBe('Additional optional factors');
           });
         }
       );
-      itp('shows enrolled factors as a minimized list', function () {
-        return setupWithRequiredAllRequiredEnrolled().then(function (test) {
+      itp('shows enrolled factors as a minimized list', function() {
+        return setupWithRequiredAllRequiredEnrolled().then(function(test) {
           expect(test.form.isFactorMinimized('GOOGLE_AUTH')).toBe(true);
           expect(test.form.isFactorMinimized('QUESTION')).toBe(true);
         });
       });
-      itp('shows optional factors in their expanded title + description state', function () {
-        return setupWithRequiredAllRequiredEnrolled().then(function (test) {
+      itp('shows optional factors in their expanded title + description state', function() {
+        return setupWithRequiredAllRequiredEnrolled().then(function(test) {
           expect(test.form.isFactorMinimized('OKTA_VERIFY')).toBe(false);
           expect(test.form.isFactorMinimized('SYMANTEC_VIP')).toBe(false);
           expect(test.form.isFactorMinimized('RSA_SECURID')).toBe(false);
@@ -511,8 +511,8 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.isFactorMinimized('CUSTOM_CLAIMS')).toBe(false);
         });
       });
-      itp('shows optional factors in their expanded title + description state (On-Prem)', function () {
-        return setupWithRequiredAllRequiredEnrolled(true).then(function (test) {
+      itp('shows optional factors in their expanded title + description state (On-Prem)', function() {
+        return setupWithRequiredAllRequiredEnrolled(true).then(function(test) {
           expect(test.form.isFactorMinimized('OKTA_VERIFY')).toBe(false);
           expect(test.form.isFactorMinimized('SYMANTEC_VIP')).toBe(false);
           expect(test.form.isFactorMinimized('ON_PREM')).toBe(false);
@@ -525,8 +525,8 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.isFactorMinimized('CUSTOM_CLAIMS')).toBe(false);
         });
       });
-      itp('has a setup button for each unenrolled optional factor which navigates to the correct page', function () {
-        return setupWithAllOptionalSomeEnrolled().then(function (test) {
+      itp('has a setup button for each unenrolled optional factor which navigates to the correct page', function() {
+        return setupWithAllOptionalSomeEnrolled().then(function(test) {
           expect(test.form.factorButton('OKTA_VERIFY').length).toBe(1);
           expect(test.form.factorButton('GOOGLE_AUTH').length).toBe(1);
           expect(test.form.factorButton('SYMANTEC_VIP').length).toBe(1);
@@ -545,8 +545,8 @@ Expect.describe('EnrollChoices', function () {
       });
       itp(
         'has a setup button for each unenrolled optional factor which navigates to the correct page (On-Prem)',
-        function () {
-          return setupWithAllOptionalSomeEnrolled(true).then(function (test) {
+        function() {
+          return setupWithAllOptionalSomeEnrolled(true).then(function(test) {
             expect(test.form.factorButton('OKTA_VERIFY_PUSH').length).toBe(0);
             expect(test.form.factorButton('QUESTION').length).toBe(1);
             expect(test.form.factorButton('GOOGLE_AUTH').length).toBe(1);
@@ -567,25 +567,25 @@ Expect.describe('EnrollChoices', function () {
           });
         }
       );
-      itp('has the button "Finish" if all required factors have been enrolled', function () {
-        return setupWithRequiredAllRequiredEnrolled().then(function (test) {
+      itp('has the button "Finish" if all required factors have been enrolled', function() {
+        return setupWithRequiredAllRequiredEnrolled().then(function(test) {
           expect(test.form.submitButtonText()).toBe('Finish');
         });
       });
-      itp('has the button "Finish" if only optional factors, but at least one has been enrolled', function () {
-        return setupWithAllOptionalSomeEnrolled().then(function (test) {
+      itp('has the button "Finish" if only optional factors, but at least one has been enrolled', function() {
+        return setupWithAllOptionalSomeEnrolled().then(function(test) {
           expect(test.form.submitButtonText()).toBe('Finish');
         });
       });
-      itp('it uses the finish link to finish enrollment if Finish is clicked', function () {
+      itp('it uses the finish link to finish enrollment if Finish is clicked', function() {
         return setupWithAllOptionalSomeEnrolled()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resAllFactors);
             test.form.submit();
             return tick();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/skip',
@@ -598,23 +598,23 @@ Expect.describe('EnrollChoices', function () {
       itp(
         'does not show the Finish button if there are no required factors and no ' +
           'optional factors have been enrolled',
-        function () {
-          return setupWithAllOptionalNoneEnrolled().then(function (test) {
+        function() {
+          return setupWithAllOptionalNoneEnrolled().then(function(test) {
             expect(test.form.submitButton().length).toBe(0);
           });
         }
       );
     });
 
-    describe('Grace period', function () {
-      beforeEach(function () {
+    describe('Grace period', function() {
+      beforeEach(function() {
         const today = new Date('2019-06-25T00:00:00.000Z');
 
         jasmine.clock().mockDate(today);
       });
-      describe('all factors are required and none are enrolled', function () {
-        itp('has default subtitle', function () {
-          return setupWithRequiredNoneEnrolled(null, '2019-06-28T00:00:00.000Z').then(function (test) {
+      describe('all factors are required and none are enrolled', function() {
+        itp('has default subtitle', function() {
+          return setupWithRequiredNoneEnrolled(null, '2019-06-28T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company requires multifactor authentication to add an ' +
                 'additional layer of security when signing in to your account'
@@ -622,17 +622,17 @@ Expect.describe('EnrollChoices', function () {
           });
         });
       });
-      describe('all factors are required and at least one is enrolled', function () {
-        itp('has default subtitle when endDate is null', function () {
-          return setupWithRequiredSomeRequiredEnrolled(null).then(function (test) {
+      describe('all factors are required and at least one is enrolled', function() {
+        itp('has default subtitle when endDate is null', function() {
+          return setupWithRequiredSomeRequiredEnrolled(null).then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company requires multifactor authentication to add an additional ' +
                 'layer of security when signing in to your account'
             );
           });
         });
-        itp('has grace period subtitle when endDate is not null', function () {
-          return setupWithRequiredSomeRequiredEnrolled('2019-06-28T00:00:00.000Z').then(function (test) {
+        itp('has grace period subtitle when endDate is not null', function() {
+          return setupWithRequiredSomeRequiredEnrolled('2019-06-28T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company recommends setting up additional factors for authentication. ' +
                 'Set up will be required in: 3 day(s).'
@@ -642,11 +642,11 @@ Expect.describe('EnrollChoices', function () {
         itp(
           'has grace period less than one day subtitle when time remaining is less \
           than a day',
-          function () {
+          function() {
             const today = new Date('2019-06-25T11:59:59.000Z');
 
             jasmine.clock().mockDate(today);
-            return setupWithRequiredSomeRequiredEnrolled('2019-06-26T00:00:00.000Z').then(function (test) {
+            return setupWithRequiredSomeRequiredEnrolled('2019-06-26T00:00:00.000Z').then(function(test) {
               expect(test.form.subtitleText()).toBe(
                 'Your company recommends setting up additional factors for authentication. ' +
                   'Set up will be required in: less than 1 day.'
@@ -654,11 +654,11 @@ Expect.describe('EnrollChoices', function () {
             });
           }
         );
-        itp('has default subtitle when todays date is past endDate', function () {
+        itp('has default subtitle when todays date is past endDate', function() {
           const today = new Date('2019-06-26T11:59:59.000Z');
 
           jasmine.clock().mockDate(today);
-          return setupWithRequiredSomeRequiredEnrolled('2019-06-26T00:00:00.000Z').then(function (test) {
+          return setupWithRequiredSomeRequiredEnrolled('2019-06-26T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company requires multifactor authentication to add an additional ' +
                 'layer of security when signing in to your account'
@@ -666,16 +666,16 @@ Expect.describe('EnrollChoices', function () {
           });
         });
       });
-      describe('all factors are required and all are enrolled', function () {
-        itp('has optional subtitle', function () {
-          return setupWithRequiredAllRequiredEnrolled(null, '2019-06-28T00:00:00.000Z').then(function (test) {
+      describe('all factors are required and all are enrolled', function() {
+        itp('has optional subtitle', function() {
+          return setupWithRequiredAllRequiredEnrolled(null, '2019-06-28T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe('You can configure any additional optional factor or click finish');
           });
         });
       });
-      describe('all factors optional and none are enrolled', function () {
-        itp('has default subtitle', function () {
-          return setupWithAllOptionalNoneEnrolled(null, '2019-06-28T00:00:00.000Z').then(function (test) {
+      describe('all factors optional and none are enrolled', function() {
+        itp('has default subtitle', function() {
+          return setupWithAllOptionalNoneEnrolled(null, '2019-06-28T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe(
               'Your company requires multifactor authentication to add an ' +
                 'additional layer of security when signing in to your account'
@@ -683,9 +683,9 @@ Expect.describe('EnrollChoices', function () {
           });
         });
       });
-      describe('all factors optional and some are enrolled', function () {
-        itp('has optional subtitle', function () {
-          return setupWithAllOptionalSomeEnrolled(null, '2019-06-28T00:00:00.000Z').then(function (test) {
+      describe('all factors optional and some are enrolled', function() {
+        itp('has optional subtitle', function() {
+          return setupWithAllOptionalSomeEnrolled(null, '2019-06-28T00:00:00.000Z').then(function(test) {
             expect(test.form.subtitleText()).toBe('You can configure any additional optional factor or click finish');
           });
         });
@@ -693,8 +693,8 @@ Expect.describe('EnrollChoices', function () {
     });
   });
 
-  describe('Factor list', function () {
-    describe('OKTA_VERIFY', function () {
+  describe('Factor list', function() {
+    describe('OKTA_VERIFY', function() {
       itHasIconAndText(
         'OKTA_VERIFY',
         'mfa-okta-verify',
@@ -703,7 +703,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('OKTA_VERIFY_PUSH', function () {
+    describe('OKTA_VERIFY_PUSH', function() {
       itHasIconAndText(
         'OKTA_VERIFY_PUSH',
         'mfa-okta-verify',
@@ -711,20 +711,20 @@ Expect.describe('EnrollChoices', function () {
         'Use a push notification sent to the mobile app.',
         resPush
       );
-      itp('does not show okta totp row when push is available', function () {
-        return setup(resPush).then(function (test) {
+      itp('does not show okta totp row when push is available', function() {
+        return setup(resPush).then(function(test) {
           expect(test.form.factorRow('OKTA_VERIFY').length).toBe(0);
         });
       });
-      itp('does not show okta totp row when push is enrolled', function () {
-        return setupWithOktaVerifyPushWithPushEnrolled().then(function (test) {
+      itp('does not show okta totp row when push is enrolled', function() {
+        return setupWithOktaVerifyPushWithPushEnrolled().then(function(test) {
           expect(test.form.factorRow('OKTA_VERIFY').length).toBe(0);
           expect(test.form.factorRow('OKTA_VERIFY_PUSH').length).toBe(1);
           expect(test.form.factorHasSuccessCheck('OKTA_VERIFY_PUSH')).toBe(true);
         });
       });
-      itp('does not show okta push row when softtoken is enrolled', function () {
-        return setupWithOktaVerifyPushWithSofttokenEnrolled().then(function (test) {
+      itp('does not show okta push row when softtoken is enrolled', function() {
+        return setupWithOktaVerifyPushWithSofttokenEnrolled().then(function(test) {
           expect(test.form.factorRow('OKTA_VERIFY_PUSH').length).toBe(0);
           expect(test.form.factorRow('OKTA_VERIFY').length).toBe(1);
           expect(test.form.factorHasSuccessCheck('OKTA_VERIFY')).toBe(true);
@@ -733,8 +733,8 @@ Expect.describe('EnrollChoices', function () {
       itp(
         'redirects straight to finish link when all factors are enrolled \
           and OktaVerify softtoken factor enrolled while push is on',
-        function () {
-          return setupWithAllEnrolledButOktaVerifyPushWithSofttokenEnrolled().then(function () {
+        function() {
+          return setupWithAllEnrolledButOktaVerifyPushWithSofttokenEnrolled().then(function() {
             Expect.isJsonPost(Util.lastAjaxRequest(), {
               url: 'https://foo.com/api/v1/authn/skip',
               data: {
@@ -745,7 +745,7 @@ Expect.describe('EnrollChoices', function () {
         }
       );
     });
-    describe('GOOGLE_AUTH', function () {
+    describe('GOOGLE_AUTH', function() {
       itHasIconAndText(
         'GOOGLE_AUTH',
         'mfa-google-auth',
@@ -754,7 +754,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('SYMANTEC_VIP', function () {
+    describe('SYMANTEC_VIP', function() {
       itHasIconAndText(
         'SYMANTEC_VIP',
         'mfa-symantec',
@@ -763,7 +763,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('RSA_SECURID', function () {
+    describe('RSA_SECURID', function() {
       itHasIconAndText(
         'RSA_SECURID',
         'mfa-rsa',
@@ -772,7 +772,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('ON_PREM', function () {
+    describe('ON_PREM', function() {
       itHasIconAndText(
         'ON_PREM',
         'mfa-onprem',
@@ -781,7 +781,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactorsOnPrem
       );
     });
-    describe('DUO', function () {
+    describe('DUO', function() {
       itHasIconAndText(
         'DUO',
         'mfa-duo',
@@ -790,7 +790,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('SMS', function () {
+    describe('SMS', function() {
       itHasIconAndText(
         'SMS',
         'mfa-okta-sms',
@@ -798,14 +798,14 @@ Expect.describe('EnrollChoices', function () {
         'Enter a single-use code sent to your mobile phone.',
         resAllFactors
       );
-      itp('has the right click event', function () {
-        return setup(resAllFactors).then(function (test) {
+      itp('has the right click event', function() {
+        return setup(resAllFactors).then(function(test) {
           test.form.factorButton('SMS').click();
           expect(test.router.navigate).toHaveBeenCalledWith('signin/enroll/okta/sms', { trigger: true });
         });
       });
     });
-    describe('CALL', function () {
+    describe('CALL', function() {
       itHasIconAndText(
         'CALL',
         'mfa-okta-call',
@@ -813,14 +813,14 @@ Expect.describe('EnrollChoices', function () {
         'Use a phone to authenticate by following voice instructions.',
         resAllFactors
       );
-      itp('has the right click event', function () {
-        return setup(resAllFactors).then(function (test) {
+      itp('has the right click event', function() {
+        return setup(resAllFactors).then(function(test) {
           test.form.factorButton('CALL').click();
           expect(test.router.navigate).toHaveBeenCalledWith('signin/enroll/okta/call', { trigger: true });
         });
       });
     });
-    describe('EMAIL', function () {
+    describe('EMAIL', function() {
       itHasIconAndText(
         'EMAIL',
         'mfa-okta-email',
@@ -828,14 +828,14 @@ Expect.describe('EnrollChoices', function () {
         'Enter a verification code sent to your email.',
         resAllFactors
       );
-      itp('has the right click event', function () {
-        return setup(resAllFactors).then(function (test) {
+      itp('has the right click event', function() {
+        return setup(resAllFactors).then(function(test) {
           test.form.factorButton('EMAIL').click();
           expect(test.router.navigate).toHaveBeenCalledWith('signin/enroll/okta/email', { trigger: true });
         });
       });
     });
-    describe('U2F', function () {
+    describe('U2F', function() {
       itHasIconAndText(
         'U2F',
         'mfa-u2f',
@@ -844,7 +844,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('U2F WITH BRANDNAME', function () {
+    describe('U2F WITH BRANDNAME', function() {
       itHasIconAndText(
         'U2F',
         'mfa-u2f',
@@ -855,7 +855,7 @@ Expect.describe('EnrollChoices', function () {
         'Spaghetti Inc.'
       );
     });
-    describe('WEBAUTHN', function () {
+    describe('WEBAUTHN', function() {
       itHasIconAndText(
         'WEBAUTHN',
         'mfa-webauthn',
@@ -865,7 +865,7 @@ Expect.describe('EnrollChoices', function () {
         true
       );
     });
-    describe('Hotp', function () {
+    describe('Hotp', function() {
       itHasIconAndText(
         'CUSTOM_HOTP',
         'mfa-hotp',
@@ -874,14 +874,14 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
 
-      itp('displays enrolled profile name if already enrolled', function () {
-        return setup(resEnrolledHotp).then(function (test) {
+      itp('displays enrolled profile name if already enrolled', function() {
+        return setup(resEnrolledHotp).then(function(test) {
           expect(test.form.factorTitle('CUSTOM_HOTP')).toBe('Entrust2');
           expect(test.form.factorHasSuccessCheck('CUSTOM_HOTP')).toBe(true);
         });
       });
     });
-    describe('QUESTION', function () {
+    describe('QUESTION', function() {
       itHasIconAndText(
         'QUESTION',
         'mfa-okta-security-question',
@@ -890,7 +890,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('CUSTOM CLAIMS FACTOR', function () {
+    describe('CUSTOM CLAIMS FACTOR', function() {
       itHasIconAndText(
         'CUSTOM_CLAIMS',
         'mfa-custom-factor',
@@ -899,7 +899,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('CUSTOM SAML FACTOR', function () {
+    describe('CUSTOM SAML FACTOR', function() {
       itHasIconAndText(
         'GENERIC_SAML',
         'mfa-custom-factor',
@@ -908,7 +908,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('CUSTOM SAML FACTOR WITH BRANDNAME', function () {
+    describe('CUSTOM SAML FACTOR WITH BRANDNAME', function() {
       itHasIconAndText(
         'GENERIC_SAML',
         'mfa-custom-factor',
@@ -919,7 +919,7 @@ Expect.describe('EnrollChoices', function () {
         'Spaghetti Inc.'
       );
     });
-    describe('CUSTOM OIDC FACTOR', function () {
+    describe('CUSTOM OIDC FACTOR', function() {
       itHasIconAndText(
         'GENERIC_OIDC',
         'mfa-custom-factor',
@@ -928,7 +928,7 @@ Expect.describe('EnrollChoices', function () {
         resAllFactors
       );
     });
-    describe('CUSTOM OIDC FACTOR WITH BRANDNAME', function () {
+    describe('CUSTOM OIDC FACTOR WITH BRANDNAME', function() {
       itHasIconAndText(
         'GENERIC_OIDC',
         'mfa-custom-factor',
@@ -941,9 +941,9 @@ Expect.describe('EnrollChoices', function () {
     });
   });
 
-  describe('Factor list order', function () {
-    itp('is in correct order', function () {
-      return setup(resAllFactors).then(function (test) {
+  describe('Factor list order', function() {
+    itp('is in correct order', function() {
+      return setup(resAllFactors).then(function(test) {
         const factorList = test.form.getFactorList();
 
         expect(factorList).toEqual([
@@ -966,8 +966,8 @@ Expect.describe('EnrollChoices', function () {
         ]);
       });
     });
-    itp('with push and onPrem is in correct order', function () {
-      return setup(resAllFactorsOnPrem).then(function (test) {
+    itp('with push and onPrem is in correct order', function() {
+      return setup(resAllFactorsOnPrem).then(function(test) {
         const factorList = test.form.getFactorList();
 
         expect(factorList).toEqual([
@@ -991,17 +991,17 @@ Expect.describe('EnrollChoices', function () {
     });
   });
 
-  describe('Multiple Enrollments', function () {
-    function testMultipleEnrollmentsForFactor (factorName, webauthnEnabled, useProfiles, enrolledFactor) {
-      itp('does not display cardinality text if it is optional', function () {
+  describe('Multiple Enrollments', function() {
+    function testMultipleEnrollmentsForFactor(factorName, webauthnEnabled, useProfiles, enrolledFactor) {
+      itp('does not display cardinality text if it is optional', function() {
         const res = useProfiles ? resAllFactorsProfile : resAllFactors;
 
-        return setup(res, false, webauthnEnabled).then(function (test) {
+        return setup(res, false, webauthnEnabled).then(function(test) {
           expect(test.form.factorButtonText(factorName)).toBe('Setup');
           expect(test.form.factorCardinalityText(factorName)).toBe('');
         });
       });
-      itp('does not display cardinality text when factor is REQUIRED and maximum=1', function () {
+      itp('does not display cardinality text when factor is REQUIRED and maximum=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1009,13 +1009,13 @@ Expect.describe('EnrollChoices', function () {
           cardinality: { enrolled: 0, minimum: 0, maximum: 1 },
           webauthnEnabled,
           useProfiles,
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.factorButtonText(factorName)).toBe('');
           expect(test.form.factorCardinalityText(factorName)).toBe('');
           expect(test.form.submitButtonText()).toBe('Configure factor');
         });
       });
-      itp('displays correct button and cardinality text when enrolled=1 optional=2', function () {
+      itp('displays correct button and cardinality text when enrolled=1 optional=2', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1024,7 +1024,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1041,7 +1041,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(null, optionalFactorRow)).toBe('');
         });
       });
-      itp('displays correct button and cardinality text when enrolled=2 optional=1', function () {
+      itp('displays correct button and cardinality text when enrolled=2 optional=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1050,7 +1050,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1067,7 +1067,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(null, optionalFactorRow)).toBe('');
         });
       });
-      itp('displays correct button and cardinality text when enrolled=3 optional=0', function () {
+      itp('displays correct button and cardinality text when enrolled=3 optional=0', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1076,7 +1076,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays only one row for enrolled, none for optional
@@ -1086,7 +1086,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(factorName)).toBe('(3 set up)');
         });
       });
-      itp('displays correct cardinality text when enrolled=0 required=2', function () {
+      itp('displays correct cardinality text when enrolled=0 required=2', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1094,13 +1094,13 @@ Expect.describe('EnrollChoices', function () {
           cardinality: { enrolled: 0, minimum: 2, maximum: 3 },
           webauthnEnabled,
           useProfiles,
-        }).then(function (test) {
+        }).then(function(test) {
           //enrolled factor row should have pending check and cardinality text
           expect(test.form.factorHasPendingCheck(factorName)).toBe(true);
           expect(test.form.factorCardinalityText(factorName)).toBe('(0 of 2 set up)');
         });
       });
-      itp('displays correct cardinality text when enrolled=1 required=1', function () {
+      itp('displays correct cardinality text when enrolled=1 required=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1109,13 +1109,13 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           //enrolled factor row should have pending check and cardinality text
           expect(test.form.factorHasPendingCheck(factorName)).toBe(true);
           expect(test.form.factorCardinalityText(factorName)).toBe('(1 of 2 set up)');
         });
       });
-      itp('does not have skip set up link when enrolled=1 required=1', function () {
+      itp('does not have skip set up link when enrolled=1 required=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1124,18 +1124,18 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.skipSetUpLink().length).toBe(0);
         });
       });
-      itp('displays correct cardinality text when enrolled=2 required=0 and question required', function () {
+      itp('displays correct cardinality text when enrolled=2 required=0 and question required', function() {
         return setupMultipleRequiredActiveEnrollmentsForFactorAndAnotherFactorRequired({
           factorName,
           cardinality: { enrolled: 2, minimum: 2, maximum: 3 },
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           //enrolled factor row should have success check and cardinality text
           expect(test.form.factorHasSuccessCheck(factorName)).toBe(true);
           expect(test.form.factorCardinalityText(factorName)).toBe('(2 set up)');
@@ -1143,19 +1143,19 @@ Expect.describe('EnrollChoices', function () {
       });
       itp(
         'has skip set up link when it is in the response and enrolled=2 required=0 and question required',
-        function () {
+        function() {
           return setupMultipleRequiredActiveEnrollmentsForFactorAndAnotherFactorRequired({
             factorName,
             cardinality: { enrolled: 2, minimum: 2, maximum: 3 },
             webauthnEnabled,
             useProfiles,
             enrolledFactor,
-          }).then(function (test) {
+          }).then(function(test) {
             expect(test.form.skipSetUpLink().length).toBe(1);
           });
         }
       );
-      itp('displays correct cardinality text when enrolled=2 required=0 optional=1', function () {
+      itp('displays correct cardinality text when enrolled=2 required=0 optional=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1164,7 +1164,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1181,7 +1181,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(null, optionalFactorRow)).toBe('');
         });
       });
-      itp('displays correct cardinality text when enrolled=3 required=0 optional=0', function () {
+      itp('displays correct cardinality text when enrolled=3 required=0 optional=0', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1190,7 +1190,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays only one row for enrolled, none for optional
@@ -1200,7 +1200,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(factorName)).toBe('(3 set up)');
         });
       });
-      itp('checks that the order of factors is correct during enroll if enrollment OPTIONAL', function () {
+      itp('checks that the order of factors is correct during enroll if enrollment OPTIONAL', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1209,7 +1209,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.optionalFactorList();
           const factorIndex = factorRows.find(`[data-se="${factorName}"]`).index();
           const expectedIndex =
@@ -1222,7 +1222,7 @@ Expect.describe('EnrollChoices', function () {
           expect(factorIndex).toBe(expectedIndex);
         });
       });
-      itp('checks that the order of factors is correct during enroll if enrollment REQUIRED', function () {
+      itp('checks that the order of factors is correct during enroll if enrollment REQUIRED', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1231,7 +1231,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.optionalFactorList();
           const factorIndex = factorRows.find(`[data-se="${factorName}"]`).index();
           const expectedIndex =
@@ -1246,20 +1246,20 @@ Expect.describe('EnrollChoices', function () {
       });
     }
 
-    function testMultipleEnrollmentsWhenSingleFactor (
+    function testMultipleEnrollmentsWhenSingleFactor(
       factorName,
       singleFactorRes,
       webauthnEnabled,
       useProfiles,
       enrolledFactor
     ) {
-      itp('does not display cardinality text if factor is optional', function () {
-        return setup(singleFactorRes, false, webauthnEnabled).then(function (test) {
+      itp('does not display cardinality text if factor is optional', function() {
+        return setup(singleFactorRes, false, webauthnEnabled).then(function(test) {
           expect(test.form.factorButtonText(factorName)).toBe('Setup');
           expect(test.form.factorCardinalityText(factorName)).toBe('');
         });
       });
-      itp('displays correct button and cardinality text when enrolled=1 optional=2', function () {
+      itp('displays correct button and cardinality text when enrolled=1 optional=2', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1269,7 +1269,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1286,7 +1286,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(null, optionalFactorRow)).toBe('');
         });
       });
-      itp('displays correct button and cardinality text when enrolled=2 optional=1', function () {
+      itp('displays correct button and cardinality text when enrolled=2 optional=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1296,7 +1296,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1313,7 +1313,7 @@ Expect.describe('EnrollChoices', function () {
           expect(test.form.factorCardinalityText(null, optionalFactorRow)).toBe('');
         });
       });
-      itp('displays correct cardinality text when enrolled=0 required=2', function () {
+      itp('displays correct cardinality text when enrolled=0 required=2', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1322,13 +1322,13 @@ Expect.describe('EnrollChoices', function () {
           singleFactorRes,
           webauthnEnabled,
           useProfiles,
-        }).then(function (test) {
+        }).then(function(test) {
           //enrolled factor row should have pending check and cardinality text
           expect(test.form.factorHasPendingCheck(factorName)).toBe(true);
           expect(test.form.factorCardinalityText(factorName)).toBe('(0 of 2 set up)');
         });
       });
-      itp('displays correct cardinality text when enrolled=1 required=1', function () {
+      itp('displays correct cardinality text when enrolled=1 required=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'NOT_SETUP',
@@ -1338,13 +1338,13 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           //enrolled factor row should have pending check and cardinality text
           expect(test.form.factorHasPendingCheck(factorName)).toBe(true);
           expect(test.form.factorCardinalityText(factorName)).toBe('(1 of 2 set up)');
         });
       });
-      itp('displays correct cardinality text when enrolled=2 required=0 optional=1', function () {
+      itp('displays correct cardinality text when enrolled=2 required=0 optional=1', function() {
         return setupMultipleFactorEnrollments({
           factorName,
           status: 'ACTIVE',
@@ -1354,7 +1354,7 @@ Expect.describe('EnrollChoices', function () {
           webauthnEnabled,
           useProfiles,
           enrolledFactor,
-        }).then(function (test) {
+        }).then(function(test) {
           const factorRows = test.form.factorRow(factorName);
 
           //displays one row for enrolled, one for optional
@@ -1373,22 +1373,22 @@ Expect.describe('EnrollChoices', function () {
       });
     }
 
-    describe('U2F multi enrollments', function () {
+    describe('U2F multi enrollments', function() {
       testMultipleEnrollmentsForFactor('U2F');
     });
-    describe('with only U2F configured', function () {
+    describe('with only U2F configured', function() {
       testMultipleEnrollmentsWhenSingleFactor('U2F', resMultipleU2F);
     });
-    describe('WEBAUTHN multi enrollments', function () {
+    describe('WEBAUTHN multi enrollments', function() {
       testMultipleEnrollmentsForFactor('WEBAUTHN', true);
     });
-    describe('with only WEBAUTHN configured', function () {
+    describe('with only WEBAUTHN configured', function() {
       testMultipleEnrollmentsWhenSingleFactor('WEBAUTHN', resMultipleWebauthn, true);
     });
-    describe('WEBAUTHN with profiles', function () {
+    describe('WEBAUTHN with profiles', function() {
       testMultipleEnrollmentsForFactor('WEBAUTHN', true, true, enrolledWebauthnFactor);
     });
-    describe('with only WEBAUTHN configured with profiles', function () {
+    describe('with only WEBAUTHN configured with profiles', function() {
       testMultipleEnrollmentsWhenSingleFactor(
         'WEBAUTHN',
         resMultipleWebauthnProfile,
@@ -1397,10 +1397,10 @@ Expect.describe('EnrollChoices', function () {
         enrolledWebauthnFactor
       );
     });
-    describe('Okta Verify', function () {
+    describe('Okta Verify', function() {
       testMultipleEnrollmentsForFactor('OKTA_VERIFY');
     });
-    describe('with only Okta Verify totp configured', function () {
+    describe('with only Okta Verify totp configured', function() {
       const resMultipleOktaVerifyTotp = deepClone(resMultipleOktaVerify);
 
       resMultipleOktaVerifyTotp.response._embedded.factors = _.where(
@@ -1409,7 +1409,7 @@ Expect.describe('EnrollChoices', function () {
       );
       testMultipleEnrollmentsWhenSingleFactor('OKTA_VERIFY', resMultipleOktaVerifyTotp);
     });
-    describe('with only Okta Verify push configured', function () {
+    describe('with only Okta Verify push configured', function() {
       const resMultipleOktaVerifyTotp = deepClone(resMultipleOktaVerify);
 
       resMultipleOktaVerifyTotp.response._embedded.factors = _.where(
@@ -1418,7 +1418,7 @@ Expect.describe('EnrollChoices', function () {
       );
       testMultipleEnrollmentsWhenSingleFactor('OKTA_VERIFY_PUSH', resMultipleOktaVerifyTotp);
     });
-    describe('with only Okta Verify Totp/Push configured', function () {
+    describe('with only Okta Verify Totp/Push configured', function() {
       testMultipleEnrollmentsWhenSingleFactor('OKTA_VERIFY_PUSH', resMultipleOktaVerify);
     });
   });

--- a/test/unit/spec/EnrollCustomFactor_spec.js
+++ b/test/unit/spec/EnrollCustomFactor_spec.js
@@ -17,8 +17,8 @@ import LoginUtil from 'util/Util';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-Expect.describe('EnrollCustomFactor', function () {
-  function setup (factorType) {
+Expect.describe('EnrollCustomFactor', function() {
+  function setup(factorType) {
     const setNextResponse = Util.mockAjax([responseMfaEnrollAll]);
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -37,7 +37,7 @@ Expect.describe('EnrollCustomFactor', function () {
 
     setNextResponse(responseMfaEnrollAll);
     router.refreshAuthState('dummy-token');
-    return Expect.waitForEnrollChoices().then(function () {
+    return Expect.waitForEnrollChoices().then(function() {
       switch (factorType) {
       case 'custom_oidc':
         router.enrollOIDCFactor();
@@ -61,31 +61,31 @@ Expect.describe('EnrollCustomFactor', function () {
     });
   }
 
-  Expect.describe('Enroll factor', function () {
-    Expect.describe('GENERIC_SAML', function () {
-      itp('displays the correct factorBeacon', function () {
-        return setup('custom_saml').then(function (test) {
+  Expect.describe('Enroll factor', function() {
+    Expect.describe('GENERIC_SAML', function() {
+      itp('displays the correct factorBeacon', function() {
+        return setup('custom_saml').then(function(test) {
           expect(test.beacon.isFactorBeacon()).toBe(true);
           expect(test.beacon.hasClass('mfa-custom-factor')).toBe(true);
         });
       });
 
-      itp('has a "back" link in the footer', function () {
-        return setup('custom_saml').then(function (test) {
+      itp('has a "back" link in the footer', function() {
+        return setup('custom_saml').then(function(test) {
           Expect.isVisible(test.form.backLink());
         });
       });
 
-      itp('displays correct title', function () {
-        return setup('custom_saml').then(function (test) {
+      itp('displays correct title', function() {
+        return setup('custom_saml').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.titleText()).toBe('Third Party Factor');
           expect(test.form.buttonBar().hasClass('hide')).toBe(false);
         });
       });
 
-      itp('displays correct subtitle', function () {
-        return setup('custom_saml').then(function (test) {
+      itp('displays correct subtitle', function() {
+        return setup('custom_saml').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.subtitleText()).toBe(
             'Clicking below will redirect to MFA enrollment with Third Party Factor'
@@ -94,29 +94,29 @@ Expect.describe('EnrollCustomFactor', function () {
         });
       });
 
-      itp('redirects to third party when Enroll button is clicked', function () {
+      itp('redirects to third party when Enroll button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setup('custom_saml')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([responseMfaEnrollActivateCustomSaml, responseSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/policy/mfa-saml-idp-redirect?okta_key=mfa.redirect.id'
             );
           });
       });
 
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setup('custom_saml')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -146,118 +146,118 @@ Expect.describe('EnrollCustomFactor', function () {
       });
     });
 
-    Expect.describe('GENERIC_OIDC', function () {
-      itp('displays the correct factorBeacon', function () {
-        return setup('custom_oidc').then(function (test) {
+    Expect.describe('GENERIC_OIDC', function() {
+      itp('displays the correct factorBeacon', function() {
+        return setup('custom_oidc').then(function(test) {
           expect(test.beacon.isFactorBeacon()).toBe(true);
           expect(test.beacon.hasClass('mfa-custom-factor')).toBe(true);
         });
       });
 
-      itp('has a "back" link in the footer', function () {
-        return setup('custom_oidc').then(function (test) {
+      itp('has a "back" link in the footer', function() {
+        return setup('custom_oidc').then(function(test) {
           Expect.isVisible(test.form.backLink());
         });
       });
 
-      itp('displays correct title', function () {
-        return setup('custom_oidc').then(function (test) {
+      itp('displays correct title', function() {
+        return setup('custom_oidc').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.titleText()).toBe('OIDC Factor');
           expect(test.form.buttonBar().hasClass('hide')).toBe(false);
         });
       });
 
-      itp('displays correct subtitle', function () {
-        return setup('custom_oidc').then(function (test) {
+      itp('displays correct subtitle', function() {
+        return setup('custom_oidc').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.subtitleText()).toBe('Clicking below will redirect to MFA enrollment with OIDC Factor');
           expect(test.form.buttonBar().hasClass('hide')).toBe(false);
         });
       });
 
-      itp('redirects to third party when Enroll button is clicked', function () {
+      itp('redirects to third party when Enroll button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setup('custom_oidc')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([responseMfaEnrollActivateCustomOidc, responseSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/policy/mfa-oidc-idp-redirect?okta_key=mfa.redirect.id'
             );
           });
       });
 
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setup('custom_oidc')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
           });
       });
     });
 
-    Expect.describe('CUSTOM_CLAIMS', function () {
-      itp('displays the correct factorBeacon', function () {
-        return setup('claims_provider').then(function (test) {
+    Expect.describe('CUSTOM_CLAIMS', function() {
+      itp('displays the correct factorBeacon', function() {
+        return setup('claims_provider').then(function(test) {
           expect(test.beacon.isFactorBeacon()).toBe(true);
           expect(test.beacon.hasClass('mfa-custom-factor')).toBe(true);
         });
       });
 
-      itp('has a "back" link in the footer', function () {
-        return setup('claims_provider').then(function (test) {
+      itp('has a "back" link in the footer', function() {
+        return setup('claims_provider').then(function(test) {
           Expect.isVisible(test.form.backLink());
         });
       });
 
-      itp('displays correct title', function () {
-        return setup('claims_provider').then(function (test) {
+      itp('displays correct title', function() {
+        return setup('claims_provider').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.titleText()).toBe('IDP factor');
           expect(test.form.buttonBar().hasClass('hide')).toBe(false);
         });
       });
 
-      itp('displays correct subtitle', function () {
-        return setup('claims_provider').then(function (test) {
+      itp('displays correct subtitle', function() {
+        return setup('claims_provider').then(function(test) {
           test.setNextResponse(responseSuccess);
           expect(test.form.subtitleText()).toBe('Clicking below will redirect to MFA enrollment with IDP factor');
           expect(test.form.buttonBar().hasClass('hide')).toBe(false);
         });
       });
 
-      itp('redirects to third party when Enroll button is clicked', function () {
+      itp('redirects to third party when Enroll button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setup('claims_provider')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([responseMfaEnrollActivateClaimsProvider, responseSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/sso/idps/idpId?stateToken=testStateToken'
             );
           });
       });
 
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setup('claims_provider')
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
           });

--- a/test/unit/spec/EnrollDuo_spec.js
+++ b/test/unit/spec/EnrollDuo_spec.js
@@ -14,8 +14,8 @@ import $sandbox from 'sandbox';
 const itp = Expect.itp;
 const tick = Expect.tick;
 
-Expect.describe('EnrollDuo', function () {
-  function setup (startRouter) {
+Expect.describe('EnrollDuo', function() {
+  function setup(startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
@@ -41,7 +41,7 @@ Expect.describe('EnrollDuo', function () {
     const enrollDuo = test => {
       setNextResponse(resAllFactors);
       router.refreshAuthState('dummy-token');
-      return Expect.waitForEnrollChoices(test).then(function (test) {
+      return Expect.waitForEnrollChoices(test).then(function(test) {
         setNextResponse(resActivateDuo);
         router.enrollDuo();
         return Expect.waitForEnrollDuo(test);
@@ -55,26 +55,26 @@ Expect.describe('EnrollDuo', function () {
     }
   }
 
-  itp('displays the correct factorBeacon', function () {
-    return setup().then(function (test) {
+  itp('displays the correct factorBeacon', function() {
+    return setup().then(function(test) {
       expect(test.beacon.isFactorBeacon()).toBe(true);
       expect(test.beacon.hasClass('mfa-duo')).toBe(true);
     });
   });
-  itp('iframe has title', function () {
-    return setup().then(function (test) {
+  itp('iframe has title', function() {
+    return setup().then(function(test) {
       expect(test.form.iframe().attr('title')).toBe(test.form.titleText());
     });
   });
-  itp('visits previous link when back link is clicked', function () {
+  itp('visits previous link when back link is clicked', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resAllFactors);
         test.form.backLink().click();
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/previous',
@@ -84,20 +84,20 @@ Expect.describe('EnrollDuo', function () {
         });
       });
   });
-  itp('returns to factor list when browser\'s back button is clicked', function () {
+  itp('returns to factor list when browser\'s back button is clicked', function() {
     return setup(true)
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resAllFactors);
         Util.triggerBrowserBackButton();
         return Expect.waitForEnrollChoices(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         Expect.isEnrollChoices(test.router.controller);
         Util.stopRouter();
       });
   });
-  itp('makes the right init request', function () {
-    return setup().then(function () {
+  itp('makes the right init request', function() {
+    return setup().then(function() {
       expect(Util.numAjaxRequests()).toBe(2);
       Expect.isJsonPost(Util.getAjaxRequest(1), {
         url: 'https://foo.com/api/v1/authn/factors',
@@ -109,8 +109,8 @@ Expect.describe('EnrollDuo', function () {
       });
     });
   });
-  itp('initializes duo correctly', function () {
-    return setup().then(function (test) {
+  itp('initializes duo correctly', function() {
+    return setup().then(function(test) {
       const initOptions = Duo.init.calls.mostRecent().args[0];
 
       expect(initOptions.host).toBe('api123443.duosecurity.com');
@@ -119,9 +119,9 @@ Expect.describe('EnrollDuo', function () {
       expect(_.isFunction(initOptions.post_action)).toBe(true);
     });
   });
-  itp('notifies okta when duo is done, and completes enrollment', function () {
+  itp('notifies okta when duo is done, and completes enrollment', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         // Duo callback (returns an empty response)
@@ -135,7 +135,7 @@ Expect.describe('EnrollDuo', function () {
         postAction('someSignedResponse');
         return tick();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isFormPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/lifecycle/activate/response',

--- a/test/unit/spec/EnrollEmail_spec.js
+++ b/test/unit/spec/EnrollEmail_spec.js
@@ -15,8 +15,8 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-Expect.describe('EnrollEmail', function () {
-  function setup (resp) {
+Expect.describe('EnrollEmail', function() {
+  function setup(resp) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'http://localhost:3000';
     const authClient = createAuthClient({
@@ -36,7 +36,7 @@ Expect.describe('EnrollEmail', function () {
     Util.mockRouterNavigate(router, false);
     setNextResponse(resp);
     router.refreshAuthState('dummy-token');
-    return Expect.waitForEnrollChoices().then(function () {
+    return Expect.waitForEnrollChoices().then(function() {
       router.enrollEmail();
       return Expect.waitForEnrollEmail({
         router: router,
@@ -49,9 +49,9 @@ Expect.describe('EnrollEmail', function () {
     });
   }
 
-  itp('display start enroll email form and is able to send code to email', function () {
+  itp('display start enroll email form and is able to send code to email', function() {
     return setup(xhrEnrollEmail)
-      .then(function (test) {
+      .then(function(test) {
         // 1. verify the page loads
         expect(test.form.titleText()).toBe('Set up Email Authentication');
         expect(test.form.enrollEmailContent()).toBe('Send a verification code to your registered email.');
@@ -61,14 +61,14 @@ Expect.describe('EnrollEmail', function () {
 
         return test;
       })
-      .then(function (test) {
+      .then(function(test) {
         // 2. mock data and click send button.
         Util.resetAjaxRequests();
         test.setNextResponse(xhrEnrollActivateEmail);
         test.form.submit();
         return Expect.waitForAjaxRequest();
       })
-      .then(function () {
+      .then(function() {
         // 3. verify request has been made
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -82,16 +82,16 @@ Expect.describe('EnrollEmail', function () {
       });
   });
 
-  itp('verify email code', function () {
+  itp('verify email code', function() {
     return setup(xhrEnrollEmail)
-      .then(function (test) {
+      .then(function(test) {
         // 1. click 'send to email' button
         Util.resetAjaxRequests();
         test.setNextResponse(xhrEnrollActivateEmail);
         test.form.submit();
         return Expect.waitForEnrollActivateEmail(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         // 2. assert landing on the email code verification page
         const form = new EnrollActivateEmailForm($sandbox);
         expect(form.titleText()).toBe('Set up Email Authentication');
@@ -107,7 +107,7 @@ Expect.describe('EnrollEmail', function () {
 
         return Object.assign({}, test, { form: form });
       })
-      .then(function (test) {
+      .then(function(test) {
         // 3. submit verification code
         Util.resetAjaxRequests();
         test.setNextResponse(xhrSUCCESS);
@@ -115,7 +115,7 @@ Expect.describe('EnrollEmail', function () {
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         // 4. enroll successfully
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -146,17 +146,17 @@ Expect.describe('EnrollEmail', function () {
         });
       });
   });
-  itp('shall be able to resend email', function () {
+  itp('shall be able to resend email', function() {
     Util.speedUpDelay();
     return setup(xhrEnrollEmail)
-      .then(function (test) {
+      .then(function(test) {
         // 1. click 'send to email' button
         Util.resetAjaxRequests();
         test.setNextResponse(xhrEnrollActivateEmail);
         test.form.submit();
         return Expect.waitForEnrollActivateEmail(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         // 2. verify resend again view
         const form = new EnrollActivateEmailForm($sandbox);
         expect(form.getResendEmailMessage().length).toBe(1);
@@ -171,7 +171,7 @@ Expect.describe('EnrollEmail', function () {
         expect(form.getResendEmailView().attr('class')).toBe('resend-email-infobox hide');
         return Expect.waitForAjaxRequest(Object.assign(test, { form }));
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'http://localhost:3000/api/v1/authn' + '/factors/eml198rKSEWOSKRIVIFT/lifecycle/resend',
@@ -183,22 +183,22 @@ Expect.describe('EnrollEmail', function () {
           return test.form.getResendEmailView().attr('class') === 'resend-email-infobox';
         }, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.getResendEmailMessage().length).toBe(1);
         expect(test.form.getResendButton().length).toBe(1);
       });
   });
-  itp('shall display resend email error', function () {
+  itp('shall display resend email error', function() {
     Util.speedUpDelay();
     return setup(xhrEnrollEmail)
-      .then(function (test) {
+      .then(function(test) {
         // 1. click 'send to email' button
         Util.resetAjaxRequests();
         test.setNextResponse(xhrEnrollActivateEmail);
         test.form.submit();
         return Expect.waitForEnrollActivateEmail(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         // 2. verify resend again view
         const form = new EnrollActivateEmailForm($sandbox);
         expect(form.getResendEmailMessage().length).toBe(1);
@@ -213,7 +213,7 @@ Expect.describe('EnrollEmail', function () {
         expect(form.getResendEmailView().attr('class')).toBe('resend-email-infobox hide');
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox().length).toBe(1);
         expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');

--- a/test/unit/spec/EnrollHotpController_spec.js
+++ b/test/unit/spec/EnrollHotpController_spec.js
@@ -10,8 +10,8 @@ import $sandbox from 'sandbox';
 
 const itp = Expect.itp;
 
-Expect.describe('EnrollHotp', function () {
-  function setup () {
+Expect.describe('EnrollHotp', function() {
+  function setup() {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
@@ -29,7 +29,7 @@ Expect.describe('EnrollHotp', function () {
 
     setNextResponse(resEnrollAllFactors);
     router.refreshAuthState('dummy-token');
-    return Expect.waitForEnrollChoices().then(function () {
+    return Expect.waitForEnrollChoices().then(function() {
       router.enrollHotpFactor('custom', 'token:hotp');
       return Expect.waitForEnrollHotp({
         router: router,
@@ -43,30 +43,30 @@ Expect.describe('EnrollHotp', function () {
     });
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-hotp')).toBe(true);
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
-    itp('is restricted', function () {
-      return setup().then(function (test) {
+  Expect.describe('Enroll factor', function() {
+    itp('is restricted', function() {
+      return setup().then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual('Contact your administrator to continue enrollment.');
       });
     });
 
-    itp('has right profile name', function () {
-      return setup().then(function (test) {
+    itp('has right profile name', function() {
+      return setup().then(function(test) {
         expect(test.form.title()).toHaveLength(1);
         expect(test.form.title().html()).toEqual('Setup Entrust');
       });

--- a/test/unit/spec/EnrollOnPrem_spec.js
+++ b/test/unit/spec/EnrollOnPrem_spec.js
@@ -15,8 +15,8 @@ import $sandbox from 'sandbox';
 const itp = Expect.itp;
 const tick = Expect.tick;
 
-Expect.describe('EnrollOnPrem', function () {
-  function setup (response, includeOnPrem, startRouter) {
+Expect.describe('EnrollOnPrem', function() {
+  function setup(response, includeOnPrem, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
@@ -32,14 +32,14 @@ Expect.describe('EnrollOnPrem', function () {
     Util.registerRouter(router);
     Util.mockRouterNavigate(router, startRouter);
     return tick()
-      .then(function () {
+      .then(function() {
         const res = response ? response : resAllFactors;
 
         setNextResponse(res);
         router.refreshAuthState('dummy-token');
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         const test = {
           router: router,
           beacon: new Beacon($sandbox),
@@ -60,7 +60,7 @@ Expect.describe('EnrollOnPrem', function () {
 
   const setupOnPrem = _.partial(setup, resAllFactorsOnPrem, true);
 
-  const getResponseNoProfile = function (response, factorType, provider) {
+  const getResponseNoProfile = function(response, factorType, provider) {
     const responseCopy = Util.deepCopy(response);
     const factors = responseCopy['response']['_embedded']['factors'];
 
@@ -70,19 +70,19 @@ Expect.describe('EnrollOnPrem', function () {
     return responseCopy;
   };
 
-  const setupRsaNoProfile = function () {
+  const setupRsaNoProfile = function() {
     const res = getResponseNoProfile(resAllFactors, 'token', 'RSA');
 
     return setup(res, false);
   };
 
-  const setupOnPremNoProfile = function () {
+  const setupOnPremNoProfile = function() {
     const res = getResponseNoProfile(resAllFactorsOnPrem, 'token', 'DEL_OATH');
 
     return setup(res, true);
   };
 
-  const setupXssVendorName = function () {
+  const setupXssVendorName = function() {
     const responseCopy = Util.deepCopy(resAllFactorsOnPrem);
     const factors = responseCopy['response']['_embedded']['factors'];
 
@@ -92,65 +92,65 @@ Expect.describe('EnrollOnPrem', function () {
     return setup(responseCopy, true);
   };
 
-  Expect.describe('RSA', function () {
-    Expect.describe('Header & Footer', function () {
-      itp('displays the correct factorBeacon', function () {
-        return setup().then(function (test) {
+  Expect.describe('RSA', function() {
+    Expect.describe('Header & Footer', function() {
+      itp('displays the correct factorBeacon', function() {
+        return setup().then(function(test) {
           expect(test.beacon.isFactorBeacon()).toBe(true);
           expect(test.beacon.hasClass('mfa-rsa')).toBe(true);
         });
       });
-      itp('has a "back" link in the footer', function () {
-        return setup().then(function (test) {
+      itp('has a "back" link in the footer', function() {
+        return setup().then(function(test) {
           Expect.isVisible(test.form.backLink());
         });
       });
-      itp('does not allow autocomplete', function () {
-        return setup().then(function (test) {
+      itp('does not allow autocomplete', function() {
+        return setup().then(function(test) {
           expect(test.form.getCodeFieldAutocomplete()).toBe('off');
         });
       });
-      itp('returns to factor list when browser\'s back button is clicked', function () {
+      itp('returns to factor list when browser\'s back button is clicked', function() {
         return setup(false, false, true)
-          .then(function (test) {
+          .then(function(test) {
             Util.triggerBrowserBackButton();
             return Expect.waitForEnrollChoices(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Expect.isEnrollChoices(test.router.controller);
             Util.stopRouter();
           });
       });
     });
 
-    Expect.describe('Enroll factor', function () {
-      itp('has a credentialId text field', function () {
-        return setup().then(function (test) {
+    Expect.describe('Enroll factor', function() {
+      itp('has a credentialId text field', function() {
+        return setup().then(function(test) {
           Expect.isTextField(test.form.credentialIdField());
         });
       });
-      itp('autopopulates credentialId text field', function () {
-        return setup().then(function (test) {
+      itp('autopopulates credentialId text field', function() {
+        return setup().then(function(test) {
           expect(test.form.getCredentialId()).toEqual('test123');
         });
       });
-      itp('does not autopopulate credentialId when profile does not exist', function () {
-        return setupRsaNoProfile().then(function (test) {
+      itp('does not autopopulate credentialId when profile does not exist', function() {
+        return setupRsaNoProfile().then(function(test) {
           expect(test.form.getCredentialId()).toEqual('');
         });
       });
-      itp('has passCode text field', function () {
-        return setup().then(function (test) {
+      itp('has passCode text field', function() {
+        return setup().then(function(test) {
           Expect.isPasswordField(test.form.codeField());
         });
       });
-      itp('has a verify button', function () {
-        return setup().then(function (test) {
+      itp('has a verify button', function() {
+        return setup().then(function(test) {
           Expect.isVisible(test.form.submitButton());
         });
       });
-      itp('does not send request and shows error if code is not entered', function () {
-        return setup().then(function (test) {
+      itp('does not send request and shows error if code is not entered', function() {
+        return setup().then(function(test) {
           Util.resetAjaxRequests();
           test.form.setCredentialId('Username');
           test.form.submit();
@@ -158,16 +158,16 @@ Expect.describe('EnrollOnPrem', function () {
           expect(Util.numAjaxRequests()).toBe(0);
         });
       });
-      itp('shows error in case of an error response', function () {
+      itp('shows error in case of an error response', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resEnrollError);
             test.form.setCredentialId('Username');
             test.form.setCode(123);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             // Note: This will change when we get field specific error messages
             expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
@@ -196,24 +196,24 @@ Expect.describe('EnrollOnPrem', function () {
             ]);
           });
       });
-      itp('clears passcode field if error is for PIN change', function () {
+      itp('clears passcode field if error is for PIN change', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resRSAChangePin);
             test.form.setCredentialId('Username');
             test.form.setCode(123);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
             expect(test.form.codeField().val()).toEqual('');
           });
       });
-      itp('calls activate with the right params', function () {
+      itp('calls activate with the right params', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.setCode(123456);
@@ -221,7 +221,7 @@ Expect.describe('EnrollOnPrem', function () {
             test.form.submit();
             return tick();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
@@ -238,65 +238,65 @@ Expect.describe('EnrollOnPrem', function () {
     });
   });
 
-  Expect.describe('On Prem (custom)', function () {
-    Expect.describe('Header & Footer', function () {
-      itp('displays the correct factorBeacon', function () {
-        return setupOnPrem().then(function (test) {
+  Expect.describe('On Prem (custom)', function() {
+    Expect.describe('Header & Footer', function() {
+      itp('displays the correct factorBeacon', function() {
+        return setupOnPrem().then(function(test) {
           expect(test.beacon.isFactorBeacon()).toBe(true);
           expect(test.beacon.hasClass('mfa-onprem')).toBe(true);
         });
       });
-      itp('has a "back" link in the footer', function () {
-        return setupOnPrem().then(function (test) {
+      itp('has a "back" link in the footer', function() {
+        return setupOnPrem().then(function(test) {
           Expect.isVisible(test.form.backLink());
         });
       });
-      itp('does not allow autocomplete', function () {
-        return setupOnPrem().then(function (test) {
+      itp('does not allow autocomplete', function() {
+        return setupOnPrem().then(function(test) {
           expect(test.form.getCodeFieldAutocomplete()).toBe('off');
         });
       });
-      itp('returns to factor list when browser\'s back button is clicked', function () {
+      itp('returns to factor list when browser\'s back button is clicked', function() {
         return setupOnPrem(true)
-          .then(function (test) {
+          .then(function(test) {
             Util.triggerBrowserBackButton();
             return Expect.waitForEnrollChoices(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Expect.isEnrollChoices(test.router.controller);
             Util.stopRouter();
           });
       });
     });
 
-    Expect.describe('Enroll factor', function () {
-      itp('has a credentialId text field', function () {
-        return setupOnPrem().then(function (test) {
+    Expect.describe('Enroll factor', function() {
+      itp('has a credentialId text field', function() {
+        return setupOnPrem().then(function(test) {
           Expect.isTextField(test.form.credentialIdField());
         });
       });
-      itp('autopopulates credentialId text field', function () {
-        return setupOnPrem().then(function (test) {
+      itp('autopopulates credentialId text field', function() {
+        return setupOnPrem().then(function(test) {
           expect(test.form.getCredentialId()).toEqual('test123');
         });
       });
-      itp('does not autopopulate credentialId when profile does not exist', function () {
-        return setupOnPremNoProfile().then(function (test) {
+      itp('does not autopopulate credentialId when profile does not exist', function() {
+        return setupOnPremNoProfile().then(function(test) {
           expect(test.form.getCredentialId()).toEqual('');
         });
       });
-      itp('has passCode text field', function () {
-        return setupOnPrem().then(function (test) {
+      itp('has passCode text field', function() {
+        return setupOnPrem().then(function(test) {
           Expect.isPasswordField(test.form.codeField());
         });
       });
-      itp('has a verify button', function () {
-        return setupOnPrem().then(function (test) {
+      itp('has a verify button', function() {
+        return setupOnPrem().then(function(test) {
           Expect.isVisible(test.form.submitButton());
         });
       });
-      itp('does not send request and shows error if code is not entered', function () {
-        return setupOnPrem().then(function (test) {
+      itp('does not send request and shows error if code is not entered', function() {
+        return setupOnPrem().then(function(test) {
           Util.resetAjaxRequests();
           test.form.setCredentialId('Username');
           test.form.submit();
@@ -304,16 +304,16 @@ Expect.describe('EnrollOnPrem', function () {
           expect(Util.numAjaxRequests()).toBe(0);
         });
       });
-      itp('shows error in case of an error response', function () {
+      itp('shows error in case of an error response', function() {
         return setupOnPrem()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resEnrollError);
             test.form.setCredentialId('Username');
             test.form.setCode(123);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             // Note: This will change when we get field specific error messages
             expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
@@ -342,24 +342,24 @@ Expect.describe('EnrollOnPrem', function () {
             ]);
           });
       });
-      itp('clears passcode field if error is for PIN change', function () {
+      itp('clears passcode field if error is for PIN change', function() {
         return setupOnPrem()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resRSAChangePin);
             test.form.setCredentialId('Username');
             test.form.setCode(123);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
             expect(test.form.codeField().val()).toEqual('');
           });
       });
-      itp('calls activate with the right params', function () {
+      itp('calls activate with the right params', function() {
         return setupOnPrem()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setCredentialId('Username');
             test.form.setCode(123456);
@@ -367,7 +367,7 @@ Expect.describe('EnrollOnPrem', function () {
             test.form.submit();
             return tick();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors',
@@ -381,8 +381,8 @@ Expect.describe('EnrollOnPrem', function () {
             });
           });
       });
-      itp('does not have explains by default', function () {
-        return setupXssVendorName().then(function (test) {
+      itp('does not have explains by default', function() {
+        return setupXssVendorName().then(function(test) {
           expect(test.form.credIdExplain().length).toBe(0);
           expect(test.form.codeExplain().length).toBe(0);
         });

--- a/test/unit/spec/EnrollPassword_spec.js
+++ b/test/unit/spec/EnrollPassword_spec.js
@@ -14,8 +14,8 @@ import RouterUtil from 'util/RouterUtil';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-Expect.describe('EnrollPassword', function () {
-  function setup (startRouter) {
+Expect.describe('EnrollPassword', function() {
+  function setup(startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -46,7 +46,7 @@ Expect.describe('EnrollPassword', function () {
     const enrollPassword = test => {
       setNextResponse(resAllFactors);
       router.refreshAuthState('dummy-token');
-      return Expect.waitForEnrollChoices(test).then(function (test) {
+      return Expect.waitForEnrollChoices(test).then(function(test) {
         router.enrollPassword();
         return Expect.waitForEnrollPassword(test);
       });
@@ -59,68 +59,68 @@ Expect.describe('EnrollPassword', function () {
     }
   }
 
-  itp('displays the correct factorBeacon', function () {
-    return setup().then(function (test) {
+  itp('displays the correct factorBeacon', function() {
+    return setup().then(function(test) {
       expect(test.beacon.isFactorBeacon()).toBe(true);
       expect(test.beacon.hasClass('mfa-okta-password')).toBe(true);
     });
   });
-  itp('does not allow autocomplete', function () {
-    return setup().then(function (test) {
+  itp('does not allow autocomplete', function() {
+    return setup().then(function(test) {
       expect(test.form.getPasswordAutocomplete()).toBe('off');
       expect(test.form.getConfirmPasswordAutocomplete()).toBe('off');
     });
   });
-  itp('has a password field', function () {
-    return setup().then(function (test) {
+  itp('has a password field', function() {
+    return setup().then(function(test) {
       const password = test.form.passwordField();
 
       expect(password.length).toBe(1);
       expect(password.attr('type')).toEqual('password');
     });
   });
-  itp('has a confirm password field', function () {
-    return setup().then(function (test) {
+  itp('has a confirm password field', function() {
+    return setup().then(function(test) {
       const confirmPassword = test.form.confirmPasswordField();
 
       expect(confirmPassword.length).toBe(1);
       expect(confirmPassword.attr('type')).toEqual('password');
     });
   });
-  itp('returns to factor list when browser\'s back button is clicked', function () {
+  itp('returns to factor list when browser\'s back button is clicked', function() {
     return setup(true)
-      .then(function (test) {
+      .then(function(test) {
         Util.triggerBrowserBackButton();
         return Expect.waitForEnrollChoices(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         Expect.isEnrollChoices(test.router.controller);
         Util.stopRouter();
       });
   });
 
-  itp('calls enroll with the right arguments when save is clicked', function () {
+  itp('calls enroll with the right arguments when save is clicked', function() {
     return setup(false)
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setPassword('somepassword');
         test.form.setConfirmPassword('somepassword');
         test.setNextResponse(resSuccess);
-        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function() {
           return true;
         });
-        spyOn(document, 'addEventListener').and.callFake(function (type, fn) {
+        spyOn(document, 'addEventListener').and.callFake(function(type, fn) {
           fn();
         });
         spyOn(document, 'removeEventListener').and.callThrough();
         test.form.submit();
 
-        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function () {
+        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function() {
           return true;
         });
         return Expect.waitForSpyCall(test.successSpy, test);
       })
-      .then(function () {
+      .then(function() {
         expect(RouterUtil.isHostBackgroundChromeTab).toHaveBeenCalled();
         expect(RouterUtil.isDocumentVisible).toHaveBeenCalled();
         expect(document.removeEventListener).toHaveBeenCalled();
@@ -140,8 +140,8 @@ Expect.describe('EnrollPassword', function () {
       });
   });
 
-  itp('validates password and confirmPassword cannot be empty', function () {
-    return setup().then(function (test) {
+  itp('validates password and confirmPassword cannot be empty', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.submit();
       expect(test.form.hasErrors()).toBe(true);
@@ -153,8 +153,8 @@ Expect.describe('EnrollPassword', function () {
       expect(Util.numAjaxRequests()).toBe(0);
     });
   });
-  itp('validates password and confirmPassword fields match and errors before the request', function () {
-    return setup().then(function (test) {
+  itp('validates password and confirmPassword fields match and errors before the request', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.setPassword('somepassword');
       test.form.setConfirmPassword('someotherpassword');
@@ -167,9 +167,9 @@ Expect.describe('EnrollPassword', function () {
       expect(Util.numAjaxRequests()).toBe(0);
     });
   });
-  itp('shows error if error response on enrollment', function () {
+  itp('shows error if error response on enrollment', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Q.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setPassword('somepassword');
@@ -177,7 +177,7 @@ Expect.describe('EnrollPassword', function () {
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.hasPasswordFieldErrors()).toBe(true);
         expect(test.form.hasConfirmPasswordFieldErrors()).toBe(false);
@@ -212,8 +212,8 @@ Expect.describe('EnrollPassword', function () {
         ]);
       });
   });
-  itp('returns to factor list when back link is clicked', function () {
-    return setup().then(function (test) {
+  itp('returns to factor list when back link is clicked', function() {
+    return setup().then(function(test) {
       test.form.backLink().click();
       expect(test.router.navigate.calls.mostRecent().args).toEqual(['signin/enroll', { trigger: true }]);
     });

--- a/test/unit/spec/EnrollQuestions_spec.js
+++ b/test/unit/spec/EnrollQuestions_spec.js
@@ -19,7 +19,7 @@ import RouterUtil from 'util/RouterUtil';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-function setup (res, startRouter, languagesResponse) {
+function setup(res, startRouter, languagesResponse) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -52,7 +52,7 @@ function setup (res, startRouter, languagesResponse) {
       setNextResponse(languagesResponse);
     }
     router.refreshAuthState('dummy-token');
-    return Expect.waitForEnrollChoices(test).then(function (test) {
+    return Expect.waitForEnrollChoices(test).then(function(test) {
       setNextResponse(resQuestions);
       router.enrollQuestion();
       return Expect.waitForEnrollQuestion(test);
@@ -65,26 +65,26 @@ function setup (res, startRouter, languagesResponse) {
   }
 }
 
-function setupWithLanguage (res, options, startRouter) {
+function setupWithLanguage(res, options, startRouter) {
   spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(options.localStorageIsNotSupported);
   spyOn(BrowserFeatures, 'getUserLanguages').and.returnValue(['ja', 'en']);
   return setup(res, startRouter, [_.extend({ delay: 0 }, labelsLoginJa), _.extend({ delay: 0 }, labelsCountryJa)]);
 }
 
-function testEnrollQuestion (allFactors, expectedStateToken) {
-  itp('displays the correct factorBeacon', function () {
-    return setup(allFactors).then(function (test) {
+function testEnrollQuestion(allFactors, expectedStateToken) {
+  itp('displays the correct factorBeacon', function() {
+    return setup(allFactors).then(function(test) {
       expect(test.beacon.isFactorBeacon()).toBe(true);
       expect(test.beacon.hasClass('mfa-okta-security-question')).toBe(true);
     });
   });
-  itp('does not allow autocomplete', function () {
-    return setup(allFactors).then(function (test) {
+  itp('does not allow autocomplete', function() {
+    return setup(allFactors).then(function(test) {
       expect(test.form.getAnswerAutocomplete()).toBe('off');
     });
   });
-  itp('has a list of questions to choose from', function () {
-    return setup(allFactors).then(function (test) {
+  itp('has a list of questions to choose from', function() {
+    return setup(allFactors).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -98,8 +98,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('has a localized list of questions if language is specified no local storage', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function (test) {
+  itp('has a localized list of questions if language is specified no local storage', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -109,8 +109,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('has a localized list of questions if language is specified', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function (test) {
+  itp('has a localized list of questions if language is specified', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -120,8 +120,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('has a localized list of questions if language is specified and no local storage', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function (test) {
+  itp('has a localized list of questions if language is specified and no local storage', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -131,8 +131,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('has a localized list of questions if language is specified', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function (test) {
+  itp('has a localized list of questions if language is specified', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -142,8 +142,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('fallbacks to English if the question is not in the specified language bundle with local storage', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function (test) {
+  itp('fallbacks to English if the question is not in the specified language bundle with local storage', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: false }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -153,8 +153,8 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('fallbacks to English if the question is not in the specified language bundle no local storage', function () {
-    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function (test) {
+  itp('fallbacks to English if the question is not in the specified language bundle no local storage', function() {
+    return setupWithLanguage(allFactors, { localStorageIsNotSupported: true }).then(function(test) {
       const questions = test.form.questionList();
 
       expect(questions.length).toBe(20);
@@ -164,47 +164,47 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
     });
   });
-  itp('has an answer text box', function () {
-    return setup(allFactors).then(function (test) {
+  itp('has an answer text box', function() {
+    return setup(allFactors).then(function(test) {
       const answer = test.form.answerField();
 
       expect(answer.length).toBe(1);
       expect(answer.attr('type')).toEqual('text');
     });
   });
-  itp('returns to factor list when browser\'s back button is clicked', function () {
+  itp('returns to factor list when browser\'s back button is clicked', function() {
     return setup(allFactors, true)
-      .then(function (test) {
+      .then(function(test) {
         Util.triggerBrowserBackButton();
         return Expect.waitForEnrollChoices(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         Expect.isEnrollChoices(test.router.controller);
         Util.stopRouter();
       });
   });
-  itp('calls enroll with the right arguments when save is clicked', function () {
+  itp('calls enroll with the right arguments when save is clicked', function() {
     return setup(allFactors)
-      .then(function (test) {
+      .then(function(test) {
         test.successSpy.calls.reset();
         Util.resetAjaxRequests();
         test.form.selectQuestion('favorite_security_question');
         test.form.setAnswer('No question! Hah!');
         test.setNextResponse(resSuccess);
-        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function () {
+        spyOn(RouterUtil, 'isHostBackgroundChromeTab').and.callFake(function() {
           return true;
         });
-        spyOn(document, 'addEventListener').and.callFake(function (type, fn) {
+        spyOn(document, 'addEventListener').and.callFake(function(type, fn) {
           fn();
         });
         spyOn(document, 'removeEventListener').and.callThrough();
         test.form.submit();
-        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function () {
+        spyOn(RouterUtil, 'isDocumentVisible').and.callFake(function() {
           return true;
         });
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(RouterUtil.isHostBackgroundChromeTab).toHaveBeenCalled();
         expect(RouterUtil.isDocumentVisible).toHaveBeenCalled();
         expect(document.removeEventListener).toHaveBeenCalled();
@@ -225,24 +225,24 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
       });
   });
 
-  itp('validates answer field and errors before the request', function () {
-    return setup(allFactors).then(function (test) {
+  itp('validates answer field and errors before the request', function() {
+    return setup(allFactors).then(function(test) {
       Util.resetAjaxRequests();
       test.form.submit();
       expect(test.form.hasErrors()).toBe(true);
       expect(Util.numAjaxRequests()).toBe(0);
     });
   });
-  itp('shows error if error response on enrollment', function () {
+  itp('shows error if error response on enrollment', function() {
     return setup(allFactors)
-      .then(function (test) {
+      .then(function(test) {
         Q.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setAnswer('the answer');
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('Invalid Profile.');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -274,14 +274,14 @@ function testEnrollQuestion (allFactors, expectedStateToken) {
         ]);
       });
   });
-  itp('returns to factor list when back link is clicked', function () {
-    return setup(allFactors).then(function (test) {
+  itp('returns to factor list when back link is clicked', function() {
+    return setup(allFactors).then(function(test) {
       test.form.backLink().click();
       expect(test.router.navigate.calls.mostRecent().args).toEqual(['signin/enroll', { trigger: true }]);
     });
   });
 }
 
-Expect.describe('EnrollQuestions', function () {
+Expect.describe('EnrollQuestions', function() {
   testEnrollQuestion(resAllFactors, 'testStateToken');
 });

--- a/test/unit/spec/EnrollSms_spec.js
+++ b/test/unit/spec/EnrollSms_spec.js
@@ -18,8 +18,8 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-Expect.describe('EnrollSms', function () {
-  function setup (resp, startRouter, routerOptions = {}) {
+Expect.describe('EnrollSms', function() {
+  function setup(resp, startRouter, routerOptions = {}) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -50,7 +50,7 @@ Expect.describe('EnrollSms', function () {
       setNextResponse(resp || resAllFactors);
       router.refreshAuthState('dummy-token');
       return Expect.waitForEnrollChoices(test)
-        .then(function (test) {
+        .then(function(test) {
           router.enrollSms();
           return Expect.waitForEnrollSms(test);
         })
@@ -67,19 +67,19 @@ Expect.describe('EnrollSms', function () {
     }
   }
 
-  function enterCode (test, countryCode, phoneNumber) {
+  function enterCode(test, countryCode, phoneNumber) {
     test.form.selectCountry(countryCode);
     test.form.setPhoneNumber(phoneNumber);
   }
 
-  function sendCode (test, res, countryCode, phoneNumber) {
+  function sendCode(test, res, countryCode, phoneNumber) {
     test.setNextResponse(res);
     enterCode(test, countryCode, phoneNumber);
     test.form.sendCodeButton().click();
     return test;
   }
 
-  function sendCodeOnEnter (test, res, countryCode, phoneNumber) {
+  function sendCodeOnEnter(test, res, countryCode, phoneNumber) {
     test.setNextResponse(res);
     enterCode(test, countryCode, phoneNumber);
     const keydown = $.Event('keydown');
@@ -93,39 +93,39 @@ Expect.describe('EnrollSms', function () {
     return test;
   }
 
-  function waitForEnrollActivateSuccess (test) {
+  function waitForEnrollActivateSuccess(test) {
     test.router.controller.trapAuthResponse.calls.reset();
     return Expect.waitForSpyCall(test.router.controller.trapAuthResponse, test);
   }
 
-  function setupAndSendCode (res, countryCode, phoneNumber) {
-    return setup().then(function (test) {
+  function setupAndSendCode(res, countryCode, phoneNumber) {
+    return setup().then(function(test) {
       return sendCode(test, res, countryCode, phoneNumber);
     });
   }
 
-  const setupAndSendValidCode = function () {
-    return setup().then(function (test) {
+  const setupAndSendValidCode = function() {
+    return setup().then(function(test) {
       sendCode(test, resEnrollSuccess, 'US', '4151234567');
       return waitForEnrollActivateSuccess(test);
     });
   };
 
-  const setupAndSendInvalidCode = function () {
-    return setup().then(function (test) {
+  const setupAndSendInvalidCode = function() {
+    return setup().then(function(test) {
       sendCode(test, resEnrollError, 'US', '415');
       return Expect.waitForFormError(test.form, test);
     });
   };
 
-  function expectResendButton (test) {
+  function expectResendButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Re-send code');
     expect(button.hasClass('button-primary')).toBe(false);
   }
 
-  function expectSentButton (test) {
+  function expectSentButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Sent');
@@ -133,46 +133,46 @@ Expect.describe('EnrollSms', function () {
     expect(button.attr('class')).toMatch('link-button-disabled');
   }
 
-  function expectSendButton (test) {
+  function expectSendButton(test) {
     const button = test.form.sendCodeButton();
 
     expect(button.trimmedText()).toEqual('Send code');
     expect(button.hasClass('button-primary')).toBe(true);
   }
 
-  function testHeaderAndFooter (allFactorsRes, sendValidCodeFn, expectedStateToken) {
-    itp('displays the correct factorBeacon', function () {
-      return setup(allFactorsRes).then(function (test) {
+  function testHeaderAndFooter(allFactorsRes, sendValidCodeFn, expectedStateToken) {
+    itp('displays the correct factorBeacon', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-okta-sms')).toBe(true);
       });
     });
-    itp('links back to factors directly if phone has not been enrolled', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('links back to factors directly if phone has not been enrolled', function() {
+      return setup(allFactorsRes).then(function(test) {
         test.form.backLink().click();
         expect(test.router.navigate.calls.mostRecent().args).toEqual(['signin/enroll', { trigger: true }]);
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setup(allFactorsRes, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('visits previous link if phone is enrolled, but not activated', function () {
+    itp('visits previous link if phone is enrolled, but not activated', function() {
       return sendValidCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resAllFactors);
           test.form.backLink().click();
           return Expect.waitForEnrollChoices();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/previous',
@@ -185,9 +185,9 @@ Expect.describe('EnrollSms', function () {
     });
   }
 
-  function testEnrollPhoneNumber (allFactorsRes, successRes, sendCodeFn, expectedStateToken) {
-    itp('has a list of countries in alphabetical order', function () {
-      return setup(allFactorsRes).then(function (test) {
+  function testEnrollPhoneNumber(allFactorsRes, successRes, sendCodeFn, expectedStateToken) {
+    itp('has a list of countries in alphabetical order', function() {
+      return setup(allFactorsRes).then(function(test) {
         const countries = test.form.countriesList();
 
         expect(countries[0]).toEqual({ val: 'AF', text: 'Afghanistan' });
@@ -195,8 +195,8 @@ Expect.describe('EnrollSms', function () {
         expect(countries[239]).toEqual({ val: 'ZW', text: 'Zimbabwe' });
       });
     });
-    itp('does not include countries with no calling codes', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('does not include countries with no calling codes', function() {
+      return setup(allFactorsRes).then(function(test) {
         const countries = test.form.countriesList();
 
         expect(_.findWhere(countries, { val: 'HM' })).toBe(undefined);
@@ -204,94 +204,94 @@ Expect.describe('EnrollSms', function () {
         expect(_.findWhere(countries, { val: 'TF' })).toBe(undefined);
       });
     });
-    itp('beacon could not be minimized if it is a factor beacon', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('beacon could not be minimized if it is a factor beacon', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.authContainer.canBeMinimized()).toBe(false);
       });
     });
-    itp('has autocomplete set to false', function () {
-      return setup().then(function (test) {
+    itp('has autocomplete set to false', function() {
+      return setup().then(function(test) {
         expect(test.form.getCodeFieldAutocomplete()).toBe('off');
       });
     });
-    itp('defaults to United States for the country', function () {
+    itp('defaults to United States for the country', function() {
       return setup(allFactorsRes)
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.hasCountriesList();
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.selectedCountry()).toBe('United States');
         });
     });
-    itp('selects country based on defaultCountryCode from settings', function () {
+    itp('selects country based on defaultCountryCode from settings', function() {
       return setup(allFactorsRes, undefined, { defaultCountryCode: 'GB' })
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.hasCountriesList();
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.selectedCountry()).toBe('United Kingdom');
         });
     });
-    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function () {
+    itp('uses "US" as countryCode if settings.defaultCountryCode is not valid', function() {
       return setup(allFactorsRes, undefined, { defaultCountryCode: 'FAKECODE' })
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.hasCountriesList();
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.selectedCountry()).toBe('United States');
         });
     });
-    itp('updates the phone number country calling code when country is changed', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('updates the phone number country calling code when country is changed', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.form.phonePrefixText()).toBe('+1');
         test.form.selectCountry('AQ');
         expect(test.form.phonePrefixText()).toBe('+672');
       });
     });
-    itp('has a phone number text field', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('has a phone number text field', function() {
+      return setup(allFactorsRes).then(function(test) {
         Expect.isTextField(test.form.phoneNumberField());
       });
     });
-    itp('allows autocomplete for phone number text field', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('allows autocomplete for phone number text field', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.form.getPhoneNumberAutocomplete()).toBe('tel');
       });
     });
-    itp('has a button with primary class and text "Send Code"', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('has a button with primary class and text "Send Code"', function() {
+      return setup(allFactorsRes).then(function(test) {
         expectSendButton(test);
       });
     });
-    itp('does not show divider', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('does not show divider', function() {
+      return setup(allFactorsRes).then(function(test) {
         Expect.isNotVisible(test.form.divider());
       });
     });
-    itp('does not show enter code input', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('does not show enter code input', function() {
+      return setup(allFactorsRes).then(function(test) {
         Expect.isNotVisible(test.form.codeField());
       });
     });
-    itp('does not show verify button', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('does not show verify button', function() {
+      return setup(allFactorsRes).then(function(test) {
         Expect.isNotVisible(test.form.submitButton());
       });
     });
 
-    itp('sends sms when return key is pressed in phoneNumber field', function () {
+    itp('sends sms when return key is pressed in phoneNumber field', function() {
       return setup(allFactorsRes)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           return sendCodeOnEnter(test, successRes, 'US', '4151111111');
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -307,36 +307,36 @@ Expect.describe('EnrollSms', function () {
         });
     });
 
-    itp('clears previous errors in form when resend code', function () {
+    itp('clears previous errors in form when resend code', function() {
       return setupAndSendInvalidCode()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Invalid Phone Number.');
           sendCodeOnEnter(test, successRes, 'US', '4151111111');
           return waitForEnrollActivateSuccess(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
         });
     });
 
-    itp('validation error if phone number field is blank', function () {
-      return sendCodeFn(successRes, 'US', '').then(function (test) {
+    itp('validation error if phone number field is blank', function() {
+      return sendCodeFn(successRes, 'US', '').then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
       });
     });
 
-    itp('shows warning message to click "Re-send" after 30s', function () {
+    itp('shows warning message to click "Re-send" after 30s', function() {
       Util.speedUpDelay();
       return sendCodeFn(successRes, 'US', '4151111111')
         .then(waitForEnrollActivateSuccess)
-        .then(function (test) {
+        .then(function(test) {
           expectResendButton(test);
           expect(test.form.hasWarningMessage()).toBe(true);
           expect(test.form.warningMessage()).toContain('Haven\'t received an SMS? To try again, click Re-send code.');
           return test;
         })
-        .then(function (test) {
+        .then(function(test) {
           // Re-send will clear the warning
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
@@ -346,15 +346,15 @@ Expect.describe('EnrollSms', function () {
           return test;
         })
         .then(waitForEnrollActivateSuccess)
-        .then(function (test) {
+        .then(function(test) {
           // Re-send after 30s wil show the warning again
           expectResendButton(test);
           expect(test.form.warningMessage()).toContain('Haven\'t received an SMS? To try again, click Re-send code.');
         });
     });
 
-    itp('enrolls with correct info when sendCode is clicked', function () {
-      return sendCodeFn(successRes, 'AQ', '12345678900').then(waitForEnrollActivateSuccess).then(function () {
+    itp('enrolls with correct info when sendCode is clicked', function() {
+      return sendCodeFn(successRes, 'AQ', '12345678900').then(waitForEnrollActivateSuccess).then(function() {
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/introspect',
@@ -376,8 +376,8 @@ Expect.describe('EnrollSms', function () {
       });
     });
 
-    itp('shows error and does not go to next step if error response', function () {
-      return setupAndSendInvalidCode().then(function (test) {
+    itp('shows error and does not go to next step if error response', function() {
+      return setupAndSendInvalidCode().then(function(test) {
         expectSendButton(test);
         Expect.isNotVisible(test.form.divider());
         Expect.isNotVisible(test.form.codeField());
@@ -415,19 +415,19 @@ Expect.describe('EnrollSms', function () {
     });
   }
 
-  function testVerifyPhoneNumber (allFactorsRes, successRes, sendValidCodeFn, existingPhoneRes, expectedStateToken) {
-    itp('replaces send code with sent button, disabled and with no primary class', function () {
-      return sendValidCodeFn().then(function (test) {
+  function testVerifyPhoneNumber(allFactorsRes, successRes, sendValidCodeFn, existingPhoneRes, expectedStateToken) {
+    itp('replaces send code with sent button, disabled and with no primary class', function() {
+      return sendValidCodeFn().then(function(test) {
         expectSentButton(test);
       });
     });
-    itp('uses send code button with updatePhone=true, if user has an existing phone', function () {
+    itp('uses send code button with updatePhone=true, if user has an existing phone', function() {
       return setup(existingPhoneRes)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           return sendCode(test, successRes, 'US', '4151234567');
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors?updatePhone=true',
@@ -442,14 +442,14 @@ Expect.describe('EnrollSms', function () {
           });
         });
     });
-    itp('uses send code button with validatePhone:false if user has retried with invalid phone number', function () {
+    itp('uses send code button with validatePhone:false if user has retried with invalid phone number', function() {
       return setup(allFactorsRes)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -472,7 +472,7 @@ Expect.describe('EnrollSms', function () {
           sendCode(test, resEnrollInvalidPhoneError, 'PF', '12345678');
           return Expect.waitForAjaxRequest(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -488,14 +488,14 @@ Expect.describe('EnrollSms', function () {
           });
         });
     });
-    itp('does not set validatePhone:false if the error is not a validation error (E0000098).', function () {
+    itp('does not set validatePhone:false if the error is not a validation error (E0000098).', function() {
       return setup(allFactorsRes)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           sendCode(test, resEnrollError, 'PF', '12345678');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -516,7 +516,7 @@ Expect.describe('EnrollSms', function () {
           sendCode(test, resEnrollError, 'PF', '12345678');
           return Expect.waitForAjaxRequest(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -531,16 +531,16 @@ Expect.describe('EnrollSms', function () {
           });
         });
     });
-    itp('uses resend and not enrollFactor when re-send is clicked', function () {
+    itp('uses resend and not enrollFactor when re-send is clicked', function() {
       Util.speedUpDelay();
       return sendValidCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           test.form.sendCodeButton().click();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
@@ -553,9 +553,9 @@ Expect.describe('EnrollSms', function () {
     itp(
       'if phone number is changed after enroll, resets the status to MFA_Enroll ' +
         'and then enrolls with updatePhone=true',
-      function () {
+      function() {
         return sendValidCodeFn()
-          .then(function (test) {
+          .then(function(test) {
             expectSentButton(test);
             Expect.isVisible(test.form.codeField());
             enterCode(test, 'US', '4151112222');
@@ -567,7 +567,7 @@ Expect.describe('EnrollSms', function () {
               return Util.numAjaxRequests() === 2;
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(Util.numAjaxRequests()).toBe(2);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/previous',
@@ -586,7 +586,7 @@ Expect.describe('EnrollSms', function () {
             });
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // form wasn't rerendered
             expect(test.form.phoneNumberField().val()).toEqual('4151112222');
             expectSentButton(test);
@@ -597,25 +597,25 @@ Expect.describe('EnrollSms', function () {
     );
     itp(
       'submitting a number, then changing it, and then changing it back ' + 'will still use the resend endpoint',
-      function () {
+      function() {
         // The send button is normally diabled for several seconds
         // to prevent too many calls to the API, but for testing
         // we mock out the delay function to wait 0 seconds.
         Util.speedUpDelay();
         return sendValidCodeFn()
-          .then(function (test) {
+          .then(function(test) {
             // change the number from 'US' to 'AQ'
             enterCode(test, 'AQ', '4151234567');
             expectSendButton(test);
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // change the number back to 'US'
             enterCode(test, 'US', '4151234567');
             expectResendButton(test);
             return test;
           })
-          .then(function (test) {
+          .then(function(test) {
             // resubmit the 'US' number
             Util.resetAjaxRequests();
             test.setNextResponse(successRes);
@@ -623,7 +623,7 @@ Expect.describe('EnrollSms', function () {
             expectSentButton(test);
             return Expect.waitForAjaxRequest();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/resend',
@@ -634,32 +634,32 @@ Expect.describe('EnrollSms', function () {
           });
       }
     );
-    itp('shows divider', function () {
-      return sendValidCodeFn().then(function (test) {
+    itp('shows divider', function() {
+      return sendValidCodeFn().then(function(test) {
         Expect.isVisible(test.form.divider());
       });
     });
-    itp('shows enter code input', function () {
-      return sendValidCodeFn().then(function (test) {
+    itp('shows enter code input', function() {
+      return sendValidCodeFn().then(function(test) {
         Expect.isVisible(test.form.codeField());
       });
     });
-    itp('shows verify button when enrolled', function () {
-      return sendValidCodeFn().then(function (test) {
+    itp('shows verify button when enrolled', function() {
+      return sendValidCodeFn().then(function(test) {
         Expect.isVisible(test.form.submitButton());
       });
     });
-    itp('does not send request and shows error if code is not entered', function () {
-      return sendValidCodeFn().then(function (test) {
+    itp('does not send request and shows error if code is not entered', function() {
+      return sendValidCodeFn().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.hasErrors()).toBe(true);
       });
     });
-    itp('calls activate with the right params if passes validation', function () {
+    itp('calls activate with the right params if passes validation', function() {
       return sendValidCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           expect(test.form.codeField().attr('type')).toBe('tel');
           test.form.setCode(123456);
@@ -667,7 +667,7 @@ Expect.describe('EnrollSms', function () {
           test.form.submit();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/mbli45IDbggtwb4j40g3/lifecycle/activate',
@@ -678,15 +678,15 @@ Expect.describe('EnrollSms', function () {
           });
         });
     });
-    itp('shows error if error response on verification', function () {
+    itp('shows error if error response on verification', function() {
       return sendValidCodeFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resEnrollActivateError);
           test.form.setCode(123);
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Your token doesn\'t match our records. Please try again.');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -720,15 +720,15 @@ Expect.describe('EnrollSms', function () {
     });
   }
 
-  describe('Header & Footer', function () {
+  describe('Header & Footer', function() {
     testHeaderAndFooter(resAllFactors, setupAndSendValidCode, 'testStateToken');
   });
 
-  describe('Enroll phone number', function () {
+  describe('Enroll phone number', function() {
     testEnrollPhoneNumber(resAllFactors, resEnrollSuccess, setupAndSendCode, 'testStateToken');
   });
 
-  describe('Verify phone number', function () {
+  describe('Verify phone number', function() {
     testVerifyPhoneNumber(resAllFactors, resSuccess, setupAndSendValidCode, resExistingPhone, 'testStateToken');
   });
 });

--- a/test/unit/spec/EnrollSymantecVip_spec.js
+++ b/test/unit/spec/EnrollSymantecVip_spec.js
@@ -12,8 +12,8 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-Expect.describe('EnrollSymantecVip', function () {
-  function setup (startRouter) {
+Expect.describe('EnrollSymantecVip', function() {
+  function setup(startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -41,7 +41,7 @@ Expect.describe('EnrollSymantecVip', function () {
     const enrollSymantecVip = test => {
       setNextResponse(resAllFactors);
       router.refreshAuthState('dummy-token');
-      return Expect.waitForEnrollChoices(test).then(function (test) {
+      return Expect.waitForEnrollChoices(test).then(function(test) {
         router.enrollSymantecVip();
         return Expect.waitForEnrollSymantecVip(test);
       });
@@ -54,55 +54,55 @@ Expect.describe('EnrollSymantecVip', function () {
     }
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-symantec')).toBe(true);
       });
     });
-    itp('has autocomplete off', function () {
-      return setup().then(function (test) {
+    itp('has autocomplete off', function() {
+      return setup().then(function(test) {
         expect(test.form.getCodeFieldAutocomplete()).toBe('off');
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setup(true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
-    itp('has a credentialId text field', function () {
-      return setup().then(function (test) {
+  Expect.describe('Enroll factor', function() {
+    itp('has a credentialId text field', function() {
+      return setup().then(function(test) {
         Expect.isTextField(test.form.credentialIdField());
       });
     });
-    itp('has two text fields for pass codes', function () {
-      return setup().then(function (test) {
+    itp('has two text fields for pass codes', function() {
+      return setup().then(function(test) {
         Expect.isTextField(test.form.codeField());
         Expect.isTextField(test.form.secondCodeField());
       });
     });
-    itp('has a verify button', function () {
-      return setup().then(function (test) {
+    itp('has a verify button', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.submitButton());
       });
     });
-    itp('does not send request and shows error if codes are not entered', function () {
-      return setup().then(function (test) {
+    itp('does not send request and shows error if codes are not entered', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setCredentialId('Cred_Id');
         test.form.submit();
@@ -110,9 +110,9 @@ Expect.describe('EnrollSymantecVip', function () {
         expect(Util.numAjaxRequests()).toBe(0);
       });
     });
-    itp('shows error in case of an error response', function () {
+    itp('shows error in case of an error response', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resEnrollError);
           test.form.setCredentialId('Cred_Id');
           test.form.setCode(123);
@@ -120,7 +120,7 @@ Expect.describe('EnrollSymantecVip', function () {
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Invalid Phone Number.');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -152,8 +152,8 @@ Expect.describe('EnrollSymantecVip', function () {
           ]);
         });
     });
-    itp('calls activate with the right params', function () {
-      return setup().then(function (test) {
+    itp('calls activate with the right params', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setCredentialId('Cred_Id');
         test.form.setCode(123456);

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -26,8 +26,8 @@ import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 const tick = Expect.tick;
 
-Expect.describe('EnrollTotp', function () {
-  function setup (res, selectedFactor, settings, startRouter) {
+Expect.describe('EnrollTotp', function() {
+  function setup(res, selectedFactor, settings, startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -49,12 +49,12 @@ Expect.describe('EnrollTotp', function () {
     Util.mockRouterNavigate(router, startRouter);
 
     return tick()
-      .then(function () {
+      .then(function() {
         setNextResponse(res);
         router.refreshAuthState('dummy-token');
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         router.enrollTotpFactor(selectedFactor.provider, selectedFactor.factorType);
         return Expect.waitForEnrollTotp({
           router: router,
@@ -86,94 +86,94 @@ Expect.describe('EnrollTotp', function () {
     factorType: 'push',
   });
 
-  function enrollFactor (test, res) {
+  function enrollFactor(test, res) {
     test.setNextResponse(res || resTotpEnrollSuccess);
     test.form.selectDeviceType('APPLE');
     test.form.submit();
     return test;
   }
 
-  function setupAndEnrollOktaTotp () {
+  function setupAndEnrollOktaTotp() {
     return setupOktaTotp()
-      .then(function (test) {
+      .then(function(test) {
         return enrollFactor(test, resTotpEnrollSuccess);
       })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForBarcodeTotp(test);
       });
   }
 
-  function setupAndEnrollGoogleTotp () {
+  function setupAndEnrollGoogleTotp() {
     return setupGoogleTotp()
-      .then(function (test) {
+      .then(function(test) {
         return enrollFactor(test, resTotpEnrollSuccess);
       })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForBarcodeTotp(test);
       });
   }
 
-  function setupAndEnrollOktaPush () {
+  function setupAndEnrollOktaPush() {
     return setupOktaPush()
-      .then(function (test) {
+      .then(function(test) {
         test.originalAjax = Util.stallEnrollFactorPoll(test.ac);
         return enrollFactor(test, resPushEnrollSuccess);
       })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForBarcodePush(test);
       });
   }
 
-  function enrollOktaPushGoCannotScan () {
-    return setupAndEnrollOktaPush().then(function (test) {
+  function enrollOktaPushGoCannotScan() {
+    return setupAndEnrollOktaPush().then(function(test) {
       test.setNextResponse([resFactorsWithPush, resPushEnrollSuccess]);
       test.scanCodeForm.clickManualSetupLink();
       return Expect.waitForManualSetupPush(test);
     });
   }
 
-  function enrollOktaPushUseManualTotp () {
-    return enrollOktaPushGoCannotScan().then(function (test) {
+  function enrollOktaPushUseManualTotp() {
+    return enrollOktaPushGoCannotScan().then(function(test) {
       test.setNextResponse([resAllFactors, resTotpEnrollSuccess]);
       test.manualSetupForm.selectManualOption();
       return test.manualSetupForm.waitForManual(test);
     });
   }
 
-  function testEnrollFactor (
+  function testEnrollFactor(
     setupOktaTotpFn,
     setupAndEnrollOktaTotpFn,
     setupGoogleTotpFn,
     setupAndEnrollGoogleTotpFn,
     expectedStateToken
   ) {
-    itp('has correct device type options for Okta Verify', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has correct device type options for Okta Verify', function() {
+      return setupOktaTotpFn().then(function(test) {
         expect(test.form.deviceTypeOptions().length).toBe(2);
         expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
         expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
       });
     });
-    itp('has correct device type options for Google Authenticator', function () {
-      return setupGoogleTotpFn().then(function (test) {
+    itp('has correct device type options for Google Authenticator', function() {
+      return setupGoogleTotpFn().then(function(test) {
         expect(test.form.deviceTypeOptions().length).toBe(2);
         expect(test.form.deviceTypeOptionLabel('APPLE').length).toBe(1);
         expect(test.form.deviceTypeOptionLabel('ANDROID').length).toBe(1);
       });
     });
-    itp('has app download instructions not displayed until device type is selected', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has app download instructions not displayed until device type is selected', function() {
+      return setupOktaTotpFn().then(function(test) {
         Expect.isNotVisible(test.form.appDownloadInstructions());
       });
     });
-    itp('has app download instructions displayed when device type is selected', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has app download instructions displayed when device type is selected', function() {
+      return setupOktaTotpFn().then(function(test) {
         test.form.selectDeviceType('APPLE');
         Expect.isVisible(test.form.appDownloadInstructions());
       });
     });
-    itp('has correct app download instructions displayed for Okta Verify', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has correct app download instructions displayed for Okta Verify', function() {
+      return setupOktaTotpFn().then(function(test) {
         test.form.selectDeviceType('APPLE');
         expect(test.form.appDownloadInstructionsLinkText()).toEqual('Okta Verify from the App Store');
         expect(test.form.appDownloadInstructionsAppLogo('.okta-verify-38').length).toBe(1);
@@ -181,8 +181,8 @@ Expect.describe('EnrollTotp', function () {
         expect(test.form.appDownloadInstructionsLinkText()).toEqual('Okta Verify from the Google Play Store');
       });
     });
-    itp('has correct app download instructions displayed for Google Auth', function () {
-      return setupGoogleTotpFn().then(function (test) {
+    itp('has correct app download instructions displayed for Google Auth', function() {
+      return setupGoogleTotpFn().then(function(test) {
         test.form.selectDeviceType('APPLE');
         expect(test.form.appDownloadInstructionsLinkText()).toEqual('Google Authenticator from the App Store');
         expect(test.form.appDownloadInstructionsAppLogo('.google-auth-38').length).toBe(1);
@@ -190,30 +190,30 @@ Expect.describe('EnrollTotp', function () {
         expect(test.form.appDownloadInstructionsLinkText()).toEqual('Google Authenticator from the Google Play Store');
       });
     });
-    itp('has a next button not displayed until device type is selected', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has a next button not displayed until device type is selected', function() {
+      return setupOktaTotpFn().then(function(test) {
         Expect.isNotVisible(test.form.submitButton());
       });
     });
-    itp('has a next button displayed when device type is selected', function () {
-      return setupOktaTotpFn().then(function (test) {
+    itp('has a next button displayed when device type is selected', function() {
+      return setupOktaTotpFn().then(function(test) {
         test.form.selectDeviceType('APPLE');
         Expect.isVisible(test.form.submitButton());
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaTotpFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('sends enroll request with correct params for Okta totp', function () {
-      return setupAndEnrollOktaTotpFn().then(function () {
+    itp('sends enroll request with correct params for Okta totp', function() {
+      return setupAndEnrollOktaTotpFn().then(function() {
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isJsonPost(Util.getAjaxRequest(1), {
           url: 'https://foo.com/api/v1/authn/factors',
@@ -225,8 +225,8 @@ Expect.describe('EnrollTotp', function () {
         });
       });
     });
-    itp('sends enroll request with correct params for Google totp', function () {
-      return setupAndEnrollGoogleTotpFn().then(function () {
+    itp('sends enroll request with correct params for Google totp', function() {
+      return setupAndEnrollGoogleTotpFn().then(function() {
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isJsonPost(Util.getAjaxRequest(1), {
           url: 'https://foo.com/api/v1/authn/factors',
@@ -240,14 +240,14 @@ Expect.describe('EnrollTotp', function () {
     });
   }
 
-  function testOktaVerify (
+  function testOktaVerify(
     setupAndEnrollOktaPushFn,
     setupOktaPushFn,
     activatePushSmsRes,
     activatePushTimeoutRes,
     expectedStateToken
   ) {
-    function setupPolling (test, finalResponse) {
+    function setupPolling(test, finalResponse) {
       Util.resetAjaxRequests();
 
       // 1: Set for first enrollFactor
@@ -270,72 +270,72 @@ Expect.describe('EnrollTotp', function () {
           return Expect.waitForAjaxRequests(3, test); // Final response tick
         });
     }
-    itp('has qrcode image with alt attr', function () {
-      return setupAndEnrollOktaPushFn().then(function (test) {
+    itp('has qrcode image with alt attr', function() {
+      return setupAndEnrollOktaPushFn().then(function(test) {
         expect(test.scanCodeForm.qrcodeImg().length).toBe(1);
         expect(test.scanCodeForm.qrcodeImg().attr('src')).toEqual('/base/test/unit/assets/1x1.gif');
         expect(test.scanCodeForm.qrcodeImg().attr('alt')).toEqual('qr code');
       });
     });
-    itp('has a link to setup app manually', function () {
-      return setupAndEnrollOktaPushFn().then(function (test) {
+    itp('has a link to setup app manually', function() {
+      return setupAndEnrollOktaPushFn().then(function(test) {
         Expect.isVisible(test.scanCodeForm.manualSetupLink());
       });
     });
-    itp('does not have "Next" button', function () {
-      return setupAndEnrollOktaPushFn().then(function (test) {
+    itp('does not have "Next" button', function() {
+      return setupAndEnrollOktaPushFn().then(function(test) {
         expect(test.scanCodeForm.submitButton().length).toBe(0);
       });
     });
-    itp('removes the scan code form on clicking "Back to factor list" link', function () {
+    itp('removes the scan code form on clicking "Back to factor list" link', function() {
       return setupOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           return setupPolling(test, resSuccess);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resFactorsWithPush]);
           test.scanCodeForm.clickBackLink();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.scanCodeForm.container().length).toBe(0);
         });
     });
-    itp('removes the scan code form on clicking "Can\'t scan" link', function () {
+    itp('removes the scan code form on clicking "Can\'t scan" link', function() {
       return setupOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           return setupPolling(test, activatePushSmsRes);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resFactorsWithPush, resPushEnrollSuccess]);
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupPush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.scanCodeForm.container().length).toBe(0);
         });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaPushFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           return setupPolling(test, resSuccess);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resFactorsWithPush]);
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('polls until SUCCESS when submitted', function () {
+    itp('polls until SUCCESS when submitted', function() {
       return setupOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           return setupPolling(test, resSuccess);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(3);
 
           // initial enrollFactor call
@@ -365,9 +365,9 @@ Expect.describe('EnrollTotp', function () {
           });
         });
     });
-    itp('shows "Refresh code" link if got network error while polling', function () {
+    itp('shows "Refresh code" link if got network error while polling', function() {
       // Simulate polling with Auth SDK's exponential backoff (6 failed requests)
-      function setupFailurePolling (test) {
+      function setupFailurePolling(test) {
         const failureResponse = { status: 0, response: {} };
 
         Util.resetAjaxRequests();
@@ -414,14 +414,14 @@ Expect.describe('EnrollTotp', function () {
           });
       }
       return setupOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'callGlobalError');
           return setupFailurePolling(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           return test.scanCodeForm.waitForRefreshQrcodeLink(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(8);
           expect(test.scanCodeForm.hasManualSetupLink()).toBe(false);
           expect(test.scanCodeForm.hasRefreshQrcodeLink()).toBe(true);
@@ -435,7 +435,7 @@ Expect.describe('EnrollTotp', function () {
           test.scanCodeForm.clickrefreshQrcodeLink();
           return Expect.waitForAjaxRequests(2, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // errors cleared
           expect(test.scanCodeForm.hasErrors()).toBe(false);
 
@@ -459,9 +459,9 @@ Expect.describe('EnrollTotp', function () {
           });
         });
     });
-    itp('allows refresh after TIMEOUT', function () {
+    itp('allows refresh after TIMEOUT', function() {
       return setupOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
 
           // 1: Set for first enrollFactor
@@ -478,13 +478,13 @@ Expect.describe('EnrollTotp', function () {
             return Expect.waitForAjaxRequests(2, test); // 2: submit enrollFactor poll
           });
         })
-        .then(function (test) {
+        .then(function(test) {
           // After TIMEOUT, refresh the QR code
           Expect.isVisible(test.scanCodeForm.refreshLink());
           test.scanCodeForm.clickRefreshLink();
           return Expect.waitForAjaxRequests(3, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(3);
 
           // initial enrollFactor call
@@ -516,7 +516,7 @@ Expect.describe('EnrollTotp', function () {
     });
   }
 
-  function testManualSetup (
+  function testManualSetup(
     enrollOktaPushGoCannotScanFn,
     setupAndEnrollOktaPushFn,
     enrollOktaPushUseManualTotpFn,
@@ -526,22 +526,22 @@ Expect.describe('EnrollTotp', function () {
     pushEnrollSuccessNewQRRes,
     expectedStateToken
   ) {
-    itp('is rendered on "Can\'t scan" link click', function () {
-      return enrollOktaPushGoCannotScanFn().then(function (test) {
+    itp('is rendered on "Can\'t scan" link click', function() {
+      return enrollOktaPushGoCannotScanFn().then(function(test) {
         Expect.isVisible(test.manualSetupForm.form());
         Expect.isVisible(test.manualSetupForm.dropdownElement());
         Expect.isVisible(test.manualSetupForm.gotoScanBarcodeLink());
       });
     });
-    itp('has correct fields displayed when different dropdown options selected', function () {
+    itp('has correct fields displayed when different dropdown options selected', function() {
       return enrollOktaPushGoCannotScanFn()
-        .then(function (test) {
+        .then(function(test) {
           return test.manualSetupForm.waitForDropdownElement(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           return test.manualSetupForm.waitForCountryCodeSelect(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.manualSetupForm.dropdownElement());
           // sms (default)
           Expect.isVisible(test.manualSetupForm.countryCodeSelect());
@@ -552,7 +552,7 @@ Expect.describe('EnrollTotp', function () {
           test.manualSetupForm.selectEmailOption();
           return test.manualSetupForm.waitForEmail(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // email option
           Expect.isNotVisible(test.manualSetupForm.countryCodeSelect());
           Expect.isNotVisible(test.manualSetupForm.phoneNumberField());
@@ -564,7 +564,7 @@ Expect.describe('EnrollTotp', function () {
           test.manualSetupForm.selectManualOption();
           return test.manualSetupForm.waitForManual(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // manual option
           Expect.isNotVisible(test.manualSetupForm.countryCodeSelect());
           Expect.isNotVisible(test.manualSetupForm.phoneNumberField());
@@ -573,32 +573,32 @@ Expect.describe('EnrollTotp', function () {
           Expect.isVisible(test.manualSetupForm.nextButton());
         });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaPushFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           test.originalAjax = Util.stallEnrollFactorPoll(test.ac);
           return enrollFactor(test, pushEnrollSuccessRes);
         })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForBarcodePush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([factorsWithPushRes, pushEnrollSuccessRes]);
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupPush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resAllFactors);
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('goes to previous link and then enrolls in totp when choosing manually', function () {
-      return enrollOktaPushUseManualTotpFn().then(function () {
+    itp('goes to previous link and then enrolls in totp when choosing manually', function() {
+      return enrollOktaPushUseManualTotpFn().then(function() {
         expect(Util.numAjaxRequests()).toBe(6);
         Expect.isJsonPost(Util.getAjaxRequest(4), {
           url: 'https://foo.com/api/v1/authn/previous',
@@ -614,16 +614,16 @@ Expect.describe('EnrollTotp', function () {
         });
       });
     });
-    itp('goes to previous link and enrolls in push when coming from manual', function () {
+    itp('goes to previous link and enrolls in push when coming from manual', function() {
       return enrollOktaPushUseManualTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           expect(test.manualSetupForm.sharedSecretFieldValue()).toEqual('superSecretSharedSecret');
           test.setNextResponse([factorsWithPushRes, pushEnrollSuccessRes]);
           test.manualSetupForm.selectSmsOption();
           return test.manualSetupForm.waitForSms(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/previous',
@@ -640,27 +640,27 @@ Expect.describe('EnrollTotp', function () {
           expect(test.manualSetupForm.sharedSecretFieldValue()).toEqual('');
         });
     });
-    itp('does not do re-enroll when switches between sms and email options', function () {
+    itp('does not do re-enroll when switches between sms and email options', function() {
       return enrollOktaPushGoCannotScanFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.manualSetupForm.selectEmailOption();
           return test.manualSetupForm.waitForEmail(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           Expect.isNotVisible(test.manualSetupForm.phoneNumberField());
           test.manualSetupForm.selectSmsOption();
           return test.manualSetupForm.waitForSms(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           Expect.isVisible(test.manualSetupForm.phoneNumberField());
         });
     });
-    itp('sends sms activation link request with correct params and shows confirmation', function () {
+    itp('sends sms activation link request with correct params and shows confirmation', function() {
       return enrollOktaPushGoCannotScanFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           Expect.isVisible(test.manualSetupForm.form());
           test.manualSetupForm.setPhoneNumber('4152554668');
@@ -668,7 +668,7 @@ Expect.describe('EnrollTotp', function () {
           test.manualSetupForm.submit();
           return Expect.waitForEnrollmentLinkSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/activate/sms',
@@ -683,10 +683,10 @@ Expect.describe('EnrollTotp', function () {
           expect(test.linkSentConfirmation.getMsgText().indexOf('+14152554668') >= 0).toBe(true);
         });
     });
-    itp('removes the sms activation form on successful activation response', function () {
+    itp('removes the sms activation form on successful activation response', function() {
       Expect.allowUnhandledPromiseRejection(); // OKTA-324849
       return enrollOktaPushGoCannotScanFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           Expect.isVisible(test.manualSetupForm.form());
           test.manualSetupForm.setPhoneNumber('4152554668');
@@ -696,20 +696,20 @@ Expect.describe('EnrollTotp', function () {
           test.originalAjax = Util.stallEnrollFactorPoll(test.ac, test.originalAjax);
           return Expect.waitForEnrollmentLinkSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.linkSentConfirmation.smsSentMsg());
           expect(test.linkSentConfirmation.getMsgText().indexOf('+14152554668') >= 0).toBe(true);
           test.originalAjax = Util.resumeEnrollFactorPoll(test.ac, test.originalAjax, resAllFactors);
           Util.callAllTimeouts();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.linkSentConfirmation.smsSentMsg().length).toBe(0);
         });
     });
-    itp('sends email activation link request with correct params and shows confirmation', function () {
+    itp('sends email activation link request with correct params and shows confirmation', function() {
       return enrollOktaPushGoCannotScanFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           Expect.isVisible(test.manualSetupForm.form());
           test.manualSetupForm.selectEmailOption();
@@ -717,7 +717,7 @@ Expect.describe('EnrollTotp', function () {
           test.manualSetupForm.submit();
           return Expect.waitForEnrollmentLinkSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/activate/email',
@@ -732,14 +732,14 @@ Expect.describe('EnrollTotp', function () {
     itp(
       'renders pass code form on "Next" button click when Manual is selected \
           and sends activation request with correct params on pass code submit',
-      function () {
+      function() {
         return enrollOktaPushUseManualTotpFn()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.manualSetupForm.nextButtonClick();
             return Expect.waitForEnterPasscodePushFlow(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Expect.isVisible(test.passCodeForm.form());
             Expect.isVisible(test.passCodeForm.codeField());
             test.passCodeForm.setCode('1234');
@@ -750,7 +750,7 @@ Expect.describe('EnrollTotp', function () {
             test.passCodeForm.submit();
             return tick(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/id1234/lifecycle/activate',
@@ -765,22 +765,22 @@ Expect.describe('EnrollTotp', function () {
     itp(
       'goes back to "Can\'t" scan screen with manual option selected \
       when Back link clicked on pass code step',
-      function () {
+      function() {
         return enrollOktaPushUseManualTotpFn()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.manualSetupForm.nextButtonClick();
             return Expect.waitForEnterPasscodePushFlow(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Expect.isVisible(test.passCodeForm.form());
             test.passCodeForm.backLink().click();
             return Expect.waitForManualSetupPush(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             return test.manualSetupForm.waitForCountryCodeSelect(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(Util.numAjaxRequests()).toBe(0);
             Expect.isVisible(test.manualSetupForm.form());
             Expect.isNotVisible(test.manualSetupForm.countryCodeSelect());
@@ -791,9 +791,9 @@ Expect.describe('EnrollTotp', function () {
           });
       }
     );
-    itp('refreshes authStatus and goes back to scan barcode screen on "Scan barcode" link click', function () {
+    itp('refreshes authStatus and goes back to scan barcode screen on "Scan barcode" link click', function() {
       return setupAndEnrollOktaPushFn()
-        .then(function (test) {
+        .then(function(test) {
           const oldQrCodeSrc = test.scanCodeForm.qrcodeImg().attr('src');
 
           expect(oldQrCodeSrc).toBe('/base/test/unit/assets/1x1.gif');
@@ -801,14 +801,14 @@ Expect.describe('EnrollTotp', function () {
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupPush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           Expect.isVisible(test.manualSetupForm.form());
           test.setNextResponse([factorsWithPushRes, pushEnrollSuccessNewQRRes]);
           test.manualSetupForm.gotoScanBarcode();
           return Expect.waitForBarcodePush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/previous',
@@ -832,112 +832,112 @@ Expect.describe('EnrollTotp', function () {
     });
   }
 
-  function testScanQRCode (setupAndEnrollOktaTotpFn, setupOktaTotpFn, totpEnrollSuccessRes, allFactorsRes) {
-    itp('has qrcode image', function () {
-      return setupAndEnrollOktaTotpFn().then(function (test) {
+  function testScanQRCode(setupAndEnrollOktaTotpFn, setupOktaTotpFn, totpEnrollSuccessRes, allFactorsRes) {
+    itp('has qrcode image', function() {
+      return setupAndEnrollOktaTotpFn().then(function(test) {
         expect(test.scanCodeForm.qrcodeImg().length).toBe(1);
         // Note: Modifying API qr code return image with something we can load locally
         expect(test.scanCodeForm.qrcodeImg().attr('src')).toEqual('/base/test/unit/assets/1x1.gif');
       });
     });
-    itp('has a link to setup app manually', function () {
-      return setupAndEnrollOktaTotpFn().then(function (test) {
+    itp('has a link to setup app manually', function() {
+      return setupAndEnrollOktaTotpFn().then(function(test) {
         Expect.isVisible(test.scanCodeForm.manualSetupLink());
       });
     });
-    itp('has "Next" button', function () {
-      return setupAndEnrollOktaTotpFn().then(function (test) {
+    itp('has "Next" button', function() {
+      return setupAndEnrollOktaTotpFn().then(function(test) {
         Expect.isVisible(test.scanCodeForm.submitButton());
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaTotpFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           return enrollFactor(test, totpEnrollSuccessRes);
         })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForBarcodeTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(allFactorsRes);
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
   }
 
-  function testScanQRCodeManualSetup (setupAndEnrollOktaTotpFn, setupOktaTotpFn, totpEnrollSuccessRes) {
-    itp('is rendered on "Can\'t scan" link click', function () {
+  function testScanQRCodeManualSetup(setupAndEnrollOktaTotpFn, setupOktaTotpFn, totpEnrollSuccessRes) {
+    itp('is rendered on "Can\'t scan" link click', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.manualSetupForm.form());
           Expect.isVisible(test.manualSetupForm.sharedSecretField());
           expect(test.manualSetupForm.sharedSecretFieldValue()).toEqual('superSecretSharedSecret');
           Expect.isVisible(test.manualSetupForm.gotoScanBarcodeLink());
         });
     });
-    itp('renders pass code form on "Next" button click', function () {
+    itp('renders pass code form on "Next" button click', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.manualSetupForm.form());
           test.manualSetupForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.passCodeForm.form());
           Expect.isVisible(test.passCodeForm.codeField());
           expect(test.passCodeForm.codeField().attr('type')).toBe('tel');
         });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaTotpFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           return enrollFactor(test, totpEnrollSuccessRes);
         })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForBarcodeTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resAllFactors);
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('refreshes authStatus and goes back to scan barcode screen on "Scan barcode" link click', function () {
+    itp('refreshes authStatus and goes back to scan barcode screen on "Scan barcode" link click', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.scanCodeForm.clickManualSetupLink();
           return Expect.waitForManualSetupTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.manualSetupForm.form());
           test.setNextResponse(totpEnrollSuccessRes);
           Util.mockSDKCookie(test.ac);
           test.manualSetupForm.gotoScanBarcode();
           return Expect.waitForBarcodeTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -948,38 +948,38 @@ Expect.describe('EnrollTotp', function () {
     });
   }
 
-  function testScanQRCodePassCodeForm (
+  function testScanQRCodePassCodeForm(
     setupAndEnrollOktaTotpFn,
     setupOktaTotpFn,
     totpEnrollSuccessRes,
     expectedStateToken
   ) {
-    itp('renders pass code form on "Next" button click', function () {
+    itp('renders pass code form on "Next" button click', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.passCodeForm.form());
           Expect.isVisible(test.passCodeForm.codeField());
           expect(test.passCodeForm.codeField().attr('type')).toBe('tel');
         });
     });
-    itp('shows error in case of an error response', function () {
+    itp('shows error in case of an error response', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.passCodeForm.form());
           test.setNextResponse(resActivateError);
           test.passCodeForm.setCode(123);
           test.passCodeForm.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.passCodeForm.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Api validation failed: factorEnrollRequest');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -1007,32 +1007,32 @@ Expect.describe('EnrollTotp', function () {
           ]);
         });
     });
-    itp('shows modified error in case of E0000079 operation not allowed error response', function () {
+    itp('shows modified error in case of E0000079 operation not allowed error response', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.passCodeForm.form());
           test.setNextResponse(resOperationNotAllowed);
           test.passCodeForm.setCode(123);
           test.passCodeForm.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.passCodeForm.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('The operation is not allowed. Please refresh the page to proceed.');
         });
     });
-    itp('calls activate with the right params', function () {
+    itp('calls activate with the right params', function() {
       return setupAndEnrollOktaTotpFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.passCodeForm.form());
           test.passCodeForm.setCode(123456);
           test.setNextResponse(resSuccess);
@@ -1047,51 +1047,51 @@ Expect.describe('EnrollTotp', function () {
           });
         });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setupOktaTotpFn({}, true)
-        .then(function (test) {
+        .then(function(test) {
           return enrollFactor(test, totpEnrollSuccessRes);
         })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForBarcodeTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.scanCodeForm.submit();
           return Expect.waitForActivateTotp(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resAllFactors);
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon for Okta Verify', function () {
-      return setupOktaTotp().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon for Okta Verify', function() {
+      return setupOktaTotp().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-okta-verify')).toBe(true);
       });
     });
-    itp('displays the correct factorBeacon for Google Authenticator', function () {
-      return setupGoogleTotp().then(function (test) {
+    itp('displays the correct factorBeacon for Google Authenticator', function() {
+      return setupGoogleTotp().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-google-auth')).toBe(true);
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setupOktaTotp().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setupOktaTotp().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
+  Expect.describe('Enroll factor', function() {
     testEnrollFactor(
       setupOktaTotp,
       setupAndEnrollOktaTotp,
@@ -1101,21 +1101,21 @@ Expect.describe('EnrollTotp', function () {
     );
   });
 
-  Expect.describe('Scan qrcode', function () {
+  Expect.describe('Scan qrcode', function() {
     testScanQRCode(setupAndEnrollOktaTotp, setupOktaTotp, resTotpEnrollSuccess, resAllFactors);
 
-    Expect.describe('Manual setup', function () {
+    Expect.describe('Manual setup', function() {
       testScanQRCodeManualSetup(setupAndEnrollOktaTotp, setupOktaTotp, resTotpEnrollSuccess, 'testStateToken');
     });
 
-    Expect.describe('Pass code form', function () {
+    Expect.describe('Pass code form', function() {
       testScanQRCodePassCodeForm(setupAndEnrollOktaTotp, setupOktaTotp, resTotpEnrollSuccess, 'testStateToken');
     });
   });
 
-  Expect.describe('Okta Verify with Push', function () {
+  Expect.describe('Okta Verify with Push', function() {
     testOktaVerify(setupAndEnrollOktaPush, setupOktaPush, resActivatePushSms, resActivatePushTimeout, 'testStateToken');
-    Expect.describe('Manual setup', function () {
+    Expect.describe('Manual setup', function() {
       testManualSetup(
         enrollOktaPushGoCannotScan,
         setupAndEnrollOktaPush,

--- a/test/unit/spec/EnrollU2F_spec.js
+++ b/test/unit/spec/EnrollU2F_spec.js
@@ -14,8 +14,8 @@ import $sandbox from 'sandbox';
 const itp = Expect.itp;
 const tick = Expect.tick;
 
-Expect.describe('EnrollU2F', function () {
-  function setup (startRouter, onlyU2F) {
+Expect.describe('EnrollU2F', function() {
+  function setup(startRouter, onlyU2F) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
@@ -32,12 +32,12 @@ Expect.describe('EnrollU2F', function () {
     Util.registerRouter(router);
     Util.mockRouterNavigate(router, startRouter);
     return tick()
-      .then(function () {
+      .then(function() {
         setNextResponse(onlyU2F ? resU2F : resAllFactors);
         router.refreshAuthState('dummy-token');
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         router.enrollU2F();
         return Expect.waitForEnrollU2F({
           router: router,
@@ -51,13 +51,13 @@ Expect.describe('EnrollU2F', function () {
       });
   }
 
-  function mockU2f () {
-    window.u2f = { register: function () {} };
+  function mockU2f() {
+    window.u2f = { register: function() {} };
   }
 
-  function mocku2fSuccessRegistration () {
+  function mocku2fSuccessRegistration() {
     mockU2f();
-    spyOn(window.u2f, 'register').and.callFake(function (appId, registerRequests, registeredKeys, callback) {
+    spyOn(window.u2f, 'register').and.callFake(function(appId, registerRequests, registeredKeys, callback) {
       callback({
         registrationData: 'someRegistrationData',
         version: 'U2F_V2',
@@ -67,21 +67,21 @@ Expect.describe('EnrollU2F', function () {
     });
   }
 
-  function setupU2fFails (errorCode) {
+  function setupU2fFails(errorCode) {
     Q.stopUnhandledRejectionTracking();
     mockU2f();
-    spyOn(window.u2f, 'register').and.callFake(function (appId, registerRequests, registeredKeys, callback) {
+    spyOn(window.u2f, 'register').and.callFake(function(appId, registerRequests, registeredKeys, callback) {
       callback({ errorCode: errorCode });
     });
 
-    return setup().then(function (test) {
+    return setup().then(function(test) {
       test.setNextResponse(resEnrollActivateU2F);
       test.form.submit();
       return tick(test);
     });
   }
 
-  function expectError (test, errorMessage) {
+  function expectError(test, errorMessage) {
     expect(window.u2f.register).toHaveBeenCalled();
     expect(test.form.hasErrors()).toBe(true);
     expect(test.form.errorBox()).toHaveLength(1);
@@ -103,25 +103,25 @@ Expect.describe('EnrollU2F', function () {
     ]);
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-u2f')).toBe(true);
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
-    itp('shows error if browser does not support u2f', function () {
+  Expect.describe('Enroll factor', function() {
+    itp('shows error if browser does not support u2f', function() {
       delete window.u2f;
 
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
           'Security Key (U2F) is not supported on this browser.' +
@@ -130,10 +130,10 @@ Expect.describe('EnrollU2F', function () {
       });
     });
 
-    itp('shows error if browser does not support u2f and only one factor', function () {
+    itp('shows error if browser does not support u2f and only one factor', function() {
       delete window.u2f;
 
-      return setup(false, true).then(function (test) {
+      return setup(false, true).then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
           'Security Key (U2F) is not supported on this browser.' + ' Contact your admin for assistance.'
@@ -141,32 +141,32 @@ Expect.describe('EnrollU2F', function () {
       });
     });
 
-    itp('does not show error if browser supports u2f', function () {
+    itp('does not show error if browser supports u2f', function() {
       mockU2f();
 
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(0);
       });
     });
 
-    itp('shows instructions and a register button', function () {
+    itp('shows instructions and a register button', function() {
       mockU2f();
 
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.submitButton());
       });
     });
 
-    itp('shows a waiting spinner and devices images after submitting the form', function () {
+    itp('shows a waiting spinner and devices images after submitting the form', function() {
       mocku2fSuccessRegistration();
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resEnrollActivateU2F, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.form.enrollWaitingText());
           Expect.isVisible(test.form.enrollDeviceImages());
           Expect.isVisible(test.form.enrollSpinningIcon());
@@ -174,16 +174,16 @@ Expect.describe('EnrollU2F', function () {
         });
     });
 
-    itp('sends enroll request after submitting the form', function () {
+    itp('sends enroll request after submitting the form', function() {
       mocku2fSuccessRegistration();
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateU2F, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -196,16 +196,16 @@ Expect.describe('EnrollU2F', function () {
         });
     });
 
-    itp('calls u2f.register and activates the factor', function () {
+    itp('calls u2f.register and activates the factor', function() {
       mocku2fSuccessRegistration();
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateU2F, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(window.u2f.register).toHaveBeenCalled();
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(1), {
@@ -221,32 +221,32 @@ Expect.describe('EnrollU2F', function () {
         });
     });
 
-    itp('shows proper error if u2f.register fails with code 1', function () {
-      return setupU2fFails(1).then(function (test) {
+    itp('shows proper error if u2f.register fails with code 1', function() {
+      return setupU2fFails(1).then(function(test) {
         expectError(test, 'An unknown error has occured. Try again or select another factor.');
       });
     });
 
-    itp('shows proper error if u2f.register fails with code 2', function () {
-      return setupU2fFails(2).then(function (test) {
+    itp('shows proper error if u2f.register fails with code 2', function() {
+      return setupU2fFails(2).then(function(test) {
         expectError(test, 'There was an error with the U2F request. Try again or select another factor.');
       });
     });
 
-    itp('shows proper error if u2f.register fails with code 3', function () {
-      return setupU2fFails(3).then(function (test) {
+    itp('shows proper error if u2f.register fails with code 3', function() {
+      return setupU2fFails(3).then(function(test) {
         expectError(test, 'There was an error with the U2F request. Try again or select another factor.');
       });
     });
 
-    itp('shows proper error if u2f.register fails with code 4', function () {
-      return setupU2fFails(4).then(function (test) {
+    itp('shows proper error if u2f.register fails with code 4', function() {
+      return setupU2fFails(4).then(function(test) {
         expectError(test, 'The security key is unsupported. Select another factor.');
       });
     });
 
-    itp('shows proper error if u2f.register fails with code 5', function () {
-      return setupU2fFails(5).then(function (test) {
+    itp('shows proper error if u2f.register fails with code 5', function() {
+      return setupU2fFails(5).then(function(test) {
         expectError(test, 'You have timed out of the authentication period. Please try again.');
       });
     });

--- a/test/unit/spec/EnrollUser_spec.js
+++ b/test/unit/spec/EnrollUser_spec.js
@@ -13,7 +13,7 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-function setup (isUnauthenticated) {
+function setup(isUnauthenticated) {
   let settings = {};
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
@@ -49,33 +49,33 @@ function setup (isUnauthenticated) {
   });
 }
 
-function setupEnroll () {
+function setupEnroll() {
   return Expect.waitForEnrollUser(setup(false));
 }
 
-function setupUnAuthenticated () {
+function setupUnAuthenticated() {
   return Expect.waitForPrimaryAuth(setup(true));
 }
 
-Expect.describe('Enroll User Form', function () {
-  itp('has the correct title on the enroll form', function () {
-    return setupEnroll().then(function (test) {
+Expect.describe('Enroll User Form', function() {
+  itp('has the correct title on the enroll form', function() {
+    return setupEnroll().then(function(test) {
       expect(test.form.formTitle().text()).toContain('Create Account');
     });
   });
-  itp('has the correct title on the register button', function () {
-    return setupEnroll().then(function (test) {
+  itp('has the correct title on the register button', function() {
+    return setupEnroll().then(function(test) {
       expect(test.form.formButton()[0].value).toEqual('Register');
     });
   });
-  itp('does not allow empty form submit', function () {
-    return setupEnroll().then(function (test) {
+  itp('does not allow empty form submit', function() {
+    return setupEnroll().then(function(test) {
       test.form.formButton().click();
       expect(test.form.errorMessage()).toEqual('We found some errors. Please review the form and make corrections.');
     });
   });
-  itp('renders the right fields based on API response', function () {
-    return setupEnroll().then(function (test) {
+  itp('renders the right fields based on API response', function() {
+    return setupEnroll().then(function(test) {
       expect(test.form.formInputs('streetAddress').length).toEqual(1);
       expect(test.form.formInputs('streetAddress').find('input').attr('placeholder')).toEqual('enter streetAddress *');
       expect(test.form.formInputs('streetAddress').hasClass('okta-form-input-field input-fix')).toBe(true);
@@ -87,14 +87,14 @@ Expect.describe('Enroll User Form', function () {
   });
   itp(
     'makes call to enroll if isEnrollWithLoginIntent is true and then renders the right fields based on API response',
-    function () {
+    function() {
       return setupUnAuthenticated()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resProfileRequiredNew);
           test.form.$('.registration-link').click();
           return Expect.waitForEnrollUser(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           expect(test.form.formInputs('streetAddress').length).toEqual(1);
@@ -109,7 +109,7 @@ Expect.describe('Enroll User Form', function () {
           model.save();
           return Expect.waitForEnrollUser(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.okta.com/api/v1/authn/enroll',
@@ -127,9 +127,9 @@ Expect.describe('Enroll User Form', function () {
         });
     }
   );
-  itp('enroll user form submit makes the correct post call', function () {
+  itp('enroll user form submit makes the correct post call', function() {
     return setupEnroll()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         const model = test.router.controller.model;
@@ -140,7 +140,7 @@ Expect.describe('Enroll User Form', function () {
         model.save();
         return Expect.waitForEnrollUser(test);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.okta.com/api/v1/authn/enroll',

--- a/test/unit/spec/EnrollWebauthn_spec.js
+++ b/test/unit/spec/EnrollWebauthn_spec.js
@@ -19,8 +19,8 @@ const itp = Expect.itp;
 const testAttestationObject = 'c29tZS1yYW5kb20tYXR0ZXN0YXRpb24tb2JqZWN0';
 const testClientData = 'c29tZS1yYW5kb20tY2xpZW50LWRhdGE=';
 
-Expect.describe('EnrollWebauthn', function () {
-  function setup (startRouter, onlyWebauthn) {
+Expect.describe('EnrollWebauthn', function() {
+  function setup(startRouter, onlyWebauthn) {
     const settings = {};
 
     settings['features.webauthn'] = true;
@@ -59,7 +59,7 @@ Expect.describe('EnrollWebauthn', function () {
     const enrollWebAuthn = test => {
       setNextResponse(onlyWebauthn ? resWebauthn : resAllFactors);
       router.refreshAuthState('dummy-token');
-      return Expect.waitForEnrollChoices(test).then(function (test) {
+      return Expect.waitForEnrollChoices(test).then(function(test) {
         router.enrollWebauthn();
         return Expect.waitForEnrollWebauthn(test);
       });
@@ -71,14 +71,14 @@ Expect.describe('EnrollWebauthn', function () {
     }
   }
 
-  function mockWebauthn () {
-    navigator.credentials = { create: function () {} };
+  function mockWebauthn() {
+    navigator.credentials = { create: function() {} };
   }
 
-  function mockWebauthnSuccessRegistration (resolvePromise) {
+  function mockWebauthnSuccessRegistration(resolvePromise) {
     mockWebauthn();
     spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-    spyOn(navigator.credentials, 'create').and.callFake(function () {
+    spyOn(navigator.credentials, 'create').and.callFake(function() {
       const deferred = Q.defer();
 
       if (resolvePromise) {
@@ -93,10 +93,10 @@ Expect.describe('EnrollWebauthn', function () {
     });
   }
 
-  function mockWebauthnFailureRegistration () {
+  function mockWebauthnFailureRegistration() {
     Q.stopUnhandledRejectionTracking();
     mockWebauthn();
-    spyOn(navigator.credentials, 'create').and.callFake(function () {
+    spyOn(navigator.credentials, 'create').and.callFake(function() {
       const deferred = Q.defer();
 
       deferred.reject({ message: 'something went wrong' });
@@ -104,25 +104,25 @@ Expect.describe('EnrollWebauthn', function () {
     });
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-webauthn')).toBe(true);
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
-    itp('shows error if browser does not support webauthn', function () {
+  Expect.describe('Enroll factor', function() {
+    itp('shows error if browser does not support webauthn', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(false);
 
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
           'Security key or biometric authenticator is not supported on this browser.' +
@@ -131,10 +131,10 @@ Expect.describe('EnrollWebauthn', function () {
       });
     });
 
-    itp('shows error if browser does not support webauthn and only one factor', function () {
+    itp('shows error if browser does not support webauthn and only one factor', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(false);
 
-      return setup(false, true).then(function (test) {
+      return setup(false, true).then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(1);
         expect(test.form.errorHtml().html()).toEqual(
           'Security key or biometric authenticator is not supported on this browser.' +
@@ -143,25 +143,25 @@ Expect.describe('EnrollWebauthn', function () {
       });
     });
 
-    itp('does not show error if browser supports webauthn', function () {
+    itp('does not show error if browser supports webauthn', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         expect(test.form.errorHtml()).toHaveLength(0);
       });
     });
 
-    itp('shows instructions and a register button', function () {
+    itp('shows instructions and a register button', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.submitButton());
       });
     });
 
-    itp('shows correct instructions for Edge browser', function () {
+    itp('shows correct instructions for Edge browser', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isEdge').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollEdgeInstructions());
         expect(test.form.enrollEdgeInstructions().text()).toEqual(
@@ -173,12 +173,12 @@ Expect.describe('EnrollWebauthn', function () {
       });
     });
 
-    itp('shows a note on support restrictions for firefox on mac', function () {
+    itp('shows a note on support restrictions for firefox on mac', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isFirefox').and.returnValue(true);
       spyOn(BrowserFeatures, 'isSafari').and.returnValue(false);
       spyOn(BrowserFeatures, 'isMac').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollRestrictions());
         expect(test.form.enrollRestrictions().text()).toEqual(
@@ -191,12 +191,12 @@ Expect.describe('EnrollWebauthn', function () {
       });
     });
 
-    itp('shows a note on support restrictions for safari on mac', function () {
+    itp('shows a note on support restrictions for safari on mac', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
       spyOn(BrowserFeatures, 'isFirefox').and.returnValue(false);
       spyOn(BrowserFeatures, 'isSafari').and.returnValue(true);
       spyOn(BrowserFeatures, 'isMac').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.enrollInstructions());
         Expect.isVisible(test.form.enrollRestrictions());
         expect(test.form.enrollRestrictions().text()).toEqual(
@@ -209,16 +209,16 @@ Expect.describe('EnrollWebauthn', function () {
       });
     });
 
-    itp('calls abort on appstate when switching to factor list after clicking enroll', function () {
+    itp('calls abort on appstate when switching to factor list after clicking enroll', function() {
       mockWebauthnSuccessRegistration(false);
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn]);
           test.form.submit();
           return Expect.waitForSpyCall(navigator.credentials.create, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.webauthnAbortController = test.router.controller.model.webauthnAbortController;
           expect(test.webauthnAbortController).toBeDefined();
@@ -227,37 +227,37 @@ Expect.describe('EnrollWebauthn', function () {
           test.form.backLink().click();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.controller.model.webauthnAbortController).not.toBeDefined();
           expect(test.webauthnAbortController.abort).toHaveBeenCalled();
         });
     });
 
-    itp('shows a waiting spinner after submitting the form', function () {
+    itp('shows a waiting spinner after submitting the form', function() {
       mockWebauthnSuccessRegistration(true);
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(navigator.credentials.create, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.form.enrollInstructions());
           Expect.isVisible(test.form.enrollSpinningIcon());
           Expect.isNotVisible(test.form.submitButton());
         });
     });
 
-    itp('sends enroll request after submitting the form', function () {
+    itp('sends enroll request after submitting the form', function() {
       mockWebauthnSuccessRegistration(true);
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',
@@ -270,16 +270,16 @@ Expect.describe('EnrollWebauthn', function () {
         });
     });
 
-    itp('calls navigator.credentials.create and activates the factor', function () {
+    itp('calls navigator.credentials.create and activates the factor', function() {
       mockWebauthnSuccessRegistration(true);
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(navigator.credentials.create).toHaveBeenCalledWith({
             publicKey: {
               rp: {
@@ -329,18 +329,18 @@ Expect.describe('EnrollWebauthn', function () {
         });
     });
 
-    itp('shows error when navigator.credentials.create failed', function () {
+    itp('shows error when navigator.credentials.create failed', function() {
       spyOn(webauthn, 'isNewApiAvailable').and.returnValue(true);
 
       mockWebauthnFailureRegistration();
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse([resEnrollActivateWebauthn, resSuccess]);
           test.form.submit();
           return Expect.waitForSpyCall(navigator.credentials.create, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(navigator.credentials.create).toHaveBeenCalled();
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox()).toHaveLength(1);

--- a/test/unit/spec/EnrollYubikey_spec.js
+++ b/test/unit/spec/EnrollYubikey_spec.js
@@ -10,8 +10,8 @@ import $sandbox from 'sandbox';
 const itp = Expect.itp;
 const tick = Expect.tick;
 
-Expect.describe('EnrollYubikey', function () {
-  function setup (startRouter) {
+Expect.describe('EnrollYubikey', function() {
+  function setup(startRouter) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl });
@@ -36,7 +36,7 @@ Expect.describe('EnrollYubikey', function () {
     const enrollYubikey = test => {
       setNextResponse(resAllFactors);
       router.refreshAuthState('dummy-token');
-      return Expect.waitForEnrollChoices(test).then(function (test) {
+      return Expect.waitForEnrollChoices(test).then(function(test) {
         router.enrollYubikey();
         return Expect.waitForEnrollYubikey(test);
       });
@@ -49,65 +49,65 @@ Expect.describe('EnrollYubikey', function () {
     }
   }
 
-  Expect.describe('Header & Footer', function () {
-    itp('displays the correct factorBeacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('Header & Footer', function() {
+    itp('displays the correct factorBeacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isFactorBeacon()).toBe(true);
         expect(test.beacon.hasClass('mfa-yubikey')).toBe(true);
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
   });
 
-  Expect.describe('Enroll factor', function () {
-    itp('has passCode field', function () {
-      return setup().then(function (test) {
+  Expect.describe('Enroll factor', function() {
+    itp('has passCode field', function() {
+      return setup().then(function(test) {
         Expect.isPasswordField(test.form.codeField());
       });
     });
-    itp('has a verify button', function () {
-      return setup().then(function (test) {
+    itp('has a verify button', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.submitButton());
       });
     });
-    itp('does not allow autocomplete', function () {
-      return setup().then(function (test) {
+    itp('does not allow autocomplete', function() {
+      return setup().then(function(test) {
         expect(test.form.getCodeFieldAutocomplete()).toBe('off');
       });
     });
-    itp('returns to factor list when browser\'s back button is clicked', function () {
+    itp('returns to factor list when browser\'s back button is clicked', function() {
       return setup(true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForEnrollChoices(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isEnrollChoices(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('does not send request and shows error if code is not entered', function () {
-      return setup().then(function (test) {
+    itp('does not send request and shows error if code is not entered', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(test.form.hasErrors()).toBe(true);
         expect(Util.numAjaxRequests()).toBe(0);
       });
     });
-    itp('calls enroll with the right params', function () {
+    itp('calls enroll with the right params', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setCode(123456);
           test.setNextResponse(resSuccess);
           test.form.submit();
           return tick();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors',

--- a/test/unit/spec/FidoUtil_spec.js
+++ b/test/unit/spec/FidoUtil_spec.js
@@ -1,12 +1,12 @@
 import Expect from 'helpers/util/Expect';
 import FidoUtil from 'util/FidoUtil';
 
-Expect.describe('FidoUtil', function () {
-  it('Gets U2F version', function () {
+Expect.describe('FidoUtil', function() {
+  it('Gets U2F version', function() {
     expect(FidoUtil.getU2fVersion()).toEqual('U2F_V2');
   });
 
-  it('Returns u2f enroll error message key', function () {
+  it('Returns u2f enroll error message key', function() {
     expect(FidoUtil.getU2fEnrollErrorMessageKeyByCode(1)).toEqual('u2f.error.other');
     expect(FidoUtil.getU2fEnrollErrorMessageKeyByCode(2)).toEqual('u2f.error.badRequest');
     expect(FidoUtil.getU2fEnrollErrorMessageKeyByCode(3)).toEqual('u2f.error.badRequest');
@@ -14,7 +14,7 @@ Expect.describe('FidoUtil', function () {
     expect(FidoUtil.getU2fEnrollErrorMessageKeyByCode(5)).toEqual('u2f.error.timeout');
   });
 
-  it('Returns u2f verify error message key', function () {
+  it('Returns u2f verify error message key', function() {
     expect(FidoUtil.getU2fVerifyErrorMessageKeyByCode(1, true)).toEqual('u2f.error.other.oneFactor');
     expect(FidoUtil.getU2fVerifyErrorMessageKeyByCode(2, true)).toEqual('u2f.error.badRequest.oneFactor');
     expect(FidoUtil.getU2fVerifyErrorMessageKeyByCode(3, true)).toEqual('u2f.error.badRequest.oneFactor');
@@ -28,13 +28,13 @@ Expect.describe('FidoUtil', function () {
     expect(FidoUtil.getU2fVerifyErrorMessageKeyByCode(5, false)).toEqual('u2f.error.timeout');
   });
 
-  it('Returns u2f enroll error message', function () {
+  it('Returns u2f enroll error message', function() {
     expect(FidoUtil.getU2fEnrollErrorMessageByCode(1)).toEqual(
       'An unknown error has occured. Try again or select another factor.'
     );
   });
 
-  it('Returns u2f verify error message', function () {
+  it('Returns u2f verify error message', function() {
     expect(FidoUtil.getU2fVerifyErrorMessageByCode(1, true)).toEqual(
       'An unknown error has occured. Try again or contact your admin for assistance.'
     );

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -17,7 +17,7 @@ import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 
-function setup (settings, startRouter) {
+function setup(settings, startRouter) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -55,7 +55,7 @@ function setup (settings, startRouter) {
   });
 }
 
-function transformUsername (name) {
+function transformUsername(name) {
   const suffix = '@example.com';
 
   return name.indexOf(suffix) !== -1 ? name : name + suffix;
@@ -82,33 +82,33 @@ const setupWithCallWithoutEmail = _.partial(setup, { 'features.callRecovery': tr
 
 const setupWithHideBackLink = _.partial(setup, { 'features.hideBackToSignInForReset': true });
 
-Expect.describe('ForgotPassword', function () {
-  Expect.describe('settings', function () {
-    itp('uses default title', function () {
-      return setup().then(function (test) {
+Expect.describe('ForgotPassword', function() {
+  Expect.describe('settings', function() {
+    itp('uses default title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toEqual('Reset Password');
       });
     });
-    itp('uses default for username label', function () {
-      return setup().then(function (test) {
+    itp('uses default for username label', function() {
+      return setup().then(function(test) {
         const $usernameLabel = test.form.usernameLabel();
 
         expect($usernameLabel.text().trim()).toEqual('Email or Username');
       });
     });
-    itp('sets autocomplete for username', function () {
-      return setup().then(function (test) {
+    itp('sets autocomplete for username', function() {
+      return setup().then(function(test) {
         expect(test.form.getUsernameAutocomplete()).toBe('username');
       });
     });
-    itp('does not have explain by default', function () {
-      return setup().then(function (test) {
+    itp('does not have explain by default', function() {
+      return setup().then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('does have explain when is customized', function () {
+    itp('does have explain when is customized', function() {
       const options = {
         i18n: {
           en: {
@@ -117,7 +117,7 @@ Expect.describe('ForgotPassword', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.text()).toEqual('Custom Explain');
@@ -125,138 +125,138 @@ Expect.describe('ForgotPassword', function () {
     });
   });
 
-  Expect.describe('elements', function () {
-    itp('has a username field', function () {
-      return setup().then(function (test) {
+  Expect.describe('elements', function() {
+    itp('has a username field', function() {
+      return setup().then(function(test) {
         const username = test.form.usernameField();
 
         expect(username.length).toBe(1);
         expect(username.attr('type')).toEqual('text');
       });
     });
-    itp('doesn\'t have an sms reset by default', function () {
-      return setup().then(function (test) {
+    itp('doesn\'t have an sms reset by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(false);
       });
     });
-    itp('doesn\'t have a Voice Call reset by default', function () {
-      return setup().then(function (test) {
+    itp('doesn\'t have a Voice Call reset by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasCallButton()).toBe(false);
       });
     });
-    itp('supports sms reset', function () {
-      return setupWithSms().then(function (test) {
+    itp('supports sms reset', function() {
+      return setupWithSms().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
         expect(test.form.hasCallButton()).toBe(false);
       });
     });
-    itp('has sms hint', function () {
-      return setupWithSms().then(function (test) {
+    itp('has sms hint', function() {
+      return setupWithSms().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'SMS can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('does not have sms hint if sms is not enabled', function () {
-      return setup().then(function (test) {
+    itp('does not have sms hint if sms is not enabled', function() {
+      return setup().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(false);
       });
     });
-    itp('supports Voice Call reset', function () {
-      return setupWithCall().then(function (test) {
+    itp('supports Voice Call reset', function() {
+      return setupWithCall().then(function(test) {
         expect(test.form.hasCallButton()).toBe(true);
         expect(test.form.hasSmsButton()).toBe(false);
       });
     });
-    itp('has Voice Call hint', function () {
-      return setupWithCall().then(function (test) {
+    itp('has Voice Call hint', function() {
+      return setupWithCall().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'Voice Call can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('supports SMS and Voice Call reset factors together', function () {
-      return setupWithSmsAndCall().then(function (test) {
+    itp('supports SMS and Voice Call reset factors together', function() {
+      return setupWithSmsAndCall().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
         expect(test.form.hasCallButton()).toBe(true);
       });
     });
-    itp('has SMS and Voice Call hint if both features are enabled', function () {
-      return setupWithSmsAndCall().then(function (test) {
+    itp('has SMS and Voice Call hint if both features are enabled', function() {
+      return setupWithSmsAndCall().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'SMS or Voice Call can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('shows a link to contact support when a help number is given', function () {
-      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function (test) {
+    itp('shows a link to contact support when a help number is given', function() {
+      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(true);
       });
     });
-    itp('shows no link to contact support by default', function () {
-      return setup().then(function (test) {
+    itp('shows no link to contact support by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(false);
       });
     });
-    itp('does not show email recovery button if emailRecovery is false', function () {
-      return setupWithoutEmail().then(function (test) {
+    itp('does not show email recovery button if emailRecovery is false', function() {
+      return setupWithoutEmail().then(function(test) {
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
-    itp('shows email recovery button if emailRecovery is true', function () {
-      return setup().then(function (test) {
+    itp('shows email recovery button if emailRecovery is true', function() {
+      return setup().then(function(test) {
         expect(test.form.hasEmailButton()).toBe(true);
       });
     });
-    itp('does not show back link if hideBackToSignInForReset is true ', function () {
-      return setupWithHideBackLink().then(function (test) {
+    itp('does not show back link if hideBackToSignInForReset is true ', function() {
+      return setupWithHideBackLink().then(function(test) {
         expect(test.form.backToLoginButton().length).toBe(0);
       });
     });
-    itp('shows error if no recovery factors are enabled', function () {
-      return setupWithoutEmail().then(function (test) {
+    itp('shows error if no recovery factors are enabled', function() {
+      return setupWithoutEmail().then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe(
           'No password reset options available. Please contact your administrator.'
         );
       });
     });
-    itp('supports SMS without email', function () {
-      return setupWithSmsWithoutEmail().then(function (test) {
+    itp('supports SMS without email', function() {
+      return setupWithSmsWithoutEmail().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
-    itp('supports Voice Call without email', function () {
-      return setupWithCallWithoutEmail().then(function (test) {
+    itp('supports Voice Call without email', function() {
+      return setupWithCallWithoutEmail().then(function(test) {
         expect(test.form.hasCallButton()).toBe(true);
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
   });
 
-  Expect.describe('events', function () {
-    itp('shows an error if username is empty and request email', function () {
-      return setup().then(function (test) {
+  Expect.describe('events', function() {
+    itp('shows an error if username is empty and request email', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.sendEmail();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('shows an error if username is too long', function () {
-      return setup().then(function (test) {
+    itp('shows an error if username is too long', function() {
+      return setup().then(function(test) {
         test.form.setUsername(Util.LoremIpsum);
         test.form.sendEmail();
         expect(test.form.usernameErrorField().length).toBe(1);
         expect(test.form.usernameErrorField().text()).toBe('Please check your username');
       });
     });
-    itp('does not send email and show error when username is all whitespace', function () {
-      return setup().then(function (test) {
+    itp('does not send email and show error when username is all whitespace', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUsername('  ');
         test.form.sendEmail();
@@ -265,16 +265,16 @@ Expect.describe('ForgotPassword', function () {
         expect(test.form.usernameErrorField().text()).toBe('This field cannot be left blank');
       });
     });
-    itp('sends email', function () {
+    itp('sends email', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBeFalsy();
           expect(test.form.titleText()).toBe('Email sent!');
           expect(Util.numAjaxRequests()).toBe(1);
@@ -287,16 +287,16 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends email with relayState', function () {
+    itp('sends email with relayState', function() {
       return setupWithRedirect()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -308,16 +308,16 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends email when pressing enter if Email is the only factor', function () {
+    itp('sends email when pressing enter if Email is the only factor', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForPwdResetEmailSent();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -328,32 +328,32 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('should hide back button in PwdResetEmailSent page when hideBackToSignInForReset is true', function () {
+    itp('should hide back button in PwdResetEmailSent page when hideBackToSignInForReset is true', function() {
       return setup({ 'features.hideBackToSignInForReset': true })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.backToLoginButton().length).toBe(0);
         });
     });
-    itp('should show back button in PwdResetEmailSent page when hideBackToSignInForReset is false', function () {
+    itp('should show back button in PwdResetEmailSent page when hideBackToSignInForReset is false', function() {
       return setup({ 'features.hideBackToSignInForReset': false })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.backToLoginButton().length).toBe(1);
         });
     });
-    itp('calls the transformUsername function with the right parameters', function () {
-      return setupWithTransformUsername().then(function (test) {
+    itp('calls the transformUsername function with the right parameters', function() {
+      return setupWithTransformUsername().then(function(test) {
         spyOn(test.router.settings, 'transformUsername');
         test.setNextResponse(resChallengeEmail);
         test.form.setUsername('foo');
@@ -362,16 +362,16 @@ Expect.describe('ForgotPassword', function () {
         expect(test.router.settings.transformUsername.calls.argsFor(0)).toEqual(['foo', 'FORGOT_PASSWORD']);
       });
     });
-    itp('appends the suffix returned by the transformUsername function to the username', function () {
+    itp('appends the suffix returned by the transformUsername function to the username', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -382,9 +382,9 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('updates appState username after sending email', function () {
+    itp('updates appState username after sending email', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
@@ -393,19 +393,19 @@ Expect.describe('ForgotPassword', function () {
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows email sent confirmation screen and has button to return to login', function () {
+    itp('shows email sent confirmation screen and has button to return to login', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('baz@bar');
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.titleText()).toBe('Email sent!');
           expect(test.form.accessibilityText()).toBe('Email sent!');
           expect(test.form.getEmailSentConfirmationText().indexOf('baz@bar') >= 0).toBe(true);
@@ -413,14 +413,14 @@ Expect.describe('ForgotPassword', function () {
           test.form.goBackToLogin();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isPrimaryAuth(test.router.controller);
         });
     });
     // Note: Let's remove this test when OKTA-69083 is resolved
-    itp('shows email sent confirmation screen even if API response is bad (OKTA-69083)', function () {
+    itp('shows email sent confirmation screen even if API response is bad (OKTA-69083)', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('baz@bar');
           test.setNextResponse({
             status: 200,
@@ -435,30 +435,30 @@ Expect.describe('ForgotPassword', function () {
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.titleText()).toBe('Email sent!');
         });
     });
-    itp('calls globalSuccessFn when an email has been sent', function () {
+    itp('calls globalSuccessFn when an email has been sent', function() {
       const successSpy = jasmine.createSpy('successSpy');
 
       return setup({ globalSuccessFn: successSpy })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('foo@bar');
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(successSpy).toHaveBeenCalledWith({
             status: 'FORGOT_PASSWORD_EMAIL_SENT',
             username: 'foo@bar',
           });
         });
     });
-    itp('shows an error if sending email results in an error', function () {
+    itp('shows an error if sending email results in an error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           Q.stopUnhandledRejectionTracking();
           test.setNextResponse(resError);
@@ -466,29 +466,29 @@ Expect.describe('ForgotPassword', function () {
           test.form.sendEmail();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
         });
     });
-    itp('shows an error if username is empty and request sms', function () {
-      return setupWithSms().then(function (test) {
+    itp('shows an error if username is empty and request sms', function() {
+      return setupWithSms().then(function(test) {
         Util.resetAjaxRequests();
         test.form.sendSms();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('sends sms', function () {
+    itp('sends sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -499,9 +499,9 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends sms without email enabled', function () {
+    itp('sends sms without email enabled', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
           Util.resetAjaxRequests();
@@ -510,7 +510,7 @@ Expect.describe('ForgotPassword', function () {
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -521,16 +521,16 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends sms when pressing enter if SMS is the only factor', function () {
+    itp('sends sms when pressing enter if SMS is the only factor', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -541,9 +541,9 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends sms when pressing enter if SMS is the first factor of the list', function () {
+    itp('sends sms when pressing enter if SMS is the first factor of the list', function() {
       return setupWithSmsAndCall()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
@@ -553,7 +553,7 @@ Expect.describe('ForgotPassword', function () {
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -564,27 +564,27 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('updates appState username after sending sms', function () {
+    itp('updates appState username after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows an error if sending sms results in an error', function () {
+    itp('shows an error if sending sms results in an error', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -612,21 +612,21 @@ Expect.describe('ForgotPassword', function () {
           ]);
         });
     });
-    itp('does not have a problem with sending email after sending sms', function () {
+    itp('does not have a problem with sending email after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.sendEmail();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -637,24 +637,24 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('shows an error if username is empty and request Voice Call', function () {
-      return setupWithCall().then(function (test) {
+    itp('shows an error if username is empty and request Voice Call', function() {
+      return setupWithCall().then(function(test) {
         Util.resetAjaxRequests();
         test.form.makeCall();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('makes a Voice Call', function () {
+    itp('makes a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -665,9 +665,9 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('makes a Voice Call without email enabled', function () {
+    itp('makes a Voice Call without email enabled', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
           Util.resetAjaxRequests();
@@ -676,7 +676,7 @@ Expect.describe('ForgotPassword', function () {
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -687,16 +687,16 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('makes a Voice Call when pressing enter if Voice Call is the only factor', function () {
+    itp('makes a Voice Call when pressing enter if Voice Call is the only factor', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -707,9 +707,9 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('makes a Voice Call when pressing enter if Voice Call is the first factor of the list', function () {
+    itp('makes a Voice Call when pressing enter if Voice Call is the first factor of the list', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
           Util.resetAjaxRequests();
@@ -718,7 +718,7 @@ Expect.describe('ForgotPassword', function () {
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -729,27 +729,27 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('updates appState username after making a Voice Call', function () {
+    itp('updates appState username after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows an error if making a Voice Call results in an error', function () {
+    itp('shows an error if making a Voice Call results in an error', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -777,21 +777,21 @@ Expect.describe('ForgotPassword', function () {
           ]);
         });
     });
-    itp('does not have a problem with sending email after making a Voice Call', function () {
+    itp('does not have a problem with sending email after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.sendEmail();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -802,48 +802,48 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('goes back', function () {
-      return setup().then(function (test) {
+    itp('goes back', function() {
+      return setup().then(function(test) {
         test.form.goBack();
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
     });
-    itp('returns to primary auth when browser\'s back button is clicked', function () {
+    itp('returns to primary auth when browser\'s back button is clicked', function() {
       return setup({}, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isPrimaryAuth(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('resets auth status on initialization', function () {
+    itp('resets auth status on initialization', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.goBack();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.loginForm.setUsername('testuser');
           test.loginForm.setPassword('pass');
           test.setNextResponse(resMfaRequired);
           test.loginForm.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForAjaxRequest();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -854,16 +854,16 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('sends email, goes back to login page and allows resending', function () {
+    itp('sends email, goes back to login page and allows resending', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -874,18 +874,18 @@ Expect.describe('ForgotPassword', function () {
           });
           return test;
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.goBackToLogin();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isPrimaryAuth(test.router.controller);
 
           // Click Forgot Password again
           test.loginForm.forgotPasswordLink().click();
           return Expect.waitForForgotPassword(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Submit the user name again
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
@@ -893,7 +893,7 @@ Expect.describe('ForgotPassword', function () {
           test.form.sendEmail();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           // Expect the same request as before
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -905,54 +905,54 @@ Expect.describe('ForgotPassword', function () {
           });
         });
     });
-    itp('shows an org\'s contact form when user clicks no email access link', function () {
-      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function (test) {
+    itp('shows an org\'s contact form when user clicks no email access link', function() {
+      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(true);
         test.form.clickCantAccessEmail();
         expect(test.form.contactSupportText()).toMatch(/\(999\) 123-4567/);
         expect(test.form.hasCantAccessEmailLink()).toBe(false);
       });
     });
-    itp('shows the "Reset via email" link after sending sms', function () {
+    itp('shows the "Reset via email" link after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Reset via email');
         });
     });
-    itp('does not show the "Reset via email" link after sending sms if emailRecovery is false', function () {
+    itp('does not show the "Reset via email" link after sending sms if emailRecovery is false', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(false);
         });
     });
-    itp('sends an email when user clicks the "Reset via email" link, after sending sms', function () {
+    itp('sends an email when user clicks the "Reset via email" link, after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo@bar');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.clickSendEmailLink();
           return Expect.waitForPwdResetEmailSent();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -965,20 +965,20 @@ Expect.describe('ForgotPassword', function () {
     });
     itp(
       'shows email sent confirmation screen when user clicks the "Reset via email" link, after sending sms',
-      function () {
+      function() {
         return setupWithSms()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeSms);
             test.form.setUsername('foo@bar');
             test.form.sendSms();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForPwdResetEmailSent(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.titleText()).toBe('Email sent!');
             expect(test.form.getEmailSentConfirmationText().indexOf('foo@bar') >= 0).toBe(true);
             expect(test.form.backToLoginButton().length).toBe(1);
@@ -987,66 +987,66 @@ Expect.describe('ForgotPassword', function () {
     );
     itp(
       'shows an error if sending email via "Reset via email" link results in an error, after sending sms',
-      function () {
+      function() {
         return setupWithSms()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeSms);
             test.form.setUsername('foo');
             test.form.sendSms();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Expect.allowUnhandledPromiseRejection();
             test.setNextResponse(resError);
             test.form.clickSendEmailLink();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
           });
       }
     );
-    itp('shows the "Reset via email" link after making a Voice Call', function () {
+    itp('shows the "Reset via email" link after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Reset via email');
         });
     });
-    itp('does not show the "Reset via email" link after making a Voice Call if emailRecovery is false', function () {
+    itp('does not show the "Reset via email" link after making a Voice Call if emailRecovery is false', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(false);
         });
     });
-    itp('sends an email when user clicks the "Reset via email" link, after making a Voice Call', function () {
+    itp('sends an email when user clicks the "Reset via email" link, after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo@bar');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.clickSendEmailLink();
           return Expect.waitForPwdResetEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/password',
@@ -1059,20 +1059,20 @@ Expect.describe('ForgotPassword', function () {
     });
     itp(
       'shows email sent confirmation screen when user clicks the "Reset via email" link, after making a Voice Call',
-      function () {
+      function() {
         return setupWithCall()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeCall);
             test.form.setUsername('foo@bar');
             test.form.makeCall();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForPwdResetEmailSent(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.titleText()).toBe('Email sent!');
             expect(test.form.getEmailSentConfirmationText().indexOf('foo@bar') >= 0).toBe(true);
             expect(test.form.backToLoginButton().length).toBe(1);
@@ -1081,21 +1081,21 @@ Expect.describe('ForgotPassword', function () {
     );
     itp(
       'shows an error if sending email via "Reset via email" link results in an error, after making a Voice Call',
-      function () {
+      function() {
         return setupWithCall()
-          .then(function (test) {
+          .then(function(test) {
             Expect.allowUnhandledPromiseRejection();
             test.setNextResponse(resChallengeCall);
             test.form.setUsername('foo');
             test.form.makeCall();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resError);
             test.form.clickSendEmailLink();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -27,7 +27,7 @@ const itp = Expect.itp;
 const BEACON_LOADING_CLS = 'beacon-loading';
 const OIDC_STATE = 'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg';
 
-function setup (settings, requests) {
+function setup(settings, requests) {
   settings || (settings = {});
   settings['features.idpDiscovery'] = true;
   settings['language'] = 'en';
@@ -36,7 +36,7 @@ function setup (settings, requests) {
   // modified to wait 0 ms.
   const debounce = _.debounce;
 
-  spyOn(_, 'debounce').and.callFake(function (fn) {
+  spyOn(_, 'debounce').and.callFake(function(fn) {
     return debounce(fn, 0);
   });
 
@@ -51,8 +51,8 @@ function setup (settings, requests) {
   const successSpy = jasmine.createSpy('success');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
 
-  const setNextWebfingerResponse = function (res, reject) {
-    spyOn(authClient, 'webfinger').and.callFake(function () {
+  const setNextWebfingerResponse = function(res, reject) {
+    spyOn(authClient, 'webfinger').and.callFake(function() {
       const deferred = Q.defer();
 
       if (reject) {
@@ -98,7 +98,7 @@ function setup (settings, requests) {
   });
 }
 
-function setupSocial (settings) {
+function setupSocial(settings) {
   Util.mockOIDCStateGenerator();
   return setup(
     _.extend(
@@ -120,8 +120,8 @@ function setupSocial (settings) {
       },
       settings
     )
-  ).then(function (test) {
-    spyOn(window, 'open').and.callFake(function () {
+  ).then(function(test) {
+    spyOn(window, 'open').and.callFake(function() {
       test.oidcWindow = { closed: false, close: jasmine.createSpy() };
       return test.oidcWindow;
     });
@@ -129,8 +129,8 @@ function setupSocial (settings) {
   });
 }
 
-function setupPasswordlessAuth (requests) {
-  return setup({ 'features.passwordlessAuth': true }, requests).then(function (test) {
+function setupPasswordlessAuth(requests) {
+  return setup({ 'features.passwordlessAuth': true }, requests).then(function(test) {
     Util.mockRouterNavigate(test.router);
     test.setNextWebfingerResponse(resSuccessOktaIDP);
     test.setNextResponse(resPasswordlessUnauthenticated);
@@ -138,7 +138,7 @@ function setupPasswordlessAuth (requests) {
   });
 }
 
-function setupRegistrationButton (featuresRegistration, registrationObj) {
+function setupRegistrationButton(featuresRegistration, registrationObj) {
   const settings = {
     registration: registrationObj,
   };
@@ -149,51 +149,51 @@ function setupRegistrationButton (featuresRegistration, registrationObj) {
   return setup(settings);
 }
 
-function waitForBeaconChange (test) {
+function waitForBeaconChange(test) {
   const cur = test.beacon.getBeaconImage();
 
-  return Expect.wait(function () {
+  return Expect.wait(function() {
     return test.beacon.getBeaconImage() !== cur;
   }, test);
 }
 
-function waitForDefaultBeaconLoaded (test) {
-  return Expect.wait(function () {
+function waitForDefaultBeaconLoaded(test) {
+  return Expect.wait(function() {
     return test.beacon.hasClass('undefined-user');
   }, test);
 }
 
-function waitForSecurityBeaconLoaded (test) {
-  return Expect.wait(function () {
+function waitForSecurityBeaconLoaded(test) {
+  return Expect.wait(function() {
     return test.beacon.hasClass('undefined-user') === false;
   }, test);
 }
 
-function waitForWebfingerCall (test) {
+function waitForWebfingerCall(test) {
   return Expect.waitForSpyCall(test.ac.webfinger, test).then(test => {
     return Expect.waitForSpyCall(test.router.appState.trigger, test);
   });
 }
 
-function transformUsername (name) {
+function transformUsername(name) {
   const nameArr = name.split('@');
 
   return nameArr[0] + '@example.com';
 }
 
-function transformUsernameOnUnlock (name, operation) {
+function transformUsernameOnUnlock(name, operation) {
   if (operation === 'UNLOCK_ACCOUNT') {
     transformUsername(name);
   }
   return name;
 }
 
-function setupWith (options) {
+function setupWith(options) {
   const examples = {
     customButton: {
       title: 'test text',
       className: 'test-class',
-      click: function (e) {
+      click: function(e) {
         $(e.target).addClass('new-class');
       },
     },
@@ -223,13 +223,13 @@ function setupWith (options) {
   return setup(settings);
 }
 
-function setupWithCustomButtons () {
+function setupWithCustomButtons() {
   const settings = {
     customButtons: [
       {
         title: 'test text',
         className: 'test-class',
-        click: function (e) {
+        click: function(e) {
           $(e.target).addClass('new-class');
         },
         dataAttr: 'test-data',
@@ -240,13 +240,13 @@ function setupWithCustomButtons () {
   return setup(settings);
 }
 
-function setupWithCustomButtonsWithIdp () {
+function setupWithCustomButtonsWithIdp() {
   const settings = {
     customButtons: [
       {
         title: 'test text',
         className: 'test-class',
-        click: function (e) {
+        click: function(e) {
           $(e.target).addClass('new-class');
         },
       },
@@ -262,7 +262,7 @@ function setupWithCustomButtonsWithIdp () {
   return setup(settings);
 }
 
-function setupWithoutCustomButtonsAndWithIdp () {
+function setupWithoutCustomButtonsAndWithIdp() {
   const settings = {
     customButtons: undefined,
     idps: [
@@ -276,7 +276,7 @@ function setupWithoutCustomButtonsAndWithIdp () {
   return setup(settings);
 }
 
-function setupWithoutCustomButtonsWithoutIdp () {
+function setupWithoutCustomButtonsWithoutIdp() {
   const settings = {
     customButtons: undefined,
     idps: undefined,
@@ -289,59 +289,59 @@ const setupWithTransformUsername = _.partial(setup, { username: 'foobar', transf
 
 const setupWithTransformUsernameOnUnlock = _.partial(setup, { transformUsername: transformUsernameOnUnlock });
 
-Expect.describe('IDPDiscovery', function () {
-  describe('IDPDiscoveryModel', function () {
-    it('returns validation error when email is blank', function () {
+Expect.describe('IDPDiscovery', function() {
+  describe('IDPDiscoveryModel', function() {
+    it('returns validation error when email is blank', function() {
       const model = new IDPDiscovery({ username: '' });
 
       expect(model.validate().username).toEqual('model.validation.field.blank');
     });
   });
 
-  describe('settings', function () {
-    itp('uses default title', function () {
-      return setup().then(function (test) {
+  describe('settings', function() {
+    itp('uses default title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toEqual('Sign In');
       });
     });
-    itp('uses default for username label', function () {
-      return setup().then(function (test) {
+    itp('uses default for username label', function() {
+      return setup().then(function(test) {
         const $usernameLabel = test.form.idpDiscoveryUsernameLabel();
 
         expect($usernameLabel.text().trim()).toEqual('Username');
       });
     });
-    itp('sets autocomplete on username', function () {
-      return setup().then(function (test) {
+    itp('sets autocomplete on username', function() {
+      return setup().then(function(test) {
         expect(test.form.getUsernameFieldAutocomplete()).toBe('username');
       });
     });
-    itp('overrides rememberMe from settings and uses default text', function () {
-      return setup({ 'features.rememberMe': true }).then(function (test) {
+    itp('overrides rememberMe from settings and uses default text', function() {
+      return setup({ 'features.rememberMe': true }).then(function(test) {
         const label = test.form.rememberMeLabelText();
 
         expect(label).toEqual('Remember me');
       });
     });
-    itp('uses default for unlock account', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('uses default for unlock account', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         const label = test.form.unlockLabel();
 
         expect(label.trim()).toBe('Unlock account?');
       });
     });
-    itp('focuses on username field in browsers other than IE', function () {
+    itp('focuses on username field in browsers other than IE', function() {
       spyOn(BrowserFeatures, 'isIE').and.returnValue(false);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         const $username = test.form.usernameField();
 
         // Focused element would be username DOM element
         expect($username[0]).toBe(document.activeElement);
       });
     });
-    itp('does not focus on username field in IE', function () {
+    itp('does not focus on username field in IE', function() {
       spyOn(BrowserFeatures, 'isIE').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         const $username = test.form.usernameField();
 
         // Focused element would be body element
@@ -350,24 +350,24 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('elements', function () {
-    itp('has a security beacon if features.securityImage is true', function () {
-      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function (test) {
+  describe('elements', function() {
+    itp('has a security beacon if features.securityImage is true', function() {
+      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
-    itp('beacon could be minimized if it is a security beacon', function () {
-      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function (test) {
+    itp('beacon could be minimized if it is a security beacon', function() {
+      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function(test) {
         expect(test.authContainer.canBeMinimized()).toBe(true);
       });
     });
-    itp('does not show a beacon if features.securityImage is false', function () {
-      return setup().then(function (test) {
+    itp('does not show a beacon if features.securityImage is false', function() {
+      return setup().then(function(test) {
         expect(test.beacon.beacon().length).toBe(0);
       });
     });
-    itp('has a username field', function () {
-      return setup().then(function (test) {
+    itp('has a username field', function() {
+      return setup().then(function(test) {
         const username = test.form.usernameField();
 
         expect(username.length).toBe(1);
@@ -375,8 +375,8 @@ Expect.describe('IDPDiscovery', function () {
         expect(username.attr('id')).toEqual('idp-discovery-username');
       });
     });
-    itp('has a next button', function () {
-      return setup().then(function (test) {
+    itp('has a next button', function() {
+      return setup().then(function(test) {
         const nextButton = test.form.nextButton();
 
         expect(nextButton.length).toBe(1);
@@ -385,28 +385,28 @@ Expect.describe('IDPDiscovery', function () {
         expect(nextButton.attr('id')).toEqual('idp-discovery-submit');
       });
     });
-    itp('has a rememberMe checkbox if features.rememberMe is true', function () {
-      return setup().then(function (test) {
+    itp('has a rememberMe checkbox if features.rememberMe is true', function() {
+      return setup().then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(1);
       });
     });
-    itp('does not have a rememberMe checkbox if features.rememberMe is false', function () {
-      return setup({ 'features.rememberMe': false }).then(function (test) {
+    itp('does not have a rememberMe checkbox if features.rememberMe is false', function() {
+      return setup({ 'features.rememberMe': false }).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
       });
     });
-    itp('username field does not have explain by default', function () {
-      return setup().then(function (test) {
+    itp('username field does not have explain by default', function() {
+      return setup().then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('username field does have explain when it is customized', function () {
+    itp('username field does have explain when it is customized', function() {
       const options = {
         i18n: {
           en: {
@@ -415,225 +415,225 @@ Expect.describe('IDPDiscovery', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.text()).toEqual('Custom Username Explain');
       });
     });
-    itp('has "Need help?" link', function () {
-      return setup().then(function (test) {
+    itp('has "Need help?" link', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooterLabel().trim()).toBe('Need help signing in?');
       });
     });
-    itp('has a help link', function () {
-      return setup().then(function (test) {
+    itp('has a help link', function() {
+      return setup().then(function(test) {
         expect(test.form.helpLinkLabel().trim()).toBe('Help');
       });
     });
-    itp('has the correct help link url', function () {
-      return setup().then(function (test) {
+    itp('has the correct help link url', function() {
+      return setup().then(function(test) {
         spyOn(SharedUtil, 'redirect');
         expect(test.form.helpLinkHref()).toBe('https://foo.com/help/login');
       });
     });
-    itp('has a custom help link url when available', function () {
-      return setup({ 'helpLinks.help': 'https://bar.com' }).then(function (test) {
+    itp('has a custom help link url when available', function() {
+      return setup({ 'helpLinks.help': 'https://bar.com' }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         expect(test.form.helpLinkHref()).toBe('https://bar.com');
       });
     });
-    itp('has helpFooter with right aria-attributes and default values', function () {
-      return setup().then(function (test) {
+    itp('has helpFooter with right aria-attributes and default values', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('false');
         expect(test.form.helpFooter().attr('aria-controls')).toBe('help-links-container');
       });
     });
-    itp('sets aria-expanded attribute correctly when clicking help', function () {
-      return setup().then(function (test) {
+    itp('sets aria-expanded attribute correctly when clicking help', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('false');
         test.form.helpFooter().click();
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('true');
       });
     });
-    itp('has a forgot password link', function () {
-      return setup().then(function (test) {
+    itp('has a forgot password link', function() {
+      return setup().then(function(test) {
         expect(test.form.forgotPasswordLabel().trim()).toBe('Forgot password?');
       });
     });
-    itp('forgot password link is not visible on load', function () {
-      return setup().then(function (test) {
+    itp('forgot password link is not visible on load', function() {
+      return setup().then(function(test) {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('shows forgot password link when clicking help', function () {
-      return setup().then(function (test) {
+    itp('shows forgot password link when clicking help', function() {
+      return setup().then(function(test) {
         test.form.helpFooter().click();
         expect(test.form.forgotPasswordLinkVisible()).toBe(true);
       });
     });
-    itp('does not show forgot password link when disabled and clicked', function () {
+    itp('does not show forgot password link when disabled and clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           expect(test.form.forgotPasswordLinkVisible()).not.toBe(true);
         });
     });
-    itp('navigates to forgot password page when click forgot password link', function () {
-      return setup().then(function (test) {
+    itp('navigates to forgot password page when click forgot password link', function() {
+      return setup().then(function(test) {
         spyOn(test.router, 'navigate');
         test.form.helpFooter().click();
         test.form.forgotPasswordLink().click();
         expect(test.router.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
       });
     });
-    itp('does not navigate to forgot password page when link disabled and clicked', function () {
+    itp('does not navigate to forgot password page when link disabled and clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router, 'navigate');
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
           expect(test.router.navigate).not.toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
         });
     });
-    itp('navigates to custom forgot password page when available', function () {
-      return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function (test) {
+    itp('navigates to custom forgot password page when available', function() {
+      return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         test.form.helpFooter().click();
         test.form.forgotPasswordLink().click();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
       });
     });
-    itp('does not navigate to custom forgot password page when link disabled and clicked', function () {
+    itp('does not navigate to custom forgot password page when link disabled and clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup({ 'helpLinks.forgotPassword': 'https://foo.com' })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
           expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
         });
     });
-    itp('unlock link is hidden on load', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('unlock link is hidden on load', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         expect(test.form.unlockLinkVisible()).toBe(false);
       });
     });
-    itp('shows unlock link when clicking help', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('shows unlock link when clicking help', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         test.form.helpFooter().click();
         expect(test.form.unlockLinkVisible()).toBe(true);
       });
     });
-    itp('navigates to unlock page when click unlock link', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('navigates to unlock page when click unlock link', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         spyOn(test.router, 'navigate');
         test.form.helpFooter().click();
         test.form.unlockLink().click();
         expect(test.router.navigate).toHaveBeenCalledWith('signin/unlock', { trigger: true });
       });
     });
-    itp('does not navigate to unlock page when link disabled and clicked', function () {
+    itp('does not navigate to unlock page when link disabled and clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router, 'navigate');
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.unlockLink().click();
           expect(test.router.navigate).not.toHaveBeenCalledWith('signin/unlock', { trigger: true });
         });
     });
-    itp('navigates to custom unlock page when available', function () {
+    itp('navigates to custom unlock page when available', function() {
       return setup({
         'helpLinks.unlock': 'https://foo.com',
         'features.selfServiceUnlock': true,
-      }).then(function (test) {
+      }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         test.form.helpFooter().click();
         test.form.unlockLink().click();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
       });
     });
-    itp('does not navigate to custom unlock page when link disabled and clicked', function () {
+    itp('does not navigate to custom unlock page when link disabled and clicked', function() {
       spyOn(SharedUtil, 'redirect');
       return setup({
         'helpLinks.unlock': 'https://foo.com',
         'features.selfServiceUnlock': true,
       })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.unlockLink().click();
           expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
         });
     });
-    itp('does not show unlock link if feature is off', function () {
-      return setup().then(function (test) {
+    itp('does not show unlock link if feature is off', function() {
+      return setup().then(function(test) {
         expect(test.form.unlockLink().length).toBe(0);
       });
     });
-    itp('does not show custom links if they do not exist', function () {
-      return setup().then(function (test) {
+    itp('does not show custom links if they do not exist', function() {
+      return setup().then(function(test) {
         expect(test.form.customLinks().length).toBe(0);
       });
     });
-    itp('shows custom links if they exist', function () {
+    itp('shows custom links if they exist', function() {
       const customLinks = [
         { text: 'github', href: 'https://github.com', rel: 'noopener noreferrer' },
         { text: 'google', href: 'https://google.com', rel: 'noopener noreferrer' },
       ];
 
-      return setup({ 'helpLinks.custom': customLinks }).then(function (test) {
+      return setup({ 'helpLinks.custom': customLinks }).then(function(test) {
         const links = test.form.customLinks();
 
         expect(links).toEqual(customLinks);
       });
     });
-    itp('shows custom links with target attribute', function () {
+    itp('shows custom links with target attribute', function() {
       const customLinks = [
         { text: 'github', href: 'https://github.com', rel: 'noopener noreferrer', target: '_blank' },
         { text: 'google', href: 'https://google.com', rel: 'noopener noreferrer' },
         { text: 'okta', href: 'https://okta.com', rel: 'noopener noreferrer', target: '_custom' },
       ];
 
-      return setup({ 'helpLinks.custom': customLinks }).then(function (test) {
+      return setup({ 'helpLinks.custom': customLinks }).then(function(test) {
         const links = test.form.customLinks();
 
         expect(links).toEqual(customLinks);
       });
     });
-    itp('toggles "focused-input" css class on focus in and focus out', function () {
-      return setup().then(function (test) {
+    itp('toggles "focused-input" css class on focus in and focus out', function() {
+      return setup().then(function(test) {
         test.form.usernameField().focus();
         expect(test.form.usernameField()[0].parentElement).toHaveClass('focused-input');
         test.form.usernameField().focusout();
@@ -642,18 +642,18 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('transform username', function () {
-    itp('calls the transformUsername function with the right parameters', function () {
+  describe('transform username', function() {
+    itp('calls the transformUsername function with the right parameters', function() {
       spyOn(SharedUtil, 'redirect');
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'transformUsername');
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.settings.transformUsername.calls.count()).toBe(1);
           expect(test.router.settings.transformUsername.calls.argsFor(0)).toEqual([
             'testuser@clouditude.net',
@@ -661,46 +661,46 @@ Expect.describe('IDPDiscovery', function () {
           ]);
         });
     });
-    itp('does not call transformUsername while loading security image', function () {
+    itp('does not call transformUsername while loading security image', function() {
       return setup({ features: { securityImage: true }, transformUsername: transformUsername })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'transformUsername');
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.settings.transformUsername.calls.count()).toBe(0);
           expect(Util.numAjaxRequests()).toBe(1);
           expect(Util.getAjaxRequest(0).url).toBe('https://foo.com/login/getimage?username=testuser%40clouditude.net');
         });
     });
-    itp('changs the suffix of the username', function () {
+    itp('changs the suffix of the username', function() {
       spyOn(SharedUtil, 'redirect');
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.ac.webfinger).toHaveBeenCalledWith({
             resource: 'okta:acct:testuser@example.com',
             requestContext: undefined,
           });
         });
     });
-    itp('does not change the suffix of the username if "IDP_DISCOVERY" operation is not handled', function () {
+    itp('does not change the suffix of the username if "IDP_DISCOVERY" operation is not handled', function() {
       spyOn(SharedUtil, 'redirect');
       return setupWithTransformUsernameOnUnlock()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.ac.webfinger).toHaveBeenCalledWith({
             resource: 'okta:acct:testuser@clouditude.net',
             requestContext: undefined,
@@ -709,11 +709,11 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('Device Fingerprint', function () {
+  describe('Device Fingerprint', function() {
     itp(
       `is not computed if securityImage is off, deviceFingerprinting is
         true and useDeviceFingerprintForSecurityImage is true`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({
           features: {
@@ -722,14 +722,14 @@ Expect.describe('IDPDiscovery', function () {
             useDeviceFingerprintForSecurityImage: true,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return Expect.wait(() => {
               return test.router.appState.get('username') === 'testuser@clouditude.net';
             });
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(0);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
           });
@@ -738,20 +738,20 @@ Expect.describe('IDPDiscovery', function () {
     itp(
       `contains fingerprint header in get security image request if deviceFingerprinting
         is true (useDeviceFingerprintForSecurityImage defaults to true)`,
-      function () {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+      function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
           const deferred = Q.defer();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
         return setup({ features: { securityImage: true, deviceFingerprinting: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -763,8 +763,8 @@ Expect.describe('IDPDiscovery', function () {
     itp(
       `contains fingerprint header in get security image request if both features(
         deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`,
-      function () {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+      function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
           const deferred = Q.defer();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
@@ -777,12 +777,12 @@ Expect.describe('IDPDiscovery', function () {
             useDeviceFingerprintForSecurityImage: true,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -794,7 +794,7 @@ Expect.describe('IDPDiscovery', function () {
     itp(
       `does not contain fingerprint header in get security image request if deviceFingerprinting
           is enabled but useDeviceFingerprintForSecurityImage is disabled`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({
           features: {
@@ -803,12 +803,12 @@ Expect.describe('IDPDiscovery', function () {
             useDeviceFingerprintForSecurityImage: false,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -820,15 +820,15 @@ Expect.describe('IDPDiscovery', function () {
     itp(
       `does not contain fingerprint header in get security image request if deviceFingerprinting
         is disabled and useDeviceFingerprintForSecurityImage is enabled`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({ features: { securityImage: true, useDeviceFingerprintForSecurityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -837,15 +837,15 @@ Expect.describe('IDPDiscovery', function () {
           });
       }
     );
-    itp('does not contain fingerprint header in get security image request if feature is disabled', function () {
+    itp('does not contain fingerprint header in get security image request if feature is disabled', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
           const ajaxArgs = Util.getAjaxRequest(0);
@@ -855,18 +855,18 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('events', function () {
-    describe('beacon loading', function () {
-      itp('shows beacon-loading animation when authClient webfinger is called', function () {
+  describe('events', function() {
+    describe('beacon loading', function() {
+      itp('shows beacon-loading animation when authClient webfinger is called', function() {
         spyOn(SharedUtil, 'redirect');
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.securityBeacon, 'toggleClass').and.callThrough();
             test.setNextWebfingerResponse(resSuccessSAML);
             test.form.submit();
@@ -877,74 +877,74 @@ Expect.describe('IDPDiscovery', function () {
             test.securityBeacon.toggleClass.calls.reset();
             return waitForWebfingerCall(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.securityBeacon.toggleClass).toHaveBeenCalledWith(BEACON_LOADING_CLS, false);
           });
       });
-      itp('does not show beacon-loading animation when authClient webfinger fails', function () {
+      itp('does not show beacon-loading animation when authClient webfinger fails', function() {
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser@clouditude.net');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextWebfingerResponse(resError, true);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
             expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
-      itp('shows beacon-loading animation when webfinger is submitted (no security image)', function () {
+      itp('shows beacon-loading animation when webfinger is submitted (no security image)', function() {
         spyOn(SharedUtil, 'redirect');
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextWebfingerResponse(resSuccessSAML);
             test.form.setUsername('testuser@clouditude.net');
             test.form.submit();
             return waitForWebfingerCall(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(true);
           });
       });
-      itp('does not show beacon-loading animation when webfinger fails (no security image)', function () {
+      itp('does not show beacon-loading animation when webfinger fails (no security image)', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             test.setNextWebfingerResponse(resError, true);
             test.form.setUsername('testuser@clouditude.net');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(false);
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
     });
-    itp('does not make securityImage requests if features.securityImage is false', function () {
+    itp('does not make securityImage requests if features.securityImage is false', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           return Expect.wait(() => {
             return test.router.appState.get('username') === 'testuser@clouditude.net';
           });
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(0);
         });
     });
-    itp('has default security image on page load and no rememberMe', function () {
-      return setup({ features: { securityImage: true } }).then(waitForDefaultBeaconLoaded).then(function (test) {
+    itp('has default security image on page load and no rememberMe', function() {
+      return setup({ features: { securityImage: true } }).then(waitForDefaultBeaconLoaded).then(function(test) {
         expect(test.form.securityBeacon()[0].className).toMatch('undefined-user');
         expect(test.form.securityBeacon()[0].className).not.toMatch('new-device');
         expect(test.form.securityBeacon().css('background-image')).toMatch(
@@ -952,36 +952,36 @@ Expect.describe('IDPDiscovery', function () {
         );
       });
     });
-    itp('updates security beacon when user enters correct username', function () {
+    itp('updates security beacon when user enters correct username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(Util.getAjaxRequest(0).url).toBe('https://foo.com/login/getimage?username=testuser%40clouditude.net');
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
           expect(test.form.accessibilityText()).toBe('a single pixel');
         });
     });
-    itp('waits for username field to lose focus before fetching the security image', function () {
+    itp('waits for username field to lose focus before fetching the security image', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           test.form.editingUsername('te');
           test.form.editingUsername('testu');
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('undefined username does not make API call', function () {
+    itp('undefined username does not make API call', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           // security image and description will be set properly when username changes
           test.router.appState.set(
@@ -998,21 +998,21 @@ Expect.describe('IDPDiscovery', function () {
             return !!test.router.appState.get('securityImage');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.router.appState.get('securityImage')).toContain('/img/security/default.png');
           expect(test.router.appState.get('securityImageDescription')).toBe('');
           expect(test.form.securityBeacon()[0].className).toContain('undefined-user');
         });
     });
-    itp('updates security beacon to show the new user image when user enters unfamiliar username', function () {
+    itp('updates security beacon to show the new user image when user enters unfamiliar username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityBeacon()[0].className).toMatch('new-user');
           expect(test.form.securityBeacon()[0].className).not.toMatch('undefined-user');
           expect(test.form.securityBeacon().css('background-image')).toMatch(
@@ -1020,22 +1020,22 @@ Expect.describe('IDPDiscovery', function () {
           );
         });
     });
-    itp('shows an unknown user message when user enters unfamiliar username', function () {
+    itp('shows an unknown user message when user enters unfamiliar username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityImageTooltipText()).toEqual(
             'This is the first time you are connecting to foo.com from this browser×'
           );
         });
     });
-    itp('does not show anti-phishing message if security image is hidden', function () {
+    itp('does not show anti-phishing message if security image is hidden', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.securityBeaconContainer().hide();
           spyOn($.qtip.prototype, 'toggle').and.callThrough();
@@ -1043,7 +1043,7 @@ Expect.describe('IDPDiscovery', function () {
           $(window).trigger('resize');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.count()).toBe(1);
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
           $.qtip.prototype.toggle.calls.reset();
@@ -1051,64 +1051,64 @@ Expect.describe('IDPDiscovery', function () {
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle);
         })
-        .then(function () {
+        .then(function() {
           expect($.qtip.prototype.toggle.calls.count()).toBe(1);
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
         });
     });
-    itp('show anti-phishing message if security image become visible', function () {
+    itp('show anti-phishing message if security image become visible', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           spyOn($.qtip.prototype, 'toggle').and.callThrough();
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().hide();
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function () {
+        .then(function() {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
         });
     });
-    itp('guards against XSS when showing the anti-phishing message', function () {
+    itp('guards against XSS when showing the anti-phishing message', function() {
       return setup({
         baseUrl: 'http://foo<i>xss</i>bar.com?bar=<i>xss</i>',
         features: { securityImage: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityImageTooltipText()).toEqual(
             'This is the first time you are connecting to foo<i>xss< from this browser×'
           );
         });
     });
-    itp('removes anti-phishing message if help link is clicked', function () {
+    itp('removes anti-phishing message if help link is clicked', function() {
       return setup({
         baseUrl: 'http://foo<i>xss</i>bar.com?bar=<i>xss</i>',
         features: { securityImage: true, selfServiceUnlock: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser@clouditude.net');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Tooltip exists
           expect(test.form.isSecurityImageTooltipDestroyed()).toBe(false);
           spyOn(test.router, 'navigate');
@@ -1119,7 +1119,7 @@ Expect.describe('IDPDiscovery', function () {
           expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
         });
     });
-    itp('updates security beacon immediately if rememberMe is available', function () {
+    itp('updates security beacon immediately if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         features: {
@@ -1131,17 +1131,17 @@ Expect.describe('IDPDiscovery', function () {
       return setup(options, [resSecurityImage])
         .then(Expect.waitForAjaxRequest())
         .then(waitForSecurityBeaconLoaded)
-        .then(function (test) {
+        .then(function(test) {
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
           expect(test.form.accessibilityText()).toBe('a single pixel');
         });
     });
-    itp('calls globalErrorFn if cors is not enabled and security image request is made', function () {
+    itp('calls globalErrorFn if cors is not enabled and security image request is made', function() {
       spyOn(BrowserFeatures, 'corsIsNotEnabled').and.returnValue(true);
       return setup({
         features: { securityImage: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse({
             responseType: 'json',
             response: '',
@@ -1151,7 +1151,7 @@ Expect.describe('IDPDiscovery', function () {
           test.form.setUsername('testuser@clouditude.net');
           return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.settings.callGlobalError.calls.count()).toBe(1);
           const err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
 
@@ -1160,112 +1160,112 @@ Expect.describe('IDPDiscovery', function () {
           expect(err.message).toEqual('There was an error sending the request - have you enabled CORS?');
         });
     });
-    itp('has username in field if rememberMe is available', function () {
+    itp('has username in field if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.usernameField().val()).toBe('testuser@clouditude.net');
       });
     });
-    itp('has rememberMe checked if rememberMe is available', function () {
+    itp('has rememberMe checked if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
       });
     });
-    itp('unchecks rememberMe if username is changed', function () {
+    itp('unchecks rememberMe if username is changed', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
         test.form.setUsername('new-user@clouditude.net');
         expect(test.form.rememberMeCheckboxStatus()).toBe('unchecked');
       });
     });
-    itp('does not re-render rememberMe checkbox on changes', function () {
+    itp('does not re-render rememberMe checkbox on changes', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const orig = test.form.rememberMeCheckbox().get(0);
 
         test.form.setUsername('new-user@clouditude.net');
         expect(test.form.rememberMeCheckbox().get(0)).toBe(orig);
       });
     });
-    itp('populates username if username is available', function () {
+    itp('populates username if username is available', function() {
       const options = {
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('populates username if username is available and when features.rememberMe is false', function () {
+    itp('populates username if username is available and when features.rememberMe is false', function() {
       const options = {
         'features.rememberMe': false,
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('ignores lastUsername and hides rememberMe if features.rememberMe is false and cookie is set', function () {
+    itp('ignores lastUsername and hides rememberMe if features.rememberMe is false and cookie is set', function() {
       Util.mockGetCookie('ln', 'testuser@ABC.com');
       const options = {
         'features.rememberMe': false,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
         expect(test.form.usernameField().val().length).toBe(0);
       });
     });
-    itp('unchecks rememberMe if username is populated and lastUsername is different from username', function () {
+    itp('unchecks rememberMe if username is populated and lastUsername is different from username', function() {
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const options = {
         'features.rememberMe': true,
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('unchecked');
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('checks rememberMe if username is populated and lastUsername is same as username', function () {
+    itp('checks rememberMe if username is populated and lastUsername is same as username', function() {
       Util.mockGetCookie('ln', 'testuser@ABC.com');
       const options = {
         'features.rememberMe': true,
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('shows an error if username is empty and submitted', function () {
-      return setup().then(function (test) {
+    itp('shows an error if username is empty and submitted', function() {
+      return setup().then(function(test) {
         test.setNextWebfingerResponse({});
         test.form.submit();
         expect(test.form.usernameErrorField().length).toBe(1);
@@ -1277,16 +1277,16 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.ac.webfinger).not.toHaveBeenCalled();
       });
     });
-    itp('calls authClient webfinger with correct values when submitted', function () {
+    itp('calls authClient webfinger with correct values when submitted', function() {
       spyOn(SharedUtil, 'redirect');
       return setup({ 'idpDiscovery.requestContext': 'http://rain.okta1.com:1802/app/UserHome' })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername(' testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.isDisabled()).toBe(true);
           expect(test.ac.webfinger).toHaveBeenCalledWith({
             resource: 'okta:acct:testuser@clouditude.net',
@@ -1294,186 +1294,186 @@ Expect.describe('IDPDiscovery', function () {
           });
         });
     });
-    itp('does not call processCreds function before saving a model', function () {
+    itp('does not call processCreds function before saving a model', function() {
       spyOn(SharedUtil, 'redirect');
       const processCredsSpy = jasmine.createSpy('processCreds');
 
       return setup({
         processCreds: processCredsSpy,
       })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(processCredsSpy.calls.count()).toBe(0);
           expect(test.ac.webfinger).toHaveBeenCalled();
         });
     });
-    itp('sets rememberMe cookie if rememberMe is enabled and checked on submit', function () {
+    itp('sets rememberMe cookie if rememberMe is enabled and checked on submit', function() {
       spyOn(SharedUtil, 'redirect');
       const cookieSpy = Util.mockSetCookie();
 
       return setup({ 'features.rememberMe': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net ');
           test.form.setRememberMe(true);
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function () {
+        .then(function() {
           expect(cookieSpy).toHaveBeenCalledWith('ln', 'testuser@clouditude.net', {
             expires: 365,
             path: '/',
           });
         });
     });
-    itp('removes rememberMe cookie if called with existing username and unchecked', function () {
+    itp('removes rememberMe cookie if called with existing username and unchecked', function() {
       spyOn(SharedUtil, 'redirect');
       Util.mockGetCookie('ln', 'testuser@clouditude.net');
       const removeCookieSpy = Util.mockRemoveCookie();
 
       return setup({ 'features.rememberMe': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.form.setRememberMe(false);
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.submit();
           return waitForWebfingerCall(test);
         })
-        .then(function () {
+        .then(function() {
           expect(removeCookieSpy).toHaveBeenCalledWith('ln', { path: '/' });
         });
     });
-    itp('removes rememberMe cookie if webfinger failed (400)', function () {
+    itp('removes rememberMe cookie if webfinger failed (400)', function() {
       const removeCookieSpy = Util.mockRemoveCookie();
 
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@clouditude.net');
           test.form.setRememberMe(true);
           test.setNextWebfingerResponse(resError, true);
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function () {
+        .then(function() {
           expect(removeCookieSpy).toHaveBeenCalledWith('ln', { path: '/' });
         });
     });
-    itp('shows an error if authClient returns with an error', function () {
+    itp('shows an error if authClient returns with an error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextWebfingerResponse(resError, true);
           test.form.setUsername('testuser@clouditude.net');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
   });
 
-  describe('IDP Discovery', function () {
-    itp('renders primary auth when idp is okta', function () {
+  describe('IDP Discovery', function() {
+    itp('renders primary auth when idp is okta', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.mockRouterNavigate(test.router);
           test.setNextWebfingerResponse(resSuccessOktaIDP);
           test.form.setUsername('testuser@clouditude.net');
           test.form.submit();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('disableUsername')).toBe(true);
           expect(test.router.navigate).toHaveBeenCalledWith('signin', { trigger: true });
         });
     });
-    itp('renders primary auth when idp is okta with shortname', function () {
+    itp('renders primary auth when idp is okta with shortname', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.mockRouterNavigate(test.router);
           test.setNextWebfingerResponse(resSuccessOktaIDP);
           test.form.setUsername('testuser');
           test.form.submit();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('disableUsername')).toBe(true);
           expect(test.router.navigate).toHaveBeenCalledWith('signin', { trigger: true });
         });
     });
-    itp('redirects to idp for SAML idps', function () {
+    itp('redirects to idp for SAML idps', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.setUsername(' testuser@clouditude.net ');
           test.form.submit();
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith('http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4');
         });
     });
-    itp('redirects using form Get to idp for SAML idps when features.redirectByFormSubmit is on', function () {
+    itp('redirects using form Get to idp for SAML idps when features.redirectByFormSubmit is on', function() {
       spyOn(WidgetUtil, 'redirectWithFormGet');
       return setup({ 'features.redirectByFormSubmit': true })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.setUsername(' testuser@clouditude.net ');
           test.form.submit();
           return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
         })
-        .then(function () {
+        .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4'
           );
         });
     });
-    itp('redirects to idp for idps other than okta/saml', function () {
+    itp('redirects to idp for idps other than okta/saml', function() {
       spyOn(SharedUtil, 'redirect');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextWebfingerResponse(resSuccessIWA);
           test.form.setUsername('testuser@clouditude.net');
           test.form.submit();
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith('http://demo.okta1.com:1802/login/sso_iwa');
         });
     });
     itp(
       'redirects using form GET to idp for idps other than okta/saml when features.redirectByFormSubmit is on',
-      function () {
+      function() {
         spyOn(WidgetUtil, 'redirectWithFormGet');
         return setup({ 'features.redirectByFormSubmit': true })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextWebfingerResponse(resSuccessIWA);
             test.form.setUsername('testuser@clouditude.net');
             test.form.submit();
             return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
           })
-          .then(function () {
+          .then(function() {
             expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith('http://demo.okta1.com:1802/login/sso_iwa');
           });
       }
     );
-    itp('redirects using form GET to idp when OKTA_INVALID_SESSION_REPOST=true', function () {
+    itp('redirects using form GET to idp when OKTA_INVALID_SESSION_REPOST=true', function() {
       spyOn(WidgetUtil, 'redirectWithFormGet');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextWebfingerResponse(resSuccessRepostIWA);
           test.form.setUsername('testuser@clouditude.net');
           test.form.submit();
           return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
         })
-        .then(function () {
+        .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://demo.okta1.com:1802/login/sso_iwa?fromURI=%2Fapp%2Finstance%2Fkey%3FSAMLRequest%3Dencoded%26RelayState%3DrelayState%26OKTA_INVALID_SESSION_REPOST%3Dtrue'
           );
@@ -1481,16 +1481,16 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('Passwordless Auth', function () {
-    itp('automatically calls authClient.signIn when idp is Okta', function () {
+  describe('Passwordless Auth', function() {
+    itp('automatically calls authClient.signIn when idp is Okta', function() {
       return setupPasswordlessAuth()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -1504,43 +1504,43 @@ Expect.describe('IDPDiscovery', function () {
           });
         });
     });
-    itp('shows MfaVerify view after authClient.signIn returns with UNAUTHENTICATED', function () {
+    itp('shows MfaVerify view after authClient.signIn returns with UNAUTHENTICATED', function() {
       return setupPasswordlessAuth()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.el('factor-question').length).toEqual(1);
         });
     });
   });
 
-  describe('Registration Flow', function () {
-    itp('does not show the registration button if features.registration is not set', function () {
-      return setup().then(function (test) {
+  describe('Registration Flow', function() {
+    itp('does not show the registration button if features.registration is not set', function() {
+      return setup().then(function(test) {
         expect(test.form.registrationContainer().length).toBe(0);
       });
     });
-    itp('does not show the registration button if features.registration is undefined', function () {
+    itp('does not show the registration button if features.registration is undefined', function() {
       const registration = {};
 
-      return setupRegistrationButton(undefined, registration).then(function (test) {
+      return setupRegistrationButton(undefined, registration).then(function(test) {
         expect(test.form.registrationContainer().length).toBe(0);
       });
     });
-    itp('does not show the registration button if features.registration is false', function () {
+    itp('does not show the registration button if features.registration is false', function() {
       const registration = {};
 
-      return setupRegistrationButton(false, registration).then(function (test) {
+      return setupRegistrationButton(false, registration).then(function(test) {
         expect(test.form.registrationContainer().length).toBe(0);
       });
     });
-    itp('show the registration button if registration.enable is true', function () {
+    itp('show the registration button if registration.enable is true', function() {
       const registration = {};
 
-      return setupRegistrationButton(true, registration).then(function (test) {
+      return setupRegistrationButton(true, registration).then(function(test) {
         expect(test.form.registrationContainer().length).toBe(1);
         expect(test.form.registrationLabel().length).toBe(1);
         expect(test.form.registrationLabel().text()).toBe('Don\'t have an account?');
@@ -1549,12 +1549,12 @@ Expect.describe('IDPDiscovery', function () {
         expect(typeof registration.click).toEqual('undefined');
       });
     });
-    itp('calls settings.registration.click if its a function and when the link is clicked', function () {
+    itp('calls settings.registration.click if its a function and when the link is clicked', function() {
       const registration = {
         click: jasmine.createSpy('registrationSpy'),
       };
 
-      return setupRegistrationButton(true, registration).then(function (test) {
+      return setupRegistrationButton(true, registration).then(function(test) {
         expect(test.form.registrationContainer().length).toBe(1);
         expect(test.form.registrationLabel().length).toBe(1);
         expect(test.form.registrationLabel().text()).toBe('Don\'t have an account?');
@@ -1566,58 +1566,58 @@ Expect.describe('IDPDiscovery', function () {
     });
   });
 
-  describe('Additional Auth Button', function () {
-    itp('does not display custom buttons when it is undefined', function () {
-      return setupWithoutCustomButtonsAndWithIdp().then(function (test) {
+  describe('Additional Auth Button', function() {
+    itp('does not display custom buttons when it is undefined', function() {
+      return setupWithoutCustomButtonsAndWithIdp().then(function(test) {
         expect(test.form.authDivider().length).toBe(1);
         expect(test.form.additionalAuthButton().length).toBe(0);
         expect(test.form.facebookButton().length).toBe(1);
       });
     });
-    itp('does not display social auth/generic idp when idps is undefined', function () {
-      return setupWithCustomButtons().then(function (test) {
+    itp('does not display social auth/generic idp when idps is undefined', function() {
+      return setupWithCustomButtons().then(function(test) {
         expect(test.form.authDivider().length).toBe(1);
         expect(test.form.additionalAuthButton().length).toBe(1);
         expect(test.form.facebookButton().length).toBe(0);
       });
     });
-    itp('does not display any additional buttons when idps and customButtons are undefined', function () {
-      return setupWithoutCustomButtonsWithoutIdp().then(function (test) {
+    itp('does not display any additional buttons when idps and customButtons are undefined', function() {
+      return setupWithoutCustomButtonsWithoutIdp().then(function(test) {
         expect(test.form.authDivider().length).toBe(0);
         expect(test.form.additionalAuthButton().length).toBe(0);
         expect(test.form.facebookButton().length).toBe(0);
       });
     });
-    itp('does not show the divider and buttons if settings.customButtons is not set', function () {
-      return setup().then(function (test) {
+    itp('does not show the divider and buttons if settings.customButtons is not set', function() {
+      return setup().then(function(test) {
         expect(test.form.authDivider().length).toBe(0);
         expect(test.form.additionalAuthButton().length).toBe(0);
       });
     });
-    itp('show the divider and buttons if settings.customButtons is not empty', function () {
-      return setupWithCustomButtons().then(function (test) {
+    itp('show the divider and buttons if settings.customButtons is not empty', function() {
+      return setupWithCustomButtons().then(function(test) {
         expect(test.form.authDivider().length).toBe(1);
         expect(test.form.additionalAuthButton().length).toBe(1);
       });
     });
-    itp('sets text with property passed', function () {
-      return setupWithCustomButtons().then(function (test) {
+    itp('sets text with property passed', function() {
+      return setupWithCustomButtons().then(function(test) {
         expect(test.form.additionalAuthButton().text()).toEqual('test text');
       });
     });
-    itp('sets class with property passed', function () {
-      return setupWithCustomButtons().then(function (test) {
+    itp('sets class with property passed', function() {
+      return setupWithCustomButtons().then(function(test) {
         expect(test.form.additionalAuthButton().hasClass('test-class')).toBe(true);
       });
     });
-    itp('clickHandler is called when button is clicked', function () {
-      return setupWithCustomButtons().then(function (test) {
+    itp('clickHandler is called when button is clicked', function() {
+      return setupWithCustomButtons().then(function(test) {
         expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(false);
         test.form.additionalAuthButton().click();
         expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(true);
       });
     });
-    itp('displays custom button translation', function () {
+    itp('displays custom button translation', function() {
       const settings = {
         i18n: {
           en: {
@@ -1631,11 +1631,11 @@ Expect.describe('IDPDiscovery', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.additionalAuthButton().text()).toEqual('Custom Translated Title');
       });
     });
-    itp('ignores custom button translation if title is passed', function () {
+    itp('ignores custom button translation if title is passed', function() {
       const settings = {
         i18n: {
           en: {
@@ -1650,12 +1650,12 @@ Expect.describe('IDPDiscovery', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.additionalAuthButton().text()).toEqual('Title Overrides i18n');
       });
     });
-    itp('displays generic idp buttons', function () {
-      return setupWith({ genericIdp: true }).then(function (test) {
+    itp('displays generic idp buttons', function() {
+      return setupWith({ genericIdp: true }).then(function(test) {
         expect(test.form.authDivider()).toHaveLength(1);
         expect(test.form.additionalAuthButton()).toHaveLength(0);
         expect(test.form.facebookButton()).toHaveLength(0);
@@ -1663,8 +1663,8 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('displays generic idp and custom buttons', function () {
-      return setupWith({ genericIdp: true, customButtons: true }).then(function (test) {
+    itp('displays generic idp and custom buttons', function() {
+      return setupWith({ genericIdp: true, customButtons: true }).then(function(test) {
         expect(test.form.authDivider()).toHaveLength(1);
         expect(test.form.additionalAuthButton()).toHaveLength(1);
         expect(test.form.facebookButton()).toHaveLength(0);
@@ -1672,8 +1672,8 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('displays generic idp and social auth buttons', function () {
-      return setupWith({ genericIdp: true, socialAuth: true }).then(function (test) {
+    itp('displays generic idp and social auth buttons', function() {
+      return setupWith({ genericIdp: true, socialAuth: true }).then(function(test) {
         expect(test.form.authDivider()).toHaveLength(1);
         expect(test.form.additionalAuthButton()).toHaveLength(0);
         expect(test.form.facebookButton()).toHaveLength(1);
@@ -1681,8 +1681,8 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('displays generic idp, custom buttons, and social auth buttons', function () {
-      return setupWith({ genericIdp: true, customButtons: true, socialAuth: true }).then(function (test) {
+    itp('displays generic idp, custom buttons, and social auth buttons', function() {
+      return setupWith({ genericIdp: true, customButtons: true, socialAuth: true }).then(function(test) {
         expect(test.form.authDivider()).toHaveLength(1);
         expect(test.form.additionalAuthButton()).toHaveLength(1);
         expect(test.form.facebookButton()).toHaveLength(1);
@@ -1690,8 +1690,8 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('displays social auth and custom buttons', function () {
-      return setupWithCustomButtonsWithIdp().then(function (test) {
+    itp('displays social auth and custom buttons', function() {
+      return setupWithCustomButtonsWithIdp().then(function(test) {
         expect(test.form.authDivider()).toHaveLength(1);
         expect(test.form.additionalAuthButton()).toHaveLength(1);
         expect(test.form.facebookButton()).toHaveLength(1);
@@ -1699,15 +1699,15 @@ Expect.describe('IDPDiscovery', function () {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('triggers the afterError event if there is no valid id token returned', function () {
+    itp('triggers the afterError event if there is no valid id token returned', function() {
       spyOn(window, 'addEventListener');
       return setupSocial()
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           // Wait for "popup" to be created (is async with okta-auth-js 2.6)
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
 
           expect(args[0]).toBe('message');
@@ -1723,7 +1723,7 @@ Expect.describe('IDPDiscovery', function () {
           });
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
           expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
             {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -60,10 +60,10 @@ const VALID_ID_TOKEN =
   'lXvxoMVtFk-fcdCkn1DnTtIzsFPOjysBl2vjwVBJXg9h1Nymd91l' +
   'dI5eorOMrbamRfxOFkEUC9P9mgO6DcVfR5oxY0pjfMA';
 
-Expect.describe('LoginRouter', function () {
-  function setup (settings, resp) {
+Expect.describe('LoginRouter', function() {
+  function setup(settings, resp) {
     settings = settings || {};
-    const setNextResponse = settings.mockAjax === false ? function () {} : Util.mockAjax();
+    const setNextResponse = settings.mockAjax === false ? function() {} : Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authParams = { issuer: baseUrl, headers: {} };
     Object.keys(settings).forEach(key => {
@@ -105,7 +105,7 @@ Expect.describe('LoginRouter', function () {
     });
   }
 
-  function setupOAuth2 (settings, options = {}) {
+  function setupOAuth2(settings, options = {}) {
     spyOn(window, 'addEventListener');
     Util.mockOIDCStateGenerator();
     return setup(
@@ -118,7 +118,7 @@ Expect.describe('LoginRouter', function () {
       ),
       resMfaRequiredOktaVerify
     )
-      .then(function (test) {
+      .then(function(test) {
         // Start in MFA_REQUIRED, and then call success. This allows us to test
         // that we are registering our handler independent of the controller we
         // are on
@@ -127,10 +127,10 @@ Expect.describe('LoginRouter', function () {
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForMfaVerify(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const origAppend = document.appendChild;
 
-        spyOn(document.body, 'appendChild').and.callFake(function (element) {
+        spyOn(document.body, 'appendChild').and.callFake(function(element) {
           if (element.tagName.toLowerCase() === 'iframe') {
             // Don't want to actually append the original iframe since it loads
             // an external url. However, we will append one without the src so
@@ -161,7 +161,7 @@ Expect.describe('LoginRouter', function () {
   }
 
   // { settings, userLanguages, supportedLanguages }
-  function setupLanguage (options) {
+  function setupLanguage(options) {
     const loadingSpy = jasmine.createSpy('loading');
     const delay = options.delay || 0;
     // TODO: remove delay from tests
@@ -169,7 +169,7 @@ Expect.describe('LoginRouter', function () {
     spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(options.localStorageIsNotSupported);
 
     return setup(options.settings)
-      .then(function (test) {
+      .then(function(test) {
         test.router.appState.on('loading', loadingSpy);
         // Use the encrollCallAndSms controller because it uses both the login
         // and country bundles
@@ -185,7 +185,7 @@ Expect.describe('LoginRouter', function () {
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForEnrollChoices(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         test.router.appState.off('loading');
         test.router.enrollCall();
         return Expect.waitForEnrollCall(
@@ -195,43 +195,43 @@ Expect.describe('LoginRouter', function () {
           })
         );
       })
-      .then(function (test) {
-        return Expect.wait(function () {
+      .then(function(test) {
+        return Expect.wait(function() {
           return test.form.hasCountriesList();
         }, test);
       });
   }
 
-  function expectPrimaryAuthRender (options = {}, path = '') {
+  function expectPrimaryAuthRender(options = {}, path = '') {
     // Reusable stub to assert that the Primary Auth for renders
     // given Widget parameters and a navigation path.
     return setup(options)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate(path);
         return Expect.waitForPrimaryAuth();
       })
-      .then(function () {
+      .then(function() {
         const form = new PrimaryAuthForm($sandbox);
 
         expect(form.isPrimaryAuth()).toBe(true);
       });
   }
 
-  function expectUnexpectedFieldLog (arg1) {
+  function expectUnexpectedFieldLog(arg1) {
     // These console warnings are called from Courage's Logger class, not
     // the Widget's. We need to assert that the following is called in specific
     // environments (window.okta && window.okta.debug are defined).
     expect(CourageLogger.warn).toHaveBeenCalledWith('Field not defined in schema', arg1);
   }
 
-  Expect.describe('Loads json bundles', function () {
+  Expect.describe('Loads json bundles', function() {
     config.supportedLanguages
-      .filter(function (lang) {
+      .filter(function(lang) {
         return lang !== 'en'; // no bundles are loaded for english
       })
-      .forEach(function (lang) {
-        it(`for language: "${lang}"`, function () {
+      .forEach(function(lang) {
+        it(`for language: "${lang}"`, function() {
           const loadingSpy = jasmine.createSpy('loading');
 
           spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(false);
@@ -242,17 +242,17 @@ Expect.describe('LoginRouter', function () {
               baseUrl: '/base/target', // local json bundles are served to us through karma
             },
           })
-            .then(function (test) {
+            .then(function(test) {
               test.router.appState.on('loading', loadingSpy);
               spyOn(Bundles, 'loadLanguage').and.callThrough();
               test.router.passwordExpired(); // choosing a simple view with text
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 const call = loadingSpy.calls.mostRecent();
 
                 return call && call.args.length === 1 && call.args[0] === false;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Bundles.loadLanguage).toHaveBeenCalled();
               expect(Bundles.currentLanguage).toBe(lang);
               // Verify that the translation is being applied
@@ -269,47 +269,47 @@ Expect.describe('LoginRouter', function () {
               // Loading English here so that other tests will not be affected.
               return Bundles.loadLanguage('en');
             })
-            .then(function () {
+            .then(function() {
               expect(Bundles.currentLanguage).toBe('en');
             });
         });
       });
   });
 
-  it('logs a ConfigError error if unknown option is passed as a widget param', function () {
+  it('logs a ConfigError error if unknown option is passed as a widget param', function() {
     spyOn(CourageLogger, 'warn');
 
-    const fn = function () {
+    const fn = function() {
       setup({ foo: 'bla' });
     };
 
     expect(fn).not.toThrowError(Errors.ConfigError);
     expectUnexpectedFieldLog('foo');
   });
-  it('has the correct error message if unknown option is passed as a widget param', function () {
+  it('has the correct error message if unknown option is passed as a widget param', function() {
     spyOn(CourageLogger, 'warn');
 
-    const fn = function () {
+    const fn = function() {
       setup({ foo: 'bla' });
     };
 
     expect(fn).not.toThrow();
     expectUnexpectedFieldLog('foo');
   });
-  it('logs a ConfigError error if el is not passed as a widget param', function () {
+  it('logs a ConfigError error if el is not passed as a widget param', function() {
     spyOn(Logger, 'error');
 
-    const fn = function () {
+    const fn = function() {
       setup({ el: undefined });
     };
 
     expect(fn).not.toThrow();
     expect(Logger.error).toHaveBeenCalled();
   });
-  it('has the correct error message if el is not passed as a widget param', function () {
+  it('has the correct error message if el is not passed as a widget param', function() {
     spyOn(Logger, 'error');
 
-    const fn = function () {
+    const fn = function() {
       setup({ el: undefined });
     };
 
@@ -319,8 +319,8 @@ Expect.describe('LoginRouter', function () {
     expect(err.name).toBe('CONFIG_ERROR');
     expect(err.message).toEqual('"el" is a required widget parameter');
   });
-  it('throws a ConfigError if issuer is not passed as a widget param', function () {
-    const fn = function () {
+  it('throws a ConfigError if issuer is not passed as a widget param', function() {
+    const fn = function() {
       setup({ authClient: createAuthClient({ issuer: undefined }) });
     };
 
@@ -330,43 +330,43 @@ Expect.describe('LoginRouter', function () {
   });
   itp(
     'renders the primary autenthentication form when no globalSuccessFn and globalErrorFn are passed as widget params',
-    function () {
+    function() {
       return expectPrimaryAuthRender({ globalSuccessFn: undefined, globalErrorFn: undefined });
     }
   );
   itp(
     'renders the primary autenthentication form when a null globalSuccessFn and globalErrorFn are passed as widget params',
-    function () {
+    function() {
       return expectPrimaryAuthRender({ globalSuccessFn: null, globalErrorFn: null });
     }
   );
-  itp('set pushState true if pushState is supported', function () {
+  itp('set pushState true if pushState is supported', function() {
     spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(true);
     spyOn(Router.prototype, 'start');
-    return setup({ 'features.router': true }).then(function (test) {
+    return setup({ 'features.router': true }).then(function(test) {
       test.router.start();
       expect(Router.prototype.start).toHaveBeenCalledWith({ pushState: true });
     });
   });
-  itp('set pushState false if pushState is not supported', function () {
+  itp('set pushState false if pushState is not supported', function() {
     spyOn(BrowserFeatures, 'supportsPushState').and.returnValue(false);
     spyOn(Router.prototype, 'start');
-    return setup({ 'features.router': true }).then(function (test) {
+    return setup({ 'features.router': true }).then(function(test) {
       test.router.start();
       expect(Router.prototype.start).toHaveBeenCalledWith({ pushState: false });
     });
   });
 
-  itp('invokes success callback if SUCCESS auth status is returned', function () {
+  itp('invokes success callback if SUCCESS auth status is returned', function() {
     const successSpy = jasmine.createSpy('successSpy');
 
     return setup({ globalSuccessFn: successSpy }, resSuccess)
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resSuccess);
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForSpyCall(successSpy);
       })
-      .then(function () {
+      .then(function() {
         const res = successSpy.calls.mostRecent().args[0];
 
         expect(res.status).toBe('SUCCESS');
@@ -384,10 +384,10 @@ Expect.describe('LoginRouter', function () {
         expect(_.isFunction(res.session.setCookieAndRedirect)).toBe(true);
       });
   });
-  itp('has a success callback which correctly implements the setCookieAndRedirect function', function () {
+  itp('has a success callback which correctly implements the setCookieAndRedirect function', function() {
     const spied = {};
 
-    spied.successFn = function (resp) {
+    spied.successFn = function(resp) {
       if (resp.status === 'SUCCESS') {
         resp.session.setCookieAndRedirect('http://baz.com/foo');
       }
@@ -395,12 +395,12 @@ Expect.describe('LoginRouter', function () {
     spyOn(spied, 'successFn').and.callThrough();
     spyOn(SharedUtil, 'redirect');
     return setup({ globalSuccessFn: spied.successFn }, resSuccess)
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resSuccess);
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForSpyCall(spied.successFn);
       })
-      .then(function () {
+      .then(function() {
         expect(SharedUtil.redirect).toHaveBeenCalledWith(
           'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
             '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
@@ -409,10 +409,10 @@ Expect.describe('LoginRouter', function () {
   });
   itp(
     'has a success callback which correctly implements the setCookieAndRedirect function when features.redirectByFormSubmit is on',
-    function () {
+    function() {
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           resp.session.setCookieAndRedirect('http://baz.com/foo');
         }
@@ -420,12 +420,12 @@ Expect.describe('LoginRouter', function () {
       spyOn(spied, 'successFn').and.callThrough();
       spyOn(WidgetUtil, 'redirectWithFormGet');
       return setup({ globalSuccessFn: spied.successFn, 'features.redirectByFormSubmit': true }, resSuccess)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccess);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
               '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
@@ -435,11 +435,11 @@ Expect.describe('LoginRouter', function () {
   );
   itp(
     'for SESSION_STEP_UP type, success callback data contains the target resource url and a finish function',
-    function () {
+    function() {
       let targetUrl;
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'SESSION_STEP_UP') {
             targetUrl = resp.stepUp.url;
@@ -450,12 +450,12 @@ Expect.describe('LoginRouter', function () {
       spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
       return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn }, resSuccessStepUp)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessStepUp);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken'
@@ -465,11 +465,11 @@ Expect.describe('LoginRouter', function () {
   );
   itp(
     'for SESSION_STEP_UP type, success callback data contains the target resource url and a finish function when features.redirectByFormSubmit is on',
-    function () {
+    function() {
       let targetUrl;
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'SESSION_STEP_UP') {
             targetUrl = resp.stepUp.url;
@@ -486,12 +486,12 @@ Expect.describe('LoginRouter', function () {
       };
 
       return setup(opt, resSuccessStepUp)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessStepUp);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(targetUrl).toBe('http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken');
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/login/step-up/redirect?stateToken=aStateToken'
@@ -501,10 +501,10 @@ Expect.describe('LoginRouter', function () {
   );
   itp(
     'for success with an original link, success callback data contains a next function that redirects to original.href',
-    function () {
+    function() {
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'NEW_TYPE' && resp.next) {
             resp.next();
@@ -514,12 +514,12 @@ Expect.describe('LoginRouter', function () {
       spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
       return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn }, resSuccessOriginal)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessOriginal);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'http://foo.okta.com/original/redirect?stateToken=aStateToken'
           );
@@ -528,10 +528,10 @@ Expect.describe('LoginRouter', function () {
   );
   itp(
     'for success with an original link, success callback data contains a next function that redirects to original.href when features.redirectByFormSubmit is on',
-    function () {
+    function() {
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'NEW_TYPE' && resp.next) {
             resp.next();
@@ -547,12 +547,12 @@ Expect.describe('LoginRouter', function () {
       };
 
       return setup(opt, resSuccessOriginal)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessOriginal);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/original/redirect?stateToken=aStateToken'
           );
@@ -561,10 +561,10 @@ Expect.describe('LoginRouter', function () {
   );
   itp(
     'for success with a next link, success callback data contains a next function that redirects to next.href',
-    function () {
+    function() {
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'NEW_TYPE' && resp.next) {
             resp.next();
@@ -574,22 +574,22 @@ Expect.describe('LoginRouter', function () {
       spyOn(spied, 'successFn').and.callThrough();
       spyOn(SharedUtil, 'redirect');
       return setup({ stateToken: 'aStateToken', globalSuccessFn: spied.successFn }, resSuccessNext)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessNext);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith('http://foo.okta.com/next/redirect?stateToken=aStateToken');
         });
     }
   );
   itp(
     'for success with a next link, success callback data contains a next function that redirects to next.href when features.redirectByFormSubmit is on',
-    function () {
+    function() {
       const spied = {};
 
-      spied.successFn = function (resp) {
+      spied.successFn = function(resp) {
         if (resp.status === 'SUCCESS') {
           if (resp.type === 'NEW_TYPE' && resp.next) {
             resp.next();
@@ -605,20 +605,20 @@ Expect.describe('LoginRouter', function () {
       };
 
       return setup(opt, resSuccessNext)
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccessNext);
           test.router.refreshAuthState('dummy-token');
           return Expect.waitForSpyCall(spied.successFn);
         })
-        .then(function () {
+        .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/next/redirect?stateToken=aStateToken'
           );
         });
     }
   );
-  it('logs an error on unrecoverable errors if no globalErrorFn is defined', function () {
-    const fn = function () {
+  it('logs an error on unrecoverable errors if no globalErrorFn is defined', function() {
+    const fn = function() {
       setup({ foo: 'bar' });
     };
 
@@ -626,10 +626,10 @@ Expect.describe('LoginRouter', function () {
     expect(fn).not.toThrow('field not allowed: foo');
     expectUnexpectedFieldLog('foo');
   });
-  it('calls globalErrorFn on unrecoverable errors if it is defined', function () {
+  it('calls globalErrorFn on unrecoverable errors if it is defined', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
 
-    const fn = function () {
+    const fn = function() {
       setup({ globalErrorFn: errorSpy, baseUrl: undefined });
     };
 
@@ -639,13 +639,13 @@ Expect.describe('LoginRouter', function () {
     expect(err.name).toBe('CONFIG_ERROR');
     expect(err.message).toEqual('"baseUrl" is a required widget parameter');
   });
-  it('calls globalErrorFn if colors.brand is in rgb format', function () {
+  it('calls globalErrorFn if colors.brand is in rgb format', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
     const colors = {
       brand: 'rgb(255,0,0)',
     };
 
-    const fn = function () {
+    const fn = function() {
       setup({ globalErrorFn: errorSpy, colors });
     };
 
@@ -655,13 +655,13 @@ Expect.describe('LoginRouter', function () {
     expect(err.name).toBe('CONFIG_ERROR');
     expect(err.message).toEqual('"colors.brand" must be in six-digit hex format');
   });
-  it('calls globalErrorFn if colors.brand is in color name format', function () {
+  it('calls globalErrorFn if colors.brand is in color name format', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
     const colors = {
       brand: 'red',
     };
 
-    const fn = function () {
+    const fn = function() {
       setup({ globalErrorFn: errorSpy, colors });
     };
 
@@ -671,25 +671,25 @@ Expect.describe('LoginRouter', function () {
     expect(err.name).toBe('CONFIG_ERROR');
     expect(err.message).toEqual('"colors.brand" must be in six-digit hex format');
   });
-  it('does not call globalErrorFn if colors.brand is in 6 digits Hex format', function () {
+  it('does not call globalErrorFn if colors.brand is in 6 digits Hex format', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
     const colors = {
       brand: '#FF0000',
     };
 
-    const fn = function () {
+    const fn = function() {
       setup({ globalErrorFn: errorSpy, colors: colors });
     };
 
     expect(fn).not.toThrow();
     expect(errorSpy).not.toHaveBeenCalled();
   });
-  it('calls globalErrorFn if cors is not supported by the browser', function () {
+  it('calls globalErrorFn if cors is not supported by the browser', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
 
     spyOn(BrowserFeatures, 'corsIsNotSupported').and.returnValue(true);
 
-    const fn = function () {
+    const fn = function() {
       setup({ globalErrorFn: errorSpy });
     };
 
@@ -700,96 +700,96 @@ Expect.describe('LoginRouter', function () {
     expect(err.name).toBe('UNSUPPORTED_BROWSER_ERROR');
     expect(err.message).toEqual('Unsupported browser - missing CORS support');
   });
-  itp('uses default router navigate if features.router param is true', function () {
+  itp('uses default router navigate if features.router param is true', function() {
     spyOn(Router.prototype, 'navigate');
-    return setup({ 'features.router': true }).then(function (test) {
+    return setup({ 'features.router': true }).then(function(test) {
       test.router.navigate('signin/forgot-password', { trigger: true });
       expect(Router.prototype.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
     });
   });
-  itp('uses history loadUrl if features.router param is false', function () {
+  itp('uses history loadUrl if features.router param is false', function() {
     spyOn(Router.prototype, 'navigate');
     spyOn(Backbone.history, 'loadUrl');
-    return setup({ 'features.router': false }).then(function (test) {
+    return setup({ 'features.router': false }).then(function(test) {
       test.router.navigate('signin/forgot-password', { trigger: true });
       expect(Router.prototype.navigate).not.toHaveBeenCalled();
       expect(Backbone.history.loadUrl).toHaveBeenCalledWith('signin/forgot-password');
     });
   });
-  itp('navigates to PrimaryAuth if requesting a stateful url without a stateToken', function () {
+  itp('navigates to PrimaryAuth if requesting a stateful url without a stateToken', function() {
     return expectPrimaryAuthRender({}, 'signin/recovery-question');
   });
-  itp('navigates to IDPDiscovery if features.idpDiscovery is set to true', function () {
+  itp('navigates to IDPDiscovery if features.idpDiscovery is set to true', function() {
     return setup({ 'features.idpDiscovery': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('');
         return Expect.waitForIDPDiscovery();
       })
-      .then(function () {
+      .then(function() {
         const form = new IDPDiscoveryForm($sandbox);
 
         expect(form.isIDPDiscovery()).toBe(true);
       });
   });
-  itp('navigates to IDPDiscovery for /login/login.htm when features.idpDiscovery is true', function () {
+  itp('navigates to IDPDiscovery for /login/login.htm when features.idpDiscovery is true', function() {
     return setup({ 'features.idpDiscovery': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('login/login.htm');
         return Expect.waitForIDPDiscovery();
       })
-      .then(function () {
+      .then(function() {
         const form = new IDPDiscoveryForm($sandbox);
 
         expect(form.isIDPDiscovery()).toBe(true);
       });
   });
-  itp('navigates to PrimaryAuth for /login/login.htm when features.idpDiscovery is false', function () {
+  itp('navigates to PrimaryAuth for /login/login.htm when features.idpDiscovery is false', function() {
     return expectPrimaryAuthRender({}, 'login/login.htm');
   });
-  itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is true', function () {
+  itp('navigates to IDPDiscovery for /app/salesforce/{id}/sso/saml when features.idpDiscovery is true', function() {
     return setup({ 'features.idpDiscovery': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('/app/salesforce/abc123sef/sso/saml');
         return Expect.waitForIDPDiscovery();
       })
-      .then(function () {
+      .then(function() {
         const form = new IDPDiscoveryForm($sandbox);
 
         expect(form.isIDPDiscovery()).toBe(true);
       });
   });
-  itp('navigates to PrimaryAuth for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function () {
+  itp('navigates to PrimaryAuth for /app/salesforce/{id}/sso/saml when features.idpDiscovery is false', function() {
     return expectPrimaryAuthRender({ 'features.idpDiscovery': false }, '/app/salesforce/abc123sef/sso/saml');
   });
-  itp('navigates to IDPDiscovery for /any/other when features.idpDiscovery is true', function () {
+  itp('navigates to IDPDiscovery for /any/other when features.idpDiscovery is true', function() {
     return setup({ 'features.idpDiscovery': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('any/other');
         return Expect.waitForIDPDiscovery();
       })
-      .then(function () {
+      .then(function() {
         const form = new IDPDiscoveryForm($sandbox);
 
         expect(form.isIDPDiscovery()).toBe(true);
       });
   });
-  itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is false', function () {
+  itp('navigates to PrimaryAuth for /any/other when features.idpDiscovery is false', function() {
     return expectPrimaryAuthRender({ 'features.idpDiscovery': false }, 'any/other');
   });
-  itp('refreshes auth state on stateful url if it needs a refresh', function () {
+  itp('refreshes auth state on stateful url if it needs a refresh', function() {
     return setup({}, resRecovery)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         Util.mockSDKCookie(test.ac);
         test.setNextResponse(resRecovery);
         test.router.navigate('signin/recovery-question');
         return Expect.waitForRecoveryQuestion();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn',
@@ -802,15 +802,15 @@ Expect.describe('LoginRouter', function () {
         expect(form.isRecoveryQuestion()).toBe(true);
       });
   });
-  itp('calls status and redirects if initialized with a stateToken', function () {
+  itp('calls status and redirects if initialized with a stateToken', function() {
     return setup({ stateToken: 'dummy-token' }, resRecovery)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resRecovery);
         test.router.navigate('');
         return Expect.waitForRecoveryQuestion();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/introspect',
@@ -823,15 +823,15 @@ Expect.describe('LoginRouter', function () {
         expect(form.isRecoveryQuestion()).toBe(true);
       });
   });
-  itp('navigates to PrimaryAuth and shows a flash error if the stateToken expires', function () {
+  itp('navigates to PrimaryAuth and shows a flash error if the stateToken expires', function() {
     return setup({}, resRecovery)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resRecovery);
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForRecoveryQuestion(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(errorInvalidToken);
         const form = new RecoveryForm($sandbox);
 
@@ -839,7 +839,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
         expect(test.afterErrorHandler.calls.allArgs()).toEqual([
           [
@@ -876,22 +876,22 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForMfaVerify(test);
       })
-      .then(function () {
+      .then(function() {
         const form = new MfaVerifyForm($sandbox);
 
         expect(form.isSecurityQuestion()).toBe(true);
         expect(form.hasErrors()).toBe(false);
       });
   });
-  itp('navigates to ErrorState page and shows a flash error if the stateToken expires', function () {
+  itp('navigates to ErrorState page and shows a flash error if the stateToken expires', function() {
     return setup({'features.mfaOnlyFlow': true }, resRecovery)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resRecovery);
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForRecoveryQuestion(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(errorInvalidToken);
         const form = new RecoveryForm($sandbox);
 
@@ -899,7 +899,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForErrorState(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
         expect(test.afterErrorHandler.calls.allArgs()).toEqual([
           [
@@ -929,15 +929,15 @@ Expect.describe('LoginRouter', function () {
         expect(form.errorMessage()).toBe('Unable to authenticate at this time.');
       });
   });
-  itp('navigates to PrimaryAuth if status is UNAUTHENTICATED, and IDP_DISCOVERY is disabled', function () {
+  itp('navigates to PrimaryAuth if status is UNAUTHENTICATED, and IDP_DISCOVERY is disabled', function() {
     return setup({ stateToken: 'dummy-token' }, resUnauthenticated)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resUnauthenticated);
         test.router.navigate('/app/sso');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/introspect',
@@ -951,15 +951,15 @@ Expect.describe('LoginRouter', function () {
         expect(form.isPrimaryAuth()).toBe(true);
       });
   });
-  itp('navigates to IDPDiscovery if status is UNAUTHENTICATED, and IDP_DISCOVERY is enabled', function () {
+  itp('navigates to IDPDiscovery if status is UNAUTHENTICATED, and IDP_DISCOVERY is enabled', function() {
     return setup({ stateToken: 'dummy-token', 'features.idpDiscovery': true }, resUnauthenticated)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resUnauthenticated);
         test.router.navigate('/app/sso');
         return Expect.waitForIDPDiscovery(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/introspect',
@@ -973,42 +973,42 @@ Expect.describe('LoginRouter', function () {
         expect(form.isIDPDiscovery()).toBe(true);
       });
   });
-  itp('navigates to default route when status is UNAUTHENTICATED', function () {
+  itp('navigates to default route when status is UNAUTHENTICATED', function() {
     return setup({ stateToken: 'aStateToken' }, resUnauthenticated)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resUnauthenticated);
         test.router.navigate('/app/sso');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
   });
-  itp('triggers an afterRender event when routing to default route and when status is UNAUTHENTICATED', function () {
+  itp('triggers an afterRender event when routing to default route and when status is UNAUTHENTICATED', function() {
     return setup({ stateToken: 'aStateToken' }, resUnauthenticated)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.setNextResponse(resUnauthenticated);
         test.router.navigate('/app/sso');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         expect(test.afterRenderHandler).toHaveBeenCalledTimes(2);
         expect(test.afterRenderHandler.calls.allArgs()[0]).toEqual([{ controller: 'refresh-auth-state' }]);
         expect(test.afterRenderHandler.calls.allArgs()[1]).toEqual([{ controller: 'primary-auth' }]);
       });
   });
-  itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function () {
+  itp('does not show two forms if the duo fetchInitialData request fails with an expired stateToken', function() {
     Util.mockDuo();
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.primaryAuth();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         Expect.allowUnhandledPromiseRejection();
         test.setNextResponse([resMfaRequiredDuo, errorInvalidToken]);
         const form = new PrimaryAuthForm($sandbox);
@@ -1018,7 +1018,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForAjaxRequests(2, test);
       })
-      .then(function () {
+      .then(function() {
         // 2nd form will appear until the fail() handler is called in BaseLoginRouter. With Q this happens on the next tick.
         return Expect.wait(() => {
           const form = new PrimaryAuthForm($sandbox);
@@ -1029,16 +1029,16 @@ Expect.describe('LoginRouter', function () {
       });
   });
 
-  itp('makes a call to previous if the page is refreshed in an MFA_CHALLENGE state', function () {
+  itp('makes a call to previous if the page is refreshed in an MFA_CHALLENGE state', function() {
     return setup({}, resMfaChallengeDuo)
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         Util.mockSDKCookie(test.ac);
         test.setNextResponse([resMfaChallengeDuo, resMfa]);
         test.router.navigate('signin/verify/duo/web', { trigger: true });
         return Expect.waitForMfaVerify(test);
       })
-      .then(function () {
+      .then(function() {
         const form = new MfaVerifyForm($sandbox);
         // Expect that we are on the MFA_CHALLENGE page (default is push for this
         // response)
@@ -1049,14 +1049,14 @@ Expect.describe('LoginRouter', function () {
         });
       });
   });
-  itp('checks auto push by default for a returning user with autoPush true', function () {
+  itp('checks auto push by default for a returning user with autoPush true', function() {
     return setup({ 'features.autoPush': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('signin');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const form = new PrimaryAuthForm($sandbox);
 
         expect(form.isPrimaryAuth()).toBe(true);
@@ -1070,7 +1070,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForMfaVerify();
       })
-      .then(function () {
+      .then(function() {
         const form = new MfaVerifyForm($sandbox);
 
         expect(form.autoPushCheckbox().length).toBe(1);
@@ -1079,7 +1079,7 @@ Expect.describe('LoginRouter', function () {
           return Util.numAjaxRequests() === 2;
         }, form);
       })
-      .then(function (form) {
+      .then(function(form) {
         expect(form.isPushSent()).toBe(true);
         expect(Util.numAjaxRequests()).toBe(2);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -1101,14 +1101,14 @@ Expect.describe('LoginRouter', function () {
         });
       });
   });
-  itp('no auto push for a new user', function () {
+  itp('no auto push for a new user', function() {
     return setup({ 'features.autoPush': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('signin');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const form = new PrimaryAuthForm($sandbox);
 
         expect(form.isPrimaryAuth()).toBe(true);
@@ -1118,7 +1118,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForMfaVerify();
       })
-      .then(function () {
+      .then(function() {
         const form = new MfaVerifyForm($sandbox);
 
         expect(form.autoPushCheckbox().length).toBe(1);
@@ -1126,14 +1126,14 @@ Expect.describe('LoginRouter', function () {
         expect(form.isPushSent()).toBe(false);
       });
   });
-  itp('sends autoPush=false as url param when auto push checkbox is unchecked', function () {
+  itp('sends autoPush=false as url param when auto push checkbox is unchecked', function() {
     return setup({ 'features.autoPush': true })
-      .then(function (test) {
+      .then(function(test) {
         Util.mockRouterNavigate(test.router);
         test.router.navigate('signin');
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const form = new PrimaryAuthForm($sandbox);
 
         expect(form.isPrimaryAuth()).toBe(true);
@@ -1143,7 +1143,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForMfaVerify(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn',
@@ -1163,7 +1163,7 @@ Expect.describe('LoginRouter', function () {
         form.submit();
         return Expect.waitForAjaxRequest();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?autoPush=false&rememberDevice=false',
@@ -1174,8 +1174,8 @@ Expect.describe('LoginRouter', function () {
       });
   });
 
-  Expect.describe('OIDC - okta is the idp and oauth2 is enabled', function () {
-    function expectAuthorizeUrl (url, options) {
+  Expect.describe('OIDC - okta is the idp and oauth2 is enabled', function() {
+    function expectAuthorizeUrl(url, options) {
       const parsed = new URL(url);
       const params = parsed.searchParams;
       const authorizeUrl = options.authorizeUrl || 'https://foo.com/oauth2/v1/authorize';
@@ -1212,18 +1212,18 @@ Expect.describe('LoginRouter', function () {
       }
     }
 
-    function expectCodeRedirect (options) {
-      return function (test) {
+    function expectCodeRedirect(options) {
+      return function(test) {
         const spy = test.ac.token.getWithRedirect._setLocation;
 
-        return Expect.waitForSpyCall(spy).then(function () {
+        return Expect.waitForSpyCall(spy).then(function() {
           expect(spy.calls.count()).toBe(1);
           expectAuthorizeUrl(spy.calls.argsFor(0)[0], options);
         });
       };
     }
 
-    itp('uses PKCE by default', function () {
+    itp('uses PKCE by default', function() {
       return setupOAuth2({}, { mockWellKnown: true }).then(test => {
         expectAuthorizeUrl(test.iframeElem.src, {
           responseType: 'code',
@@ -1235,7 +1235,7 @@ Expect.describe('LoginRouter', function () {
       });
     });
 
-    itp('can use implicit flow', function () {
+    itp('can use implicit flow', function() {
       return setupOAuth2({
         'authParams.pkce': false
       }).then(test => {
@@ -1248,7 +1248,7 @@ Expect.describe('LoginRouter', function () {
       });
     });
 
-    itp('can redirect with PKCE flow', function () {
+    itp('can redirect with PKCE flow', function() {
       return setupOAuth2({
         'redirect': 'always'
       }, { mockWellKnown: true, expectRedirect: true }).then(
@@ -1259,7 +1259,7 @@ Expect.describe('LoginRouter', function () {
       );
     });
 
-    itp('can redirect with PKCE flow and responseMode "fragment"', function () {
+    itp('can redirect with PKCE flow and responseMode "fragment"', function() {
       return setupOAuth2({
         'redirect': 'always',
         'authParams.responseMode': 'fragment',
@@ -1272,7 +1272,7 @@ Expect.describe('LoginRouter', function () {
       );
     });
 
-    itp('can redirect with implicit flow', function () {
+    itp('can redirect with implicit flow', function() {
       return setupOAuth2({
         'redirect': 'always',
         'authParams.pkce': false,
@@ -1283,13 +1283,13 @@ Expect.describe('LoginRouter', function () {
       );
     });
 
-    itp('authorization_code flow: redirects instead of using an iframe', function () {
+    itp('authorization_code flow: redirects instead of using an iframe', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false
       }, { expectRedirect: true }).then(expectCodeRedirect({ responseType: 'code' }));
     });
-    itp('authorization_code flow: redirects to alternate authorizeUrl', function () {
+    itp('authorization_code flow: redirects to alternate authorizeUrl', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false,
@@ -1301,7 +1301,7 @@ Expect.describe('LoginRouter', function () {
         })
       );
     });
-    itp('authorization_code flow: redirects to alternate authorizeUrl if an alternate issuer is provided', function () {
+    itp('authorization_code flow: redirects to alternate authorizeUrl if an alternate issuer is provided', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false,
@@ -1314,7 +1314,7 @@ Expect.describe('LoginRouter', function () {
       );
     });
     itp('authorization_code flow: redirects to alternate authorizeUrl if an alternate issuer and alternate authorizeUrl is provided',
-      function () {
+      function() {
         return setupOAuth2({
           'authParams.responseType': 'code',
           'authParams.pkce': false,
@@ -1328,7 +1328,7 @@ Expect.describe('LoginRouter', function () {
         );
       }
     );
-    itp('authorization_code flow: redirects with alternate state provided', function () {
+    itp('authorization_code flow: redirects with alternate state provided', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false,
@@ -1340,7 +1340,7 @@ Expect.describe('LoginRouter', function () {
         })
       );
     });
-    itp('authorization_code flow: redirects with alternate nonce provided', function () {
+    itp('authorization_code flow: redirects with alternate nonce provided', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false,
@@ -1352,7 +1352,7 @@ Expect.describe('LoginRouter', function () {
         })
       );
     });
-    itp('authorization_code flow: redirects with alternate state and nonce provided', function () {
+    itp('authorization_code flow: redirects with alternate state and nonce provided', function() {
       return setupOAuth2({
         'authParams.responseType': 'code',
         'authParams.pkce': false,
@@ -1366,10 +1366,10 @@ Expect.describe('LoginRouter', function () {
         })
       );
     });
-    itp('removes the iframe when it returns with the redirect data', function () {
-      return setupOAuth2({}, { mockWellKnown: true }).then(function () {
+    itp('removes the iframe when it returns with the redirect data', function() {
+      return setupOAuth2({}, { mockWellKnown: true }).then(function() {
         return Expect.waitForWindowListener('message');
-      }).then(function () {
+      }).then(function() {
         const args = window.addEventListener.calls.mostRecent().args;
         const callback = args[1];
         expect($sandbox.find('#' + OIDC_IFRAME_ID).length).toBe(1);
@@ -1381,20 +1381,20 @@ Expect.describe('LoginRouter', function () {
             state: OIDC_STATE,
           },
         });
-        return Expect.wait(function () {
+        return Expect.wait(function() {
           return $sandbox.find('#' + OIDC_IFRAME_ID).length === 0;
         });
       });
     });
-    itp('invokes the success function with idToken and user data when the iframe returns with data', function () {
+    itp('invokes the success function with idToken and user data when the iframe returns with data', function() {
       Util.loadWellKnownAndKeysCache();
       const successSpy = jasmine.createSpy('successSpy');
 
       return setupOAuth2({ globalSuccessFn: successSpy }, { mockWellKnown: true })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function () {
+        .then(function() {
           const args = window.addEventListener.calls.mostRecent().args;
           // Simulate callback from an iframe
           const callback = args[1];
@@ -1407,7 +1407,7 @@ Expect.describe('LoginRouter', function () {
           });
           return Expect.waitForSpyCall(successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(successSpy.calls.count()).toBe(1);
           const data = successSpy.calls.argsFor(0)[0];
 
@@ -1436,11 +1436,11 @@ Expect.describe('LoginRouter', function () {
           });
         });
     });
-    itp('triggers the afterError event if an idToken is not returned', function () {
+    itp('triggers the afterError event if an idToken is not returned', function() {
       return setupOAuth2({}, { mockWellKnown: true })
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForWindowListener('message', test);
-        }).then(function (test) {
+        }).then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
           const callback = args[1];
           callback.call(null, {
@@ -1453,7 +1453,7 @@ Expect.describe('LoginRouter', function () {
           });
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
           expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
             {
@@ -1468,52 +1468,52 @@ Expect.describe('LoginRouter', function () {
     });
   });
 
-  Expect.describe('Events', function () {
-    itp('triggers a pageRendered event when first controller is loaded', function () {
+  Expect.describe('Events', function() {
+    itp('triggers a pageRendered event when first controller is loaded', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.router.primaryAuth();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.eventSpy.calls.count()).toBe(1);
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth' });
         });
     });
-    itp('triggers an afterRender event when first controller is loaded', function () {
+    itp('triggers an afterRender event when first controller is loaded', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.router.primaryAuth();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
           expect(test.afterRenderHandler).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
     });
-    itp('triggers both pageRendered and afterRender events when first controller is loaded', function () {
+    itp('triggers both pageRendered and afterRender events when first controller is loaded', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.router.primaryAuth();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.eventSpy).toHaveBeenCalledTimes(1);
           expect(test.eventSpy).toHaveBeenCalledWith({ page: 'primary-auth' });
           expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
           expect(test.afterRenderHandler).toHaveBeenCalledWith({ controller: 'primary-auth' });
         });
     });
-    itp('triggers a pageRendered event when navigating to a new controller', function () {
+    itp('triggers a pageRendered event when navigating to a new controller', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           // Test navigation from primary Auth to Forgot password page
           test.router.primaryAuth();
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // since the event is triggered from the success function of the animation
           // as well as after render, we expect two calls
           expect(test.eventSpy.calls.count()).toBe(2);
@@ -1521,21 +1521,21 @@ Expect.describe('LoginRouter', function () {
           expect(test.eventSpy.calls.allArgs()[1]).toEqual([{ page: 'forgot-password' }]);
         });
     });
-    itp('triggers an afterRender event when navigating to a new controller', function () {
+    itp('triggers an afterRender event when navigating to a new controller', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           // Test navigation from primary Auth to Forgot password page
           test.router.primaryAuth();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
           expect(test.afterRenderHandler.calls.allArgs()[0]).toEqual([{ controller: 'primary-auth' }]);
           Util.mockRouterNavigate(test.router);
           test.router.navigate('signin/forgot-password');
           return Expect.waitForForgotPassword(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // since the event is triggered from the success function of the animation
           // as well as after render, we expect two calls
           expect(test.afterRenderHandler).toHaveBeenCalledTimes(2);
@@ -1544,8 +1544,8 @@ Expect.describe('LoginRouter', function () {
     });
   });
 
-  Expect.describe('Config: "i18n"', function () {
-    itp('supports deprecated "labels" and "country" options no locatl storage', function () {
+  Expect.describe('Config: "i18n"', function() {
+    itp('supports deprecated "labels" and "country" options no locatl storage', function() {
       return setupLanguage({
         settings: {
           labels: {
@@ -1556,14 +1556,14 @@ Expect.describe('LoginRouter', function () {
           },
         },
         localStorageIsNotSupported: true,
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.selectCountry('JP');
         expect(test.form.titleText()).toBe('test override title');
         expect(test.form.selectedCountry()).toBe('Nihon');
         Expect.deprecated('Use "i18n" instead of "labels" and "country"');
       });
     });
-    itp('supports deprecated "labels" and "country" options', function () {
+    itp('supports deprecated "labels" and "country" options', function() {
       return setupLanguage({
         settings: {
           labels: {
@@ -1574,14 +1574,14 @@ Expect.describe('LoginRouter', function () {
           },
         },
         localStorageIsNotSupported: false,
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.selectCountry('JP');
         expect(test.form.titleText()).toBe('test override title');
         expect(test.form.selectedCountry()).toBe('Nihon');
         Expect.deprecated('Use "i18n" instead of "labels" and "country"');
       });
     });
-    itp('overrides text in the login bundle', function () {
+    itp('overrides text in the login bundle', function() {
       return setupLanguage({
         settings: {
           i18n: {
@@ -1590,13 +1590,13 @@ Expect.describe('LoginRouter', function () {
             },
           },
         },
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.titleText()).toBe('test override title');
       });
     });
     itp(
       'overrides text in the login bundle if language field and key in i18n object is in different cases',
-      function () {
+      function() {
         return setupLanguage({
           settings: {
             language: 'zz-zz',
@@ -1606,14 +1606,14 @@ Expect.describe('LoginRouter', function () {
               },
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.titleText()).toBe('custom label');
         });
       }
     );
     itp(
       'overrides text in the login bundle if language field and key in i18n object is in different cases',
-      function () {
+      function() {
         return setupLanguage({
           settings: {
             language: 'zz-ZZ',
@@ -1623,14 +1623,14 @@ Expect.describe('LoginRouter', function () {
               },
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.titleText()).toBe('custom label');
         });
       }
     );
     itp(
       'overrides text in the login bundle if language field and key in i18n object is in different cases',
-      function () {
+      function() {
         return setupLanguage({
           settings: {
             language: 'nl',
@@ -1640,14 +1640,14 @@ Expect.describe('LoginRouter', function () {
               },
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.titleText()).toBe('custom label');
         });
       }
     );
     itp(
       'overrides text in the login bundle if language field and key in i18n object is in different cases',
-      function () {
+      function() {
         return setupLanguage({
           settings: {
             language: 'NL',
@@ -1657,12 +1657,12 @@ Expect.describe('LoginRouter', function () {
               },
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.titleText()).toBe('custom label');
         });
       }
     );
-    itp('uses "country.COUNTRY" to override text in the country bundle', function () {
+    itp('uses "country.COUNTRY" to override text in the country bundle', function() {
       return setupLanguage({
         settings: {
           i18n: {
@@ -1671,12 +1671,12 @@ Expect.describe('LoginRouter', function () {
             },
           },
         },
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.selectCountry('JP');
         expect(test.form.selectedCountry()).toBe('Nihon');
       });
     });
-    itp('uses "country.COUNTRY" to override text in the country bundle no local storage', function () {
+    itp('uses "country.COUNTRY" to override text in the country bundle no local storage', function() {
       return setupLanguage({
         settings: {
           i18n: {
@@ -1686,13 +1686,13 @@ Expect.describe('LoginRouter', function () {
           },
         },
         localStorageIsNotSupported: true,
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.selectCountry('JP');
         expect(test.form.selectedCountry()).toBe('Nihon');
       });
     });
 
-    itp('overrides text in the courage bundle for non English language', function () {
+    itp('overrides text in the courage bundle for non English language', function() {
       return setupLanguage({
         settings: {
           language: 'NL',
@@ -1702,26 +1702,26 @@ Expect.describe('LoginRouter', function () {
             },
           },
         },
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.submit();
         expect(test.form.errorMessage()).toBe('Dutch error banner title');
       });
     });
 
-    itp('Strings in courage bundle are in jp as set in settings.language', function () {
+    itp('Strings in courage bundle are in jp as set in settings.language', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
           language: 'ja',
         },
-      }).then(function (test) {
+      }).then(function(test) {
         test.form.submit();
         expect(test.form.errorMessage()).toBe('JA: Japanese error banner title');
       });
     });
 
-    itp('Strings in courage bundle are in en by default', function () {
-      return setupLanguage({}).then(function (test) {
+    itp('Strings in courage bundle are in en by default', function() {
+      return setupLanguage({}).then(function(test) {
         test.form.submit();
         expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
       });
@@ -1729,7 +1729,7 @@ Expect.describe('LoginRouter', function () {
 
     itp(
       'Sends the default accept lang header en with API calls if widget is not configured with a language',
-      function () {
+      function() {
         const success = jasmine.createSpy('successSpy');
 
         return setupLanguage({
@@ -1737,12 +1737,12 @@ Expect.describe('LoginRouter', function () {
             globalSuccessFn: success,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSuccess);
             test.router.navigate('');
             return Expect.waitForPrimaryAuth(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const form = new PrimaryAuthForm($sandbox);
 
             expect(form.isPrimaryAuth()).toBe(true);
@@ -1757,7 +1757,7 @@ Expect.describe('LoginRouter', function () {
       }
     );
 
-    itp('Sends the right accept lang header with API calls if widget is configured with a language', function () {
+    itp('Sends the right accept lang header with API calls if widget is configured with a language', function() {
       const success = jasmine.createSpy('successSpy');
 
       return setupLanguage({
@@ -1767,12 +1767,12 @@ Expect.describe('LoginRouter', function () {
           language: 'ja',
         },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSuccess);
           test.router.navigate('');
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const form = new PrimaryAuthForm($sandbox);
 
           expect(form.isPrimaryAuth()).toBe(true);
@@ -1787,8 +1787,8 @@ Expect.describe('LoginRouter', function () {
     });
   });
 
-  Expect.describe('Config: "assets"', function () {
-    function expectBundles (baseUrl, login, country) {
+  Expect.describe('Config: "assets"', function() {
+    function expectBundles(baseUrl, login, country) {
       expect(Util.numAjaxRequests()).toBe(3);
       const loginCall = Util.getAjaxRequest(0);
       const countryCall = Util.getAjaxRequest(1);
@@ -1810,17 +1810,17 @@ Expect.describe('LoginRouter', function () {
 
     const expectDefaultCdn = _.partial(expectBundles, 'https://global.oktacdn.com/okta-signin-widget/9.9.99');
 
-    itp('loads properties from the cdn if no baseUrl and path overrides are supplied', function () {
+    itp('loads properties from the cdn if no baseUrl and path overrides are supplied', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
           language: 'ja',
         },
-      }).then(function () {
+      }).then(function() {
         expectDefaultPaths('https://global.oktacdn.com/okta-signin-widget/9.9.99');
       });
     });
-    itp('loads properties from the given baseUrl', function () {
+    itp('loads properties from the given baseUrl', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
@@ -1829,11 +1829,11 @@ Expect.describe('LoginRouter', function () {
             baseUrl: 'http://foo.com',
           },
         },
-      }).then(function () {
+      }).then(function() {
         expectDefaultPaths('http://foo.com');
       });
     });
-    itp('will clean up any trailing slashes in baseUrl', function () {
+    itp('will clean up any trailing slashes in baseUrl', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
@@ -1842,45 +1842,45 @@ Expect.describe('LoginRouter', function () {
             baseUrl: 'http://foo.com/',
           },
         },
-      }).then(function () {
+      }).then(function() {
         expectDefaultPaths('http://foo.com');
       });
     });
-    itp('can override bundle paths with rewrite', function () {
+    itp('can override bundle paths with rewrite', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
           language: 'ja',
           assets: {
-            rewrite: function (file) {
+            rewrite: function(file) {
               return file.replace('.json', '.sha.json');
             },
           },
         },
-      }).then(function () {
+      }).then(function() {
         expectDefaultCdn('/labels/json/login_ja.sha.json', '/labels/json/country_ja.sha.json');
       });
     });
-    itp('can override bundles with both baseUrl and rewrite', function () {
+    itp('can override bundles with both baseUrl and rewrite', function() {
       return setupLanguage({
         mockLanguageRequest: 'ja',
         settings: {
           language: 'ja',
           assets: {
             baseUrl: 'http://foo.com',
-            rewrite: function (file) {
+            rewrite: function(file) {
               return file.replace('.json', '.1.json');
             },
           },
         },
-      }).then(function () {
+      }).then(function() {
         expectBundles('http://foo.com', '/labels/json/login_ja.1.json', '/labels/json/country_ja.1.json');
       });
     });
   });
 
-  Expect.describe('Config: "language"', function () {
-    function expectLanguage (titleText, countryText, test) {
+  Expect.describe('Config: "language"', function() {
+    function expectLanguage(titleText, countryText, test) {
       test.form.selectCountry('JP');
       expect(test.form.selectedCountry()).toBe(countryText);
       expect(test.form.titleText()).toBe(titleText);
@@ -1893,19 +1893,19 @@ Expect.describe('LoginRouter', function () {
 
     const expectZz = _.partial(expectLanguage, 'ZZ: enroll.call.setup', 'ZZ: country.JP');
 
-    Expect.describe('Choosing a language', function () {
-      itp('defaults to english if "language" is not specified and there are no user languages detected', function () {
+    Expect.describe('Choosing a language', function() {
+      itp('defaults to english if "language" is not specified and there are no user languages detected', function() {
         return setupLanguage({
           userLanguages: [],
         }).then(expectEn);
       });
-      itp('uses the first match of user language and supported language if user languages detected', function () {
+      itp('uses the first match of user language and supported language if user languages detected', function() {
         return setupLanguage({
           userLanguages: ['ja', 'ko', 'en'],
           mockLanguageRequest: 'ja',
         }).then(expectJa);
       });
-      itp('will ignore case differences when finding languages, i.e. for Safari', function () {
+      itp('will ignore case differences when finding languages, i.e. for Safari', function() {
         return setupLanguage({
           userLanguages: ['pt-br', 'ja'],
           mockLanguageRequest: 'ja',
@@ -1914,7 +1914,7 @@ Expect.describe('LoginRouter', function () {
               baseUrl: '/assets',
             },
           },
-        }).then(function () {
+        }).then(function() {
           const loginCall = Util.getAjaxRequest(0);
           const countryCall = Util.getAjaxRequest(1);
 
@@ -1922,7 +1922,7 @@ Expect.describe('LoginRouter', function () {
           expect(countryCall.url).toBe('/assets/labels/json/country_pt_BR.json');
         });
       });
-      itp('will use base languageCode even if region is not supported', function () {
+      itp('will use base languageCode even if region is not supported', function() {
         return setupLanguage({
           userLanguages: ['ja-ZZ', 'ko', 'en'],
           mockLanguageRequest: 'ja',
@@ -1931,7 +1931,7 @@ Expect.describe('LoginRouter', function () {
               baseUrl: '/assets',
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expectJa(test);
           const loginCall = Util.getAjaxRequest(0);
           const countryCall = Util.getAjaxRequest(1);
@@ -1940,7 +1940,7 @@ Expect.describe('LoginRouter', function () {
           expect(countryCall.url).toBe('/assets/labels/json/country_ja.json');
         });
       });
-      itp('will use base languageCode with region even if dialect is not supported', function () {
+      itp('will use base languageCode with region even if dialect is not supported', function() {
         return setupLanguage({
           userLanguages: ['pt-BR-zz', 'ko', 'en'],
           mockLanguageRequest: 'ja',
@@ -1949,7 +1949,7 @@ Expect.describe('LoginRouter', function () {
               baseUrl: '/assets',
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expectJa(test);
           const loginCall = Util.getAjaxRequest(0);
           const countryCall = Util.getAjaxRequest(1);
@@ -1958,7 +1958,7 @@ Expect.describe('LoginRouter', function () {
           expect(countryCall.url).toBe('/assets/labels/json/country_pt_BR.json');
         });
       });
-      itp('accepts a language code string as "language"', function () {
+      itp('accepts a language code string as "language"', function() {
         return setupLanguage({
           mockLanguageRequest: 'ja',
           settings: {
@@ -1966,17 +1966,17 @@ Expect.describe('LoginRouter', function () {
           },
         }).then(expectJa);
       });
-      itp('accepts a function that returns a language code', function () {
+      itp('accepts a function that returns a language code', function() {
         return setupLanguage({
           mockLanguageRequest: 'ja',
           settings: {
-            language: function () {
+            language: function() {
               return 'ja';
             },
           },
         }).then(expectJa);
       });
-      itp('passes the list of supported languages and user languages to the function', function () {
+      itp('passes the list of supported languages and user languages to the function', function() {
         const spy = jasmine.createSpy('language').and.returnValue('en');
 
         return setupLanguage({
@@ -1984,7 +1984,7 @@ Expect.describe('LoginRouter', function () {
             language: spy,
           },
           userLanguages: ['ja', 'ko', 'en'],
-        }).then(function () {
+        }).then(function() {
           expect(spy.calls.count()).toBe(1);
           const args = spy.calls.argsFor(0);
           const supported = args[0];
@@ -2026,7 +2026,7 @@ Expect.describe('LoginRouter', function () {
       });
       itp(
         'allows the developer to pass in a new language and will add that to the list of supported languages',
-        function () {
+        function() {
           const spy = jasmine.createSpy('language').and.returnValue('zz-zz');
 
           return setupLanguage({
@@ -2039,7 +2039,7 @@ Expect.describe('LoginRouter', function () {
                 },
               },
             },
-          }).then(function (test) {
+          }).then(function(test) {
             const supported = spy.calls.argsFor(0)[0];
 
             expect(supported).toContain('zz-zz');
@@ -2047,7 +2047,7 @@ Expect.describe('LoginRouter', function () {
           });
         }
       );
-      itp('will default to detection if the "language" property does not return a supported language', function () {
+      itp('will default to detection if the "language" property does not return a supported language', function() {
         return setupLanguage({
           mockLanguageRequest: 'ja',
           userLanguages: ['ja'],
@@ -2058,22 +2058,22 @@ Expect.describe('LoginRouter', function () {
       });
     });
 
-    Expect.describe('Behavior', function () {
-      itp('shows a spinner until the language is loaded if it takes longer than 200ms (i.e. ajax request)', function () {
+    Expect.describe('Behavior', function() {
+      itp('shows a spinner until the language is loaded if it takes longer than 200ms (i.e. ajax request)', function() {
         return setupLanguage({
           delay: 300, // TODO: remove delay
           mockLanguageRequest: 'ja',
           settings: {
             language: 'ja',
           },
-        }).then(function (test) {
+        }).then(function(test) {
           // 2 for the initial refreshAuthState call, and 2 for our spinner
           expect(test.loadingSpy.calls.count()).toBe(4);
           expect(test.loadingSpy.calls.argsFor(2)[0]).toBe(true);
           expect(test.loadingSpy.calls.argsFor(3)[0]).toBe(false);
         });
       });
-      itp('can load a new language dynamically by updating the appState', function () {
+      itp('can load a new language dynamically by updating the appState', function() {
         return setupLanguage({
           settings: {
             i18n: {
@@ -2085,27 +2085,27 @@ Expect.describe('LoginRouter', function () {
           },
         })
           .then(expectEn)
-          .then(function (test) {
+          .then(function(test) {
             // The new language will be rendered on the next router render, but we need
             // navigate away from the page first for the wait to work.
             test.router.forgotPassword();
             return Expect.waitForForgotPassword(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.router.appState.set('languageCode', 'zz-zz');
             test.router.enrollCall();
             return Expect.waitForEnrollCall(test);
           })
           .then(expectZz);
       });
-      itp('caches the language after the initial fetch', function () {
+      itp('caches the language after the initial fetch', function() {
         spyOn(Storage.prototype, 'setItem').and.callThrough();
         return setupLanguage({
           mockLanguageRequest: 'ja',
           settings: {
             language: 'ja',
           },
-        }).then(function () {
+        }).then(function() {
           expect(localStorage.setItem).toHaveBeenCalledWith(
             'osw.languages',
             JSON.stringify({
@@ -2124,8 +2124,8 @@ Expect.describe('LoginRouter', function () {
           );
         });
       });
-      itp('fetches from the cache if it is available', function () {
-        spyOn(Storage.prototype, 'getItem').and.callFake(function (key) {
+      itp('fetches from the cache if it is available', function() {
+        spyOn(Storage.prototype, 'getItem').and.callFake(function(key) {
           if (key === 'osw.languages') {
             return JSON.stringify({
               version: '9.9.99',
@@ -2148,8 +2148,8 @@ Expect.describe('LoginRouter', function () {
           },
         }).then(expectJa);
       });
-      itp('fetches language again (even if its cached) after the osw version is updated', function () {
-        spyOn(Storage.prototype, 'getItem').and.callFake(function (key) {
+      itp('fetches language again (even if its cached) after the osw version is updated', function() {
+        spyOn(Storage.prototype, 'getItem').and.callFake(function(key) {
           if (key === 'osw.languages') {
             return JSON.stringify({
               version: '0.0.00',
@@ -2171,7 +2171,7 @@ Expect.describe('LoginRouter', function () {
           },
         }).then(expectJa);
       });
-      itp('will default i18n to english if properties do not exist in a given language', function () {
+      itp('will default i18n to english if properties do not exist in a given language', function() {
         return setupLanguage({
           settings: {
             i18n: {
@@ -2181,7 +2181,7 @@ Expect.describe('LoginRouter', function () {
               },
             },
           },
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.submitButtonText()).toBe('Verify');
         });
       });

--- a/test/unit/spec/MfaVerifyEmail_spec.js
+++ b/test/unit/spec/MfaVerifyEmail_spec.js
@@ -15,7 +15,7 @@ import $sandbox from 'sandbox';
 import LoginUtil from 'util/Util';
 const itp = Expect.itp;
 
-function createRouter (baseUrl, authClient, successSpy, settings) {
+function createRouter(baseUrl, authClient, successSpy, settings) {
   const router = new Router(
     _.extend(
       {
@@ -33,7 +33,7 @@ function createRouter (baseUrl, authClient, successSpy, settings) {
   return router;
 }
 
-function setupEmail () {
+function setupEmail() {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({
@@ -49,14 +49,14 @@ function setupEmail () {
   setNextResponse(resAllFactors);
   router.refreshAuthState('dummy-token');
   return Expect.waitForMfaVerify()
-    .then(function () {
+    .then(function() {
       const factors = router.appState.get('factors');
       const selectedFactor = factors.findWhere({ factorType: 'email' });
 
       router.verify(selectedFactor.get('provider'), selectedFactor.get('factorType'));
       return Expect.waitForVerifyEmail();
     })
-    .then(function () {
+    .then(function() {
       const form = new MfaVerifyForm($sandbox);
       const beacon = new Beacon($sandbox);
 
@@ -72,8 +72,8 @@ function setupEmail () {
     });
 }
 
-function setupEmailAndClickSend () {
-  return setupEmail().then(function (test) {
+function setupEmailAndClickSend() {
+  return setupEmail().then(function(test) {
     Util.resetAjaxRequests();
     test.setNextResponse(resChallengeEmail);
     test.form.submit();
@@ -81,22 +81,22 @@ function setupEmailAndClickSend () {
   });
 }
 
-function waitForEmailVerificationPage (test) {
+function waitForEmailVerificationPage(test) {
   return Expect.wait(() => {
     return test.form.submitButtonText() === 'Verify';
   }, test);
 }
 
-Expect.describe('MFA Verify (Email)', function () {
-  itp('is email', function () {
-    return setupEmail().then(function (test) {
+Expect.describe('MFA Verify (Email)', function() {
+  itp('is email', function() {
+    return setupEmail().then(function(test) {
       expect(test.form.isEmail()).toBe(true);
       expect(test.beacon.isFactorBeacon()).toBe(true);
       expect(test.beacon.hasClass('mfa-okta-email')).toBe(true);
     });
   });
-  itp('shows send email page', function () {
-    return setupEmail().then(function (test) {
+  itp('shows send email page', function() {
+    return setupEmail().then(function(test) {
       expect(test.form.titleText()).toBe('Verify with Email Authentication');
       expect(test.form.el('mfa-send-email-content').html()).toBe(
         'Send a verification code to ' + '<span class="mask-email">a...1@clouditude.net</span>.'
@@ -106,8 +106,8 @@ Expect.describe('MFA Verify (Email)', function () {
     });
   });
 
-  itp('click send email will send request to factor endpoint', function () {
-    return setupEmailAndClickSend().then(function () {
+  itp('click send email will send request to factor endpoint', function() {
+    return setupEmailAndClickSend().then(function() {
       expect(Util.numAjaxRequests()).toBe(1);
       Expect.isJsonPost(Util.getAjaxRequest(0), {
         url: 'https://foo.com/api/v1/authn/factors/emailhp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
@@ -118,8 +118,8 @@ Expect.describe('MFA Verify (Email)', function () {
       });
     });
   });
-  itp('click send email and show verify passcode page', function () {
-    return setupEmailAndClickSend().then(function (test) {
+  itp('click send email and show verify passcode page', function() {
+    return setupEmailAndClickSend().then(function(test) {
       const answer = test.form.answerField();
 
       expect(answer.length).toBe(1);
@@ -132,15 +132,15 @@ Expect.describe('MFA Verify (Email)', function () {
       Expect.isVisible(test.form.rememberDeviceCheckbox());
     });
   });
-  itp('shows errors if verify button is clicked and answer is empty', function () {
+  itp('shows errors if verify button is clicked and answer is empty', function() {
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resChallengeEmail);
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.passCodeErrorField().length).toBe(1);
         expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
@@ -150,9 +150,9 @@ Expect.describe('MFA Verify (Email)', function () {
       });
   });
 
-  itp('calls verifyFactor with rememberDevice URL param', function () {
+  itp('calls verifyFactor with rememberDevice URL param', function() {
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.setAnswer('456123');
@@ -160,7 +160,7 @@ Expect.describe('MFA Verify (Email)', function () {
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/factors/emailhp9NXcoXu8z2wN0g3/verify?rememberDevice=true',
@@ -171,16 +171,16 @@ Expect.describe('MFA Verify (Email)', function () {
         });
       });
   });
-  itp('calls verify endpoint when form is submitted with a passcode', function () {
+  itp('calls verify endpoint when form is submitted with a passcode', function() {
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.setAnswer('456123');
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/factors/emailhp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
@@ -191,15 +191,15 @@ Expect.describe('MFA Verify (Email)', function () {
         });
       });
   });
-  itp('shows proper account locked error after too many failed MFA attempts.', function () {
+  itp('shows proper account locked error after too many failed MFA attempts.', function() {
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resMfaLocked);
         test.form.setAnswer('12345');
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox().length).toBe(1);
         expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
@@ -229,9 +229,9 @@ Expect.describe('MFA Verify (Email)', function () {
       });
   });
 
-  itp('posts to resend link when click the `send again` button', function () {
+  itp('posts to resend link when click the `send again` button', function() {
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resChallengeEmail);
         expect(test.form.$('.resend-email-infobox').length).toBe(1);
@@ -240,7 +240,7 @@ Expect.describe('MFA Verify (Email)', function () {
           return test.form.$('.resend-email-infobox.hide').length === 1;
         }, test);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           data: { stateToken: 'testStateToken' },
@@ -249,17 +249,17 @@ Expect.describe('MFA Verify (Email)', function () {
       });
   });
 
-  itp('display resend error', function () {
+  itp('display resend error', function() {
     Util.speedUpDelay();
     return setupEmailAndClickSend()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resResendError);
         expect(test.form.$('.resend-email-infobox:not(.hide)').length).toBe(1);
         test.form.$('.resend-email-btn').click();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox().length).toBe(1);
         expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -76,16 +76,16 @@ const factors = {
 const resRejectedPushAppUpgrade = deepClone(resRejectedPush);
 resRejectedPushAppUpgrade.response.factorResultMessage = 'OKTA_VERIFY_UPGRADE_REQUIRED';
 
-function clickFactorInDropdown (test, factorName) {
+function clickFactorInDropdown(test, factorName) {
   //assumes dropdown has all factors
   test.beacon.getOptionsLinks().eq(factors[factorName]).click();
 }
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-Expect.describe('MFA Verify', function () {
+Expect.describe('MFA Verify', function() {
 
   const configWithCustomLink = {
     helpLinks: {
@@ -112,7 +112,7 @@ Expect.describe('MFA Verify', function () {
     }
   };
 
-  function createRouter (baseUrl, authClient, successSpy, settings) {
+  function createRouter(baseUrl, authClient, successSpy, settings) {
     const router = new Router(
       _.extend(
         {
@@ -130,7 +130,7 @@ Expect.describe('MFA Verify', function () {
     return router;
   }
 
-  function setup (res, selectedFactorProps, settings, languagesResponse, useResForIntrospect) {
+  function setup(res, selectedFactorProps, settings, languagesResponse, useResForIntrospect) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -147,7 +147,7 @@ Expect.describe('MFA Verify', function () {
     }
     router.refreshAuthState('dummy-token');
     return Expect.waitForMfaVerify()
-      .then(function () {
+      .then(function() {
         if (selectedFactorProps) {
           const factors = router.appState.get('factors');
           const selectedFactor = factors.findWhere(selectedFactorProps);
@@ -180,10 +180,10 @@ Expect.describe('MFA Verify', function () {
           }
         }
       })
-      .then(function () {
+      .then(function() {
         const $forms = $sandbox.find('.o-form');
 
-        let forms = _.map($forms, function (form) {
+        let forms = _.map($forms, function(form) {
           return new MfaVerifyForm($(form));
         });
 
@@ -204,7 +204,7 @@ Expect.describe('MFA Verify', function () {
       });
   }
 
-  function setupNoProvider (res, selectedFactorProps, settings) {
+  function setupNoProvider(res, selectedFactorProps, settings) {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -216,7 +216,7 @@ Expect.describe('MFA Verify', function () {
     setNextResponse(res);
     router.refreshAuthState('dummy-token');
     return Expect.waitForMfaVerify()
-      .then(function () {
+      .then(function() {
         if (selectedFactorProps) {
           const factors = router.appState.get('factors');
           const selectedFactor = factors.findWhere(selectedFactorProps);
@@ -226,10 +226,10 @@ Expect.describe('MFA Verify', function () {
           return Expect.waitForMfaVerify();
         }
       })
-      .then(function () {
+      .then(function() {
         const $forms = $sandbox.find('.o-form');
 
-        let forms = _.map($forms, function (form) {
+        let forms = _.map($forms, function(form) {
           return new MfaVerifyForm($(form));
         });
 
@@ -250,7 +250,7 @@ Expect.describe('MFA Verify', function () {
       });
   }
 
-  function setupWindowsHelloOnly () {
+  function setupWindowsHelloOnly() {
     const setNextResponse = Util.mockAjax();
     const baseUrl = 'https://foo.com';
     const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -260,17 +260,17 @@ Expect.describe('MFA Verify', function () {
     setNextResponse([resRequiredWindowsHello, resChallengeWindowsHello, resSuccess]);
     router.refreshAuthState('dummy-token');
     return Expect.waitForVerifyWindowsHello()
-      .then(function () {
+      .then(function() {
         return Expect.waitForSpyCall(successSpy);
       })
-      .then(function () {
+      .then(function() {
         return {
           router: router,
         };
       });
   }
 
-  function setupWithMfaPolicy (options) {
+  function setupWithMfaPolicy(options) {
     const res = JSON.parse(JSON.stringify(resMfaAlwaysPolicy));
 
     if (options) {
@@ -331,7 +331,7 @@ Expect.describe('MFA Verify', function () {
 
   const setupOktaPushWithRefreshAuth = _.partial(setup, resVerifyPushOnly, { factorType: 'push' });
 
-  const setupWindowsHello = function (settings) {
+  const setupWindowsHello = function(settings) {
     return setup(
       resAllFactors,
       { factorType: 'webauthn', provider: 'FIDO' },
@@ -368,7 +368,7 @@ Expect.describe('MFA Verify', function () {
     'features.securityImage': true,
   });
 
-  function setupSecurityQuestionLocalized (options) {
+  function setupSecurityQuestionLocalized(options) {
     spyOn(BrowserFeatures, 'localStorageIsNotSupported').and.returnValue(options.localStorageIsNotSupported);
     spyOn(BrowserFeatures, 'getUserLanguages').and.returnValue(['ja', 'en']);
     return setup(resAllFactors, { factorType: 'question' }, {}, [
@@ -379,7 +379,7 @@ Expect.describe('MFA Verify', function () {
 
   const setupMultipleOktaVerify = _.partial(setup, resVerifyMultiple, { factorType: 'push' }, null, null, true);
 
-  function setupMultipleOktaTOTP (settings) {
+  function setupMultipleOktaTOTP(settings) {
     const totpOnly = deepClone(resVerifyMultiple);
 
     totpOnly.response._embedded.factors = _.where(totpOnly.response._embedded.factors, {
@@ -388,7 +388,7 @@ Expect.describe('MFA Verify', function () {
     return setupNoProvider(totpOnly, { factorType: 'token:software:totp' }, settings);
   }
 
-  function setupMultipleOktaPush (settings) {
+  function setupMultipleOktaPush(settings) {
     const pushOnly = deepClone(resVerifyMultiple);
 
     pushOnly.response._embedded.factors = _.where(pushOnly.response._embedded.factors, { factorType: 'push' });
@@ -396,7 +396,7 @@ Expect.describe('MFA Verify', function () {
     return setup(pushOnly, { factorType: 'push' }, settings, null, true);
   }
 
-  function setupU2F (options) {
+  function setupU2F(options) {
     options || (options = {});
 
     if (options.u2f) {
@@ -404,10 +404,10 @@ Expect.describe('MFA Verify', function () {
         sign: jasmine.createSpy('window-u2f-spy'),
       };
       if (options && options.signStub) {
-        window.u2f.sign.and.callFake(function () {
+        window.u2f.sign.and.callFake(function() {
           const signArgs = arguments;
 
-          window.u2f.tap = function () {
+          window.u2f.tap = function() {
             options.signStub.apply(window.u2f, signArgs);
           };
         });
@@ -417,7 +417,7 @@ Expect.describe('MFA Verify', function () {
     }
 
     return setup(options.nextResponse ? options.nextResponse : resAllFactors, null, options.settings, null, true)
-      .then(function (test) {
+      .then(function(test) {
         const responses = options.multipleU2F ? [resChallengeMultipleU2F] : [resChallengeU2F];
 
         if (options && options.res) {
@@ -427,21 +427,21 @@ Expect.describe('MFA Verify', function () {
         test.router.verifyU2F();
         return Expect.waitForVerifyU2F(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         return _.extend(test, {
           form: new MfaVerifyForm($sandbox.find('.o-form')),
         });
       });
   }
 
-  function setupMultipleU2F (options) {
+  function setupMultipleU2F(options) {
     options || (options = {});
     options.nextResponse = resMultipleFactors;
     options.multipleU2F = true;
     return setupU2F(options);
   }
 
-  function setupMultipleU2FOnly (options) {
+  function setupMultipleU2FOnly(options) {
     options || (options = {});
 
     if (options.u2f) {
@@ -449,10 +449,10 @@ Expect.describe('MFA Verify', function () {
         sign: jasmine.createSpy('window-u2f-spy'),
       };
       if (options && options.signStub) {
-        window.u2f.sign.and.callFake(function () {
+        window.u2f.sign.and.callFake(function() {
           const signArgs = arguments;
 
-          window.u2f.tap = function () {
+          window.u2f.tap = function() {
             options.signStub.apply(window.u2f, signArgs);
           };
         });
@@ -476,10 +476,10 @@ Expect.describe('MFA Verify', function () {
     }
     setNextResponse(responses);
     router.refreshAuthState('dummy-token');
-    return Expect.waitForVerifyU2F().then(function () {
+    return Expect.waitForVerifyU2F().then(function() {
       const $forms = $sandbox.find('.o-form');
 
-      let forms = _.map($forms, function (form) {
+      let forms = _.map($forms, function(form) {
         return new MfaVerifyForm($(form));
       });
 
@@ -500,7 +500,7 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  function setupMfaChallengeClaimsFactor (options) {
+  function setupMfaChallengeClaimsFactor(options) {
     options = options || {};
     const initResponse = getInitialChallengeResponse(options);
     const setNextResponse = Util.mockAjax([initResponse, resAllFactors]);
@@ -516,10 +516,10 @@ Expect.describe('MFA Verify', function () {
     router.refreshAuthState('dummy-token');
     const verifyView = options.factorResult === 'FAILED' ? 'waitForVerifyCustomFactor' : 'waitForMfaVerify';
 
-    return Expect[verifyView]().then(function () {
+    return Expect[verifyView]().then(function() {
       const $forms = $sandbox.find('.o-form');
 
-      let forms = _.map($forms, function (form) {
+      let forms = _.map($forms, function(form) {
         return new MfaVerifyForm($(form));
       });
 
@@ -540,7 +540,7 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  function getInitialChallengeResponse (options) {
+  function getInitialChallengeResponse(options) {
     const initResponse = deepClone(resChallengeClaimsProvider);
 
     if (options && options.setFactorResult) {
@@ -550,17 +550,17 @@ Expect.describe('MFA Verify', function () {
     return initResponse;
   }
 
-  function emulateNotWindows () {
+  function emulateNotWindows() {
     spyOn(webauthn, 'isAvailable').and.returnValue(false);
     spyOn(webauthn, 'makeCredential');
     spyOn(webauthn, 'getAssertion');
     return Q();
   }
 
-  function emulateWindows (errorType) {
+  function emulateWindows(errorType) {
     spyOn(webauthn, 'isAvailable').and.returnValue(true);
 
-    spyOn(webauthn, 'getAssertion').and.callFake(function () {
+    spyOn(webauthn, 'getAssertion').and.callFake(function() {
       const deferred = Q.defer();
 
       switch (errorType) {
@@ -597,7 +597,7 @@ Expect.describe('MFA Verify', function () {
   }
 
   // Mocks the right calls for Auth SDK's transactions handled in the widget
-  function mockTransactions (controller, isTotp) {
+  function mockTransactions(controller, isTotp) {
     const model = isTotp ? controller.model.get('backupFactor') : controller.model;
     // Spy on backup factor model for TOTP, since TOTP is special
 
@@ -613,7 +613,7 @@ Expect.describe('MFA Verify', function () {
   // 1. setTransaction on model is called with transaction
   // 2. controller sets the transaction property on the appState
   // 3. routerAfterAuthStatusChange is called with the right parameters (success response)
-  function expectSetTransaction (router, res, isTotp) {
+  function expectSetTransaction(router, res, isTotp) {
     const mockTransaction = jasmine.objectContaining({ data: res.response, status: res.response.status });
     let model = router.controller.model;
     // Spy on backup factor model for TOTP, since TOTP is special
@@ -634,7 +634,7 @@ Expect.describe('MFA Verify', function () {
   // 1. model triggers the setTransactionError event
   // 2. controller sets the transactionError property on the appState
   // 3. routerAfterAuthStatusChange is called with the right parameters (error response)
-  function expectSetTransactionError (router, res, isTotp) {
+  function expectSetTransactionError(router, res, isTotp) {
     const mockError = jasmine.objectContaining(res.response);
     let model = router.controller.model;
     // Spy on backup factor model for TOTP, since TOTP is special
@@ -649,12 +649,12 @@ Expect.describe('MFA Verify', function () {
     expect(RouterUtil.routeAfterAuthStatusChangeError).toHaveBeenCalledWith(router, mockError);
   }
 
-  function setupDuo (settings) {
+  function setupDuo(settings) {
     Util.mockDuo();
     return setup(resAllFactors, { factorType: 'web', provider: 'DUO' }, settings);
   }
 
-  function setupWithFirstFactor (factorIdentifier, settings) {
+  function setupWithFirstFactor(factorIdentifier, settings) {
     const res = JSON.parse(JSON.stringify(resAllFactors));
     const factors = res.response._embedded.factors;
 
@@ -666,9 +666,9 @@ Expect.describe('MFA Verify', function () {
     return setup(res, null, settings, null, true);
   }
 
-  function setupPolling (test, finalResponse, firstPollResponse) {
+  function setupPolling(test, finalResponse, firstPollResponse) {
     // This is to reduce delay before initiating polling in the tests.
-    spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
+    spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function() {
       return setTimeout(arguments[0]);
     });
     Util.resetAjaxRequests();
@@ -694,7 +694,7 @@ Expect.describe('MFA Verify', function () {
         return Expect.waitForAjaxRequests(3, test); // The next tick will trigger the final response
       })
       .then(() => {
-        return Expect.wait(function () {
+        return Expect.wait(function() {
           return (
             JSON.stringify(test.router.controller.model.appState.get('lastAuthResponse')) ===
             JSON.stringify(finalResponse.response)
@@ -703,24 +703,24 @@ Expect.describe('MFA Verify', function () {
       });
   }
 
-  function expectHasRightBeaconImage (test, desiredClassName) {
+  function expectHasRightBeaconImage(test, desiredClassName) {
     expect(test.beacon.isFactorBeacon()).toBe(true);
     expect(test.beacon.hasClass(desiredClassName)).toBe(true);
   }
 
-  function expectTitleToBe (test, desiredTitle) {
+  function expectTitleToBe(test, desiredTitle) {
     expect(test.form.titleText()).toBe(desiredTitle);
   }
 
-  function expectSubtitleToBe (test, desiredSubtitle) {
+  function expectSubtitleToBe(test, desiredSubtitle) {
     expect(test.form.subtitleText()).toBe(desiredSubtitle);
   }
 
-  function expectLabelToBe (test, desiredLabel, fieldName) {
+  function expectLabelToBe(test, desiredLabel, fieldName) {
     expect(test.form.labelText(fieldName)).toBe(desiredLabel);
   }
 
-  function expectHasAnswerField (test, fieldType) {
+  function expectHasAnswerField(test, fieldType) {
     fieldType || (fieldType = 'text');
     const answer = test.form.answerField();
 
@@ -728,7 +728,7 @@ Expect.describe('MFA Verify', function () {
     expect(answer.attr('type')).toEqual(fieldType);
   }
 
-  function expectHasPasswordField (test, fieldType) {
+  function expectHasPasswordField(test, fieldType) {
     fieldType || (fieldType = 'text');
     const password = test.form.passwordField();
 
@@ -736,13 +736,13 @@ Expect.describe('MFA Verify', function () {
     expect(password.attr('type')).toEqual(fieldType);
   }
 
-  function expectError (test, code, message, controller, resError) {
+  function expectError(test, code, message, controller, resError) {
     expect(test.form.hasErrors()).toBe(true);
     expect(test.form.errorMessage()).toBe(message);
     expectErrorEvent(test, code, message, controller, resError);
   }
 
-  function expectErrorEvent (test, code, message, controller, resError) {
+  function expectErrorEvent(test, code, message, controller, resError) {
     expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
     expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
       {
@@ -757,16 +757,16 @@ Expect.describe('MFA Verify', function () {
     ]);
   }
 
-  function beaconTest (allFactorsRes, singleFactorRes, allFactorOnPremRes) {
-    itp('has no dropdown if there is only one factor', function () {
-      return setup(singleFactorRes, null, null, null, true).then(function (test) {
+  function beaconTest(allFactorsRes, singleFactorRes, allFactorOnPremRes) {
+    itp('has no dropdown if there is only one factor', function() {
+      return setup(singleFactorRes, null, null, null, true).then(function(test) {
         const options = test.beacon.getOptionsLinks();
 
         expect(options.length).toBe(0);
       });
     });
-    itp('has a dropdown if there is more than one factor', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('has a dropdown if there is more than one factor', function() {
+      return setup(allFactorsRes).then(function(test) {
         const options = test.beacon.getOptionsLinks();
 
         expect(options.length).toBe(17);
@@ -775,8 +775,8 @@ Expect.describe('MFA Verify', function () {
     itp(
       'shows the right options in the dropdown, removes okta totp if ' +
         'okta push exists, and orders factors by security',
-      function () {
-        return setup(allFactorsRes).then(function (test) {
+      function() {
+        return setup(allFactorsRes).then(function(test) {
           const options = test.beacon.getOptionsLinksText();
 
           expect(options).toEqual([
@@ -804,8 +804,8 @@ Expect.describe('MFA Verify', function () {
     itp(
       'shows the right options in the dropdown, removes okta totp if ' +
         'okta push exists, and orders factors by security (On-Prem, no Password)',
-      function () {
-        return setup(allFactorOnPremRes, null, null, null, true).then(function (test) {
+      function() {
+        return setup(allFactorOnPremRes, null, null, null, true).then(function(test) {
           const options = test.beacon.getOptionsLinksText();
 
           expect(options).toEqual([
@@ -825,29 +825,29 @@ Expect.describe('MFA Verify', function () {
         });
       }
     );
-    itp('opens dropDown options when dropDown link is clicked', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('opens dropDown options when dropDown link is clicked', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.beacon.getOptionsList().is(':visible')).toBe(false);
         test.beacon.dropDownButton().click();
         expect(test.beacon.getOptionsList().is(':visible')).toBe(true);
       });
     });
-    itp('sets aria-expanded when dropDown link is clicked', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('sets aria-expanded when dropDown link is clicked', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('false');
         test.beacon.dropDownButton().click();
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('true');
       });
     });
-    itp('sets aria-expanded when beacon is clicked', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('sets aria-expanded when beacon is clicked', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('false');
         test.beacon.factorBeacon().click();
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('true');
       });
     });
-    itp('sets aria-expanded to false when anywhere outside of the dropdown is clicked', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('sets aria-expanded to false when anywhere outside of the dropdown is clicked', function() {
+      return setup(allFactorsRes).then(function(test) {
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('false');
         test.beacon.factorBeacon().click();
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('true');
@@ -855,22 +855,22 @@ Expect.describe('MFA Verify', function () {
         expect(test.beacon.dropDownButton().attr('aria-expanded')).toBe('false');
       });
     });
-    itp('updates beacon image when different factor is selected', function () {
+    itp('updates beacon image when different factor is selected', function() {
       return setup(allFactorsRes)
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-security-question');
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'GOOGLE_AUTH');
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.beacon.hasClass('mfa-google-auth');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-google-auth');
         });
     });
-    itp('changes selectedFactor if option is chosen', function () {
-      return setup(allFactorsRes).then(function (test) {
+    itp('changes selectedFactor if option is chosen', function() {
+      return setup(allFactorsRes).then(function(test) {
         test.beacon.dropDownButton().click();
         clickFactorInDropdown(test, 'GOOGLE_AUTH');
         expect(test.router.navigate).toHaveBeenCalledWith('signin/verify/google/token%3Asoftware%3Atotp', {
@@ -878,23 +878,23 @@ Expect.describe('MFA Verify', function () {
         });
       });
     });
-    itp('is able to switch between factors even when the auth status is MF_CHALLENGE', function () {
+    itp('is able to switch between factors even when the auth status is MF_CHALLENGE', function() {
       spyOn(Duo, 'init');
       return setup(allFactorsRes)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeDuo);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'DUO');
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(allFactorsRes);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'GOOGLE_AUTH');
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.navigate).toHaveBeenCalledWith('signin/verify/google/token%3Asoftware%3Atotp', {
             trigger: true,
           });
@@ -902,7 +902,7 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  function switchFactorTest (
+  function switchFactorTest(
     setupSmsFn,
     setupOktaPushWithTOTPFn,
     setupGoogleTOTPAutoPushTrueFn,
@@ -911,22 +911,22 @@ Expect.describe('MFA Verify', function () {
     challengeRes,
     expectedStateToken
   ) {
-    itp('Verify Security Question after switching from SMS MFA/FACTOR_CHALLENGE', function () {
+    itp('Verify Security Question after switching from SMS MFA/FACTOR_CHALLENGE', function() {
       return setupSmsFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeRes);
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(allFactorsRes);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'QUESTION');
           return Expect.waitForVerifyQuestion(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           // We cannot use test.form here since refers to SMS form,
@@ -936,7 +936,7 @@ Expect.describe('MFA Verify', function () {
           test.questionForm.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=false',
@@ -947,15 +947,15 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('Verify Push after switching from Google TOTP', function () {
+    itp('Verify Push after switching from Google TOTP', function() {
       return setupGoogleTOTPAutoPushTrueFn({ 'features.autoPush': true })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengePush);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'OKTA_VERIFY_PUSH');
           return Expect.waitForVerifyPush(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
@@ -963,14 +963,14 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(true);
         });
     });
-    itp('Verify Google TOTP after switching from Push MFA/FACTOR_CHALLENGE', function () {
+    itp('Verify Google TOTP after switching from Push MFA/FACTOR_CHALLENGE', function() {
       return setupOktaPushWithTOTPFn()
-        .then(function (test) {
+        .then(function(test) {
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'GOOGLE_AUTH');
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           // We cannot use test.form here since refers to SMS form,
@@ -980,7 +980,7 @@ Expect.describe('MFA Verify', function () {
           test.googleTOTPForm.submit();
           return tick(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=false',
@@ -993,57 +993,57 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  function testSecurityQuestion (setupFn, setupFnLocalized, expectedStateToken) {
-    itp('is security question', function () {
-      return setupFn().then(function (test) {
+  function testSecurityQuestion(setupFn, setupFnLocalized, expectedStateToken) {
+    itp('is security question', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isSecurityQuestion()).toBe(true);
       });
     });
-    itp('shows the right beacon', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-okta-security-question');
       });
     });
-    itp('shows the right title', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'Security Question');
       });
     });
-    itp('sets the label to the user\'s security question', function () {
-      return setupFn().then(function (test) {
+    itp('sets the label to the user\'s security question', function() {
+      return setupFn().then(function(test) {
         expectLabelToBe(test, 'What is the food you least liked as a child?', 'answer');
       });
     });
-    itp('sets the label to the user\'s security question (localized)', function () {
-      return setupFnLocalized({ localStorageIsNotSupported: false }).then(function (test) {
+    itp('sets the label to the user\'s security question (localized)', function() {
+      return setupFnLocalized({ localStorageIsNotSupported: false }).then(function(test) {
         expectLabelToBe(test, 'JA: What is the food you least liked as a child?', 'answer');
       });
     });
-    itp('sets the label to the user\'s security question (localized + no local storage)', function () {
-      return setupFnLocalized({ localStorageIsNotSupported: true }).then(function (test) {
+    itp('sets the label to the user\'s security question (localized + no local storage)', function() {
+      return setupFnLocalized({ localStorageIsNotSupported: true }).then(function(test) {
         expectLabelToBe(test, 'JA: What is the food you least liked as a child?', 'answer');
       });
     });
-    itp('has an answer field', function () {
-      return setupFn().then(function (test) {
+    itp('has an answer field', function() {
+      return setupFn().then(function(test) {
         expectHasAnswerField(test, 'password');
       });
     });
-    itp('has remember device checkbox', function () {
-      return setupFn().then(function (test) {
+    itp('has remember device checkbox', function() {
+      return setupFn().then(function(test) {
         Expect.isVisible(test.form.rememberDeviceCheckbox());
       });
     });
-    itp('no auto push checkbox', function () {
-      return setupFn({ 'features.autoPush': true }).then(function (test) {
+    itp('no auto push checkbox', function() {
+      return setupFn({ 'features.autoPush': true }).then(function(test) {
         expect(test.form.autoPushCheckbox().length).toBe(0);
       });
     });
     itp(
       'an answer field type is "password" initially and can be switched between "text" and "password" \
           by clicking on "show"/"hide" buttons',
-      function () {
-        return setupFn().then(function (test) {
+      function() {
+        return setupFn().then(function(test) {
           const answer = test.form.answerField();
 
           expect(answer.attr('type')).toEqual('password');
@@ -1060,9 +1060,9 @@ Expect.describe('MFA Verify', function () {
         });
       }
     );
-    itp('calls authClient verifyFactor with correct args when submitted', function () {
+    itp('calls authClient verifyFactor with correct args when submitted', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('food');
           test.form.setRememberDevice(true);
@@ -1070,7 +1070,7 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=true',
@@ -1081,9 +1081,9 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('disables the "verify button" when clicked', function () {
+    itp('disables the "verify button" when clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('who cares');
           test.setNextResponse(resInvalid);
@@ -1095,7 +1095,7 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(true);
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
@@ -1103,37 +1103,37 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(false);
         });
     });
-    itp('shows an error if error response from authClient', function () {
+    itp('shows an error if error response from authClient', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resInvalid);
           test.form.setAnswer('wrong');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Your answer doesn\'t match our records. Please try again.');
         });
     });
-    itp('shows errors if verify button is clicked and answer is empty', function () {
+    itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('sets the transaction on the appState on success response', function () {
+    itp('sets the transaction on the appState on success response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           Util.resetAjaxRequests();
           test.form.setAnswer('food');
@@ -1141,13 +1141,13 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransaction(test.router, resSuccess);
         });
     });
-    itp('sets the transaction error on the appState on error response', function () {
+    itp('sets the transaction error on the appState on error response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           Util.resetAjaxRequests();
           test.form.setAnswer('food');
@@ -1155,74 +1155,74 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransactionError(test.router, resInvalid);
         });
     });
   }
 
-  function testSms (setupFn, challengeSmsRes, successRes, expectedStateToken) {
-    beforeEach(function () {
+  function testSms(setupFn, challengeSmsRes, successRes, expectedStateToken) {
+    beforeEach(function() {
       const throttle = _.throttle;
 
-      spyOn(_, 'throttle').and.callFake(function (fn) {
+      spyOn(_, 'throttle').and.callFake(function(fn) {
         return throttle(fn, 0);
       });
     });
 
-    itp('is sms', function () {
-      return setupFn().then(function (test) {
+    itp('is sms', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isSMS()).toBe(true);
       });
     });
-    itp('shows the right beacon', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-okta-sms');
       });
     });
-    itp('does not autocomplete', function () {
-      return setupFn().then(function (test) {
+    itp('does not autocomplete', function() {
+      return setupFn().then(function(test) {
         expect(test.form.getAutocomplete()).toBe('off');
       });
     });
-    itp('shows the phone number in the title', function () {
-      return setupFn().then(function (test) {
+    itp('shows the phone number in the title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'SMS Authentication');
         expectSubtitleToBe(test, '(+1 XXX-XXX-6688)');
       });
     });
-    itp('has a button to send the code', function () {
-      return setupFn().then(function (test) {
+    itp('has a button to send the code', function() {
+      return setupFn().then(function(test) {
         const button = test.form.smsSendCode();
 
         expect(button.length).toBe(1);
         expect(button.is('a')).toBe(true);
       });
     });
-    itp('has a passCode field', function () {
-      return setupFn().then(function (test) {
+    itp('has a passCode field', function() {
+      return setupFn().then(function(test) {
         expectHasAnswerField(test, 'tel');
       });
     });
-    itp('has remember device checkbox', function () {
-      return setupFn().then(function (test) {
+    itp('has remember device checkbox', function() {
+      return setupFn().then(function(test) {
         Expect.isVisible(test.form.rememberDeviceCheckbox());
       });
     });
-    itp('clears the passcode text field on clicking the "Send code" button', function () {
+    itp('clears the passcode text field on clicking the "Send code" button', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeSmsRes);
 
           expect(test.form.smsSendCode().trimmedText()).toEqual('Send code');
           test.form.setAnswer('123456');
           expect(test.form.answerField().val()).toEqual('123456');
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.answerField().val() === '';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.smsSendCode().trimmedText()).toEqual('Sent');
           expect(test.form.answerField().val()).toEqual('');
 
@@ -1234,15 +1234,15 @@ Expect.describe('MFA Verify', function () {
           return test;
         });
     });
-    itp('calls verifyFactor with empty code if send code button is clicked', function () {
+    itp('calls verifyFactor with empty code if send code button is clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
@@ -1254,32 +1254,32 @@ Expect.describe('MFA Verify', function () {
         });
     });
 
-    itp('posts resend if send code button is clicked second time', function () {
+    itp('posts resend if send code button is clicked second time', function() {
       Util.mockQDelay();
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeSmsRes);
           expect(test.form.smsSendCode().text()).toBe('Send code');
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().text() === 'Re-send code';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.submitButton().prop('disabled')).toBe(false);
           Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().text() === 'Sent';
           }, test);
         })
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.smsSendCode().text() === 'Re-send code';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(test.form.submitButton().prop('disabled')).toBe(false);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -1290,18 +1290,18 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    it('shows warning message to click "Re-send" after 30s', function () {
+    it('shows warning message to click "Re-send" after 30s', function() {
       Util.mockQDelay();
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeSmsRes);
           expect(test.form.smsSendCode().text()).toBe('Send code');
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().text() === 'Re-send code';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.smsSendCode().text()).toBe('Re-send code');
           expect(test.form.warningMessage()).toContain('Haven\'t received an SMS? To try again, click Re-send code.');
 
@@ -1311,26 +1311,26 @@ Expect.describe('MFA Verify', function () {
           test.form.smsSendCode().click();
           expect(test.form.smsSendCode().text()).toBe('Sent');
           expect(test.form.hasWarningMessage()).toBe(false);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().text() === 'Re-send code';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Re-send after 30s wil show the warning again
           expect(test.form.smsSendCode().text()).toBe('Re-send code');
           expect(test.form.warningMessage()).toContain('Haven\'t received an SMS? To try again, click Re-send code.');
         });
     });
-    itp('calls verifyFactor with rememberDevice URL param', function () {
+    itp('calls verifyFactor with rememberDevice URL param', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=true',
@@ -1341,44 +1341,44 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('calls verifyFactor with empty code if verify button is clicked', function () {
+    itp('calls verifyFactor with empty code if verify button is clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setAnswer('');
           test.form.submit();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('calls verifyFactor with given code if verify button is clicked', function () {
+    itp('calls verifyFactor with given code if verify button is clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setAnswer('123456');
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=false',
@@ -1389,38 +1389,38 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('shows errors if verify button is clicked and answer is empty', function () {
+    itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+    itp('calls authClient verifyFactor with rememberDevice URL param', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeSmsRes);
           test.form.smsSendCode().click();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           test.form.setAnswer('123456');
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/smshp9NXcoXu8z2wN0g3/verify?rememberDevice=true',
@@ -1434,78 +1434,78 @@ Expect.describe('MFA Verify', function () {
     itp(
       'temporarily disables the send code button before displaying re-send \
               to avoid exceeding the rate limit',
-      function () {
+      function() {
         const deferred = Util.mockRateLimiting();
 
         return setupFn()
-          .then(function (test) {
+          .then(function(test) {
             test.button = test.form.smsSendCode();
             expect(test.button.trimmedText()).toEqual('Send code');
             test.setNextResponse(challengeSmsRes);
             test.form.smsSendCode().click();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return test.button.trimmedText() === 'Sent';
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.button.trimmedText()).toEqual('Sent');
             deferred.resolve();
 
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return test.button.trimmedText() === 'Re-send code';
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.button.length).toBe(1);
             expect(test.button.trimmedText()).toEqual('Re-send code');
           });
       }
     );
-    itp('displays only one error block if got an error resp on "Send code"', function () {
+    itp('displays only one error block if got an error resp on "Send code"', function() {
       const deferred = Util.mockRateLimiting();
 
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
           test.setNextResponse(resResendError);
           expect(test.form.smsSendCode().hasClass('disabled')).toBe(false);
           expect(test.afterErrorHandler.calls.count()).toBe(0);
           test.form.smsSendCode().click();
           expect(test.form.smsSendCode().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.afterErrorHandler.calls.count() > 0;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           deferred.resolve();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resResendError);
           test.form.smsSendCode().click();
           expect(test.form.smsSendCode().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
         });
     });
-    itp('shows proper account locked error after too many failed MFA attempts.', function () {
+    itp('shows proper account locked error after too many failed MFA attempts.', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resMfaLocked);
           test.form.setAnswer('12345');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
@@ -1523,15 +1523,15 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('hides error messages after clicking on send sms', function () {
+    itp('hides error messages after clicking on send sms', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           test.setNextResponse(challengeSmsRes);
@@ -1539,74 +1539,74 @@ Expect.describe('MFA Verify', function () {
           test.form.smsSendCode().click();
           expect(test.form.hasErrors()).toBe(false);
           expect(test.form.smsSendCode().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.smsSendCode().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
           expect(test.form.errorBox().length).toBe(0);
         });
     });
   }
 
-  function testCall (setupFn, challengeCallRes, successRes, expectedStateToken) {
-    beforeEach(function () {
+  function testCall(setupFn, challengeCallRes, successRes, expectedStateToken) {
+    beforeEach(function() {
       const throttle = _.throttle;
 
-      spyOn(_, 'throttle').and.callFake(function (fn) {
+      spyOn(_, 'throttle').and.callFake(function(fn) {
         return throttle(fn, 0);
       });
     });
 
-    itp('is call', function () {
-      return setupFn().then(function (test) {
+    itp('is call', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isCall()).toBe(true);
       });
     });
-    itp('shows the right beacon', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-okta-call');
       });
     });
-    itp('does not autocomplete', function () {
-      return setupFn().then(function (test) {
+    itp('does not autocomplete', function() {
+      return setupFn().then(function(test) {
         expect(test.form.getAutocomplete()).toBe('off');
       });
     });
-    itp('shows the phone number in the title', function () {
-      return setupFn().then(function (test) {
+    itp('shows the phone number in the title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'Voice Call Authentication');
         expectSubtitleToBe(test, '(+1 XXX-XXX-7799)');
       });
     });
-    itp('has a button to make a call', function () {
-      return setupFn().then(function (test) {
+    itp('has a button to make a call', function() {
+      return setupFn().then(function(test) {
         const button = test.form.makeCall();
 
         expect(button.length).toBe(1);
         expect(button.is('a')).toBe(true);
       });
     });
-    itp('has a passCode field', function () {
-      return setupFn().then(function (test) {
+    itp('has a passCode field', function() {
+      return setupFn().then(function(test) {
         expectHasAnswerField(test, 'tel');
       });
     });
-    itp('clears the passcode text field on clicking the "Call" button', function () {
+    itp('clears the passcode text field on clicking the "Call" button', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.button = test.form.makeCall();
           test.form.setAnswer('123456');
           test.setNextResponse(challengeCallRes);
           expect(test.button.trimmedText()).toEqual('Call');
           expect(test.form.answerField().val()).toEqual('123456');
           test.form.makeCall().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.answerField().val() === '';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.button.trimmedText()).toEqual('Calling');
           expect(test.form.answerField().val()).toEqual('');
           const button = test.form.submitButton();
@@ -1617,8 +1617,8 @@ Expect.describe('MFA Verify', function () {
           return test;
         });
     });
-    itp('calls verifyFactor with empty code if call button is clicked', function () {
-      return setupFn().then(function (test) {
+    itp('calls verifyFactor with empty code if call button is clicked', function() {
+      return setupFn().then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(challengeCallRes);
         test.form.makeCall().click();
@@ -1633,13 +1633,13 @@ Expect.describe('MFA Verify', function () {
         expect(test.form.makeCall().hasClass('disabled')).toBe(true);
         // Wait for PassCodeForm save logic to finish up
         Util.mockQDelay();
-        return Expect.wait(function () {
+        return Expect.wait(function() {
           return test.form.makeCall().hasClass('disabled') === false;
         }, test);
       });
     });
-    itp('calls verifyFactor with rememberDevice URL param', function () {
-      return setupFn().then(function (test) {
+    itp('calls verifyFactor with rememberDevice URL param', function() {
+      return setupFn().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setRememberDevice(true);
         test.setNextResponse(challengeCallRes);
@@ -1655,14 +1655,14 @@ Expect.describe('MFA Verify', function () {
         expect(test.form.makeCall().hasClass('disabled')).toBe(true);
         // Wait for PassCodeForm save logic to finish up
         Util.mockQDelay();
-        return Expect.wait(function () {
+        return Expect.wait(function() {
           return test.form.makeCall().hasClass('disabled') === false;
         }, test);
       });
     });
-    itp('calls verifyFactor with empty code if verify button is clicked', function () {
+    itp('calls verifyFactor with empty code if verify button is clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
@@ -1670,11 +1670,11 @@ Expect.describe('MFA Verify', function () {
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
           // Wait for PassCodeForm save logic to finish up
           Util.mockQDelay();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           test.form.setAnswer('');
@@ -1682,31 +1682,31 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('calls verifyFactor with given code if verify button is clicked', function () {
+    itp('calls verifyFactor with given code if verify button is clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return Util.numAjaxRequests() > 0;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           test.form.setAnswer('123456');
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=false',
@@ -1717,25 +1717,25 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+    itp('calls authClient verifyFactor with rememberDevice URL param', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setRememberDevice(true);
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return Util.numAjaxRequests() > 0;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(successRes);
           test.form.setAnswer('123456');
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/clfk6mRsVLrhHznVe0g3/verify?rememberDevice=true',
@@ -1746,15 +1746,15 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('shows errors if verify button is clicked and answer is empty', function () {
+    itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
@@ -1764,75 +1764,75 @@ Expect.describe('MFA Verify', function () {
     itp(
       'temporarily disables the call button before displaying redial \
               to avoid exceeding the rate limit',
-      function () {
+      function() {
         const deferred = Util.mockRateLimiting();
 
         return setupFn()
-          .then(function (test) {
+          .then(function(test) {
             test.button = test.form.makeCall();
             expect(test.button.trimmedText()).toEqual('Call');
             test.setNextResponse(challengeCallRes);
             test.form.makeCall().click();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return test.button.trimmedText() === 'Calling';
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.button.trimmedText()).toEqual('Calling');
             deferred.resolve();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return test.button.trimmedText() === 'Redial';
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.button.length).toBe(1);
             expect(test.button.trimmedText()).toEqual('Redial');
           });
       }
     );
-    itp('displays only one error block if got an error resp on "Call"', function () {
+    itp('displays only one error block if got an error resp on "Call"', function() {
       const deferred = Util.mockRateLimiting();
 
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resResendError);
           test.form.makeCall().click();
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.afterErrorHandler.calls.count() > 0;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           test.afterErrorHandler.calls.reset();
           deferred.resolve();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resResendError);
           test.form.makeCall().click();
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
         });
     });
-    itp('shows proper account locked error after too many failed MFA attempts.', function () {
+    itp('shows proper account locked error after too many failed MFA attempts.', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resMfaLocked);
           test.form.setAnswer('12345');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           expect(test.form.errorMessage()).toBe('Your account is locked because of too many authentication attempts.');
@@ -1850,14 +1850,14 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('hides error messages after clicking on call', function () {
+    itp('hides error messages after clicking on call', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox().length).toBe(1);
           test.setNextResponse(challengeCallRes);
@@ -1865,29 +1865,29 @@ Expect.describe('MFA Verify', function () {
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
           // Wait for PassCodeForm save logic to finish up
           Util.mockQDelay();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(false);
           expect(test.form.errorBox().length).toBe(0);
         });
     });
 
-    itp('shows warning message to click "Redial" after 30s', function () {
+    itp('shows warning message to click "Redial" after 30s', function() {
       Util.mockQDelay();
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeCallRes);
           expect(test.form.makeCall().text()).toBe('Call');
           test.form.makeCall().click();
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.makeCall().text()).toBe('Redial');
           expect(test.form.warningMessage()).toContain('Haven\'t received a voice call? To try again, click Redial.');
 
@@ -1898,42 +1898,42 @@ Expect.describe('MFA Verify', function () {
           expect(test.form.makeCall().text()).toBe('Calling');
           expect(test.form.hasWarningMessage()).toBe(false);
           expect(test.form.makeCall().hasClass('disabled')).toBe(true);
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().hasClass('disabled') === false;
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Re-send after 30s wil show the warning again
           expect(test.form.makeCall().text()).toBe('Redial');
           expect(test.form.warningMessage()).toContain('Haven\'t received a voice call? To try again, click Redial.');
         });
     });
-    itp('posts to resend link if call button is clicked for the second time', function () {
+    itp('posts to resend link if call button is clicked for the second time', function() {
       Util.mockQDelay();
       return setupCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(challengeCallRes);
           expect(test.form.makeCall().text()).toBe('Call');
           test.form.makeCall().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().text() === 'Redial';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.submitButton().prop('disabled')).toBe(false);
           Util.resetAjaxRequests();
           test.setNextResponse(challengeCallRes);
           test.form.makeCall().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.form.makeCall().text() === 'Calling';
           }, test);
         })
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.makeCall().text() === 'Redial';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.submitButton().prop('disabled')).toBe(false);
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -1944,53 +1944,53 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  function testGoogleTOTP (setupFn, expectedStateToken) {
-    itp('is totp', function () {
-      return setupFn().then(function (test) {
+  function testGoogleTOTP(setupFn, expectedStateToken) {
+    itp('is totp', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isTOTP()).toBe(true);
       });
     });
-    itp('shows the right beacon for google TOTP', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon for google TOTP', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-google-auth');
       });
     });
-    itp('does not autocomplete', function () {
-      return setupFn().then(function (test) {
+    itp('does not autocomplete', function() {
+      return setupFn().then(function(test) {
         expect(test.form.getAutocomplete()).toBe('off');
       });
     });
 
-    itp('references factorName in title', function () {
-      return setupFn().then(function (test) {
+    itp('references factorName in title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'Google Authenticator');
       });
     });
-    itp('shows the right subtitle for Google Auth', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right subtitle for Google Auth', function() {
+      return setupFn().then(function(test) {
         expectSubtitleToBe(test, 'Enter your Google Authenticator passcode');
       });
     });
-    itp('has a passCode field', function () {
-      return setupFn().then(function (test) {
+    itp('has a passCode field', function() {
+      return setupFn().then(function(test) {
         expectHasAnswerField(test, 'tel');
       });
     });
-    itp('has remember device checkbox', function () {
-      return setupFn().then(function (test) {
+    itp('has remember device checkbox', function() {
+      return setupFn().then(function(test) {
         Expect.isVisible(test.form.rememberDeviceCheckbox());
       });
     });
-    itp('calls authClient verifyFactor with correct args when submitted', function () {
+    itp('calls authClient verifyFactor with correct args when submitted', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=false',
@@ -2001,9 +2001,9 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+    itp('calls authClient verifyFactor with rememberDevice URL param', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.form.setRememberDevice(true);
@@ -2011,7 +2011,7 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g3/verify?rememberDevice=true',
@@ -2022,9 +2022,9 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('disables the "verify button" when clicked', function () {
+    itp('disables the "verify button" when clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('who cares');
           test.setNextResponse(resInvalid);
@@ -2036,7 +2036,7 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(true);
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
@@ -2045,15 +2045,15 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(false);
         });
     });
-    itp('shows an error if error response from authClient', function () {
+    itp('shows an error if error response from authClient', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resInvalidTotp);
           test.form.setAnswer('wrong');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectError(test, 403, 'Invalid Passcode/Answer', 'mfa-verify', {
             status: 403,
             responseType: 'json',
@@ -2068,85 +2068,85 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('shows errors if verify button is clicked and answer is empty', function () {
+    itp('shows errors if verify button is clicked and answer is empty', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passCodeErrorField().length).toBe(1);
           expect(test.form.passCodeErrorField().text()).toBe('This field cannot be left blank');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('sets the transaction on the appState on success response', function () {
+    itp('sets the transaction on the appState on success response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           test.form.setAnswer('123456');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransaction(test.router, resSuccess);
         });
     });
-    itp('sets the transaction error on the appState on error response', function () {
+    itp('sets the transaction error on the appState on error response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           test.setNextResponse(resInvalidTotp);
           test.form.setAnswer('wrong');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransactionError(test.router, resInvalidTotp);
         });
     });
   }
 
-  function testPassword (setupFn, expectedStateToken) {
-    itp('is password', function () {
-      return setupFn().then(function (test) {
+  function testPassword(setupFn, expectedStateToken) {
+    itp('is password', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isPassword()).toBe(true);
       });
     });
-    itp('shows the right beacon', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-okta-password');
       });
     });
-    itp('shows the right title', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'Password');
       });
     });
-    itp('has a password field', function () {
-      return setupFn().then(function (test) {
+    itp('has a password field', function() {
+      return setupFn().then(function(test) {
         expectHasPasswordField(test, 'password');
       });
     });
-    itp('has remember device checkbox', function () {
-      return setupFn().then(function (test) {
+    itp('has remember device checkbox', function() {
+      return setupFn().then(function(test) {
         Expect.isVisible(test.form.rememberDeviceCheckbox());
       });
     });
-    itp('no auto push checkbox', function () {
-      return setupFn({ 'features.autoPush': true }).then(function (test) {
+    itp('no auto push checkbox', function() {
+      return setupFn({ 'features.autoPush': true }).then(function(test) {
         expect(test.form.autoPushCheckbox().length).toBe(0);
       });
     });
     itp(
       'a password field type is "password" initially and can be switched between "text" and "password" \
           by clicking on "show"/"hide" buttons',
-      function () {
-        return setupFn().then(function (test) {
+      function() {
+        return setupFn().then(function(test) {
           const answer = test.form.passwordField();
 
           expect(answer.attr('type')).toEqual('password');
@@ -2159,9 +2159,9 @@ Expect.describe('MFA Verify', function () {
         });
       }
     );
-    itp('calls authClient verifyFactor with correct args when submitted', function () {
+    itp('calls authClient verifyFactor with correct args when submitted', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
           test.form.setRememberDevice(true);
@@ -2169,7 +2169,7 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'http://rain.okta1.com:1802/api/v1/authn/factors/password/verify?rememberDevice=true',
@@ -2180,9 +2180,9 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('disables the "verify button" when clicked', function () {
+    itp('disables the "verify button" when clicked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setPassword('Abcd');
           test.setNextResponse(resInvalidPassword);
@@ -2194,7 +2194,7 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(true);
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
@@ -2202,15 +2202,15 @@ Expect.describe('MFA Verify', function () {
           expect(button.prop('disabled')).toBe(false);
         });
     });
-    itp('shows an error if error response from authClient', function () {
+    itp('shows an error if error response from authClient', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resInvalidPassword);
           test.form.setPassword('wrong');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Password is incorrect');
           expectErrorEvent(test, 403, 'Invalid Passcode/Answer', 'mfa-verify', {
@@ -2231,24 +2231,24 @@ Expect.describe('MFA Verify', function () {
           });
         });
     });
-    itp('shows errors if verify button is clicked and password is empty', function () {
+    itp('shows errors if verify button is clicked and password is empty', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setPassword('');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(0);
           expect(test.form.passwordErrorField().length).toBe(1);
           expect(test.form.passwordErrorField().text()).toBe('Please enter a password');
           expect(test.form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
         });
     });
-    itp('sets the transaction on the appState on success response', function () {
+    itp('sets the transaction on the appState on success response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
@@ -2256,13 +2256,13 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransaction(test.router, resSuccess);
         });
     });
-    itp('sets the transaction error on the appState on error response', function () {
+    itp('sets the transaction error on the appState on error response', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           mockTransactions(test.router.controller);
           Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
@@ -2270,122 +2270,122 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectSetTransactionError(test.router, resInvalidPassword);
         });
     });
   }
 
-  Expect.describe('General', function () {
-    Expect.describe('Defaults to the last used factor', function () {
-      itp('Security Question', function () {
-        return setup(resAllFactors).then(function (test) {
+  Expect.describe('General', function() {
+    Expect.describe('Defaults to the last used factor', function() {
+      itp('Security Question', function() {
+        return setup(resAllFactors).then(function(test) {
           expect(test.form.isSecurityQuestion()).toBe(true);
         });
       });
-      itp('Google TOTP', function () {
-        return setupWithFirstFactor({ provider: 'GOOGLE', factorType: 'token:software:totp' }).then(function (test) {
+      itp('Google TOTP', function() {
+        return setupWithFirstFactor({ provider: 'GOOGLE', factorType: 'token:software:totp' }).then(function(test) {
           expect(test.form.isTOTP()).toBe(true);
         });
       });
       // TOTP and push have the same form. If either of them is the last used, we show the push form.
-      itp('Okta TOTP/Push', function () {
-        return setupWithFirstFactor({ provider: 'OKTA', factorType: 'token:software:totp' }).then(function (test) {
+      itp('Okta TOTP/Push', function() {
+        return setupWithFirstFactor({ provider: 'OKTA', factorType: 'token:software:totp' }).then(function(test) {
           expect(test.form[0].isPush()).toBe(true);
         });
       });
-      itp('Okta Push', function () {
-        return setupWithFirstFactor({ factorType: 'push' }).then(function (test) {
+      itp('Okta Push', function() {
+        return setupWithFirstFactor({ factorType: 'push' }).then(function(test) {
           expect(test.form[0].isPush()).toBe(true);
         });
       });
-      itp('Okta SMS', function () {
-        return setupWithFirstFactor({ factorType: 'sms' }).then(function (test) {
+      itp('Okta SMS', function() {
+        return setupWithFirstFactor({ factorType: 'sms' }).then(function(test) {
           expect(test.form.isSMS()).toBe(true);
         });
       });
-      itp('Okta Email', function () {
-        return setupWithFirstFactor({ factorType: 'email' }).then(function (test) {
+      itp('Okta Email', function() {
+        return setupWithFirstFactor({ factorType: 'email' }).then(function(test) {
           expect(test.form.isEmail()).toBe(true);
         });
       });
     });
-    Expect.describe('Factor page custom link', function () {
-      itp('is visible if configured and has correct text and url', function () {
-        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLink).then(function (test) {
+    Expect.describe('Factor page custom link', function() {
+      itp('is visible if configured and has correct text and url', function() {
+        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLink).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
           expect(test.form.factorPageCustomLinkLabel($sandbox).trim()).toBe('Need help with MFA?');
           expect(test.form.factorPageCustomLinkHref($sandbox).trim()).toBe('https://acme.com/mfa-help');
         });
       });
-      itp('is not visible if not configured', function () {
-        return setupWithFirstFactor({ factorType: 'question' }).then(function (test) {
+      itp('is not visible if not configured', function() {
+        return setupWithFirstFactor({ factorType: 'question' }).then(function(test) {
           expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
         });
       });
-      itp('is not visible if configured without text', function () {
-        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLinkNoText).then(function (test) {
+      itp('is not visible if configured without text', function() {
+        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLinkNoText).then(function(test) {
           expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
         });
       });
-      itp('is not visible if configured without url', function () {
-        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLinkNoHref).then(function (test) {
+      itp('is not visible if configured without url', function() {
+        return setupWithFirstFactor({ factorType: 'question' }, configWithCustomLinkNoHref).then(function(test) {
           expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
         });
       });
-      itp('is visible if configured with features.hideSignOutLinkInMFA is true', function () {
-        return setupWithFirstFactor({ factorType: 'question' }, { ...configWithCustomLink, 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+      itp('is visible if configured with features.hideSignOutLinkInMFA is true', function() {
+        return setupWithFirstFactor({ factorType: 'question' }, { ...configWithCustomLink, 'features.hideSignOutLinkInMFA': true }).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('is visible if configured with features.mfaOnlyFlow is true', function () {
-        return setupWithFirstFactor({ factorType: 'question' }, { ...configWithCustomLink, 'features.mfaOnlyFlow': true }).then(function (test) {
+      itp('is visible if configured with features.mfaOnlyFlow is true', function() {
+        return setupWithFirstFactor({ factorType: 'question' }, { ...configWithCustomLink, 'features.mfaOnlyFlow': true }).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('is visible if configured for U2F', function () {
-        return setupU2F({ u2f: true, settings: configWithCustomLink }).then(function (test) {
+      itp('is visible if configured for U2F', function() {
+        return setupU2F({ u2f: true, settings: configWithCustomLink }).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
         });
       });
-      itp('is visible if configured for custom factor', function () {
-        return setupClaimsProviderFactorWithIntrospect(configWithCustomLink).then(function (test) {
+      itp('is visible if configured for custom factor', function() {
+        return setupClaimsProviderFactorWithIntrospect(configWithCustomLink).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
         });
       });
-      itp('is visible if configured for Duo', function () {
-        return setupDuo(configWithCustomLink).then(function (test) {
+      itp('is visible if configured for Duo', function() {
+        return setupDuo(configWithCustomLink).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
         });
       });
-      itp('is visible if configured for Windows Hello', function () {
-        return setupWindowsHello(configWithCustomLink).then(function (test) {
+      itp('is visible if configured for Windows Hello', function() {
+        return setupWindowsHello(configWithCustomLink).then(function(test) {
           Expect.isVisible(test.form.factorPageCustomLink($sandbox));
         });
       });
     });
-    Expect.describe('Sign out link', function () {
-      itp('is visible', function () {
-        return setupWithFirstFactor({ factorType: 'question' }).then(function (test) {
+    Expect.describe('Sign out link', function() {
+      itp('is visible', function() {
+        return setupWithFirstFactor({ factorType: 'question' }).then(function(test) {
           Expect.isVisible(test.form.signoutLink($sandbox));
         });
       });
-      itp('is not present if features.hideSignOutLinkInMFA is true', function () {
-        return setupSecurityQuestion({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+      itp('is not present if features.hideSignOutLinkInMFA is true', function() {
+        return setupSecurityQuestion({ 'features.hideSignOutLinkInMFA': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('is not present if features.mfaOnlyFlow is true', function () {
-        return setupSecurityQuestion({ 'features.mfaOnlyFlow': true }).then(function (test) {
+      itp('is not present if features.mfaOnlyFlow is true', function() {
+        return setupSecurityQuestion({ 'features.mfaOnlyFlow': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
 
-      itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+      itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function() {
         return setupSecurityQuestion()
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(RouterUtil, 'routeAfterAuthStatusChange').and.callThrough();
             Util.resetAjaxRequests();
@@ -2393,7 +2393,7 @@ Expect.describe('MFA Verify', function () {
             test.form.signoutLink($sandbox).click();
             return Expect.waitForPrimaryAuth(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
@@ -2409,20 +2409,20 @@ Expect.describe('MFA Verify', function () {
 
       itp(
         'has a signout link which cancels the current stateToken and redirects to the provided signout url',
-        function () {
+        function() {
           return setupSecurityQuestion({ signOutLink: 'http://www.goodbye.com' })
-            .then(function (test) {
+            .then(function(test) {
               spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
               spyOn(RouterUtil, 'routeAfterAuthStatusChange').and.callThrough();
               spyOn(SharedUtil, 'redirect');
               Util.resetAjaxRequests();
               test.setNextResponse(resCancel);
               test.form.signoutLink($sandbox).click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return RouterUtil.routeAfterAuthStatusChange.calls.count() > 0;
               }, test);
             })
-            .then(function (test) {
+            .then(function(test) {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/cancel',
@@ -2437,130 +2437,130 @@ Expect.describe('MFA Verify', function () {
         }
       );
     });
-    Expect.describe('Remember device', function () {
-      itp('is rendered', function () {
-        return setup(resAllFactors).then(function (test) {
+    Expect.describe('Remember device', function() {
+      itp('is rendered', function() {
+        return setup(resAllFactors).then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('has the right text for device based policy', function () {
-        return setupWithMfaPolicy({ minutes: 0 }).then(function (test) {
+      itp('has the right text for device based policy', function() {
+        return setupWithMfaPolicy({ minutes: 0 }).then(function(test) {
           expect(test.form.rememberDeviceLabelText()).toEqual('Do not challenge me on this device again');
         });
       });
-      itp('has the right text for time based policy (1 minute)', function () {
-        return setupWithMfaPolicy({ minutes: 1 }).then(function (test) {
+      itp('has the right text for time based policy (1 minute)', function() {
+        return setupWithMfaPolicy({ minutes: 1 }).then(function(test) {
           expect(test.form.rememberDeviceLabelText()).toEqual('Do not challenge me on this device for the next minute');
         });
       });
-      itp('has the right text for time based policy (minutes)', function () {
-        return setupWithMfaPolicy({ minutes: 15 }).then(function (test) {
+      itp('has the right text for time based policy (minutes)', function() {
+        return setupWithMfaPolicy({ minutes: 15 }).then(function(test) {
           expect(test.form.rememberDeviceLabelText()).toEqual(
             'Do not challenge me on this device for the next 15 minutes'
           );
         });
       });
-      itp('has the right text for time based policy (hours)', function () {
-        return setupWithMfaPolicy({ minutes: 120 }).then(function (test) {
+      itp('has the right text for time based policy (hours)', function() {
+        return setupWithMfaPolicy({ minutes: 120 }).then(function(test) {
           expect(test.form.rememberDeviceLabelText()).toEqual(
             'Do not challenge me on this device for the next 2 hours'
           );
         });
       });
-      itp('has the right text for time based policy (days)', function () {
-        return setupWithMfaPolicy({ minutes: 2880 }).then(function (test) {
+      itp('has the right text for time based policy (days)', function() {
+        return setupWithMfaPolicy({ minutes: 2880 }).then(function(test) {
           expect(test.form.rememberDeviceLabelText()).toEqual('Do not challenge me on this device for the next 2 days');
         });
       });
-      itp('is not rendered when policy is always ask for mfa', function () {
-        return setup(resMfaAlwaysPolicy, null, null, null, true).then(function (test) {
+      itp('is not rendered when policy is always ask for mfa', function() {
+        return setup(resMfaAlwaysPolicy, null, null, null, true).then(function(test) {
           expect(test.form.rememberDeviceCheckbox().length).toEqual(0);
         });
       });
-      itp('is checked by default if policy rememberDeviceByDefault is true', function () {
-        return setupWithMfaPolicy({ minutes: 15, byDefault: true }).then(function (test) {
+      itp('is checked by default if policy rememberDeviceByDefault is true', function() {
+        return setupWithMfaPolicy({ minutes: 15, byDefault: true }).then(function(test) {
           expect(test.form.isRememberDeviceChecked()).toBe(true);
         });
       });
-      itp('is not checked by default if policy rememberDeviceByDefault is false', function () {
-        return setupWithMfaPolicy({ minutes: 0 }).then(function (test) {
+      itp('is not checked by default if policy rememberDeviceByDefault is false', function() {
+        return setupWithMfaPolicy({ minutes: 0 }).then(function(test) {
           expect(test.form.isRememberDeviceChecked()).toBe(false);
         });
       });
     });
   });
 
-  Expect.describe('Factor types', function () {
-    Expect.describe('Security Question', function () {
+  Expect.describe('Factor types', function() {
+    Expect.describe('Security Question', function() {
       testSecurityQuestion(setupSecurityQuestion, setupSecurityQuestionLocalized, 'testStateToken');
     });
 
-    Expect.describe('TOTP', function () {
+    Expect.describe('TOTP', function() {
       testGoogleTOTP(setupGoogleTOTP, 'testStateToken');
-      itp('shows the right beacon for Okta TOTP', function () {
-        return setupOktaTOTP().then(function (test) {
+      itp('shows the right beacon for Okta TOTP', function() {
+        return setupOktaTOTP().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-verify');
         });
       });
-      itp('shows the right subtitle for Okta TOTP', function () {
-        return setupOktaTOTP().then(function (test) {
+      itp('shows the right subtitle for Okta TOTP', function() {
+        return setupOktaTOTP().then(function(test) {
           expectSubtitleToBe(test, 'Enter your Okta Verify passcode');
         });
       });
-      itp('no auto push checkbox for Okta TOTP', function () {
-        return setupOktaTOTP({ 'features.autoPush': true }).then(function (test) {
+      itp('no auto push checkbox for Okta TOTP', function() {
+        return setupOktaTOTP({ 'features.autoPush': true }).then(function(test) {
           expect(test.form.autoPushCheckbox().length).toBe(0);
         });
       });
-      itp('has a masked passCode field for RSA', function () {
-        return setupRsaTOTP().then(function (test) {
+      itp('has a masked passCode field for RSA', function() {
+        return setupRsaTOTP().then(function(test) {
           expectHasAnswerField(test, 'password');
         });
       });
-      itp('has a masked passCode field for On-Prem', function () {
-        return setupOnPremTOTP().then(function (test) {
+      itp('has a masked passCode field for On-Prem', function() {
+        return setupOnPremTOTP().then(function(test) {
           expectHasAnswerField(test, 'password');
         });
       });
-      itp('shows the right beacon for RSA TOTP', function () {
-        return setupRsaTOTP().then(function (test) {
+      itp('shows the right beacon for RSA TOTP', function() {
+        return setupRsaTOTP().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-rsa');
         });
       });
-      itp('shows the right beacon for On Prem TOTP', function () {
-        return setupOnPremTOTP().then(function (test) {
+      itp('shows the right beacon for On Prem TOTP', function() {
+        return setupOnPremTOTP().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-onprem');
         });
       });
 
-      itp('shows the right beacon for Symantec TOTP', function () {
-        return setupSymantecTOTP().then(function (test) {
+      itp('shows the right beacon for Symantec TOTP', function() {
+        return setupSymantecTOTP().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-symantec');
         });
       });
-      itp('clears input field value if error is for PIN change (RSA)', function () {
+      itp('clears input field value if error is for PIN change (RSA)', function() {
         return setupRsaTOTP()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resRSAChangePin);
             test.form.setAnswer('correct');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('Enter a new PIN having from 4 to 8 digits:');
             expect(test.form.answerField().val()).toEqual('');
           });
       });
-      itp('clears input field value if error is for PIN change (On-Prem)', function () {
+      itp('clears input field value if error is for PIN change (On-Prem)', function() {
         return setupOnPremTOTP()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resRSAChangePin);
             test.form.setAnswer('correct');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(test, 409, 'Enter a new PIN having from 4 to 8 digits:', 'mfa-verify', {
               status: 409,
               responseType: 'json',
@@ -2578,42 +2578,42 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Yubikey', function () {
-      itp('shows the right beacon for Yubikey', function () {
-        return setupYubikey().then(function (test) {
+    Expect.describe('Yubikey', function() {
+      itp('shows the right beacon for Yubikey', function() {
+        return setupYubikey().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-yubikey');
         });
       });
-      itp('has an answer field', function () {
-        return setupYubikey().then(function (test) {
+      itp('has an answer field', function() {
+        return setupYubikey().then(function(test) {
           expectHasAnswerField(test, 'password');
         });
       });
-      itp('has right label for answer field', function () {
-        return setupYubikey().then(function (test) {
+      itp('has right label for answer field', function() {
+        return setupYubikey().then(function(test) {
           const $answerLabel = test.form.answerLabel();
 
           expect($answerLabel.text().trim()).toEqual('Click here, then tap your YubiKey');
         });
       });
-      itp('does not autocomplete', function () {
-        return setupYubikey().then(function (test) {
+      itp('does not autocomplete', function() {
+        return setupYubikey().then(function(test) {
           expect(test.form.getAutocomplete()).toBe('off');
         });
       });
-      itp('shows the right title', function () {
-        return setupYubikey().then(function (test) {
+      itp('shows the right title', function() {
+        return setupYubikey().then(function(test) {
           expectTitleToBe(test, 'YubiKey');
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupYubikey().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupYubikey().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('disables the "verify button" when clicked', function () {
+      itp('disables the "verify button" when clicked', function() {
         return setupYubikey()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setAnswer('who cares');
             test.setNextResponse(resInvalid);
@@ -2625,7 +2625,7 @@ Expect.describe('MFA Verify', function () {
             expect(button.prop('disabled')).toBe(true);
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const button = test.form.submitButton();
             const buttonClass = button.attr('class');
 
@@ -2633,16 +2633,16 @@ Expect.describe('MFA Verify', function () {
             expect(button.prop('disabled')).toBe(false);
           });
       });
-      itp('calls authClient verifyFactor with correct args when submitted', function () {
+      itp('calls authClient verifyFactor with correct args when submitted', function() {
         return setupYubikey()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ykf2l0aUIe5VBplDj0g4/verify?rememberDevice=false',
@@ -2653,9 +2653,9 @@ Expect.describe('MFA Verify', function () {
             });
           });
       });
-      itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+      itp('calls authClient verifyFactor with rememberDevice URL param', function() {
         return setupYubikey()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.form.setRememberDevice(true);
@@ -2663,7 +2663,7 @@ Expect.describe('MFA Verify', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ykf2l0aUIe5VBplDj0g4/verify?rememberDevice=true',
@@ -2674,131 +2674,131 @@ Expect.describe('MFA Verify', function () {
             });
           });
       });
-      itp('sets the transaction on the appState on success response', function () {
+      itp('sets the transaction on the appState on success response', function() {
         return setupYubikey()
-          .then(function (test) {
+          .then(function(test) {
             mockTransactions(test.router.controller);
             test.form.setAnswer('123456');
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectSetTransaction(test.router, resSuccess);
           });
       });
-      itp('sets the transaction error on the appState on error response', function () {
+      itp('sets the transaction error on the appState on error response', function() {
         return setupYubikey()
-          .then(function (test) {
+          .then(function(test) {
             mockTransactions(test.router.controller);
             test.setNextResponse(resInvalid);
             test.form.setAnswer('wrong');
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectSetTransactionError(test.router, resInvalid);
           });
       });
     });
 
-    Expect.describe('SMS', function () {
+    Expect.describe('SMS', function() {
       testSms(setupSMS, resChallengeSms, resSuccess, 'testStateToken');
     });
 
-    Expect.describe('Call', function () {
+    Expect.describe('Call', function() {
       testCall(setupCall, resChallengeCall, resSuccess, 'testStateToken');
     });
 
-    Expect.describe('Okta Push', function () {
+    Expect.describe('Okta Push', function() {
       // Remember device for Push form exists out of the form.
-      function getRememberDeviceForPushForm (test) {
+      function getRememberDeviceForPushForm(test) {
         const rememberDevice = test.router.controller.$('[data-se="o-form-input-rememberDevice"]');
         const checkbox = rememberDevice.find(':checkbox');
 
         return checkbox;
       }
-      function setRememberDeviceForPushForm (test, val) {
+      function setRememberDeviceForPushForm(test, val) {
         const checkbox = getRememberDeviceForPushForm(test);
 
         checkbox.prop('checked', val);
         checkbox.trigger('change');
       }
-      function getAutoPushCheckbox (test) {
+      function getAutoPushCheckbox(test) {
         const autoPush = test.router.controller.$('[data-se="o-form-input-autoPush"]');
         const checkbox = autoPush.find(':checkbox');
 
         return checkbox;
       }
-      function setAutoPushCheckbox (test, val) {
+      function setAutoPushCheckbox(test, val) {
         const checkbox = getAutoPushCheckbox(test);
 
         checkbox.prop('checked', val);
         checkbox.trigger('change');
       }
-      function getAutoPushLabel (test) {
+      function getAutoPushLabel(test) {
         const autoPush = test.router.controller.$('[data-se="o-form-input-autoPush"]');
         const autoPushLabel = autoPush.find('Label').text();
 
         return autoPushLabel;
       }
-      itp('has push without totp when totp is not in the factors list', function () {
-        return setupOktaPushWithRefreshAuth().then(function (test) {
+      itp('has push without totp when totp is not in the factors list', function() {
+        return setupOktaPushWithRefreshAuth().then(function(test) {
           expect(test.form.isPush()).toBe(true);
         });
       });
-      itp('has push and an inline totp form when totp is available', function () {
-        return setupOktaPushWithTOTP().then(function (test) {
+      itp('has push and an inline totp form when totp is available', function() {
+        return setupOktaPushWithTOTP().then(function(test) {
           expect(test.form[0].isPush()).toBe(true);
           expect(test.form[1].isInlineTOTP()).toBe(true);
         });
       });
-      itp('shows the right beacon', function () {
-        return setupOktaPush().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupOktaPush().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-verify');
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupOktaPush().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupOktaPush().then(function(test) {
           Expect.isVisible(getRememberDeviceForPushForm(test));
         });
       });
 
-      Expect.describe('Auto Push', function () {
-        itp('has auto push checkbox', function () {
-          return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+      Expect.describe('Auto Push', function() {
+        itp('has auto push checkbox', function() {
+          return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
             Expect.isVisible(getAutoPushCheckbox(test));
           });
         });
-        itp('auto push has the right text', function () {
-          return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+        itp('auto push has the right text', function() {
+          return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
             expect(getAutoPushLabel(test)).toEqual('Send push automatically');
           });
         });
-        itp('has no auto push checkbox when feature is off', function () {
-          return setupOktaPush({ 'features.autoPush': false }).then(function (test) {
+        itp('has no auto push checkbox when feature is off', function() {
+          return setupOktaPush({ 'features.autoPush': false }).then(function(test) {
             expect(getAutoPushCheckbox(test).length).toBe(0);
           });
         });
       });
-      Expect.describe('Push', function () {
-        itp('shows a title that includes the device name', function () {
-          return setupOktaPushWithIntrospect().then(function (test) {
+      Expect.describe('Push', function() {
+        itp('shows a title that includes the device name', function() {
+          return setupOktaPushWithIntrospect().then(function(test) {
             expect(test.form.titleText()).toBe('Okta Verify (Test iPhone)');
           });
         });
-        itp('calls authClient verifyFactor with correct args when submitted', function () {
+        itp('calls authClient verifyFactor with correct args when submitted', function() {
           return setupOktaPushWithIntrospect()
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               setRememberDeviceForPushForm(test, true);
               test.setNextResponse(resSuccess);
               test.form.submit();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return Util.numAjaxRequests() > 0;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify?rememberDevice=true',
@@ -2808,18 +2808,18 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        itp('calls authClient verifyFactor with correct args when autoPush is checked', function () {
+        itp('calls authClient verifyFactor with correct args when autoPush is checked', function() {
           return setupOktaPushWithRefreshAuth({ 'features.autoPush': true })
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               setAutoPushCheckbox(test, true);
               test.setNextResponse(resSuccess);
               test.form.submit();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return Util.numAjaxRequests() > 0;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
@@ -2830,18 +2830,18 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        itp('calls authClient verifyFactor with correct args when autoPush is not checked', function () {
+        itp('calls authClient verifyFactor with correct args when autoPush is not checked', function() {
           return setupOktaPushWithRefreshAuth({ 'features.autoPush': true })
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               setAutoPushCheckbox(test, false);
               test.setNextResponse(resSuccess);
               test.form.submit();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return Util.numAjaxRequests() > 0;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/opfhw7v2OnxKpftO40g3/verify' +
@@ -2852,11 +2852,11 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        Expect.describe('polling', function () {
-          itp('will pass rememberMe on the first request', function () {
-            return setupOktaPush().then(function (test) {
+        Expect.describe('polling', function() {
+          itp('will pass rememberMe on the first request', function() {
+            return setupOktaPush().then(function(test) {
               setRememberDeviceForPushForm(test, true);
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(Util.numAjaxRequests()).toBe(3);
                 // initial verifyFactor call
                 Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2884,10 +2884,10 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('will pass autoPush as true if checkbox checked during polling', function () {
-            return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+          itp('will pass autoPush as true if checkbox checked during polling', function() {
+            return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
               setAutoPushCheckbox(test, true);
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(Util.numAjaxRequests()).toBe(3);
                 // initial verifyFactor call
                 Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2918,10 +2918,10 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('will pass autoPush as false if checkbox unchecked during polling', function () {
-            return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+          itp('will pass autoPush as false if checkbox unchecked during polling', function() {
+            return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
               setAutoPushCheckbox(test, false);
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(Util.numAjaxRequests()).toBe(3);
                 // initial verifyFactor call
                 Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2952,11 +2952,11 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('will pass rememberDevice as true if checkbox checked during polling', function () {
-            return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+          itp('will pass rememberDevice as true if checkbox checked during polling', function() {
+            return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
               setAutoPushCheckbox(test, true);
               setRememberDeviceForPushForm(test, true);
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(Util.numAjaxRequests()).toBe(3);
                 // initial verifyFactor call
                 Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2987,11 +2987,11 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('will pass rememberDevice as true if checkbox checked during polling and autoPush is false', function () {
-            return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+          itp('will pass rememberDevice as true if checkbox checked during polling and autoPush is false', function() {
+            return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
               setAutoPushCheckbox(test, false);
               setRememberDeviceForPushForm(test, true);
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(Util.numAjaxRequests()).toBe(3);
                 // initial verifyFactor call
                 Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -3022,26 +3022,26 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('will disable form submit', function () {
-            return setupOktaPush().then(function (test) {
+          itp('will disable form submit', function() {
+            return setupOktaPush().then(function(test) {
               return setupPolling(test, resSuccess)
-                .then(function () {
+                .then(function() {
                   expect(test.form.submitButton().attr('class')).toMatch('link-button-disabled');
                   expect(test.form.submitButton().prop('disabled')).toBe(true);
                   Util.resetAjaxRequests();
                   test.form.submit();
                   return tick(test); // Final tick - SUCCESS
                 })
-                .then(function () {
+                .then(function() {
                   expect(Util.numAjaxRequests()).toBe(0);
                 });
             });
           });
-          itp('on SUCCESS, sets transaction, polling stops and form is submitted', function () {
-            return setupOktaPush().then(function (test) {
+          itp('on SUCCESS, sets transaction, polling stops and form is submitted', function() {
+            return setupOktaPush().then(function(test) {
               spyOn(test.router.controller.model, 'setTransaction').and.callThrough();
               spyOn(test.router.settings, 'callGlobalSuccess');
-              return setupPolling(test, resSuccess).then(function () {
+              return setupPolling(test, resSuccess).then(function() {
                 expect(test.router.settings.callGlobalSuccess).toHaveBeenCalled();
                 // One after first poll returns and one after polling finished.
                 const calls = test.router.controller.model.setTransaction.calls;
@@ -3052,24 +3052,24 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('sets transaction state to MFA_CHALLENGE before poll', function () {
-            return setupOktaPushWithIntrospect().then(function (test) {
+          itp('sets transaction state to MFA_CHALLENGE before poll', function() {
+            return setupOktaPushWithIntrospect().then(function(test) {
               Util.resetAjaxRequests();
               test.setNextResponse(resChallengePush);
               test.form.submit();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
               });
             });
           });
-          itp('starts poll after a delay of 4000ms', function () {
+          itp('starts poll after a delay of 4000ms', function() {
             let callAfterTimeoutStub;
 
             return setupOktaPushWithIntrospect()
-              .then(function (test) {
-                spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function (pullPromiseResolver) {
+              .then(function(test) {
+                spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function(pullPromiseResolver) {
                   // setup a deterministic callAfterTimeout stub
-                  callAfterTimeoutStub = function () {
+                  callAfterTimeoutStub = function() {
                     pullPromiseResolver();
                   };
                 });
@@ -3083,7 +3083,7 @@ Expect.describe('MFA Verify', function () {
                 // wait for callAfterTimeout to be called at `models/Factor#save`
                 return Expect.waitForSpyCall(LoginUtil.callAfterTimeout, test);
               })
-              .then(function (test) {
+              .then(function(test) {
                 expect(LoginUtil.callAfterTimeout.calls.argsFor(0)[1]).toBe(4000);
                 expect(test.router.controller.model.appState.get('transaction').status).toBe('MFA_CHALLENGE');
                 const transaction = test.router.controller.model.appState.get('transaction');
@@ -3093,7 +3093,7 @@ Expect.describe('MFA Verify', function () {
                 callAfterTimeoutStub();
                 return Expect.waitForSpyCall(transaction.poll, transaction);
               })
-              .then(function (transaction) {
+              .then(function(transaction) {
                 expect(transaction.poll.calls.count()).toBe(1);
                 expect(transaction.poll).toHaveBeenCalledWith({
                   delay: 4000,
@@ -3101,21 +3101,21 @@ Expect.describe('MFA Verify', function () {
                 });
               });
           });
-          itp('does not start polling if factor was switched before the initial poll delay', function () {
+          itp('does not start polling if factor was switched before the initial poll delay', function() {
             return setupOktaPushWithTOTP()
-              .then(function (test) {
-                spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
+              .then(function(test) {
+                spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function() {
                   // reducing the timeout to 100 so that test is fast.
                   return setTimeout(arguments[0], 100);
                 });
                 Util.resetAjaxRequests();
                 test.setNextResponse([resChallengePush, resAllFactors, resInvalid]);
                 test.form[0].submit();
-                return Expect.wait(function () {
+                return Expect.wait(function() {
                   return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
                 }, test);
               })
-              .then(function (test) {
+              .then(function(test) {
                 const deferred = Q.defer();
 
                 expect(test.router.controller.model.appState.get('transaction').status).toBe('MFA_CHALLENGE');
@@ -3126,38 +3126,38 @@ Expect.describe('MFA Verify', function () {
                 clickFactorInDropdown(test, 'DUO');
                 expect(test.router.controller.model.appState.trigger).toHaveBeenCalledWith('factorSwitched');
                 setTimeout(deferred.resolve, 150);
-                return deferred.promise.then(function () {
+                return deferred.promise.then(function() {
                   expect(transaction.poll).not.toHaveBeenCalled();
                 });
               });
           });
-          itp('stops listening on factorSwitched when we start polling', function () {
-            spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
+          itp('stops listening on factorSwitched when we start polling', function() {
+            spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function() {
               return setTimeout(arguments[0]);
             });
             let stopListening;
             let appState;
 
             return setupOktaPushWithIntrospect()
-              .then(function (test) {
+              .then(function(test) {
                 appState = test.router.controller.model.appState;
                 stopListening = spyOn(test.router.controller.model, 'stopListening').and.callThrough();
                 test.setNextResponse([resChallengePush, resInvalid]);
                 test.form.submit();
                 expect(test.form.submitButton().prop('disabled')).toBe(true);
-                return Expect.wait(function () {
+                return Expect.wait(function() {
                   return stopListening.calls.count() > 0;
                 }, test);
               })
-              .then(function (test) {
+              .then(function(test) {
                 expect(stopListening).toHaveBeenCalledWith(appState, 'factorSwitched');
               });
           });
-          itp('on REJECTED, re-enables submit, displays an error, and allows resending', function () {
-            return setupOktaPush().then(function (test) {
+          itp('on REJECTED, re-enables submit, displays an error, and allows resending', function() {
+            return setupOktaPush().then(function(test) {
               return (setupPolling(test, resRejectedPush)
               // Final response - REJECTED
-                .then(function (test) {
+                .then(function(test) {
                   expect(test.form.errorMessage()).toBe('You have chosen to reject this login.');
                   expect(test.form.submitButton().prop('disabled')).toBe(false);
 
@@ -3178,7 +3178,7 @@ Expect.describe('MFA Verify', function () {
                       return Expect.waitForAjaxRequests(3, test); // 3: resSuccess
                     });
                 })
-                .then(function () {
+                .then(function() {
                   expect(Util.numAjaxRequests()).toBe(3);
 
                   // initial resendByName call
@@ -3209,11 +3209,11 @@ Expect.describe('MFA Verify', function () {
           });
           itp(
             'on REJECTED requiring app upgrade on ios, re-enables submit, displays an error, and allows resending',
-            function () {
-              return setupOktaPush().then(function (test) {
+            function() {
+              return setupOktaPush().then(function(test) {
                 return (setupPolling(test, resRejectedPushAppUpgrade)
                 // Final response - REJECTED - requires app upgrade
-                  .then(function (test) {
+                  .then(function(test) {
                     expect(test.form.errorMessage()).toBe(
                       'Verification failed because your Okta Verify version is no longer supported. To sign in, please update Okta Verify on the App Store, then try again.'
                     );
@@ -3226,7 +3226,7 @@ Expect.describe('MFA Verify', function () {
                     // Click submit
                     test.form.submit();
                   })
-                  .then(function () {
+                  .then(function() {
                     return Expect.waitForAjaxRequests(1, test) // 1: resChallengePush
                       .then(() => {
                         Util.callAllTimeouts();
@@ -3237,7 +3237,7 @@ Expect.describe('MFA Verify', function () {
                         return Expect.waitForAjaxRequests(3, test); // 3: resSuccess
                       });
                   })
-                  .then(function () {
+                  .then(function() {
                     expect(Util.numAjaxRequests()).toBe(3);
 
                     // initial resendByName call
@@ -3269,16 +3269,16 @@ Expect.describe('MFA Verify', function () {
           );
           itp(
             'on REJECTED requiring app upgrade on android, re-enables submit, displays an error, and allows resending',
-            function () {
+            function() {
               const resRejectedPushAppUpgradeAndroid = deepClone(resRejectedPushAppUpgrade);
               resRejectedPushAppUpgradeAndroid.response._embedded.factor.profile.platform = 'ANDROID';
-              return setupOktaPush().then(function (test) {
+              return setupOktaPush().then(function(test) {
                 // setting the platform as android in intial poll response too.
                 const resChallengePushAndroid = deepClone(resChallengePush);
                 resChallengePushAndroid.response._embedded.factor.profile.platform = 'ANDROID';
                 return (setupPolling(test, resRejectedPushAppUpgradeAndroid, resChallengePushAndroid)
                 // Final response - REJECTED - requires app upgrade
-                  .then(function (test) {
+                  .then(function(test) {
                     expect(test.form.errorMessage()).toBe(
                       'Verification failed because your Okta Verify version is no longer supported. To sign in, please update Okta Verify on Google Play, then try again.'
                     );
@@ -3291,7 +3291,7 @@ Expect.describe('MFA Verify', function () {
                     // Click submit
                     test.form.submit();
                   })
-                  .then(function () {
+                  .then(function() {
                     return Expect.waitForAjaxRequests(1, test) // 1: resChallengePush
                       .then(() => {
                         Util.callAllTimeouts();
@@ -3302,7 +3302,7 @@ Expect.describe('MFA Verify', function () {
                         return Expect.waitForAjaxRequests(3, test); // 3: resSuccess
                       });
                   })
-                  .then(function () {
+                  .then(function() {
                     expect(Util.numAjaxRequests()).toBe(3);
 
                     // initial resendByName call
@@ -3332,20 +3332,20 @@ Expect.describe('MFA Verify', function () {
               });
             }
           );
-          itp('on TIMEOUT, re-enables submit, displays an error, and allows resending', function () {
-            return setupOktaPush().then(function (test) {
+          itp('on TIMEOUT, re-enables submit, displays an error, and allows resending', function() {
+            return setupOktaPush().then(function(test) {
               return (setupPolling(test, resTimeoutPush)
               // Final response - TIMEOUT
-                .then(function (test) {
+                .then(function(test) {
                   expect(test.form.errorMessage()).toBe('Your push notification has expired.');
                   expect(test.form.submitButton().prop('disabled')).toBe(false);
                 }) );
             });
           });
-          itp('re-enables submit and displays an error when request fails', function () {
-            function setupFailurePolling (test) {
+          itp('re-enables submit and displays an error when request fails', function() {
+            function setupFailurePolling(test) {
               // This is to reduce delay before initiating polling in the tests.
-              spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
+              spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function() {
                 return setTimeout(arguments[0]);
               });
               const failureResponse = { status: 0, response: {} };
@@ -3395,12 +3395,12 @@ Expect.describe('MFA Verify', function () {
                   return Expect.waitForFormError(test.form, test);
                 });
             }
-            return setupOktaPushWithIntrospect().then(function (test) {
+            return setupOktaPushWithIntrospect().then(function(test) {
               spyOn(test.router.settings, 'callGlobalError');
               Q.stopUnhandledRejectionTracking();
               return (setupFailurePolling(test)
               // Final response - failed
-                .then(function (test) {
+                .then(function(test) {
                   expect(test.form.errorMessage()).toBe(
                     'Unable to connect to the server. Please check your network connection.'
                   );
@@ -3408,9 +3408,9 @@ Expect.describe('MFA Verify', function () {
                 }) );
             });
           });
-          itp('on WARNING_TIMEOUT, shows warning message', function () {
-            return setupOktaPush().then(function (test) {
-              return setupPolling(test, resSuccess).then(function (test) {
+          itp('on WARNING_TIMEOUT, shows warning message', function() {
+            return setupOktaPush().then(function(test) {
+              return setupPolling(test, resSuccess).then(function(test) {
                 expect(test.form.warningMessage()).toBe(
                   'Haven\'t received a push notification yet? Try opening the Okta Verify App on your phone.'
                 );
@@ -3418,9 +3418,9 @@ Expect.describe('MFA Verify', function () {
               });
             });
           });
-          itp('removes warnings and displays error when an error occurs', function () {
-            function setupFailurePolling (test) {
-              spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function () {
+          itp('removes warnings and displays error when an error occurs', function() {
+            function setupFailurePolling(test) {
+              spyOn(LoginUtil, 'callAfterTimeout').and.callFake(function() {
                 return setTimeout(arguments[0]);
               });
               const failureResponse = { status: 0, response: {} };
@@ -3463,16 +3463,16 @@ Expect.describe('MFA Verify', function () {
                   return Expect.waitForAjaxRequests(7, test); // 7: failureResponse
                 })
                 .then(() => {
-                  return Expect.wait(function () {
+                  return Expect.wait(function() {
                     return test.form.hasWarningMessage();
                   }, test);
                 });
             }
-            return setupOktaPushWithIntrospect().then(function (test) {
+            return setupOktaPushWithIntrospect().then(function(test) {
               spyOn(test.router.settings, 'callGlobalError');
               Q.stopUnhandledRejectionTracking();
               return setupFailurePolling(test)
-                .then(function (test) {
+                .then(function(test) {
                   expect(test.form.submitButton().prop('disabled')).toBe(true);
                   expect(test.form.submitButtonText()).toBe('Push sent!');
                   expect(test.form.$('.accessibility-text').text().trim()).toBe('Push sent!');
@@ -3482,7 +3482,7 @@ Expect.describe('MFA Verify', function () {
                   Util.callAllTimeouts();
                   return Expect.waitForFormError(test.form, test);
                 })
-                .then(function (test) {
+                .then(function(test) {
                   expect(test.form.errorMessage()).toBe(
                     'Unable to connect to the server. Please check your network connection.'
                   );
@@ -3493,15 +3493,15 @@ Expect.describe('MFA Verify', function () {
           });
         });
       });
-      Expect.describe('TOTP', function () {
-        itp('has a link to enter code', function () {
-          return setupOktaPushWithTOTP().then(function (test) {
+      Expect.describe('TOTP', function() {
+        itp('has a link to enter code', function() {
+          return setupOktaPushWithTOTP().then(function(test) {
             Expect.isLink(test.form[1].inlineTOTPAdd());
             expect(test.form[1].inlineTOTPAddText()).toEqual('Or enter code');
           });
         });
-        itp('removes link when clicking it and replaces with totp form', function () {
-          return setupOktaPushWithTOTP().then(function (test) {
+        itp('removes link when clicking it and replaces with totp form', function() {
+          return setupOktaPushWithTOTP().then(function(test) {
             const form = test.form[1];
 
             form.inlineTOTPAdd().click();
@@ -3511,19 +3511,19 @@ Expect.describe('MFA Verify', function () {
             expect(test.form[1].inlineTOTPVerifyText()).toEqual('Verify');
           });
         });
-        itp('calls authClient verifyFactor with correct args when submitted', function () {
+        itp('calls authClient verifyFactor with correct args when submitted', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
               test.setNextResponse(resSuccess);
               test.form[1].inlineTOTPVerify().click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return Util.numAjaxRequests() > 0;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=false',
@@ -3534,27 +3534,27 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        itp('clears any errors from push when submitting inline totp', function () {
+        itp('clears any errors from push when submitting inline totp', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               const pushForm = test.form[0];
               const inlineForm = test.form[1];
 
               return (setupPolling(test, resRejectedPush)
-                .then(function () {
-                  return Expect.wait(function () {
+                .then(function() {
+                  return Expect.wait(function() {
                     return Util.numAjaxRequests() === 3;
                   }, test);
                 })
               // Final response - REJECTED
-                .then(function () {
+                .then(function() {
                   return Expect.waitForFormError(pushForm, {
                     test: test,
                     inlineForm: inlineForm,
                   });
                 }) );
             })
-            .then(function (res) {
+            .then(function(res) {
               expect(res.test.form.errorMessage()).toBe('You have chosen to reject this login.');
               res.inlineForm.inlineTOTPAdd().click();
               res.inlineForm.setAnswer('654321');
@@ -3562,24 +3562,24 @@ Expect.describe('MFA Verify', function () {
               res.inlineForm.inlineTOTPVerify().click();
               return Expect.waitForSpyCall(res.test.successSpy, res.test);
             })
-            .then(function (test) {
+            .then(function(test) {
               expect(test.form.hasErrors()).toBe(false);
             });
         });
-        itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+        itp('calls authClient verifyFactor with rememberDevice URL param', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
               setRememberDeviceForPushForm(test, true);
               test.setNextResponse(resSuccess);
               test.form[1].inlineTOTPVerify().click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return Util.numAjaxRequests() > 0;
               }, test);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=true',
@@ -3590,9 +3590,9 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        itp('shows an error if error response from authClient', function () {
+        itp('shows an error if error response from authClient', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               const form = test.form[1];
 
               form.inlineTOTPAdd().click();
@@ -3600,18 +3600,18 @@ Expect.describe('MFA Verify', function () {
               test.setNextResponse(resInvalidTotp);
               form.setAnswer('wrong');
               form.inlineTOTPVerify().click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 return form.hasErrors();
               }, form);
             })
-            .then(function (form) {
+            .then(function(form) {
               expect(form.hasErrors()).toBe(true);
               expect(form.errorMessage()).toBe('Invalid Passcode/Answer');
             });
         });
-        itp('shows errors if verify button is clicked and answer is empty', function () {
+        itp('shows errors if verify button is clicked and answer is empty', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               const form = test.form[1];
 
               Util.resetAjaxRequests();
@@ -3619,15 +3619,15 @@ Expect.describe('MFA Verify', function () {
               form.inlineTOTPVerify().click();
               return Expect.waitForFormError(form, form);
             })
-            .then(function (form) {
+            .then(function(form) {
               expect(Util.numAjaxRequests()).toBe(0);
               expect(form.errorMessage()).toBe('We found some errors. Please review the form and make corrections.');
               expect(form.passCodeErrorField().text()).toBe('This field cannot be left blank');
             });
         });
-        itp('clears previous error when submitting empty totp', function () {
+        itp('clears previous error when submitting empty totp', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               const form = test.form[1];
 
               form.inlineTOTPAdd().click();
@@ -3637,7 +3637,7 @@ Expect.describe('MFA Verify', function () {
               form.inlineTOTPVerify().click();
               return Expect.waitForFormError(form, form);
             })
-            .then(function (form) {
+            .then(function(form) {
               form.setAnswer('');
               // clicks are throttled with 100ms.
               // _.thrrottle cannot be mocked by jasmine.clock.tick
@@ -3645,37 +3645,37 @@ Expect.describe('MFA Verify', function () {
               setTimeout(() => {
                 form.inlineTOTPVerify().click();
               }, 100);
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 // Not waiting for form error but rather wait for a specific error to differentiate
                 // between two errors.
                 return form.errorMessage() === 'We found some errors. Please review the form and make corrections.';
               }, form);
             })
-            .then(function (form) {
+            .then(function(form) {
               expect(form.getErrors().length).toBe(1);
             });
         });
-        itp('sets the transaction on the appState on success response', function () {
+        itp('sets the transaction on the appState on success response', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               mockTransactions(test.router.controller, true);
               test.form[1].inlineTOTPAdd().click();
               test.form[1].setAnswer('654321');
               test.setNextResponse(resSuccess);
               test.form[1].inlineTOTPVerify().click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 const model = test.router.controller.model.get('backupFactor');
 
                 return model.setTransaction.calls.count() > 0;
               }, test);
             })
-            .then(function (test) {
+            .then(function(test) {
               expectSetTransaction(test.router, resSuccess, true);
             });
         });
-        itp('sets the transaction error on the appState on error response', function () {
+        itp('sets the transaction error on the appState on error response', function() {
           return setupOktaPushWithTOTP()
-            .then(function (test) {
+            .then(function(test) {
               mockTransactions(test.router.controller, true);
               Q.stopUnhandledRejectionTracking();
               test.setNextResponse(resInvalidTotp);
@@ -3684,49 +3684,49 @@ Expect.describe('MFA Verify', function () {
               form.inlineTOTPAdd().click();
               form.setAnswer('wrong');
               form.inlineTOTPVerify().click();
-              return Expect.wait(function () {
+              return Expect.wait(function() {
                 const model = test.router.controller.model.get('backupFactor');
 
-                return model.trigger.calls.allArgs().filter(function (a) {
+                return model.trigger.calls.allArgs().filter(function(a) {
                   return a.length && a[0] === 'setTransactionError';
                 }).length;
               }, test);
             })
-            .then(function (test) {
+            .then(function(test) {
               expectSetTransactionError(test.router, resInvalidTotp, true);
             });
         });
       });
     });
 
-    Expect.describe('Duo', function () {
-      itp('is duo', function () {
-        return setupDuo().then(function (test) {
+    Expect.describe('Duo', function() {
+      itp('is duo', function() {
+        return setupDuo().then(function(test) {
           expect(test.form.isDuo()).toBe(true);
         });
       });
-      itp('shows the right beacon', function () {
-        return setupDuo().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupDuo().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-duo');
         });
       });
-      itp('shows the right title', function () {
-        return setupDuo().then(function (test) {
+      itp('shows the right title', function() {
+        return setupDuo().then(function(test) {
           expectTitleToBe(test, 'Duo Security');
         });
       });
-      itp('iframe has title', function () {
-        return setupDuo().then(function (test) {
+      itp('iframe has title', function() {
+        return setupDuo().then(function(test) {
           expect(test.form.$('iframe').attr('title')).toBe(test.form.titleText());
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupDuo().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupDuo().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('makes the right init request', function () {
-        return setupDuo().then(function () {
+      itp('makes the right init request', function() {
+        return setupDuo().then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
           Expect.isJsonPost(Util.getAjaxRequest(1), {
             url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify?rememberDevice=false',
@@ -3736,24 +3736,24 @@ Expect.describe('MFA Verify', function () {
           });
         });
       });
-      itp('has a sign out link', function () {
-        return setupDuo().then(function (test) {
+      itp('has a sign out link', function() {
+        return setupDuo().then(function(test) {
           Expect.isVisible(test.form.signoutLink($sandbox));
         });
       });
-      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
-        return setupDuo({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
+        return setupDuo({ 'features.hideSignOutLinkInMFA': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
-        return setupDuo({ 'features.mfaOnlyFlow': true }).then(function (test) {
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
+        return setupDuo({ 'features.mfaOnlyFlow': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('makes the correct request when rememberDevice is checked', function () {
+      itp('makes the correct request when rememberDevice is checked', function() {
         return setupDuo()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setRememberDevice(true);
             test.setNextResponse(resSuccess);
@@ -3768,7 +3768,7 @@ Expect.describe('MFA Verify', function () {
             postAction('someSignedResponse');
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(2);
             Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify?rememberDevice=true',
@@ -3778,8 +3778,8 @@ Expect.describe('MFA Verify', function () {
             });
           });
       });
-      itp('initializes duo correctly', function () {
-        return setupDuo().then(function (test) {
+      itp('initializes duo correctly', function() {
+        return setupDuo().then(function(test) {
           const initOptions = Duo.init.calls.mostRecent().args[0];
 
           expect(initOptions.host).toBe('api123443.duosecurity.com');
@@ -3788,9 +3788,9 @@ Expect.describe('MFA Verify', function () {
           expect(_.isFunction(initOptions.post_action)).toBe(true);
         });
       });
-      itp('notifies okta when duo is done, and completes verification', function () {
+      itp('notifies okta when duo is done, and completes verification', function() {
         return setupDuo()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             // Duo callback (returns an empty response)
@@ -3804,7 +3804,7 @@ Expect.describe('MFA Verify', function () {
             postAction('someSignedResponse');
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(2);
             Expect.isFormPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/ost947vv5GOSPjt9C0g4/verify/response',
@@ -3824,52 +3824,52 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Windows Hello', function () {
-      itp('shows the right beacon for Windows Hello', function () {
-        return emulateNotWindows().then(setupWindowsHello).then(function (test) {
+    Expect.describe('Windows Hello', function() {
+      itp('shows the right beacon for Windows Hello', function() {
+        return emulateNotWindows().then(setupWindowsHello).then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-windows-hello');
         });
       });
 
-      itp('displays error message if not Windows', function () {
-        return emulateNotWindows().then(setupWindowsHello).then(function (test) {
+      itp('displays error message if not Windows', function() {
+        return emulateNotWindows().then(setupWindowsHello).then(function(test) {
           expect(test.form.el('o-form-error-html').length).toBe(1);
           expect(test.form.submitButton().length).toBe(0);
         });
       });
 
-      itp('does not display error message if Windows', function () {
-        return emulateWindows().then(setupWindowsHello).then(function (test) {
+      itp('does not display error message if Windows', function() {
+        return emulateWindows().then(setupWindowsHello).then(function(test) {
           expect(test.form.el('o-form-error-html').length).toBe(0);
           expect(test.form.submitButton().length).toBe(1);
         });
       });
 
-      itp('has a sign out link', function () {
-        return setupWindowsHello().then(function (test) {
+      itp('has a sign out link', function() {
+        return setupWindowsHello().then(function(test) {
           Expect.isVisible(test.form.signoutLink($sandbox));
         });
       });
-      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
-        return setupWindowsHello({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
+        return setupWindowsHello({ 'features.hideSignOutLinkInMFA': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
-        return setupWindowsHello({ 'features.mfaOnlyFlow': true }).then(function (test) {
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
+        return setupWindowsHello({ 'features.mfaOnlyFlow': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
 
-      itp('calls webauthn.getAssertion and verifies factor', function () {
+      itp('calls webauthn.getAssertion and verifies factor', function() {
         return emulateWindows()
           .then(setupWindowsHello)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeWindowsHello, resSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(webauthn.getAssertion).toHaveBeenCalledWith('NONCE', [{ id: 'credentialId' }]);
             expect(Util.numAjaxRequests()).toBe(3);
             Expect.isJsonPost(Util.getAjaxRequest(2), {
@@ -3884,29 +3884,29 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('does not show error if webauthn.getAssertion fails with AbortError', function () {
+      itp('does not show error if webauthn.getAssertion fails with AbortError', function() {
         return emulateWindows('AbortError')
           .then(setupWindowsHello)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeWindowsHello);
             test.form.submit();
             return Expect.waitForSpyCall(webauthn.getAssertion, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.el('o-form-error-html').length).toBe(0);
             expect(Util.numAjaxRequests()).toBe(2);
           });
       });
 
-      itp('shows error if webauthn.getAssertion fails with NotSupportedError', function () {
+      itp('shows error if webauthn.getAssertion fails with NotSupportedError', function() {
         return emulateWindows('NotSupportedError')
           .then(setupWindowsHello)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeWindowsHello);
             test.form.submit();
             return Expect.waitForFormErrorBox(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(webauthn.getAssertion.calls.count()).toBe(1);
             expect(test.form.errorBox().length).toBe(1);
             expect(test.form.errorBox().text().trim()).toBe(
@@ -3917,15 +3917,15 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('shows error if webauthn.getAssertion fails with NotFound', function () {
+      itp('shows error if webauthn.getAssertion fails with NotFound', function() {
         return emulateWindows('NotFoundError')
           .then(setupWindowsHello)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeWindowsHello);
             test.form.submit();
             return Expect.waitForFormErrorBox(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(webauthn.getAssertion.calls.count()).toBe(1);
             expect(test.form.errorBox().length).toBe(1);
             expect(test.form.errorBox().text().trim()).toBe(
@@ -3936,10 +3936,10 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('subtitle changes after submitting the form', function () {
+      itp('subtitle changes after submitting the form', function() {
         return emulateWindows()
           .then(setupWindowsHello)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeWindowsHello, resSuccess]);
             expect(test.form.subtitleText()).toBe('Verify your identity with Windows Hello');
             expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(false);
@@ -3951,23 +3951,23 @@ Expect.describe('MFA Verify', function () {
             spyOn(test.router.controller.model, 'trigger').and.callThrough();
             return Expect.waitForSpyCall(webauthn.getAssertion, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             return Expect.wait(() => {
               const allArgs = test.router.controller.model.trigger.calls.allArgs();
               const flattedArgs = Array.prototype.concat.apply([], allArgs);
               return flattedArgs.includes('sync') && flattedArgs.includes('signIn');
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.subtitleText()).toBe('Signing in...');
             expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(true);
           });
       });
 
-      itp('subtitle changes after submitting the form to correct subtitle if config has a brandName', function () {
+      itp('subtitle changes after submitting the form to correct subtitle if config has a brandName', function() {
         return emulateWindows()
           .then(setupWindowsHelloWithBrandName)
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeWindowsHello, resSuccess]);
             expect(test.form.subtitleText()).toBe('Verify your identity with Windows Hello');
             expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(false);
@@ -3979,21 +3979,21 @@ Expect.describe('MFA Verify', function () {
             spyOn(test.router.controller.model, 'trigger').and.callThrough();
             return Expect.waitForSpyCall(webauthn.getAssertion, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             return Expect.wait(() => {
               const allArgs = test.router.controller.model.trigger.calls.allArgs();
               const flattedArgs = Array.prototype.concat.apply([], allArgs);
               return flattedArgs.includes('sync') && flattedArgs.includes('signIn');
             }, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.subtitleText()).toBe('Signing in to Spaghetti Inc....');
             expect(test.form.$('.o-form-button-bar').hasClass('hide')).toBe(true);
           });
       });
 
-      itp('automatically triggers Windows Hello only once', function () {
-        return emulateWindows().then(setupWindowsHelloOnly).then(function (test) {
+      itp('automatically triggers Windows Hello only once', function() {
+        return emulateWindows().then(setupWindowsHelloOnly).then(function(test) {
           expect(test.router.controller.model.get('__autoTriggered__')).toBe(true);
           spyOn(test.router.controller.model, 'save');
           test.router.controller.postRender();
@@ -4002,23 +4002,23 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Security Key (U2F)', function () {
-      itp('shows the right beacon for Security Key (U2F)', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+    Expect.describe('Security Key (U2F)', function() {
+      itp('shows the right beacon for Security Key (U2F)', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-u2f');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows the right title', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+      itp('shows the right title', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           expectTitleToBe(test, 'Security Key (U2F)');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows error if browser does not support u2f', function () {
-        return setupU2F({ u2f: false }).then(function (test) {
+      itp('shows error if browser does not support u2f', function() {
+        return setupU2F({ u2f: false }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(1);
           expect(test.form.el('o-form-error-html').find('strong').html()).toEqual(
             'Security Key (U2F) is not supported on this browser. ' +
@@ -4027,8 +4027,8 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('shows error if browser does not support u2f and only one factor', function () {
-        return setupU2F({ u2f: false, nextResponse: resU2F }).then(function (test) {
+      itp('shows error if browser does not support u2f and only one factor', function() {
+        return setupU2F({ u2f: false, nextResponse: resU2F }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(1);
           expect(test.form.el('o-form-error-html').find('strong').html()).toEqual(
             'Security Key (U2F) is not supported on this browser. Contact your admin for assistance.'
@@ -4036,43 +4036,43 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('does not show error if browser supports u2f', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+      itp('does not show error if browser supports u2f', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(0);
         });
       });
 
-      itp('shows a spinner while waiting for u2f challenge', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+      itp('shows a spinner while waiting for u2f challenge', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           expect(test.form.el('u2f-waiting').length).toBe(1);
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('has remember device checkbox', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
 
-      itp('has a sign out link', function () {
-        return setupU2F({ u2f: true }).then(function (test) {
+      itp('has a sign out link', function() {
+        return setupU2F({ u2f: true }).then(function(test) {
           Expect.isVisible(test.form.signoutLink($sandbox));
         });
       });
-      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
-        return setupU2F({ u2f: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function (test) {
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
+        return setupU2F({ u2f: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
-        return setupU2F({ u2f: true, settings: {'features.mfaOnlyFlow': true} }).then(function (test) {
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
+        return setupU2F({ u2f: true, settings: {'features.mfaOnlyFlow': true} }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
 
-      itp('calls u2f.sign and verifies factor', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -4081,10 +4081,10 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupU2F({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function () {
+          .then(function() {
             return Expect.waitForSpyCall(window.u2f.sign);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'https://test.okta.com',
@@ -4104,8 +4104,8 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -4114,11 +4114,11 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupU2F({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function (test) {
+          .then(function(test) {
             test.form.setRememberDevice(true);
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'https://test.okta.com',
@@ -4138,22 +4138,22 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('shows an error if u2f.sign fails', function () {
+      itp('shows an error if u2f.sign fails', function() {
         Expect.allowUnhandledPromiseRejection();
 
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({ errorCode: 2 });
         };
 
         return setupU2F({ u2f: true, signStub: signStub })
-          .then(function (test) {
+          .then(function(test) {
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             window.u2f.tap();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(window.u2f.sign).toHaveBeenCalled();
             expect(test.form.hasErrors()).toBe(true);
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -4175,54 +4175,54 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Custom SAML Factor', function () {
-      itp('is custom SAML factor', function () {
-        return setupCustomSAMLFactor().then(function (test) {
+    Expect.describe('Custom SAML Factor', function() {
+      itp('is custom SAML factor', function() {
+        return setupCustomSAMLFactor().then(function(test) {
           expect(test.form.isCustomFactor()).toBe(true);
         });
       });
-      itp('shows the right beacon', function () {
-        return setupCustomSAMLFactor().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupCustomSAMLFactor().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-custom-factor');
         });
       });
-      itp('shows the right title', function () {
-        return setupCustomSAMLFactor().then(function (test) {
+      itp('shows the right title', function() {
+        return setupCustomSAMLFactor().then(function(test) {
           expectTitleToBe(test, 'SAML Factor');
         });
       });
-      itp('shows the right subtitle', function () {
-        return setupCustomSAMLFactor().then(function (test) {
+      itp('shows the right subtitle', function() {
+        return setupCustomSAMLFactor().then(function(test) {
           expectSubtitleToBe(test, 'Clicking below will redirect to verification with SAML Factor');
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupCustomSAMLFactor().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupCustomSAMLFactor().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('redirects to third party when Verify button is clicked', function () {
+      itp('redirects to third party when Verify button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setupCustomSAMLFactor()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeCustomSAMLFactor, resSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/policy/mfa-saml-idp-redirect?okta_key=mfa.redirect.id'
             );
           });
       });
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setupCustomSAMLFactor()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(
               test,
               403,
@@ -4243,16 +4243,16 @@ Expect.describe('MFA Verify', function () {
             );
           });
       });
-      itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+      itp('calls authClient verifyFactor with rememberDevice URL param', function() {
         return setupCustomSAMLFactor()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'http://rain.okta1.com:1802/api/v1/authn/factors/customFactorId/verify?rememberDevice=true',
@@ -4263,54 +4263,54 @@ Expect.describe('MFA Verify', function () {
           });
       });
     });
-    Expect.describe('Custom OIDC Factor', function () {
-      itp('is custom factor', function () {
-        return setupCustomOIDCFactor().then(function (test) {
+    Expect.describe('Custom OIDC Factor', function() {
+      itp('is custom factor', function() {
+        return setupCustomOIDCFactor().then(function(test) {
           expect(test.form.isCustomFactor()).toBe(true);
         });
       });
-      itp('shows the right beacon', function () {
-        return setupCustomOIDCFactor().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupCustomOIDCFactor().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-custom-factor');
         });
       });
-      itp('shows the right title', function () {
-        return setupCustomOIDCFactor().then(function (test) {
+      itp('shows the right title', function() {
+        return setupCustomOIDCFactor().then(function(test) {
           expectTitleToBe(test, 'OIDC Factor');
         });
       });
-      itp('shows the right subtitle', function () {
-        return setupCustomOIDCFactor().then(function (test) {
+      itp('shows the right subtitle', function() {
+        return setupCustomOIDCFactor().then(function(test) {
           expectSubtitleToBe(test, 'Clicking below will redirect to verification with OIDC Factor');
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupCustomOIDCFactor().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupCustomOIDCFactor().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('redirects to third party when Verify button is clicked', function () {
+      itp('redirects to third party when Verify button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setupCustomOIDCFactor()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeCustomOIDCFactor, resSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/policy/mfa-oidc-idp-redirect?okta_key=mfa.redirect.id'
             );
           });
       });
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setupCustomOIDCFactor()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(
               test,
               403,
@@ -4331,16 +4331,16 @@ Expect.describe('MFA Verify', function () {
             );
           });
       });
-      itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+      itp('calls authClient verifyFactor with rememberDevice URL param', function() {
         return setupCustomOIDCFactor()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'http://rain.okta1.com:1802/api/v1/authn/factors/customFactorId/verify?rememberDevice=true',
@@ -4351,69 +4351,69 @@ Expect.describe('MFA Verify', function () {
           });
       });
     });
-    Expect.describe('Claims Provider Factor', function () {
-      itp('is claims provider factor', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+    Expect.describe('Claims Provider Factor', function() {
+      itp('is claims provider factor', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           expect(test.form.isCustomFactor()).toBe(true);
         });
       });
-      itp('shows the right beacon', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-custom-factor');
         });
       });
-      itp('shows the right title', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+      itp('shows the right title', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           expectTitleToBe(test, 'IDP factor');
         });
       });
-      itp('shows the right subtitle', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+      itp('shows the right subtitle', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           expectSubtitleToBe(test, 'Clicking below will redirect to verification with IDP factor');
         });
       });
-      itp('has remember device checkbox', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
-      itp('has a sign out link', function () {
-        return setupClaimsProviderFactorWithIntrospect().then(function (test) {
+      itp('has a sign out link', function() {
+        return setupClaimsProviderFactorWithIntrospect().then(function(test) {
           Expect.isVisible(test.form.signoutLink($sandbox));
         });
       });
-      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
-        return setupClaimsProviderFactorWithIntrospect({ 'features.hideSignOutLinkInMFA': true }).then(function (test) {
+      itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
+        return setupClaimsProviderFactorWithIntrospect({ 'features.hideSignOutLinkInMFA': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
-        return setupClaimsProviderFactorWithIntrospect({ 'features.mfaOnlyFlow': true }).then(function (test) {
+      itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
+        return setupClaimsProviderFactorWithIntrospect({ 'features.mfaOnlyFlow': true }).then(function(test) {
           expect(test.form.signoutLink($sandbox).length).toBe(0);
         });
       });
-      itp('redirects to third party when Verify button is clicked', function () {
+      itp('redirects to third party when Verify button is clicked', function() {
         spyOn(SharedUtil, 'redirect');
         return setupClaimsProviderFactorWithIntrospect()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse([resChallengeClaimsProvider, resSuccess]);
             test.form.submit();
             return Expect.waitForSpyCall(SharedUtil.redirect);
           })
-          .then(function () {
+          .then(function() {
             expect(SharedUtil.redirect).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802/sso/idps/idpId?stateToken=testStateToken'
             );
           });
       });
-      itp('displays error when error response received', function () {
+      itp('displays error when error response received', function() {
         return setupClaimsProviderFactorWithIntrospect()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resNoPermissionError);
             test.form.submit();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(
               test,
               403,
@@ -4434,16 +4434,16 @@ Expect.describe('MFA Verify', function () {
             );
           });
       });
-      itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+      itp('calls authClient verifyFactor with rememberDevice URL param', function() {
         return setupClaimsProviderFactorWithIntrospect()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.setRememberDevice(true);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'http://rain.okta1.com:1802/api/v1/authn/factors/claimsProviderFactorId/verify?rememberDevice=true',
@@ -4454,78 +4454,78 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      Expect.describe('in MFA_CHALLENGE state when idp returns', function () {
-        beforeEach(function () {
+      Expect.describe('in MFA_CHALLENGE state when idp returns', function() {
+        beforeEach(function() {
           this.options = {
             setFactorResult: true,
             factorResult: 'FAILED',
             factorResultMessage: 'Verify failed.',
           };
         });
-        itp('renders claims provider factor if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('renders claims provider factor if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.isCustomFactor()).toBe(true);
           });
         });
-        itp('shows the right beacon if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('shows the right beacon if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expectHasRightBeaconImage(test, 'mfa-custom-factor');
           });
         });
-        itp('shows the right title if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('shows the right title if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expectTitleToBe(test, 'IDP factor');
           });
         });
-        itp('shows the right subtitle if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('shows the right subtitle if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expectSubtitleToBe(test, 'Clicking below will redirect to verification with IDP factor');
           });
         });
-        itp('has remember device checkbox if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('has remember device checkbox if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             Expect.isVisible(test.form.rememberDeviceCheckbox());
           });
         });
-        itp('has a sign out link if factorResult FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('has a sign out link if factorResult FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             Expect.isVisible(test.form.signoutLink($sandbox));
           });
         });
-        itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
+        itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
           this.options.settings = { 'features.hideSignOutLinkInMFA': true };
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.signoutLink($sandbox).length).toBe(0);
           });
         });
-        itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
+        itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
           this.options.settings = { 'features.mfaOnlyFlow': true };
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.signoutLink($sandbox).length).toBe(0);
           });
         });
-        itp('redirects to third party when Verify button is clicked', function () {
+        itp('redirects to third party when Verify button is clicked', function() {
           spyOn(SharedUtil, 'redirect');
           return setupMfaChallengeClaimsFactor(this.options)
-            .then(function (test) {
+            .then(function(test) {
               test.setNextResponse([resChallengeClaimsProvider, resSuccess]);
               test.form.submit();
               return Expect.waitForSpyCall(SharedUtil.redirect);
             })
-            .then(function () {
+            .then(function() {
               expect(SharedUtil.redirect).toHaveBeenCalledWith(
                 'http://rain.okta1.com:1802/sso/idps/idpId?stateToken=testStateToken'
               );
             });
         });
-        itp('displays error when error response received', function () {
+        itp('displays error when error response received', function() {
           return setupMfaChallengeClaimsFactor(this.options)
-            .then(function (test) {
+            .then(function(test) {
               test.setNextResponse(resNoPermissionError);
               test.form.submit();
               return Expect.waitForFormError(test.form, test);
             })
-            .then(function (test) {
+            .then(function(test) {
               expectError(
                 test,
                 403,
@@ -4546,16 +4546,16 @@ Expect.describe('MFA Verify', function () {
               );
             });
         });
-        itp('calls authClient verifyFactor with rememberDevice URL param', function () {
+        itp('calls authClient verifyFactor with rememberDevice URL param', function() {
           return setupMfaChallengeClaimsFactor(this.options)
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               test.form.setRememberDevice(true);
               test.form.submit();
               return Expect.waitForSpyCall(test.successSpy);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'http://rain.okta1.com:1802/api/v1/authn/factors/claimsProviderFactorId/verify?rememberDevice=true',
@@ -4565,60 +4565,60 @@ Expect.describe('MFA Verify', function () {
               });
             });
         });
-        itp('does not display error and loads first factor when factorResult is not returned', function () {
-          return setupMfaChallengeClaimsFactor().then(function (test) {
+        itp('does not display error and loads first factor when factorResult is not returned', function() {
+          return setupMfaChallengeClaimsFactor().then(function(test) {
             expect(test.form.isSecurityQuestion()).toBe(true);
             expect(test.form.el('o-form-error-html')).toHaveLength(0);
           });
         });
-        itp('displays error when factorResult is FAILED', function () {
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+        itp('displays error when factorResult is FAILED', function() {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.el('o-form-error-html')).toHaveLength(1);
             expect(test.form.el('o-form-error-html').find('strong').html()).toEqual('Verify failed.');
           });
         });
-        itp('does not display error when factorResult is WAITING', function () {
+        itp('does not display error when factorResult is WAITING', function() {
           this.options = {
             setFactorResult: true,
             factorResult: 'WAITING',
             factorResultMessage: 'Verify failed.',
           };
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.isSecurityQuestion()).toBe(true);
             expect(test.form.el('o-form-error-html')).toHaveLength(0);
           });
         });
-        itp('does not display error when factorResult is undefined', function () {
+        itp('does not display error when factorResult is undefined', function() {
           this.options = {
             setFactorResult: true,
             factorResultMessage: 'Verify failed.',
           };
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.isSecurityQuestion()).toBe(true);
             expect(test.form.el('o-form-error-html')).toHaveLength(0);
           });
         });
-        itp('displays default error when factorResultMessage is undefined', function () {
+        itp('displays default error when factorResultMessage is undefined', function() {
           this.options = {
             setFactorResult: true,
             factorResult: 'FAILED',
           };
-          return setupMfaChallengeClaimsFactor(this.options).then(function (test) {
+          return setupMfaChallengeClaimsFactor(this.options).then(function(test) {
             expect(test.form.el('o-form-error-html')).toHaveLength(1);
             expect(test.form.el('o-form-error-html').find('strong').html()).toEqual(
               'There was an unexpected internal error. Please try again.'
             );
           });
         });
-        itp('can switch to Security Question and verify successfully', function () {
+        itp('can switch to Security Question and verify successfully', function() {
           return setupMfaChallengeClaimsFactor(this.options)
-            .then(function (test) {
+            .then(function(test) {
               test.setNextResponse(resAllFactors);
               test.beacon.dropDownButton().click();
               clickFactorInDropdown(test, 'QUESTION');
               return Expect.waitForVerifyQuestion(test);
             })
-            .then(function (test) {
+            .then(function(test) {
               Util.resetAjaxRequests();
               test.setNextResponse(resSuccess);
               test.questionForm = new MfaVerifyForm($sandbox.find('.o-form'));
@@ -4626,7 +4626,7 @@ Expect.describe('MFA Verify', function () {
               test.questionForm.submit();
               return Expect.waitForSpyCall(test.successSpy);
             })
-            .then(function () {
+            .then(function() {
               expect(Util.numAjaxRequests()).toBe(1);
               Expect.isJsonPost(Util.getAjaxRequest(0), {
                 url: 'https://foo.com/api/v1/authn/factors/ufshpdkgNun3xNE3W0g3/verify?rememberDevice=false',
@@ -4639,16 +4639,16 @@ Expect.describe('MFA Verify', function () {
         });
         itp(
           'does not show error and can verify when switching to Security Question and back to idp factor',
-          function () {
+          function() {
             spyOn(SharedUtil, 'redirect');
             return setupMfaChallengeClaimsFactor(this.options)
-              .then(function (test) {
+              .then(function(test) {
                 test.setNextResponse(resAllFactors);
                 test.beacon.dropDownButton().click();
                 clickFactorInDropdown(test, 'QUESTION');
                 return Expect.waitForVerifyQuestion(test);
               })
-              .then(function (test) {
+              .then(function(test) {
                 test.questionForm = new MfaVerifyForm($sandbox.find('.o-form'));
                 expect(test.questionForm.isSecurityQuestion()).toBe(true);
                 // switch to claims provider
@@ -4657,7 +4657,7 @@ Expect.describe('MFA Verify', function () {
                 clickFactorInDropdown(test, 'CUSTOM_CLAIMS');
                 return Expect.waitForVerifyCustomFactor(test);
               })
-              .then(function (test) {
+              .then(function(test) {
                 test.claimsForm = new MfaVerifyForm($sandbox.find('.o-form'));
                 expect(test.claimsForm.isCustomFactor()).toBe(true);
                 expect(test.claimsForm.el('o-form-error-html')).toHaveLength(0);
@@ -4665,7 +4665,7 @@ Expect.describe('MFA Verify', function () {
                 test.claimsForm.submit();
                 return Expect.waitForSpyCall(SharedUtil.redirect);
               })
-              .then(function () {
+              .then(function() {
                 expect(SharedUtil.redirect).toHaveBeenCalledWith(
                   'http://rain.okta1.com:1802/sso/idps/idpId?stateToken=testStateToken'
                 );
@@ -4674,50 +4674,50 @@ Expect.describe('MFA Verify', function () {
         );
       });
     });
-    Expect.describe('Password', function () {
+    Expect.describe('Password', function() {
       testPassword(setupPassword, 'testStateToken');
     });
   });
 
-  Expect.describe('Custom HOTP Factor', function () {
+  Expect.describe('Custom HOTP Factor', function() {
     testHOTPFactor(setupHOTP, 'testStateToken');
   });
 
-  function testHOTPFactor (setupFn, expectedStateToken) {
-    itp('is totpForm', function () {
-      return setupFn().then(function (test) {
+  function testHOTPFactor(setupFn, expectedStateToken) {
+    itp('is totpForm', function() {
+      return setupFn().then(function(test) {
         expect(test.form.isTOTP()).toBe(true);
       });
     });
 
-    itp('shows the right beacon', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right beacon', function() {
+      return setupFn().then(function(test) {
         expectHasRightBeaconImage(test, 'mfa-hotp');
       });
     });
 
-    itp('shows the right title', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right title', function() {
+      return setupFn().then(function(test) {
         expectTitleToBe(test, 'Entrust');
       });
     });
 
-    itp('shows the right subtitle', function () {
-      return setupFn().then(function (test) {
+    itp('shows the right subtitle', function() {
+      return setupFn().then(function(test) {
         expectSubtitleToBe(test, 'Enter your Entrust passcode');
       });
     });
 
-    itp('calls authClient verifyFactor with correct args when submitted', function () {
+    itp('calls authClient verifyFactor with correct args when submitted', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g2/verify?rememberDevice=false',
@@ -4729,9 +4729,9 @@ Expect.describe('MFA Verify', function () {
         });
     });
 
-    itp('calls authClient verifyFactor with correct args when submitted when rememberDevice is checked', function () {
+    itp('calls authClient verifyFactor with correct args when submitted when rememberDevice is checked', function() {
       return setupFn()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setAnswer('123456');
           test.form.setRememberDevice(true);
@@ -4739,7 +4739,7 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/factors/ufthp18Zup4EGLtrd0g2/verify?rememberDevice=true',
@@ -4752,11 +4752,11 @@ Expect.describe('MFA Verify', function () {
     });
   }
 
-  Expect.describe('Beacon', function () {
+  Expect.describe('Beacon', function() {
     beaconTest(resAllFactors, resVerifyTOTPOnly, resAllFactorsOnPrem);
   });
 
-  Expect.describe('Switch between different factors and verify a factor', function () {
+  Expect.describe('Switch between different factors and verify a factor', function() {
     switchFactorTest(
       setupSMS,
       setupOktaPushWithTOTP,
@@ -4766,34 +4766,34 @@ Expect.describe('MFA Verify', function () {
       resChallengeSms,
       'testStateToken'
     );
-    itp('Verify DUO after switching from SMS MFA_CHALLENGE', function () {
+    itp('Verify DUO after switching from SMS MFA_CHALLENGE', function() {
       return setupSMS()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(Duo, 'init');
           test.setNextResponse([resAllFactors, resChallengeDuo]);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'DUO');
           return Expect.waitForVerifyDuo(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Duo.init).toHaveBeenCalled();
         });
     });
-    itp('Verify Okta TOTP success on Push MFA_REJECTED', function () {
-      return setupOktaPushWithTOTP().then(function (test) {
+    itp('Verify Okta TOTP success on Push MFA_REJECTED', function() {
+      return setupOktaPushWithTOTP().then(function(test) {
         return setupPolling(test, resRejectedPush)
-          .then(function () {
+          .then(function() {
             return tick(test);
           }) // Final response - REJECTED
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse([resAllFactors, resSuccess]);
             test.totpForm = new MfaVerifyForm($($sandbox.find('.o-form')[1]));
@@ -4801,11 +4801,11 @@ Expect.describe('MFA Verify', function () {
             test.totpForm.inlineTOTPAdd().click();
             test.totpForm.setAnswer('654321');
             test.totpForm.inlineTOTPVerify().click();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return Util.numAjaxRequests() === 2;
             }, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(2);
             // MFA_CHALLENGE to MFA_REQUIRED
             Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -4824,10 +4824,10 @@ Expect.describe('MFA Verify', function () {
           });
       });
     });
-    itp('Verify Okta TOTP success (after Push MFA_REJECTED) sets the transaction on the appState', function () {
-      return setupOktaPushWithTOTP().then(function (test) {
+    itp('Verify Okta TOTP success (after Push MFA_REJECTED) sets the transaction on the appState', function() {
+      return setupOktaPushWithTOTP().then(function(test) {
         return setupPolling(test, resRejectedPush)
-          .then(function (test) {
+          .then(function(test) {
             expect(test.router.controller.model.appState.get('transaction').factorResult).toBe('REJECTED');
 
             mockTransactions(test.router.controller, true);
@@ -4837,23 +4837,23 @@ Expect.describe('MFA Verify', function () {
             test.totpForm.inlineTOTPAdd().click();
             test.totpForm.setAnswer('654321');
             test.totpForm.inlineTOTPVerify().click();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return test.router.controller.model.appState.get('transaction').status === 'SUCCESS';
             }, test);
           })
-          .then(function () {
+          .then(function() {
             expectSetTransaction(test.router, resSuccess, true);
           });
       });
     });
-    itp('Verify Okta TOTP on active Push MFA_CHALLENGE', function () {
-      return setupOktaPushWithTOTP().then(function (test) {
+    itp('Verify Okta TOTP on active Push MFA_CHALLENGE', function() {
+      return setupOktaPushWithTOTP().then(function(test) {
         // using resTimeoutPush here for the test. This needs to be resTimeoutPush
         // or resRejectedPush, to set the transaction to MFA_CHALLENGE state and
         // mimic an active poll (Note: The transaction state is not set to MFA_CHALLENGE
         // during polling).
         return setupPolling(test, resTimeoutPush)
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse([resAllFactors, resSuccess]);
             test.totpForm = new MfaVerifyForm($($sandbox.find('.o-form')[1]));
@@ -4861,11 +4861,11 @@ Expect.describe('MFA Verify', function () {
             test.totpForm.inlineTOTPAdd().click();
             test.totpForm.setAnswer('654321');
             test.totpForm.inlineTOTPVerify().click();
-            return Expect.wait(function () {
+            return Expect.wait(function() {
               return Util.numAjaxRequests() === 2;
             }, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(2);
             Expect.isJsonPost(Util.getAjaxRequest(1), {
               url: 'https://foo.com/api/v1/authn/factors/osthw62MEvG6YFuHe0g3/verify?rememberDevice=false',
@@ -4879,33 +4879,33 @@ Expect.describe('MFA Verify', function () {
     });
   });
 
-  Expect.describe('Browser back button does not change view', function () {
-    itp('from mfa verify controller', function () {
+  Expect.describe('Browser back button does not change view', function() {
+    itp('from mfa verify controller', function() {
       return setupAllFactorsWithRouter()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(window, 'addEventListener');
           test.router.start();
           expectHasRightBeaconImage(test, 'mfa-okta-security-question');
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'SMS');
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.beacon.hasClass('mfa-okta-sms');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-sms');
           Util.triggerBrowserBackButton();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           //view is still the same
           expectHasRightBeaconImage(test, 'mfa-okta-sms');
           Util.stopRouter();
         });
     });
-    itp('from duo controller', function () {
+    itp('from duo controller', function() {
       return setupAllFactorsWithRouter()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(window, 'addEventListener');
           test.router.start();
           expectHasRightBeaconImage(test, 'mfa-okta-security-question');
@@ -4913,75 +4913,75 @@ Expect.describe('MFA Verify', function () {
           test.setNextResponse(resChallengeDuo);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'DUO');
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.beacon.hasClass('mfa-duo');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-duo');
           Util.triggerBrowserBackButton();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           //view is still the same
           expectHasRightBeaconImage(test, 'mfa-duo');
           Util.stopRouter();
         });
     });
-    itp('from windows hello controller', function () {
+    itp('from windows hello controller', function() {
       return emulateWindows()
         .then(setupAllFactorsWithRouter)
-        .then(function (test) {
+        .then(function(test) {
           spyOn(window, 'addEventListener');
           test.router.start();
           expectHasRightBeaconImage(test, 'mfa-okta-security-question');
           test.setNextResponse(resChallengeWindowsHello);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'WINDOWS_HELLO');
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.beacon.hasClass('mfa-windows-hello');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-windows-hello');
           Util.triggerBrowserBackButton();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           //view is still the same
           expectHasRightBeaconImage(test, 'mfa-windows-hello');
           Util.stopRouter();
         });
     });
-    itp('from u2f controller', function () {
+    itp('from u2f controller', function() {
       return setupAllFactorsWithRouter()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(window, 'addEventListener');
           test.router.start();
           expectHasRightBeaconImage(test, 'mfa-okta-security-question');
           return test;
         })
-        .then(function (test) {
+        .then(function(test) {
           window.u2f = {
-            sign: function () {},
+            sign: function() {},
           };
           spyOn(window.u2f, 'sign');
           test.setNextResponse(resChallengeU2F);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'U2F');
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.beacon.hasClass('mfa-u2f');
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-u2f');
           return Expect.waitForWindowListener('popstate', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return tick(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           //view is still the same
           expectHasRightBeaconImage(test, 'mfa-u2f');
           Util.stopRouter();
@@ -4989,10 +4989,10 @@ Expect.describe('MFA Verify', function () {
     });
   });
 
-  Expect.describe('The auth response', function () {
-    itp('is NOT TRAPPED when Mfa verify follows password re-auth', function () {
+  Expect.describe('The auth response', function() {
+    itp('is NOT TRAPPED when Mfa verify follows password re-auth', function() {
       return setupPassword()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(RouterUtil, 'handleResponseStatus').and.callThrough();
           Util.resetAjaxRequests();
           test.form.setPassword('Abcd1234');
@@ -5001,41 +5001,41 @@ Expect.describe('MFA Verify', function () {
           test.form.submit();
           return Expect.waitForVerifyQuestion(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.questionForm = new MfaVerifyForm($sandbox.find('.o-form'));
           expect(test.questionForm.isSecurityQuestion()).toBe(true);
           // trapAuthResponse does not prevent handleResponseStatus from being called
           expect(RouterUtil.handleResponseStatus.calls.count()).toBe(1);
         });
     });
-    itp('is TRAPPED on any factor change through the dropdown', function () {
+    itp('is TRAPPED on any factor change through the dropdown', function() {
       return setupSMS()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(RouterUtil, 'handleResponseStatus').and.callThrough();
           test.setNextResponse(resChallengeSms);
           test.form.smsSendCode().click();
-          return Expect.wait(function () {
+          return Expect.wait(function() {
             return test.router.controller.model.appState.get('transaction').status === 'MFA_CHALLENGE';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resAllFactors);
           test.beacon.dropDownButton().click();
           clickFactorInDropdown(test, 'QUESTION');
           return Expect.waitForVerifyQuestion(test);
         })
-        .then(function () {
+        .then(function() {
           // trapAuthResponse prevents handleResponseStatus from being called
           expect(RouterUtil.handleResponseStatus.calls.count()).toBe(0);
         });
     });
-    itp('is TRAPPED during verify of inline totp with Okta Verify Push', function () {
-      return setupOktaPushWithTOTP().then(function (test) {
+    itp('is TRAPPED during verify of inline totp with Okta Verify Push', function() {
+      return setupOktaPushWithTOTP().then(function(test) {
         return setupPolling(test, resRejectedPush)
-          .then(function () {
+          .then(function() {
             return tick(test);
           }) // Final response - REJECTED
-          .then(function (test) {
+          .then(function(test) {
             spyOn(RouterUtil, 'handleResponseStatus').and.callThrough();
             test.totpForm = new MfaVerifyForm($($sandbox.find('.o-form')[1]));
             test.totpForm.inlineTOTPAdd().click();
@@ -5044,7 +5044,7 @@ Expect.describe('MFA Verify', function () {
             test.totpForm.inlineTOTPVerify().click();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             // clicking on inline totp should trap auth response, SUCCESS response will
             // call handleResponseStatus.
             expect(RouterUtil.handleResponseStatus.calls.count()).toBe(1);
@@ -5053,11 +5053,11 @@ Expect.describe('MFA Verify', function () {
     });
   });
 
-  Expect.describe('Multiple Factors of the same type', function () {
-    function getPageForm () {
+  Expect.describe('Multiple Factors of the same type', function() {
+    function getPageForm() {
       const $forms = $sandbox.find('.o-form');
 
-      let forms = _.map($forms, function (form) {
+      let forms = _.map($forms, function(form) {
         return new MfaVerifyForm($(form));
       });
 
@@ -5067,31 +5067,31 @@ Expect.describe('MFA Verify', function () {
       return forms;
     }
 
-    Expect.describe('General', function () {
-      itp('Defaults to the last used factor', function () {
-        return setup(resMultipleFactors).then(function (test) {
+    Expect.describe('General', function() {
+      itp('Defaults to the last used factor', function() {
+        return setup(resMultipleFactors).then(function(test) {
           expect(test.form.isSecurityQuestion()).toBe(true);
         });
       });
     });
 
-    Expect.describe('Only multiple Security Keys (U2F) are setup', function () {
-      itp('shows the right beacon for Security Key (U2F)', function () {
-        return setupMultipleU2FOnly({ u2f: true }).then(function (test) {
+    Expect.describe('Only multiple Security Keys (U2F) are setup', function() {
+      itp('shows the right beacon for Security Key (U2F)', function() {
+        return setupMultipleU2FOnly({ u2f: true }).then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-u2f');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows the right title', function () {
-        return setupMultipleU2FOnly({ u2f: true }).then(function (test) {
+      itp('shows the right title', function() {
+        return setupMultipleU2FOnly({ u2f: true }).then(function(test) {
           expectTitleToBe(test, 'Security Key (U2F)');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows error if browser does not support u2f', function () {
-        return setupMultipleU2FOnly({ u2f: false }).then(function (test) {
+      itp('shows error if browser does not support u2f', function() {
+        return setupMultipleU2FOnly({ u2f: false }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(1);
           expect(test.form.el('o-form-error-html').find('strong').html()).toEqual(
             'Security Key (U2F) is not supported on this browser. ' + 'Contact your admin for assistance.'
@@ -5099,27 +5099,27 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('does not show error if browser supports u2f', function () {
-        return setupMultipleU2FOnly({ u2f: true }).then(function (test) {
+      itp('does not show error if browser supports u2f', function() {
+        return setupMultipleU2FOnly({ u2f: true }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(0);
         });
       });
 
-      itp('shows a spinner while waiting for u2f challenge', function () {
-        return setupMultipleU2FOnly({ u2f: true }).then(function (test) {
+      itp('shows a spinner while waiting for u2f challenge', function() {
+        return setupMultipleU2FOnly({ u2f: true }).then(function(test) {
           expect(test.form.el('u2f-waiting').length).toBe(1);
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('has remember device checkbox', function () {
-        return setupMultipleU2FOnly({ u2f: true }).then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupMultipleU2FOnly({ u2f: true }).then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
 
-      itp('calls u2f.sign and verifies factor', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -5128,10 +5128,10 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupMultipleU2FOnly({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function () {
+          .then(function() {
             return Expect.waitForSpyCall(window.u2f.sign);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802',
@@ -5155,8 +5155,8 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -5165,11 +5165,11 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupMultipleU2FOnly({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function (test) {
+          .then(function(test) {
             test.form.setRememberDevice(true);
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802',
@@ -5193,22 +5193,22 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('shows an error if u2f.sign fails', function () {
+      itp('shows an error if u2f.sign fails', function() {
         Expect.allowUnhandledPromiseRejection();
 
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({ errorCode: 2 });
         };
 
         return setupMultipleU2FOnly({ u2f: true, signStub: signStub })
-          .then(function (test) {
+          .then(function(test) {
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             window.u2f.tap();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(window.u2f.sign).toHaveBeenCalled();
             expect(test.form.hasErrors()).toBe(true);
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -5230,23 +5230,23 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Multiple Security Keys (U2F) and one more factor are setup', function () {
-      itp('shows the right beacon for Security Key (U2F)', function () {
-        return setupMultipleU2F({ u2f: true }).then(function (test) {
+    Expect.describe('Multiple Security Keys (U2F) and one more factor are setup', function() {
+      itp('shows the right beacon for Security Key (U2F)', function() {
+        return setupMultipleU2F({ u2f: true }).then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-u2f');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows the right title', function () {
-        return setupMultipleU2F({ u2f: true }).then(function (test) {
+      itp('shows the right title', function() {
+        return setupMultipleU2F({ u2f: true }).then(function(test) {
           expectTitleToBe(test, 'Security Key (U2F)');
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('shows error if browser does not support u2f', function () {
-        return setupMultipleU2F({ u2f: false }).then(function (test) {
+      itp('shows error if browser does not support u2f', function() {
+        return setupMultipleU2F({ u2f: false }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(1);
           expect(test.form.el('o-form-error-html').find('strong').html()).toEqual(
             'Security Key (U2F) is not supported on this browser. ' +
@@ -5255,27 +5255,27 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('does not show error if browser supports u2f', function () {
-        return setupMultipleU2F({ u2f: true }).then(function (test) {
+      itp('does not show error if browser supports u2f', function() {
+        return setupMultipleU2F({ u2f: true }).then(function(test) {
           expect(test.form.el('o-form-error-html')).toHaveLength(0);
         });
       });
 
-      itp('shows a spinner while waiting for u2f challenge', function () {
-        return setupMultipleU2F({ u2f: true }).then(function (test) {
+      itp('shows a spinner while waiting for u2f challenge', function() {
+        return setupMultipleU2F({ u2f: true }).then(function(test) {
           expect(test.form.el('u2f-waiting').length).toBe(1);
           return Expect.waitForSpyCall(window.u2f.sign);
         });
       });
 
-      itp('has remember device checkbox', function () {
-        return setupMultipleU2F({ u2f: true }).then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupMultipleU2F({ u2f: true }).then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
 
-      itp('calls u2f.sign and verifies factor', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -5284,10 +5284,10 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupMultipleU2F({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function () {
+          .then(function() {
             return Expect.waitForSpyCall(window.u2f.sign);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802',
@@ -5311,8 +5311,8 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function () {
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+      itp('calls u2f.sign and verifies factor when rememberDevice set to true', function() {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({
             keyHandle: 'someKeyHandle',
             clientData: 'someClientData',
@@ -5321,11 +5321,11 @@ Expect.describe('MFA Verify', function () {
         };
 
         return setupMultipleU2F({ u2f: true, signStub: signStub, res: resSuccess })
-          .then(function (test) {
+          .then(function(test) {
             test.form.setRememberDevice(true);
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function () {
+          .then(function() {
             window.u2f.tap();
             expect(window.u2f.sign).toHaveBeenCalledWith(
               'http://rain.okta1.com:1802',
@@ -5349,22 +5349,22 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('shows an error if u2f.sign fails', function () {
+      itp('shows an error if u2f.sign fails', function() {
         Expect.allowUnhandledPromiseRejection();
 
-        const signStub = function (appId, nonce, registeredKeys, callback) {
+        const signStub = function(appId, nonce, registeredKeys, callback) {
           callback({ errorCode: 2 });
         };
 
         return setupMultipleU2F({ u2f: true, signStub: signStub })
-          .then(function (test) {
+          .then(function(test) {
             return Expect.waitForSpyCall(window.u2f.sign, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             window.u2f.tap();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(window.u2f.sign).toHaveBeenCalled();
             expect(test.form.hasErrors()).toBe(true);
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -5386,47 +5386,47 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Okta Verify TOTP', function () {
-      itp('shows the right beacon', function () {
-        return setupMultipleOktaTOTP().then(function (test) {
+    Expect.describe('Okta Verify TOTP', function() {
+      itp('shows the right beacon', function() {
+        return setupMultipleOktaTOTP().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-verify');
         });
       });
 
-      itp('shows the right title', function () {
-        return setupMultipleOktaTOTP().then(function (test) {
+      itp('shows the right title', function() {
+        return setupMultipleOktaTOTP().then(function(test) {
           expectTitleToBe(test, 'Okta Verify');
         });
       });
 
-      itp('shows the right subtitle', function () {
-        return setupMultipleOktaTOTP().then(function (test) {
+      itp('shows the right subtitle', function() {
+        return setupMultipleOktaTOTP().then(function(test) {
           expectSubtitleToBe(test, 'Enter code from any registered Okta Verify device.');
         });
       });
 
-      itp('has a passCode field', function () {
-        return setupMultipleOktaTOTP().then(function (test) {
+      itp('has a passCode field', function() {
+        return setupMultipleOktaTOTP().then(function(test) {
           expectHasAnswerField(test, 'tel');
         });
       });
 
-      itp('has remember device checkbox', function () {
-        return setupMultipleOktaTOTP().then(function (test) {
+      itp('has remember device checkbox', function() {
+        return setupMultipleOktaTOTP().then(function(test) {
           Expect.isVisible(test.form.rememberDeviceCheckbox());
         });
       });
 
-      itp('calls factorType-url with correct args', function () {
+      itp('calls factorType-url with correct args', function() {
         return setupMultipleOktaTOTP()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
@@ -5438,9 +5438,9 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls factorType-url with correct args and rememberDevice URL param', function () {
+      itp('calls factorType-url with correct args and rememberDevice URL param', function() {
         return setupMultipleOktaTOTP()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setAnswer('123456');
             test.form.setRememberDevice(true);
@@ -5448,7 +5448,7 @@ Expect.describe('MFA Verify', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=true',
@@ -5461,27 +5461,27 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Okta Verify Push', function () {
-      itp('shows an Okta Push form', function () {
-        return setupMultipleOktaPush().then(function (test) {
+    Expect.describe('Okta Verify Push', function() {
+      itp('shows an Okta Push form', function() {
+        return setupMultipleOktaPush().then(function(test) {
           expect(test.form.isPush()).toBe(true);
         });
       });
 
-      itp('shows the right beacon', function () {
-        return setupMultipleOktaPush().then(function (test) {
+      itp('shows the right beacon', function() {
+        return setupMultipleOktaPush().then(function(test) {
           expectHasRightBeaconImage(test, 'mfa-okta-verify');
         });
       });
 
-      itp('shows the right title (with device name)', function () {
-        return setupMultipleOktaPush().then(function (test) {
+      itp('shows the right title (with device name)', function() {
+        return setupMultipleOktaPush().then(function(test) {
           expectTitleToBe(test, 'Okta Verify (Test Device 1)');
         });
       });
 
-      itp('shows one item in the factors dropdown for each enrolled device', function () {
-        return setupMultipleOktaPush().then(function (test) {
+      itp('shows one item in the factors dropdown for each enrolled device', function() {
+        return setupMultipleOktaPush().then(function(test) {
           expect(test.beacon.getOptionsLinks().length).toBe(3);
           expect(test.beacon.getOptionsLinksText()).toEqual([
             'Okta Verify (Test Device 1)',
@@ -5491,29 +5491,29 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('updates title when different push factor is selected', function () {
+      itp('updates title when different push factor is selected', function() {
         return setupMultipleOktaPush()
-          .then(function (test) {
+          .then(function(test) {
             expectTitleToBe(test, 'Okta Verify (Test Device 1)');
             test.beacon.dropDownButton().click();
             test.beacon.getOptionsLinks().eq('1').click();
             return tick(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.form = getPageForm();
             expectTitleToBe(test, 'Okta Verify (Test Device 2)');
           });
       });
 
-      itp('calls verifyFactor with correct args for 1st push on the list', function () {
+      itp('calls verifyFactor with correct args for 1st push on the list', function() {
         return setupMultipleOktaPush()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush1/verify?rememberDevice=false',
@@ -5524,21 +5524,21 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls verifyFactor with correct args for 2nd push on the list', function () {
+      itp('calls verifyFactor with correct args for 2nd push on the list', function() {
         return setupMultipleOktaPush()
-          .then(function (test) {
+          .then(function(test) {
             test.beacon.dropDownButton().click();
             test.beacon.getOptionsLinks().eq('1').click();
             return tick(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.form = getPageForm();
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush2/verify?rememberDevice=false',
@@ -5550,12 +5550,12 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Okta Verify Push with number challenge', function () {
-      itp('displays number challenge on poll', function () {
-        return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+    Expect.describe('Okta Verify Push with number challenge', function() {
+      itp('displays number challenge on poll', function() {
+        return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
           spyOn(test.router.controller.model, 'setTransaction').and.callThrough();
           spyOn(test.router.settings, 'callGlobalSuccess');
-          return setupPolling(test, resSuccess, resChallengePushWithNumberChallenge).then(tick).then(function () {
+          return setupPolling(test, resSuccess, resChallengePushWithNumberChallenge).then(tick).then(function() {
             // Warnings need to be cleared when switching to number challenge view.
             expect(test.form.hasWarningMessage()).toBeFalsy();
             expect(test.router.controller.$('[data-se="o-form-input-autoPush"]').is(':visible')).toBeFalsy();
@@ -5575,12 +5575,12 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('doest not display number challenge on poll in low risk cases', function () {
-        return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+      itp('doest not display number challenge on poll in low risk cases', function() {
+        return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
           spyOn(test.router.controller.model, 'setTransaction').and.callThrough();
           spyOn(test.router.settings, 'callGlobalSuccess');
           return setupPolling(test, resSuccess)
-            .then(function () {
+            .then(function() {
               expect(test.form.hasWarningMessage()).toBeTruthy();
               expect(test.router.controller.$('[data-se="o-form-input-autoPush"]').is(':visible')).toBeTruthy();
               expect(test.router.controller.$('[data-se="o-form-input-rememberDevice"]').is(':visible')).toBeTruthy();
@@ -5588,7 +5588,7 @@ Expect.describe('MFA Verify', function () {
               expect(test.form.numberChallengeView().is(':visible')).toBeFalsy();
               return tick(test);
             })
-            .then(function () {
+            .then(function() {
               expect(test.router.settings.callGlobalSuccess).toHaveBeenCalled();
               // One after first poll returns and one after polling finished.
               const calls = test.router.controller.model.setTransaction.calls;
@@ -5600,12 +5600,12 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('displays error and send push button after wrong number selection in number challenge', function () {
-        return setupOktaPush({ 'features.autoPush': true }).then(function (test) {
+      itp('displays error and send push button after wrong number selection in number challenge', function() {
+        return setupOktaPush({ 'features.autoPush': true }).then(function(test) {
           spyOn(test.router.controller.model, 'setTransaction').and.callThrough();
           spyOn(test.router.settings, 'callGlobalSuccess');
           return setupPolling(test, resRejectedPush, resChallengePushWithNumberChallenge)
-            .then(function () {
+            .then(function() {
               expect(test.form.hasErrors()).toBeTruthy();
               expect(test.form.errorMessage()).toBe('You have chosen to reject this login.');
               expect(test.form.hasWarningMessage()).toBeFalsy();
@@ -5615,7 +5615,7 @@ Expect.describe('MFA Verify', function () {
               expect(test.form.numberChallengeView().is(':visible')).toBeFalsy();
               return tick(test);
             })
-            .then(function () {
+            .then(function() {
               expect(test.router.settings.callGlobalSuccess).not.toHaveBeenCalled();
               // One after first poll returns and one after polling finished.
               const calls = test.router.controller.model.setTransaction.calls;
@@ -5628,16 +5628,16 @@ Expect.describe('MFA Verify', function () {
       });
     });
 
-    Expect.describe('Okta Verify Push with TOTP', function () {
-      itp('shows an Okta Push form', function () {
-        return setupMultipleOktaVerify().then(function (test) {
+    Expect.describe('Okta Verify Push with TOTP', function() {
+      itp('shows an Okta Push form', function() {
+        return setupMultipleOktaVerify().then(function(test) {
           expect(test.form[0].isPush()).toBe(true);
           expect(test.form[1].isInlineTOTP()).toBe(true);
         });
       });
 
-      itp('shows one item in the factors dropdown for each enrolled push factor', function () {
-        return setupMultipleOktaPush().then(function (test) {
+      itp('shows one item in the factors dropdown for each enrolled push factor', function() {
+        return setupMultipleOktaPush().then(function(test) {
           expect(test.beacon.getOptionsLinks().length).toBe(3);
           expect(test.beacon.getOptionsLinksText()).toEqual([
             'Okta Verify (Test Device 1)',
@@ -5647,9 +5647,9 @@ Expect.describe('MFA Verify', function () {
         });
       });
 
-      itp('calls factorType-url with correct args for 1st TOTP on the list', function () {
+      itp('calls factorType-url with correct args for 1st TOTP on the list', function() {
         return setupMultipleOktaVerify()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form[1].inlineTOTPAdd().click();
             test.form[1].setAnswer('654321');
@@ -5657,7 +5657,7 @@ Expect.describe('MFA Verify', function () {
             test.form[1].inlineTOTPVerify().click();
             return tick();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
@@ -5669,15 +5669,15 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls verifyFactor with correct args for 1st push on the list', function () {
+      itp('calls verifyFactor with correct args for 1st push on the list', function() {
         return setupMultipleOktaVerify()
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form[0].submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush1/verify?rememberDevice=false',
@@ -5688,14 +5688,14 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls factorType-url with correct args for 2nd TOTP on the list', function () {
+      itp('calls factorType-url with correct args for 2nd TOTP on the list', function() {
         return setupMultipleOktaVerify()
-          .then(function (test) {
+          .then(function(test) {
             test.beacon.dropDownButton().click();
             test.beacon.getOptionsLinks().eq('1').click();
             return tick(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form = getPageForm();
             test.form[1].inlineTOTPAdd().click();
@@ -5704,7 +5704,7 @@ Expect.describe('MFA Verify', function () {
             test.form[1].inlineTOTPVerify().click();
             return tick();
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/token:software:totp/verify?rememberDevice=false',
@@ -5716,21 +5716,21 @@ Expect.describe('MFA Verify', function () {
           });
       });
 
-      itp('calls verifyFactor with correct args for 2nd push on the list', function () {
+      itp('calls verifyFactor with correct args for 2nd push on the list', function() {
         return setupMultipleOktaVerify()
-          .then(function (test) {
+          .then(function(test) {
             test.beacon.dropDownButton().click();
             test.beacon.getOptionsLinks().eq('1').click();
             return tick(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.form = getPageForm();
             Util.resetAjaxRequests();
             test.setNextResponse(resSuccess);
             test.form[0].submit();
             return Expect.waitForSpyCall(test.successSpy);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/factors/oktaVerifyPush2/verify?rememberDevice=false',

--- a/test/unit/spec/OAuth2Util_spec.js
+++ b/test/unit/spec/OAuth2Util_spec.js
@@ -7,25 +7,25 @@ import { AuthSdkError } from '@okta/okta-auth-js';
 import Enums from '../../../src/util/Enums';
 
 
-describe('util/OAuth2Util', function () {
+describe('util/OAuth2Util', function() {
   class MockModel {
-    constructor () {
-      this.trigger = function () {};
+    constructor() {
+      this.trigger = function() {};
     }
   }
 
   class MockController {
-    constructor () {
+    constructor() {
       this.model = new MockModel();
-      this.trigger = function () {};
+      this.trigger = function() {};
     }
   }
-  describe('getTokens', function () {
+  describe('getTokens', function() {
     let controller;
     let authClient;
     let settings;
 
-    beforeEach(function () {
+    beforeEach(function() {
       controller = new MockController();
       authClient = createAuthClient({issuer: 'https://foo/default'});
       settings = new Settings({
@@ -38,17 +38,17 @@ describe('util/OAuth2Util', function () {
       expect(OAuth2Util.getTokens).toBeTruthy();
     });
 
-    it('emits SDK errors through \'triggerAfterError\' event', function (done) {
-      spyOn(authClient.token, 'getWithPopup').and.callFake(function () {
-        return new Promise(function () {
+    it('emits SDK errors through \'triggerAfterError\' event', function(done) {
+      spyOn(authClient.token, 'getWithPopup').and.callFake(function() {
+        return new Promise(function() {
           throw new AuthSdkError('Auth SDK error');
         });
       });
 
-      return new Promise(function (resolve) {
+      return new Promise(function(resolve) {
         spyOn(Util, 'triggerAfterError').and.callFake(resolve);
         OAuth2Util.getTokens(settings, {}, controller);
-      }).then(function () {
+      }).then(function() {
         expect(Util.triggerAfterError).toHaveBeenCalledTimes(1);
         const exceptionMessage = Util.triggerAfterError.calls.mostRecent().args[1].message;
         expect(exceptionMessage).toEqual('Auth SDK error');
@@ -56,21 +56,21 @@ describe('util/OAuth2Util', function () {
       }).catch(done.fail);
     });
 
-    it('invokes \'globalSuccessFn\' after successfull token retrieval', function (done) {
-      return new Promise(function (resolve) {
+    it('invokes \'globalSuccessFn\' after successfull token retrieval', function(done) {
+      return new Promise(function(resolve) {
         spyOn(settings, 'callGlobalSuccess').and.callFake(resolve);
-        spyOn(authClient.token, 'getWithPopup').and.callFake(function () {
+        spyOn(authClient.token, 'getWithPopup').and.callFake(function() {
           return Promise.resolve({token: 'foobar'});
         });
         OAuth2Util.getTokens(settings, {}, controller);
-      }).then(function () {
+      }).then(function() {
         expect(settings.callGlobalSuccess).toHaveBeenCalledTimes(1);
         expect(settings.callGlobalSuccess).toHaveBeenCalledWith(Enums.SUCCESS, {token: 'foobar'});
         done();
       }).catch(done.fail);
     });
 
-    it('gates non-allowlisted token parameters from widget config', function (done) {
+    it('gates non-allowlisted token parameters from widget config', function(done) {
       const settingsWithAdditionalParams = new Settings({
         baseUrl: 'https://foo',
         clientId: 'foobar',
@@ -80,10 +80,10 @@ describe('util/OAuth2Util', function () {
       });
       settingsWithAdditionalParams.setAuthClient(authClient);
 
-      return new Promise(function (resolve) {
+      return new Promise(function(resolve) {
         spyOn(authClient.token, 'getWithPopup').and.callFake(resolve);
         OAuth2Util.getTokens(settingsWithAdditionalParams, { scopes: ['openid'] }, controller);
-      }).then(function () {
+      }).then(function() {
         const tokenParameters = Object.keys(authClient.token.getWithPopup.calls.mostRecent().args[0]);
         expect(tokenParameters).not.toContain('responseMode');
         expect(tokenParameters).not.toContain('baseUrl');
@@ -93,27 +93,27 @@ describe('util/OAuth2Util', function () {
       }).catch(done.fail);
     });
 
-    it('retrieves tokens through redirect when widget is configured with "redirect" = "always"', function (done) {
+    it('retrieves tokens through redirect when widget is configured with "redirect" = "always"', function(done) {
       const settingsWithRemediationMode = new Settings({
         baseUrl: 'https://foo',
         redirect: 'always',
       });
       settingsWithRemediationMode.setAuthClient(authClient);
 
-      return new Promise(function (resolve) {
+      return new Promise(function(resolve) {
         spyOn(authClient.token, 'getWithRedirect').and.callFake(resolve);
         OAuth2Util.getTokens(settingsWithRemediationMode, {}, controller);
-      }).then(function () {
+      }).then(function() {
         expect(authClient.token.getWithRedirect).toHaveBeenCalledTimes(1);
         done();
       }).catch(done.fail);
     });
 
-    it('retrieves tokens via iframe when sessionToken is available', function (done) {
-      return new Promise(function (resolve) {
+    it('retrieves tokens via iframe when sessionToken is available', function(done) {
+      return new Promise(function(resolve) {
         spyOn(authClient.token, 'getWithoutPrompt').and.callFake(resolve);
         OAuth2Util.getTokens(settings, { sessionToken: 'foo'} , controller);
-      }).then(function () {
+      }).then(function() {
         expect(authClient.token.getWithoutPrompt).toHaveBeenCalledTimes(1);
         done();
       }).catch(done.fail);

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -23,11 +23,11 @@ import V1Router from 'LoginRouter';
 const url = 'https://foo.com';
 const itp = Expect.itp;
 
-Expect.describe('OktaSignIn initialization', function () {
+Expect.describe('OktaSignIn initialization', function() {
   let signIn;
 
   /* eslint jasmine/no-global-setup:0 */
-  beforeEach(function () {
+  beforeEach(function() {
     jasmine.Ajax.install();
     jasmine.Ajax.stubRequest(/https:\/\/foo.com.*/).andReturn({
       status: 200,
@@ -38,13 +38,13 @@ Expect.describe('OktaSignIn initialization', function () {
       baseUrl: url,
     });
   });
-  afterEach(function () {
+  afterEach(function() {
     jasmine.Ajax.uninstall();
     $sandbox.empty();
   });
 
-  Expect.describe('Debug Mode', function () {
-    it('logs a warning message on page load', function () {
+  Expect.describe('Debug Mode', function() {
+    it('logs a warning message on page load', function() {
       const debugMessage =
         '\n' +
         'The Okta Sign-In Widget is running in development mode.\n' +
@@ -55,33 +55,33 @@ Expect.describe('OktaSignIn initialization', function () {
     });
   });
 
-  Expect.describe('At the root level', function () {
-    it('has a renderEl method', function () {
+  Expect.describe('At the root level', function() {
+    it('has a renderEl method', function() {
       expect(signIn.renderEl).toBeDefined();
     });
-    it('has a authClient method', function () {
+    it('has a authClient method', function() {
       expect(signIn.authClient).toBeDefined();	
     });
-    it('has a showSignInToGetTokens method', function () {
+    it('has a showSignInToGetTokens method', function() {
       expect(signIn.showSignInToGetTokens).toBeDefined();
     });
-    it('has a showSignInAndRedirect method', function () {
+    it('has a showSignInAndRedirect method', function() {
       expect(signIn.showSignInAndRedirect).toBeDefined();
     });
-    it('has a hide method', function () {
+    it('has a hide method', function() {
       expect(signIn.hide).toBeDefined();
     });
-    it('has a show method', function () {
+    it('has a show method', function() {
       expect(signIn.show).toBeDefined();
     });
-    it('has a remove method', function () {
+    it('has a remove method', function() {
       expect(signIn.remove).toBeDefined();
     });
   });
 
-  describe('Auth Client', function () {
-    Expect.describe('authClient option', function () {
-      it('accepts an authClient option', function () {
+  describe('Auth Client', function() {
+    Expect.describe('authClient option', function() {
+      it('accepts an authClient option', function() {
         const authClient = { foo: 'bar' };
         signIn = new Widget({
           baseUrl: url,
@@ -91,12 +91,12 @@ Expect.describe('OktaSignIn initialization', function () {
       });
     });
 
-    Expect.describe('Config', function () {
-      it('has an options object', function () {
+    Expect.describe('Config', function() {
+      it('has an options object', function() {
         expect(signIn.authClient.options).toBeDefined();
       });
 
-      it('SIW passes all config within authParams to OktaAuth', function () {
+      it('SIW passes all config within authParams to OktaAuth', function() {
         const authParams = {
           // known params
           issuer: 'https://my-issuer',
@@ -108,12 +108,12 @@ Expect.describe('OktaSignIn initialization', function () {
           authParams,
         });
 
-        Object.keys(authParams).forEach(function (key) {
+        Object.keys(authParams).forEach(function(key) {
           expect(signIn.authClient.options[key]).toBe(authParams[key]);
         });
       });
 
-      it('"useInteractionCodeFlow" without PKCE throws a config error', function () {
+      it('"useInteractionCodeFlow" without PKCE throws a config error', function() {
         const fn = () => {
           signIn = new Widget({
             baseUrl: url,
@@ -127,135 +127,135 @@ Expect.describe('OktaSignIn initialization', function () {
       });
     });
 
-    Expect.describe('Session', function () {
-      it('has a session method', function () {
+    Expect.describe('Session', function() {
+      it('has a session method', function() {
         expect(signIn.authClient.session).toBeDefined();
       });
-      it('has a session.close method', function () {
+      it('has a session.close method', function() {
         expect(signIn.authClient.session.close).toBeDefined();
       });
-      it('has a session.exists method', function () {
+      it('has a session.exists method', function() {
         expect(signIn.authClient.session.exists).toBeDefined();
       });
-      it('has a session.get method', function () {
+      it('has a session.get method', function() {
         expect(signIn.authClient.session.get).toBeDefined();
       });
-      it('has a session.refresh method', function () {
+      it('has a session.refresh method', function() {
         expect(signIn.authClient.session.refresh).toBeDefined();
       });
     });
 
-    Expect.describe('Token', function () {
-      it('has a token method', function () {
+    Expect.describe('Token', function() {
+      it('has a token method', function() {
         expect(signIn.authClient.token).toBeDefined();
       });
-      it('has a token.getWithoutPrompt method', function () {
+      it('has a token.getWithoutPrompt method', function() {
         expect(signIn.authClient.token.getWithoutPrompt).toBeDefined();
       });
-      it('has a token.getWithPopup method', function () {
+      it('has a token.getWithPopup method', function() {
         expect(signIn.authClient.token.getWithPopup).toBeDefined();
       });
-      it('has a token.getWithRedirect method', function () {
+      it('has a token.getWithRedirect method', function() {
         expect(signIn.authClient.token.getWithRedirect).toBeDefined();
       });
-      it('has a token.parseFromUrl method', function () {
+      it('has a token.parseFromUrl method', function() {
         expect(signIn.authClient.token.parseFromUrl).toBeDefined();
       });
-      it('has a token.decode method', function () {
+      it('has a token.decode method', function() {
         expect(signIn.authClient.token.decode).toBeDefined();
       });
-      it('has a token.renew method', function () {
+      it('has a token.renew method', function() {
         expect(signIn.authClient.token.renew).toBeDefined();
       });
-      it('has a token.getUserInfo method', function () {
+      it('has a token.getUserInfo method', function() {
         expect(signIn.authClient.token.getUserInfo).toBeDefined();
       });
-      it('has a token.verify method', function () {
+      it('has a token.verify method', function() {
         expect(signIn.authClient.token.verify).toBeDefined();
       });
     });
 
-    Expect.describe('TokenManager', function () {
-      it('has a tokenManager method', function () {
+    Expect.describe('TokenManager', function() {
+      it('has a tokenManager method', function() {
         expect(signIn.authClient.tokenManager).toBeDefined();
       });
-      it('has a tokenManager.add method', function () {
+      it('has a tokenManager.add method', function() {
         expect(signIn.authClient.tokenManager.add).toBeDefined();
       });
-      it('has a tokenManager.get method', function () {
+      it('has a tokenManager.get method', function() {
         expect(signIn.authClient.tokenManager.get).toBeDefined();
       });
-      it('has a tokenManager.remove method', function () {
+      it('has a tokenManager.remove method', function() {
         expect(signIn.authClient.tokenManager.remove).toBeDefined();
       });
-      it('has a tokenManager.clear method', function () {
+      it('has a tokenManager.clear method', function() {
         expect(signIn.authClient.tokenManager.clear).toBeDefined();
       });
-      it('has a tokenManager.renew method', function () {
+      it('has a tokenManager.renew method', function() {
         expect(signIn.authClient.tokenManager.renew).toBeDefined();
       });
-      it('has a tokenManager.on method', function () {
+      it('has a tokenManager.on method', function() {
         expect(signIn.authClient.tokenManager.on).toBeDefined();
       });
-      it('has a tokenManager.off method', function () {
+      it('has a tokenManager.off method', function() {
         expect(signIn.authClient.tokenManager.off).toBeDefined();
       });
     });
   });
 
-  Expect.describe('events', function () {
-    afterEach(function () {
+  Expect.describe('events', function() {
+    afterEach(function() {
       signIn.remove();
       signIn.off();
     });
-    it('triggers an afterRender event when the Widget renders a page', function (done) {
+    it('triggers an afterRender event when the Widget renders a page', function(done) {
       signIn.renderEl({ el: $sandbox });
-      signIn.on('afterRender', function (context) {
+      signIn.on('afterRender', function(context) {
         expect(context).toEqual({ controller: 'primary-auth' });
         done();
       });
     });
 
-    it('triggers a ready event when the Widget renders a page', function (done) {
+    it('triggers a ready event when the Widget renders a page', function(done) {
       signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function (context) {
+      signIn.on('ready', function(context) {
         expect(context).toEqual({ controller: 'primary-auth' });
         done();
       });
     });
 
-    it('triggers a ready event when the Widget is loaded with a recoveryToken', function (done) {
+    it('triggers a ready event when the Widget is loaded with a recoveryToken', function(done) {
       signIn = new Widget({
         baseUrl: url,
         recoveryToken: 'foo',
       });
       signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function (context) {
+      signIn.on('ready', function(context) {
         expect(context).toEqual({ controller: 'recovery-loading' });
         done();
       });
     });
-    it('triggers a ready event when the Widget is loaded with using idpDiscovery', function (done) {
+    it('triggers a ready event when the Widget is loaded with using idpDiscovery', function(done) {
       signIn = new Widget({
         baseUrl: url,
         features: { idpDiscovery: true },
       });
       signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function (context) {
+      signIn.on('ready', function(context) {
         expect(context).toEqual({ controller: 'idp-discovery' });
         done();
       });
     });
-    it('does not trigger a ready event twice', function (done) {
+    it('does not trigger a ready event twice', function(done) {
       signIn.renderEl({ el: '#sandbox' });
-      signIn.on('ready', function (context) {
+      signIn.on('ready', function(context) {
         expect(context).toEqual({ controller: 'primary-auth' });
         // Navigate directly to forgot-password page
         const forgotPasswordLink = document.getElementsByClassName('link js-forgot-password');
 
         forgotPasswordLink[0].click();
       });
-      signIn.on('afterRender', function (context) {
+      signIn.on('afterRender', function(context) {
         if (context.controller === 'forgot-password') {
           done();
         }
@@ -264,10 +264,10 @@ Expect.describe('OktaSignIn initialization', function () {
   });
 });
 
-describe('OktaSignIn object API', function () {
+describe('OktaSignIn object API', function() {
   let signIn;
   let router;
-  beforeEach(function () {
+  beforeEach(function() {
     spyOn(Logger, 'warn');
     signIn = null;
     router = null;
@@ -278,7 +278,7 @@ describe('OktaSignIn object API', function () {
     $sandbox.empty();
   });
 
-  function createWidget (options = {}) {
+  function createWidget(options = {}) {
     signIn = new Widget(Object.assign({
       baseUrl: url,
       features: {
@@ -287,15 +287,15 @@ describe('OktaSignIn object API', function () {
     }, options));
   }
 
-  function submitPrimaryAuthForm () {
+  function submitPrimaryAuthForm() {
     const form = new PrimaryAuthForm($sandbox);
     form.setUsername('fake@fake.com');
     form.setPassword('FakePassword1');
     form.submit();
   }
 
-  function mockRouter () {
-    spyOn(V1Router.prototype, 'start').and.callFake(function () {
+  function mockRouter() {
+    spyOn(V1Router.prototype, 'start').and.callFake(function() {
       router = this;
       router.controller = {
         remove: () => {}
@@ -356,12 +356,12 @@ describe('OktaSignIn object API', function () {
         
         return Expect.wait(() => {
           return $('.primary-auth').length === 1;
-        }).then(function () {
+        }).then(function() {
           submitPrimaryAuthForm();
           return Expect.wait(() => {
             return successFn.calls.count() > 0;
           });
-        }).then(function () {
+        }).then(function() {
           expect(successFn).toHaveBeenCalledWith({
             user: v1Success.response._embedded.user,
             type: 'SESSION_SSO',
@@ -379,7 +379,7 @@ describe('OktaSignIn object API', function () {
 
         Expect.wait(() => {
           return $('.primary-auth').length === 1;
-        }).then(function () {
+        }).then(function() {
           submitPrimaryAuthForm();
         });
         
@@ -406,7 +406,7 @@ describe('OktaSignIn object API', function () {
         return Expect.wait(() => {
           return errorFn.calls.count() > 0;
         })
-          .then(function () {
+          .then(function() {
             const error = errorFn.calls.argsFor(0)[0];
             expect(error.message).toEqual('"el" is a required widget parameter');
           });
@@ -558,10 +558,10 @@ describe('OktaSignIn object API', function () {
 
 });
 
-Expect.describe('OktaSignIn v1 pipeline bootstrap ', function () {
+Expect.describe('OktaSignIn v1 pipeline bootstrap ', function() {
   let signIn;
   const form = new PrimaryAuthForm($sandbox);
-  beforeEach(function () {
+  beforeEach(function() {
     spyOn(Logger, 'warn');
     signIn = new Widget({
       baseUrl: url,
@@ -572,13 +572,13 @@ Expect.describe('OktaSignIn v1 pipeline bootstrap ', function () {
     });
   });
 
-  afterEach(function () {
+  afterEach(function() {
     signIn.remove();
   });
 
-  function setupIntrospect (responseData) {
+  function setupIntrospect(responseData) {
     spyOn(window.history, 'pushState');
-    spyOn(signIn.authClient.tx, 'introspect').and.callFake(function () {
+    spyOn(signIn.authClient.tx, 'introspect').and.callFake(function() {
       if (responseData.status !== 200) {
         return Q.reject(responseData.response);
       } else {
@@ -592,9 +592,9 @@ Expect.describe('OktaSignIn v1 pipeline bootstrap ', function () {
       return $('.primary-auth').length === 1;
     });
   }
-  Expect.describe('Introspects token and loads primary auth view for old pipeline', function () {
-    it('calls introspect API on page load using authjs as client', function () {
-      return setupIntrospect(introspectResponse).then(function () {
+  Expect.describe('Introspects token and loads primary auth view for old pipeline', function() {
+    it('calls introspect API on page load using authjs as client', function() {
+      return setupIntrospect(introspectResponse).then(function() {
         expect(window.history.pushState.calls.argsFor(0)[2]).toBe('/signin/refresh-auth-state/00stateToken');
         expect(signIn.authClient.tx.introspect).toHaveBeenCalledWith({ stateToken: '00stateToken' });
         expect(form.isPrimaryAuth()).toBe(true);
@@ -616,8 +616,8 @@ Expect.describe('OktaSignIn v1 pipeline bootstrap ', function () {
       });
     });
 
-    it('calls introspect API on page load and handles error using authjs as client', function () {
-      return setupIntrospect(errorResponse).then(function () {
+    it('calls introspect API on page load and handles error using authjs as client', function() {
+      return setupIntrospect(errorResponse).then(function() {
         expect(window.history.pushState.calls.argsFor(0)[2]).toBe('/signin/refresh-auth-state/00stateToken');
         expect(signIn.authClient.tx.introspect).toHaveBeenCalledWith({ stateToken: '00stateToken' });
         expect(form.isPrimaryAuth()).toBe(true);
@@ -642,13 +642,13 @@ Expect.describe('OktaSignIn v1 pipeline bootstrap ', function () {
   });
 });
 
-Expect.describe('OktaSignIn v2 bootstrap', function () {
+Expect.describe('OktaSignIn v2 bootstrap', function() {
   let signIn;
   let codeVerifier;
   let codeChallenge;
   let codeChallengeMethod;
 
-  beforeEach(function () {
+  beforeEach(function() {
     spyOn(Logger, 'error');
     signIn = null;
     codeVerifier = 'fakecodeVerifier';
@@ -656,11 +656,11 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     codeChallengeMethod = 'fakecodeChallengeMethod';
   });
 
-  afterEach(function () {
+  afterEach(function() {
     signIn && signIn.remove();
   });
 
-  function setupLoginFlow (widgetOptions, responses) {
+  function setupLoginFlow(widgetOptions, responses) {
     signIn = new Widget(
       Object.assign(
         {
@@ -683,20 +683,20 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
 
     // Add customize parser for ION request
     jasmine.Ajax.addCustomParamParser({
-      test: function (xhr) {
+      test: function(xhr) {
         return xhr.contentType().indexOf('application/ion+json;') >= 0;
       },
-      parse: function jsonParser (paramString) {
+      parse: function jsonParser(paramString) {
         return JSON.parse(paramString);
       },
     });
   }
 
-  function render () {
+  function render() {
     return signIn.renderEl({ el: $sandbox });
   }
 
-  function setupProxyIdxResponse (options) {
+  function setupProxyIdxResponse(options) {
     signIn = new Widget(
       Object.assign(
         {
@@ -719,14 +719,14 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     );
   }
 
-  Expect.describe('Introspects token and loads Identifier view for new pipeline', function () {
-    itp('calls introspect API on page load using idx-js as client', function () {
+  Expect.describe('Introspects token and loads Identifier view for new pipeline', function() {
+    itp('calls introspect API on page load using idx-js as client', function() {
       const form = new IdentifierForm($sandbox);
       setupLoginFlow({ stateToken: '02stateToken' }, idxResponse);
       render();
       return Expect.wait(() => {
         return $('.siw-main-body').length === 1;
-      }).then(function () {
+      }).then(function() {
         expect(form.getTitle()).toBe('Sign In');
         expect(form.getIdentifierInput().length).toBe(1);
         expect(form.getIdentifierInput().attr('name')).toBe('identifier');
@@ -741,7 +741,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       });
     });
 
-    itp('throws an error if invalid version is passed to idx-js', function () {
+    itp('throws an error if invalid version is passed to idx-js', function() {
       setupLoginFlow({
         stateToken: '02stateToken',
         apiVersion: '2.0.0'
@@ -754,11 +754,11 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     });
   });
 
-  Expect.describe('Interaction code flow', function () {
+  Expect.describe('Interaction code flow', function() {
     let responses;
     let interactionHandle;
 
-    beforeEach(function () {
+    beforeEach(function() {
       interactionHandle = 'fake_interaction_handle';
       responses = [
         {
@@ -772,7 +772,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       ];
     });
 
-    itp('calls interact API on page load using idx-js as client in custom hosted widget', function () {
+    itp('calls interact API on page load using idx-js as client in custom hosted widget', function() {
       const form = new IdentifierForm($sandbox);
       setupLoginFlow({ 
         clientId: 'someClientId',
@@ -783,7 +783,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       render();
       return Expect.wait(() => {
         return $('.siw-main-body').length === 1;
-      }).then(function () {
+      }).then(function() {
         expect(form.getTitle()).toBe('Sign In');
         expect(form.getIdentifierInput().length).toBe(1);
         expect(form.getIdentifierInput().attr('name')).toBe('identifier');
@@ -800,7 +800,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       });
     });
 
-    itp('throws an error if invalid version is passed to idx-js', function () {
+    itp('throws an error if invalid version is passed to idx-js', function() {
       setupLoginFlow({
         apiVersion: '2.0.0',
         clientId: 'someClientId',
@@ -834,7 +834,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         render();
         return Expect.wait(() => {
           return $('.siw-main-view.terminal').length === 1;
-        }).then(function () {
+        }).then(function() {
           expect(view.getErrorMessages()).toBe(testStr);
         });
       });
@@ -851,7 +851,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         render();
         return Expect.wait(() => {
           return $('.siw-main-view.terminal').length === 1;
-        }).then(function () {
+        }).then(function() {
           expect(view.getErrorMessages()).toBe(testStr);
         });
       });
@@ -870,7 +870,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       
       return Expect.wait(() => {
         return $('.siw-main-body').length === 1;
-      }).then(function () {
+      }).then(function() {
         expect(signIn.authClient.transactionManager.save).toHaveBeenCalledWith({
           codeChallenge,
           codeVerifier,
@@ -905,7 +905,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
       
       return Expect.wait(() => {
         return $('.siw-main-body').length === 1;
-      }).then(function () {
+      }).then(function() {
 
         expect(jasmine.Ajax.requests.count()).toBe(1);
         const firstReq = jasmine.Ajax.requests.at(0);
@@ -965,7 +965,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
           tokens: {}
         }));
 
-        return render().then(function () {
+        return render().then(function() {
           expect(signIn.authClient.transactionManager.clear).toHaveBeenCalled();
         });
       });
@@ -984,7 +984,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         render();
         return Expect.wait(() => {
           return $('.siw-main-body').length === 1;
-        }).then(function () {
+        }).then(function() {
           expect(signIn.authClient.transactionManager.clear).toHaveBeenCalled();
         });
       });
@@ -1003,7 +1003,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         render();
         return Expect.wait(() => {
           return $('.siw-main-body').length === 1;
-        }).then(function () {
+        }).then(function() {
           expect(signIn.authClient.transactionManager.clear).not.toHaveBeenCalled();
         });
       });
@@ -1030,7 +1030,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
         
         return Expect.wait(() => {
           return $('.siw-main-body').length === 1;
-        }).then(function () {
+        }).then(function() {
           expect(signIn.authClient.transactionManager.clear).not.toHaveBeenCalled();
           const $signOut = $('a[data-se="cancel"]');
           $signOut.click();
@@ -1040,7 +1040,7 @@ Expect.describe('OktaSignIn v2 bootstrap', function () {
     }); // Clear transaction
   }); // interaction code
 
-  itp('Gets proxyIdxResponse and render terminal view', function () {
+  itp('Gets proxyIdxResponse and render terminal view', function() {
     setupProxyIdxResponse({ enrollmentType : 'mdm'});
     render();
     return Expect.wait(() => {

--- a/test/unit/spec/PasswordExpired_spec.js
+++ b/test/unit/spec/PasswordExpired_spec.js
@@ -20,11 +20,11 @@ import LoginUtil from 'util/Util';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-function setup (settings, res, custom) {
+function setup(settings, res, custom) {
   settings || (settings = {});
   const successSpy = jasmine.createSpy('successSpy');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
@@ -69,28 +69,28 @@ function setup (settings, res, custom) {
   return Expect.waitForPasswordExpired(settings);
 }
 
-function setupWarn (numDays, settings) {
+function setupWarn(numDays, settings) {
   resPassWarn.response._embedded.policy.expiration.passwordExpireDays = numDays;
   return setup(settings, resPassWarn);
 }
 
-function setupCustomExpiredPassword (settings, res) {
+function setupCustomExpiredPassword(settings, res) {
   return setup(settings, res || resCustomPassExpired, true);
 }
 
-function setupCustomExpiredPasswordWarn (numDays, settings) {
+function setupCustomExpiredPasswordWarn(numDays, settings) {
   resCustomPassWarn.response._embedded.policy.expiration.passwordExpireDays = numDays;
   return setupCustomExpiredPassword(settings, resCustomPassWarn);
 }
 
-function submitNewPass (test, oldPass, newPass, confirmPass) {
+function submitNewPass(test, oldPass, newPass, confirmPass) {
   test.form.setOldPass(oldPass);
   test.form.setNewPass(newPass);
   test.form.setConfirmPass(confirmPass);
   test.form.submit();
 }
 
-function setupExcludeAttributes (excludeAttributesArray, showPasswordRequirementsAsHtmlList = false) {
+function setupExcludeAttributes(excludeAttributesArray, showPasswordRequirementsAsHtmlList = false) {
   const passwordExpiredResponse = deepClone(resPassExpired);
   const policyComplexity = passwordExpiredResponse.response._embedded.policy.complexity;
 
@@ -102,25 +102,25 @@ function setupExcludeAttributes (excludeAttributesArray, showPasswordRequirement
   );
 }
 
-Expect.describe('PasswordExpiration', function () {
-  Expect.describe('PasswordExpired', function () {
-    itp('shows security beacon', function () {
-      return setup().then(function (test) {
+Expect.describe('PasswordExpiration', function() {
+  Expect.describe('PasswordExpired', function() {
+    itp('shows security beacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
-    itp('has the correct title', function () {
-      return setup().then(function (test) {
+    itp('has the correct title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toBe('Your password has expired');
       });
     });
-    itp('has the correct title if config has a brandName', function () {
-      return setup({ brandName: 'Spaghetti Inc.' }).then(function (test) {
+    itp('has the correct title if config has a brandName', function() {
+      return setup({ brandName: 'Spaghetti Inc.' }).then(function(test) {
         expect(test.form.titleText()).toBe('Your Spaghetti Inc. password has expired');
       });
     });
-    itp('has a valid subtitle', function () {
-      return setup().then(function (test) {
+    itp('has a valid subtitle', function() {
+      return setup().then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: at least 8 characters,' +
             ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -128,8 +128,8 @@ Expect.describe('PasswordExpiration', function () {
         );
       });
     });
-    itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function () {
-      return setupExcludeAttributes(['firstName']).then(function (test) {
+    itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function() {
+      return setupExcludeAttributes(['firstName']).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: at least 8 characters,' +
             ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -137,8 +137,8 @@ Expect.describe('PasswordExpiration', function () {
         );
       });
     });
-    itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function () {
-      return setupExcludeAttributes(['lastName']).then(function (test) {
+    itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function() {
+      return setupExcludeAttributes(['lastName']).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: at least 8 characters,' +
             ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -146,8 +146,8 @@ Expect.describe('PasswordExpiration', function () {
         );
       });
     });
-    itp('has a valid subtitle if only excludeAttributes[] is defined', function () {
-      return setupExcludeAttributes([]).then(function (test) {
+    itp('has a valid subtitle if only excludeAttributes[] is defined', function() {
+      return setupExcludeAttributes([]).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: at least 8 characters,' +
             ' a lowercase letter, an uppercase letter, a number, a symbol, no parts of your username.'
@@ -155,14 +155,14 @@ Expect.describe('PasswordExpiration', function () {
       });
     });
 
-    Expect.describe('Password description in HTML', function () {
-      itp('does not have a subtitle if password requirements as HTML FF is on', function () {
-        return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function (test) {
+    Expect.describe('Password description in HTML', function() {
+      itp('does not have a subtitle if password requirements as HTML FF is on', function() {
+        return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function(test) {
           expect(test.form.subtitle().length).toEqual(0);
         });
       });
-      itp('shows password requirements as HTML list if FF is on', function () {
-        return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function (test) {
+      itp('shows password requirements as HTML list if FF is on', function() {
+        return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function(test) {
           expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(8);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -179,8 +179,8 @@ Expect.describe('PasswordExpiration', function () {
       });
       itp(
         'shows password requirements as HTML list if FF is on and if only excludeAttributes["firstName"] is defined',
-        function () {
-          return setupExcludeAttributes(['firstName'], true).then(function (test) {
+        function() {
+          return setupExcludeAttributes(['firstName'], true).then(function(test) {
             expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
             expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(7);
             expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -197,8 +197,8 @@ Expect.describe('PasswordExpiration', function () {
       );
       itp(
         'shows password requirements as HTML list if FF is on and if only excludeAttributes["lastName"] is defined',
-        function () {
-          return setupExcludeAttributes(['lastName'], true).then(function (test) {
+        function() {
+          return setupExcludeAttributes(['lastName'], true).then(function(test) {
             expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
             expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(7);
             expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -213,8 +213,8 @@ Expect.describe('PasswordExpiration', function () {
           });
         }
       );
-      itp('shows password requirements as HTML list if FF is on and if excludeAttributes is empty', function () {
-        return setupExcludeAttributes([], true).then(function (test) {
+      itp('shows password requirements as HTML list if FF is on and if excludeAttributes is empty', function() {
+        return setupExcludeAttributes([], true).then(function(test) {
           expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(6);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -227,39 +227,39 @@ Expect.describe('PasswordExpiration', function () {
       });
     });
 
-    itp('has an old password field', function () {
-      return setup().then(function (test) {
+    itp('has an old password field', function() {
+      return setup().then(function(test) {
         Expect.isPasswordField(test.form.oldPassField());
       });
     });
-    itp('has a new password field', function () {
-      return setup().then(function (test) {
+    itp('has a new password field', function() {
+      return setup().then(function(test) {
         Expect.isPasswordField(test.form.newPassField());
       });
     });
-    itp('has a confirm password field', function () {
-      return setup().then(function (test) {
+    itp('has a confirm password field', function() {
+      return setup().then(function(test) {
         Expect.isPasswordField(test.form.confirmPassField());
       });
     });
-    itp('has a change password button', function () {
-      return setup().then(function (test) {
+    itp('has a change password button', function() {
+      return setup().then(function(test) {
         expect(test.form.submitButton().length).toBe(1);
       });
     });
-    itp('has a sign out link', function () {
-      return setup().then(function (test) {
+    itp('has a sign out link', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.signoutLink());
       });
     });
-    itp('does not have a skip link', function () {
-      return setup().then(function (test) {
+    itp('does not have a skip link', function() {
+      return setup().then(function(test) {
         expect(test.form.skipLink().length).toBe(0);
       });
     });
-    itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+    itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           spyOn(SharedUtil, 'redirect');
           Util.resetAjaxRequests();
@@ -272,7 +272,7 @@ Expect.describe('PasswordExpiration', function () {
           // see RouterUtil for details
           return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/cancel',
@@ -286,9 +286,9 @@ Expect.describe('PasswordExpiration', function () {
     });
     itp(
       'has a signout link which cancels the current stateToken and redirects to the provided signout url',
-      function () {
+      function() {
         return setup({ signOutLink: 'http://www.goodbye.com' })
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
             spyOn(SharedUtil, 'redirect');
             Util.resetAjaxRequests();
@@ -301,7 +301,7 @@ Expect.describe('PasswordExpiration', function () {
             // see RouterUtil for details
             return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.com/api/v1/authn/cancel',
@@ -314,17 +314,17 @@ Expect.describe('PasswordExpiration', function () {
           });
       }
     );
-    itp('calls processCreds function before saving a model', function () {
+    itp('calls processCreds function before saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
       return setup({ processCreds: processCredsSpy })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith({
             username: 'inca@clouditude.net',
@@ -333,22 +333,22 @@ Expect.describe('PasswordExpiration', function () {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('calls async processCreds function before saving a model', function () {
+    itp('calls async processCreds function before saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
       return setup({
-        processCreds: function (creds, callback) {
+        processCreds: function(creds, callback) {
           processCredsSpy(creds, callback);
           callback();
         },
       })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith(
             {
@@ -360,21 +360,21 @@ Expect.describe('PasswordExpiration', function () {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('calls async processCreds function and can prevent saving a model', function () {
+    itp('calls async processCreds function and can prevent saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
       return setup({
-        processCreds: function (creds, callback) {
+        processCreds: function(creds, callback) {
           processCredsSpy(creds, callback);
         },
       })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpwd', 'newpwd', 'newpwd');
           return Expect.waitForSpyCall(processCredsSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith(
             {
@@ -386,15 +386,15 @@ Expect.describe('PasswordExpiration', function () {
           expect(Util.numAjaxRequests()).toBe(0);
         });
     });
-    itp('saves the new password successfully', function () {
+    itp('saves the new password successfully', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpassyo', 'boopity', 'boopity');
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/credentials/change_password',
@@ -406,45 +406,45 @@ Expect.describe('PasswordExpiration', function () {
           });
         });
     });
-    itp('makes submit button disable when form is submitted', function () {
+    itp('makes submit button disable when form is submitted', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resSuccess);
           submitNewPass(test, 'oldpass', 'newpass', 'newpass');
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
           expect(buttonClass).toContain('link-button-disabled');
         });
     });
-    itp('makes submit button enabled after error response', function () {
+    itp('makes submit button enabled after error response', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resErrorOldPass);
           submitNewPass(test, 'wrongoldpass', 'boo', 'boo');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
           expect(buttonClass).not.toContain('link-button-disabled');
         });
     });
-    itp('shows an error if the server returns a wrong old pass error', function () {
+    itp('shows an error if the server returns a wrong old pass error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resErrorOldPass);
           submitNewPass(test, 'wrongoldpass', 'boo', 'boo');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Old password is not correct');
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -476,14 +476,14 @@ Expect.describe('PasswordExpiration', function () {
           ]);
         });
     });
-    itp('shows an error if the server returns a complexity error', function () {
+    itp('shows an error if the server returns a complexity error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resErrorComplexity);
           submitNewPass(test, 'oldpassyo', 'badpass', 'badpass');
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe(
             'Password requirements were not met. Password requirements: at least 8 characters,' +
@@ -521,14 +521,14 @@ Expect.describe('PasswordExpiration', function () {
     });
     itp(
       'shows an simple error if showPasswordRequirementsAsHtmlList is on and if the server returns a complexity error',
-      function () {
+      function() {
         return setup({ 'features.showPasswordRequirementsAsHtmlList': true })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resErrorComplexity);
             submitNewPass(test, 'oldpassyo', 'badpass', 'badpass');
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('Password requirements were not met.');
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -563,14 +563,14 @@ Expect.describe('PasswordExpiration', function () {
     );
     itp(
       'shows an simple error if no error cause and if showPasswordRequirementsAsHtmlList is on and if the server returns a complexity error',
-      function () {
+      function() {
         return setup({ 'features.showPasswordRequirementsAsHtmlList': true })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resErrorNoCause);
             submitNewPass(test, 'oldpassyo', 'badpass', 'badpass');
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.hasErrors()).toBe(true);
             expect(test.form.errorMessage()).toBe('Update of credentials failed');
             expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -598,8 +598,8 @@ Expect.describe('PasswordExpiration', function () {
           });
       }
     );
-    itp('validates that fields are not empty', function () {
-      return setup().then(function (test) {
+    itp('validates that fields are not empty', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(Util.numAjaxRequests()).toBe(0);
@@ -610,8 +610,8 @@ Expect.describe('PasswordExpiration', function () {
       });
     });
 
-    itp('validates that new password is equal to confirm password', function () {
-      return setup().then(function (test) {
+    itp('validates that new password is equal to confirm password', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         submitNewPass(test, 'newpass', 'differentnewpass');
         expect(Util.numAjaxRequests()).toBe(0);
@@ -621,103 +621,103 @@ Expect.describe('PasswordExpiration', function () {
     });
   });
 
-  Expect.describe('CustomPasswordExpired', function () {
-    itp('shows security beacon', function () {
-      return setup().then(function (test) {
+  Expect.describe('CustomPasswordExpired', function() {
+    itp('shows security beacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
-    itp('has the correct title', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('has the correct title', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         expect(test.form.titleText()).toBe('Your password has expired');
       });
     });
-    itp('has the correct title if config has a brandName', function () {
-      return setupCustomExpiredPassword({ brandName: 'Spaghetti Inc.' }).then(function (test) {
+    itp('has the correct title if config has a brandName', function() {
+      return setupCustomExpiredPassword({ brandName: 'Spaghetti Inc.' }).then(function(test) {
         expect(test.form.titleText()).toBe('Your Spaghetti Inc. password has expired');
       });
     });
-    itp('has a valid subtitle', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('has a valid subtitle', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'This password is set on another website. ' + 'Click the button below to go there and set a new password.'
         );
       });
     });
-    itp('has a custom change password button', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('has a custom change password button', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         expect(test.form.customButton().length).toBe(1);
       });
     });
-    itp('has a valid custom button text', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('has a valid custom button text', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         expect(test.form.customButtonText()).toEqual('Go to Twitter');
       });
     });
-    itp('has a sign out link', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('has a sign out link', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         Expect.isVisible(test.form.signoutLink());
       });
     });
-    itp('does not have a skip link', function () {
-      return setupCustomExpiredPassword().then(function (test) {
+    itp('does not have a skip link', function() {
+      return setupCustomExpiredPassword().then(function(test) {
         expect(test.form.skipLink().length).toBe(0);
       });
     });
-    itp('redirect is called with the correct arg on custom button click', function () {
+    itp('redirect is called with the correct arg on custom button click', function() {
       spyOn(SharedUtil, 'redirect');
-      return setupCustomExpiredPassword().then(function (test) {
+      return setupCustomExpiredPassword().then(function(test) {
         test.form.clickCustomButton();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://www.twitter.com');
       });
     });
   });
 
-  Expect.describe('PasswordAboutToExpire', function () {
-    itp('has the correct title if expiring in > 0 days', function () {
-      return setupWarn(4).then(function (test) {
+  Expect.describe('PasswordAboutToExpire', function() {
+    itp('has the correct title if expiring in > 0 days', function() {
+      return setupWarn(4).then(function(test) {
         expect(test.form.titleText()).toBe('Your password will expire in 4 days');
       });
     });
-    itp('has the correct title if expiring in 0 days', function () {
-      return setupWarn(0).then(function (test) {
+    itp('has the correct title if expiring in 0 days', function() {
+      return setupWarn(0).then(function(test) {
         expect(test.form.titleText()).toBe('Your password will expire later today');
       });
     });
-    itp('has the correct title if numDays is null', function () {
-      return setupWarn(null).then(function (test) {
+    itp('has the correct title if numDays is null', function() {
+      return setupWarn(null).then(function(test) {
         expect(test.form.titleText()).toBe('Your password is expiring soon');
       });
     });
-    itp('has the correct title if numDays is undefined', function () {
-      return setupWarn(undefined).then(function (test) {
+    itp('has the correct title if numDays is undefined', function() {
+      return setupWarn(undefined).then(function(test) {
         expect(test.form.titleText()).toBe('Your password is expiring soon');
       });
     });
-    itp('has the correct subtitle', function () {
-      return setupWarn(4).then(function (test) {
+    itp('has the correct subtitle', function() {
+      return setupWarn(4).then(function(test) {
         expect(test.form.subtitleText()).toBe('When password expires you will be locked out of your account.');
       });
     });
-    itp('has the correct subtitle if config has a brandName', function () {
-      return setupWarn(4, { brandName: 'Spaghetti Inc.' }).then(function (test) {
+    itp('has the correct subtitle if config has a brandName', function() {
+      return setupWarn(4, { brandName: 'Spaghetti Inc.' }).then(function(test) {
         expect(test.form.subtitleText()).toBe(
           'When password expires you will be locked out of your Spaghetti Inc. account.'
         );
       });
     });
-    itp('has a sign out link', function () {
-      return setupWarn(4).then(function (test) {
+    itp('has a sign out link', function() {
+      return setupWarn(4).then(function(test) {
         Expect.isVisible(test.form.signoutLink());
       });
     });
-    itp('has a skip link', function () {
-      return setupWarn(4).then(function (test) {
+    itp('has a skip link', function() {
+      return setupWarn(4).then(function(test) {
         Expect.isVisible(test.form.skipLink());
       });
     });
-    itp('goToLink is called with the correct args on skip', function () {
-      return setupWarn(4).then(function (test) {
+    itp('goToLink is called with the correct args on skip', function() {
+      return setupWarn(4).then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.skip();
@@ -730,16 +730,16 @@ Expect.describe('PasswordExpiration', function () {
         });
       });
     });
-    itp('goToLink is called with the correct args on sign out', function () {
+    itp('goToLink is called with the correct args on sign out', function() {
       return setupWarn(4)
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           Util.resetAjaxRequests();
           test.setNextResponse(resCancel);
           test.form.signout();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/cancel',
@@ -753,34 +753,34 @@ Expect.describe('PasswordExpiration', function () {
     });
   });
 
-  Expect.describe('CustomPasswordAboutToExpire', function () {
-    itp('shows security beacon', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+  Expect.describe('CustomPasswordAboutToExpire', function() {
+    itp('shows security beacon', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
-    itp('has the correct title if expiring in > 0 days', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has the correct title if expiring in > 0 days', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         expect(test.form.titleText()).toBe('Your password will expire in 4 days');
       });
     });
-    itp('has the correct title if expiring in 0 days', function () {
-      return setupCustomExpiredPasswordWarn(0).then(function (test) {
+    itp('has the correct title if expiring in 0 days', function() {
+      return setupCustomExpiredPasswordWarn(0).then(function(test) {
         expect(test.form.titleText()).toBe('Your password will expire later today');
       });
     });
-    itp('has the correct title if numDays is null', function () {
-      return setupCustomExpiredPasswordWarn(null).then(function (test) {
+    itp('has the correct title if numDays is null', function() {
+      return setupCustomExpiredPasswordWarn(null).then(function(test) {
         expect(test.form.titleText()).toBe('Your password is expiring soon');
       });
     });
-    itp('has the correct title if numDays is undefined', function () {
-      return setupCustomExpiredPasswordWarn(undefined).then(function (test) {
+    itp('has the correct title if numDays is undefined', function() {
+      return setupCustomExpiredPasswordWarn(undefined).then(function(test) {
         expect(test.form.titleText()).toBe('Your password is expiring soon');
       });
     });
-    itp('has a valid subtitle', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has a valid subtitle', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'When password expires you will be locked out of your account. ' +
             'This password is set on another website. ' +
@@ -788,8 +788,8 @@ Expect.describe('PasswordExpiration', function () {
         );
       });
     });
-    itp('has a valid subtitle if config has a brandName', function () {
-      return setupCustomExpiredPasswordWarn(4, { brandName: 'Spaghetti Inc.' }).then(function (test) {
+    itp('has a valid subtitle if config has a brandName', function() {
+      return setupCustomExpiredPasswordWarn(4, { brandName: 'Spaghetti Inc.' }).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'When password expires you will be locked out of your Spaghetti Inc. account. ' +
             'This password is set on another website. ' +
@@ -797,29 +797,29 @@ Expect.describe('PasswordExpiration', function () {
         );
       });
     });
-    itp('has a custom change password button', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has a custom change password button', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         expect(test.form.customButton().length).toBe(1);
       });
     });
-    itp('has a valid custom button text', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has a valid custom button text', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         expect(test.form.customButtonText()).toEqual('Go to Google');
       });
     });
-    itp('has a sign out link', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has a sign out link', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         Expect.isVisible(test.form.signoutLink());
       });
     });
-    itp('has a skip link', function () {
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+    itp('has a skip link', function() {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         Expect.isVisible(test.form.skipLink());
       });
     });
-    itp('redirect is called with the correct arg on custom button click', function () {
+    itp('redirect is called with the correct arg on custom button click', function() {
       spyOn(SharedUtil, 'redirect');
-      return setupCustomExpiredPasswordWarn(4).then(function (test) {
+      return setupCustomExpiredPasswordWarn(4).then(function(test) {
         test.form.clickCustomButton();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://www.google.com');
       });

--- a/test/unit/spec/PasswordReset_spec.js
+++ b/test/unit/spec/PasswordReset_spec.js
@@ -17,11 +17,11 @@ import LoginUtil from 'util/Util';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-function setup (settings) {
+function setup(settings) {
   settings || (settings = {});
   const successSpy = jasmine.createSpy('successSpy');
   const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
@@ -112,20 +112,20 @@ function setup (settings) {
   });
 }
 
-function getExcludeAttributes (excludeAttributes) {
+function getExcludeAttributes(excludeAttributes) {
   return excludeAttributes || ['firstName', 'lastName'];
 }
 
-Expect.describe('PasswordReset', function () {
-  itp('displays the security beacon if enabled', function () {
-    return setup({ 'features.securityImage': true }).then(function (test) {
+Expect.describe('PasswordReset', function() {
+  itp('displays the security beacon if enabled', function() {
+    return setup({ 'features.securityImage': true }).then(function(test) {
       expect(test.beacon.isSecurityBeacon()).toBe(true);
     });
   });
 
-  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
@@ -135,7 +135,7 @@ Expect.describe('PasswordReset', function () {
         $link.click();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -148,17 +148,17 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('does not show back link if hideBackToSignInForReset is true', function () {
-    return setup({ 'features.hideBackToSignInForReset': true }).then(function (test) {
+  itp('does not show back link if hideBackToSignInForReset is true', function() {
+    return setup({ 'features.hideBackToSignInForReset': true }).then(function(test) {
       const $link = test.form.signoutLink();
 
       expect($link.length).toBe(0);
     });
   });
 
-  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function () {
+  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function() {
     return setup({ signOutLink: 'http://www.goodbye.com' })
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
@@ -174,7 +174,7 @@ Expect.describe('PasswordReset', function () {
         // see RouterUtil for details
         return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -187,70 +187,70 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('has a valid subtitle if NO password complexity defined', function () {
-    return setup().then(function (test) {
+  itp('has a valid subtitle if NO password complexity defined', function() {
+    return setup().then(function(test) {
       expect(test.form.subtitleText()).toEqual('');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "minLength" defined', function () {
-    return setup({ policyComplexity: 'minLength' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "minLength" defined', function() {
+    return setup({ policyComplexity: 'minLength' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: at least 8 characters.');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "minLowerCase" defined', function () {
-    return setup({ policyComplexity: 'minLowerCase' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "minLowerCase" defined', function() {
+    return setup({ policyComplexity: 'minLowerCase' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: a lowercase letter.');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "minUpperCase" defined', function () {
-    return setup({ policyComplexity: 'minUpperCase' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "minUpperCase" defined', function() {
+    return setup({ policyComplexity: 'minUpperCase' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: an uppercase letter.');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "minNumber" defined', function () {
-    return setup({ policyComplexity: 'minNumber' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "minNumber" defined', function() {
+    return setup({ policyComplexity: 'minNumber' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: a number.');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "minSymbol" defined', function () {
-    return setup({ policyComplexity: 'minSymbol' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "minSymbol" defined', function() {
+    return setup({ policyComplexity: 'minSymbol' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: a symbol.');
     });
   });
 
-  itp('has a valid subtitle if only password complexity "excludeUsername" defined', function () {
-    return setup({ policyComplexity: 'excludeUsername' }).then(function (test) {
+  itp('has a valid subtitle if only password complexity "excludeUsername" defined', function() {
+    return setup({ policyComplexity: 'excludeUsername' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: no parts of your username.');
     });
   });
 
-  itp('has a valid subtitle if only excludeAttributes["firstName","lastName"] is defined', function () {
-    return setup({ policyComplexity: 'excludeAttributes' }).then(function (test) {
+  itp('has a valid subtitle if only excludeAttributes["firstName","lastName"] is defined', function() {
+    return setup({ policyComplexity: 'excludeAttributes' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'Password requirements: does not include your first name,' + ' does not include your last name.'
       );
     });
   });
 
-  itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function () {
-    return setup({ policyComplexity: 'excludeAttributes', excludeAttributes: ['firstName'] }).then(function (test) {
+  itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function() {
+    return setup({ policyComplexity: 'excludeAttributes', excludeAttributes: ['firstName'] }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: does not include your first name.');
     });
   });
 
-  itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function () {
-    return setup({ policyComplexity: 'excludeAttributes', excludeAttributes: ['lastName'] }).then(function (test) {
+  itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function() {
+    return setup({ policyComplexity: 'excludeAttributes', excludeAttributes: ['lastName'] }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Password requirements: does not include your last name.');
     });
   });
 
-  itp('has a valid subtitle if only excludeAttributes[] is defined', function () {
-    return setup({ policyComplexity: 'all', excludeAttributes: [] }).then(function (test) {
+  itp('has a valid subtitle if only excludeAttributes[] is defined', function() {
+    return setup({ policyComplexity: 'all', excludeAttributes: [] }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'Password requirements: at least 8 characters, a lowercase letter,' +
           ' an uppercase letter, a number, a symbol, no parts of your username.'
@@ -258,30 +258,30 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  itp('has a valid subtitle if only password age "historyCount" defined', function () {
-    return setup({ policyAge: 'historyCount' }).then(function (test) {
+  itp('has a valid subtitle if only password age "historyCount" defined', function() {
+    return setup({ policyAge: 'historyCount' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual('Your password cannot be any of your last 7 passwords.');
     });
   });
 
-  itp('has a valid subtitle in minutes if only password age "minAgeMinutes" defined', function () {
-    return setup({ policyAge: 'minAgeMinutes' }).then(function (test) {
+  itp('has a valid subtitle in minutes if only password age "minAgeMinutes" defined', function() {
+    return setup({ policyAge: 'minAgeMinutes' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'At least 30 minute(s) must have elapsed since you last changed your password.'
       );
     });
   });
 
-  itp('has a valid subtitle in hours if only password age "minAgeMinutesinHours" defined', function () {
-    return setup({ policyAge: 'minAgeMinutesinHours' }).then(function (test) {
+  itp('has a valid subtitle in hours if only password age "minAgeMinutesinHours" defined', function() {
+    return setup({ policyAge: 'minAgeMinutesinHours' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'At least 2 hour(s) must have elapsed since you last changed your password.'
       );
     });
   });
 
-  itp('has a valid subtitle in days if only password age "minAgeMinutesinDays" defined', function () {
-    return setup({ policyAge: 'minAgeMinutesinDays' }).then(function (test) {
+  itp('has a valid subtitle in days if only password age "minAgeMinutesinDays" defined', function() {
+    return setup({ policyAge: 'minAgeMinutesinDays' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'At least 2 day(s) must have elapsed since you last changed your password.'
       );
@@ -290,8 +290,8 @@ Expect.describe('PasswordReset', function () {
 
   itp(
     'has a valid subtitle if password complexity "excludeUsername" and password age "historyCount" defined',
-    function () {
-      return setup({ policyComplexity: 'excludeUsername', policyAge: 'historyCount' }).then(function (test) {
+    function() {
+      return setup({ policyComplexity: 'excludeUsername', policyAge: 'historyCount' }).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: no parts of your username.' + ' Your password cannot be any of your last 7 passwords.'
         );
@@ -299,8 +299,8 @@ Expect.describe('PasswordReset', function () {
     }
   );
 
-  itp('has a valid subtitle if password complexity is defined with all options', function () {
-    return setup({ policyComplexity: 'all' }).then(function (test) {
+  itp('has a valid subtitle if password complexity is defined with all options', function() {
+    return setup({ policyComplexity: 'all' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'Password requirements: at least 8 characters, a lowercase letter,' +
           ' an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -309,8 +309,8 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  itp('has a valid subtitle in minutes if password age is defined with all options', function () {
-    return setup({ policyAge: 'all' }).then(function (test) {
+  itp('has a valid subtitle in minutes if password age is defined with all options', function() {
+    return setup({ policyAge: 'all' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'Your password cannot be any of your last 7 passwords.' +
           ' At least 30 minute(s) must have elapsed since you last changed your password.'
@@ -320,8 +320,8 @@ Expect.describe('PasswordReset', function () {
 
   itp(
     'has a valid subtitle if password complexity is defined with all options and password age "historyCount" defined',
-    function () {
-      return setup({ policyComplexity: 'all', policyAge: 'historyCount' }).then(function (test) {
+    function() {
+      return setup({ policyComplexity: 'all', policyAge: 'historyCount' }).then(function(test) {
         expect(test.form.subtitleText()).toEqual(
           'Password requirements: at least 8 characters, a lowercase letter,' +
             ' an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -332,8 +332,8 @@ Expect.describe('PasswordReset', function () {
     }
   );
 
-  itp('has a valid subtitle if password age and complexity are defined with all options', function () {
-    return setup({ policyComplexity: 'all', policyAge: 'all' }).then(function (test) {
+  itp('has a valid subtitle if password age and complexity are defined with all options', function() {
+    return setup({ policyComplexity: 'all', policyAge: 'all' }).then(function(test) {
       expect(test.form.subtitleText()).toEqual(
         'Password requirements: at least 8 characters, a lowercase letter,' +
           ' an uppercase letter, a number, a symbol, no parts of your username,' +
@@ -344,84 +344,84 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  Expect.describe('Password description in HTML', function () {
-    itp('does not have subtitle', function () {
-      return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function (test) {
+  Expect.describe('Password description in HTML', function() {
+    itp('does not have subtitle', function() {
+      return setup({ 'features.showPasswordRequirementsAsHtmlList': true }).then(function(test) {
         expect(test.form.subtitle().length).toEqual(0);
       });
     });
 
-    itp('has a valid subtitle if only password complexity "minLength" defined', function () {
+    itp('has a valid subtitle if only password complexity "minLength" defined', function() {
       return setup({
         policyComplexity: 'minLength',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
       });
     });
 
-    itp('has a valid subtitle if only password complexity "minLowerCase" defined', function () {
+    itp('has a valid subtitle if only password complexity "minLowerCase" defined', function() {
       return setup({
         policyComplexity: 'minLowerCase',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A lowercase letter');
       });
     });
 
-    itp('has a valid subtitle if only password complexity "minUpperCase" defined', function () {
+    itp('has a valid subtitle if only password complexity "minUpperCase" defined', function() {
       return setup({
         policyComplexity: 'minUpperCase',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('An uppercase letter');
       });
     });
 
-    itp('has a valid subtitle if only password complexity "minNumber" defined', function () {
+    itp('has a valid subtitle if only password complexity "minNumber" defined', function() {
       return setup({
         policyComplexity: 'minNumber',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A number');
       });
     });
 
-    itp('has a valid subtitle if only password complexity "minSymbol" defined', function () {
+    itp('has a valid subtitle if only password complexity "minSymbol" defined', function() {
       return setup({
         policyComplexity: 'minSymbol',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('A symbol');
       });
     });
 
-    itp('has a valid subtitle if only password complexity "excludeUsername" defined', function () {
+    itp('has a valid subtitle if only password complexity "excludeUsername" defined', function() {
       return setup({
         policyComplexity: 'excludeUsername',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
       });
     });
 
-    itp('has a valid subtitle if only excludeAttributes["firstName","lastName"] is defined', function () {
+    itp('has a valid subtitle if only excludeAttributes["firstName","lastName"] is defined', function() {
       return setup({
         policyComplexity: 'excludeAttributes',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your first name');
@@ -429,36 +429,36 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function () {
+    itp('has a valid subtitle if only excludeAttributes["firstName"] is defined', function() {
       return setup({
         policyComplexity: 'excludeAttributes',
         excludeAttributes: ['firstName'],
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your first name');
       });
     });
 
-    itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function () {
+    itp('has a valid subtitle if only excludeAttributes["lastName"] is defined', function() {
       return setup({
         policyComplexity: 'excludeAttributes',
         excludeAttributes: ['lastName'],
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('Does not include your last name');
       });
     });
 
-    itp('has a valid subtitle if only excludeAttributes[] is defined', function () {
+    itp('has a valid subtitle if only excludeAttributes[] is defined', function() {
       return setup({
         policyComplexity: 'all',
         excludeAttributes: [],
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(6);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -470,8 +470,8 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle if only password age "historyCount" defined', function () {
-      return setup({ policyAge: 'historyCount', 'features.showPasswordRequirementsAsHtmlList': true }).then(function (
+    itp('has a valid subtitle if only password age "historyCount" defined', function() {
+      return setup({ policyAge: 'historyCount', 'features.showPasswordRequirementsAsHtmlList': true }).then(function(
         test
       ) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
@@ -482,8 +482,8 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle in minutes if only password age "minAgeMinutes" defined', function () {
-      return setup({ policyAge: 'minAgeMinutes', 'features.showPasswordRequirementsAsHtmlList': true }).then(function (
+    itp('has a valid subtitle in minutes if only password age "minAgeMinutes" defined', function() {
+      return setup({ policyAge: 'minAgeMinutes', 'features.showPasswordRequirementsAsHtmlList': true }).then(function(
         test
       ) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
@@ -494,11 +494,11 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle in hours if only password age "minAgeMinutesinHours" defined', function () {
+    itp('has a valid subtitle in hours if only password age "minAgeMinutesinHours" defined', function() {
       return setup({
         policyAge: 'minAgeMinutesinHours',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
@@ -507,11 +507,11 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle in days if only password age "minAgeMinutesinDays" defined', function () {
+    itp('has a valid subtitle in days if only password age "minAgeMinutesinDays" defined', function() {
       return setup({
         policyAge: 'minAgeMinutesinDays',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(1);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
@@ -522,12 +522,12 @@ Expect.describe('PasswordReset', function () {
 
     itp(
       'has a valid subtitle if password complexity "excludeUsername" and password age "historyCount" defined',
-      function () {
+      function() {
         return setup({
           policyComplexity: 'excludeUsername',
           policyAge: 'historyCount',
           'features.showPasswordRequirementsAsHtmlList': true,
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('No parts of your username');
@@ -538,8 +538,8 @@ Expect.describe('PasswordReset', function () {
       }
     );
 
-    itp('has a valid subtitle if password complexity is defined with all options', function () {
-      return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true }).then(function (
+    itp('has a valid subtitle if password complexity is defined with all options', function() {
+      return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true }).then(function(
         test
       ) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
@@ -555,8 +555,8 @@ Expect.describe('PasswordReset', function () {
       });
     });
 
-    itp('has a valid subtitle in minutes if password age is defined with all options', function () {
-      return setup({ policyAge: 'all', 'features.showPasswordRequirementsAsHtmlList': true }).then(function (test) {
+    itp('has a valid subtitle in minutes if password age is defined with all options', function() {
+      return setup({ policyAge: 'all', 'features.showPasswordRequirementsAsHtmlList': true }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(2);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual(
@@ -570,12 +570,12 @@ Expect.describe('PasswordReset', function () {
 
     itp(
       'has a valid subtitle if password complexity is defined with all options and password age "historyCount" defined',
-      function () {
+      function() {
         return setup({
           policyComplexity: 'all',
           policyAge: 'historyCount',
           'features.showPasswordRequirementsAsHtmlList': true,
-        }).then(function (test) {
+        }).then(function(test) {
           expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
           expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(9);
           expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -595,12 +595,12 @@ Expect.describe('PasswordReset', function () {
       }
     );
 
-    itp('has a valid subtitle if password age and complexity are defined with all options', function () {
+    itp('has a valid subtitle if password age and complexity are defined with all options', function() {
       return setup({
         policyComplexity: 'all',
         policyAge: 'all',
         'features.showPasswordRequirementsAsHtmlList': true,
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.passwordRequirementsHtmlHeader().trimmedText()).toEqual('Password requirements:');
         expect(test.form.passwordRequirementsHtmlListItems().length).toEqual(10);
         expect(test.form.passwordRequirementsHtmlListItems().eq(0).text()).toEqual('At least 8 characters');
@@ -621,35 +621,35 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  itp('has a password field to enter the new password', function () {
-    return setup().then(function (test) {
+  itp('has a password field to enter the new password', function() {
+    return setup().then(function(test) {
       Expect.isPasswordField(test.form.newPasswordField());
     });
   });
 
-  itp('has autocomplete set to new-password for new password field', function () {
-    return setup().then(function (test) {
+  itp('has autocomplete set to new-password for new password field', function() {
+    return setup().then(function(test) {
       expect(test.form.getNewPasswordAutocomplete()).toBe('new-password');
     });
   });
 
-  itp('has a password field to confirm the new password', function () {
-    return setup().then(function (test) {
+  itp('has a password field to confirm the new password', function() {
+    return setup().then(function(test) {
       Expect.isPasswordField(test.form.confirmPasswordField());
     });
   });
 
-  itp('has autocomplete set to new-password for confirm password field', function () {
-    return setup().then(function (test) {
+  itp('has autocomplete set to new-password for confirm password field', function() {
+    return setup().then(function(test) {
       expect(test.form.getConfirmPasswordAutocomplete()).toBe('new-password');
     });
   });
 
-  itp('calls processCreds function before saving a model', function () {
+  itp('calls processCreds function before saving a model', function() {
     const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
     return setup({ processCreds: processCredsSpy })
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.setNewPassword('newpwd');
@@ -657,7 +657,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(processCredsSpy.calls.count()).toBe(1);
         expect(processCredsSpy).toHaveBeenCalledWith({
           username: 'administrator1@clouditude.net',
@@ -667,16 +667,16 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('calls async processCreds function before saving a model', function () {
+  itp('calls async processCreds function before saving a model', function() {
     const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
     return setup({
-      processCreds: function (creds, callback) {
+      processCreds: function(creds, callback) {
         processCredsSpy(creds, callback);
         callback();
       },
     })
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.setNewPassword('newpwd');
@@ -684,7 +684,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(processCredsSpy.calls.count()).toBe(1);
         expect(processCredsSpy).toHaveBeenCalledWith(
           {
@@ -697,15 +697,15 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('calls async processCreds function and can prevent saving a model', function () {
+  itp('calls async processCreds function and can prevent saving a model', function() {
     const processCredsSpy = jasmine.createSpy('processCredsSpy');
 
     return setup({
-      processCreds: function (creds, callback) {
+      processCreds: function(creds, callback) {
         processCredsSpy(creds, callback);
       },
     })
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resSuccess);
         test.form.setNewPassword('newpwd');
@@ -713,7 +713,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForSpyCall(processCredsSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(processCredsSpy.calls.count()).toBe(1);
         expect(processCredsSpy).toHaveBeenCalledWith(
           {
@@ -726,9 +726,9 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('makes the right auth request when form is submitted', function () {
+  itp('makes the right auth request when form is submitted', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setNewPassword('imsorrymsjackson');
         test.form.setConfirmPassword('imsorrymsjackson');
@@ -736,7 +736,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/credentials/reset_password',
@@ -748,11 +748,11 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('makes submit button disable when form is submitted', function () {
+  itp('makes submit button disable when form is submitted', function() {
     const dummySaveEventHnadler = jasmine.createSpy();
 
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         // Submit form will trigger `save` event and its handler will
         // 'disable' the button. Thus when the `dummySaveEventHnadler`
@@ -765,7 +765,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForSpyCall(dummySaveEventHnadler, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const button = test.form.submitButton();
         const buttonClass = button.attr('class');
 
@@ -773,9 +773,9 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('makes submit button enabled after error response', function () {
+  itp('makes submit button enabled after error response', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setNewPassword('pwd');
         test.form.setConfirmPassword('pwd');
@@ -783,7 +783,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         const button = test.form.submitButton();
         const buttonClass = button.attr('class');
 
@@ -791,8 +791,8 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('validates that the fields are not empty before submitting', function () {
-    return setup().then(function (test) {
+  itp('validates that the fields are not empty before submitting', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.submit();
       expect(Util.numAjaxRequests()).toBe(0);
@@ -802,8 +802,8 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  itp('validates that the passwords match before submitting', function () {
-    return setup().then(function (test) {
+  itp('validates that the passwords match before submitting', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.setNewPassword('a');
       test.form.setConfirmPassword('z');
@@ -813,9 +813,9 @@ Expect.describe('PasswordReset', function () {
     });
   });
 
-  itp('shows an error msg if there is an error submitting', function () {
+  itp('shows an error msg if there is an error submitting', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Q.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setNewPassword('a');
@@ -823,7 +823,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe(
           'Password requirements were not met. Password requirements: at least 8 characters,' +
@@ -860,9 +860,9 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('shows a simpler error msg without requirements if there is an error submitting', function () {
+  itp('shows a simpler error msg without requirements if there is an error submitting', function() {
     return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true })
-      .then(function (test) {
+      .then(function(test) {
         Q.stopUnhandledRejectionTracking();
         test.setNextResponse(resError);
         test.form.setNewPassword('a');
@@ -870,7 +870,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('Password requirements were not met.');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -903,9 +903,9 @@ Expect.describe('PasswordReset', function () {
       });
   });
 
-  itp('shows error summary if error cause is missing, if there is an error submitting', function () {
+  itp('shows error summary if error cause is missing, if there is an error submitting', function() {
     return setup({ policyComplexity: 'all', 'features.showPasswordRequirementsAsHtmlList': true })
-      .then(function (test) {
+      .then(function(test) {
         Q.stopUnhandledRejectionTracking();
         test.setNextResponse(resErrorNoCause);
         test.form.setNewPassword('a');
@@ -913,7 +913,7 @@ Expect.describe('PasswordReset', function () {
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe(
           'The password does not meet the complexity requirements of the current password policy.'

--- a/test/unit/spec/PollController_spec.js
+++ b/test/unit/spec/PollController_spec.js
@@ -9,7 +9,7 @@ import resPolling from 'helpers/xhr/POLLING';
 import resSuccess from 'helpers/xhr/SUCCESS';
 import $sandbox from 'sandbox';
 
-function setup (settings, res) {
+function setup(settings, res) {
   settings || (settings = {});
   const successSpy = jasmine.createSpy('successSpy');
   const setNextResponse = Util.mockAjax();
@@ -42,11 +42,11 @@ function setup (settings, res) {
   return Expect.waitForPoll(settings);
 }
 
-Expect.describe('Polling', function () {
-  describe('Form Content', function () {
-    it('shows the correct content on load', function (done) {
+Expect.describe('Polling', function() {
+  describe('Form Content', function() {
+    it('shows the correct content on load', function(done) {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           const title =
             'There are too many users trying to sign in right now. We will automatically retry in 1 seconds.';
           expect(test.form.pageTitle().text().trim()).toBe(title);
@@ -54,9 +54,9 @@ Expect.describe('Polling', function () {
         })
         .catch(done.fail);
     });
-    it('has the cancel button', function (done) {
+    it('has the cancel button', function(done) {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.cancelButton()).toHaveLength(1);
           expect(test.form.cancelButton().attr('value')).toBe('Cancel');
           expect(test.form.cancelButton().attr('class')).toBe('button button-primary');
@@ -64,15 +64,15 @@ Expect.describe('Polling', function () {
         })
         .catch(done.fail);
     });
-    it('cancel button clicked cancels the current stateToken and calls the cancel function', function () {
+    it('cancel button clicked cancels the current stateToken and calls the cancel function', function() {
       return setup({}, [resPolling, resPolling, resPolling, resCancel])
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resCancel);
           test.form.cancelButton().click();
           return Expect.waitForAjaxRequest(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://example.okta.com/api/v1/authn/cancel',
@@ -85,13 +85,13 @@ Expect.describe('Polling', function () {
   });
 });
 
-Expect.describe('Polling API', function () {
-  describe('called on load', function () {
-    it('makes the request correctly', function (done) {
+Expect.describe('Polling API', function() {
+  describe('called on load', function() {
+    it('makes the request correctly', function(done) {
       setup({}, [resPolling, resPolling, resSuccess])
         .then(() => {
           // TODO: refactor to use Util.callAllTimeouts() to remove long timeout value: https://oktainc.atlassian.net/browse/OKTA-291740
-          setTimeout(function () {
+          setTimeout(function() {
             expect(Util.numAjaxRequests()).toBe(3);
             // first call is for refresh-auth
             // poll

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -78,14 +78,14 @@ const typingPattern =
   '0,2.15,0,0,6,3210950388,1,95,-1,0,-1,-1,\
           0,-1,-1,9,86,44,0,-1,-1|4403,86|143,143|240,62|15,127|176,39|712,87';
 
-function setup (settings, requests, refreshState) {
+function setup(settings, requests, refreshState) {
   settings || (settings = {});
 
   // To speed up the test suite, calls to debounce are
   // modified to wait 0 ms.
   const debounce = _.debounce;
 
-  spyOn(_, 'debounce').and.callFake(function (fn) {
+  spyOn(_, 'debounce').and.callFake(function(fn) {
     return debounce(fn, 0);
   });
 
@@ -148,18 +148,18 @@ function setup (settings, requests, refreshState) {
   }
 }
 
-function setupUnauthenticated (settings, requests) {
+function setupUnauthenticated(settings, requests) {
   return setup(settings, requests, true);
 }
 
-function setupPasswordlessAuth (requests, refreshState) {
-  return setup({ 'features.passwordlessAuth': true }, requests, refreshState).then(function (test) {
+function setupPasswordlessAuth(requests, refreshState) {
+  return setup({ 'features.passwordlessAuth': true }, requests, refreshState).then(function(test) {
     test.setNextResponse(resPasswordlessUnauthenticated);
     return Q(test);
   });
 }
 
-function setupSocial (settings) {
+function setupSocial(settings) {
   Util.mockOIDCStateGenerator();
   Util.loadWellKnownAndKeysCache();
   return setup(
@@ -183,8 +183,8 @@ function setupSocial (settings) {
       },
       settings
     )
-  ).then(function (test) {
-    spyOn(window, 'open').and.callFake(function () {
+  ).then(function(test) {
+    spyOn(window, 'open').and.callFake(function() {
       test.oidcWindow = { closed: false, close: jasmine.createSpy() };
       return test.oidcWindow;
     });
@@ -192,7 +192,7 @@ function setupSocial (settings) {
   });
 }
 
-function setupSocialNoneOIDCMode (settings) {
+function setupSocialNoneOIDCMode(settings) {
   Util.mockOIDCStateGenerator();
   return setup(
     _.extend(
@@ -210,13 +210,13 @@ function setupSocialNoneOIDCMode (settings) {
   );
 }
 
-function setupWithCustomButtons () {
+function setupWithCustomButtons() {
   const settings = {
     customButtons: [
       {
         title: 'test text',
         className: 'test-class',
-        click: function (e) {
+        click: function(e) {
           $(e.target).addClass('new-class');
         },
         dataAttr: 'test-data',
@@ -227,7 +227,7 @@ function setupWithCustomButtons () {
   return setup(settings);
 }
 
-function setupPIV (pivAuthentication, useDefaultText) {
+function setupPIV(pivAuthentication, useDefaultText) {
   const buttonText = useDefaultText ? '' : 'piv test text';
   const settings = {
     piv: {
@@ -240,7 +240,7 @@ function setupPIV (pivAuthentication, useDefaultText) {
   return setup(settings);
 }
 
-function setupRegistrationButton (featuresRegistration, registrationObj) {
+function setupRegistrationButton(featuresRegistration, registrationObj) {
   const settings = {
     registration: registrationObj,
   };
@@ -251,28 +251,28 @@ function setupRegistrationButton (featuresRegistration, registrationObj) {
   return setup(settings);
 }
 
-function waitForBeaconChange (test) {
+function waitForBeaconChange(test) {
   const cur = test.beacon.getBeaconImage();
 
-  return Expect.wait(function () {
+  return Expect.wait(function() {
     return test.beacon.getBeaconImage() !== cur;
   }, test);
 }
 
-function transformUsername (name) {
+function transformUsername(name) {
   const suffix = '@example.com';
 
   return name.indexOf(suffix) !== -1 ? name : name + suffix;
 }
 
-function transformUsernameOnUnlock (name, operation) {
+function transformUsernameOnUnlock(name, operation) {
   if (operation === 'UNLOCK_ACCOUNT') {
     transformUsername(name);
   }
   return name;
 }
 
-function expectErrorEvent (test, code, err) {
+function expectErrorEvent(test, code, err) {
   expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
   expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
     {
@@ -290,76 +290,76 @@ const setupWithTransformUsername = _.partial(setup, { username: 'foobar', transf
 
 const setupWithTransformUsernameOnUnlock = _.partial(setup, { transformUsername: transformUsernameOnUnlock });
 
-Expect.describe('PrimaryAuth', function () {
-  Expect.describe('PrimaryAuthModel', function () {
-    it('returns username validation error when username is blank', function () {
+Expect.describe('PrimaryAuth', function() {
+  Expect.describe('PrimaryAuthModel', function() {
+    it('returns username validation error when username is blank', function() {
       const model = new PrimaryAuth({ username: '', password: 'pass' });
 
       expect(model.validate().username).toEqual('Please enter a username');
     });
 
-    it('returns password validation error when password is blank', function () {
+    it('returns password validation error when password is blank', function() {
       const model = new PrimaryAuth({ username: 'user', password: '' });
 
       expect(model.validate().password).toEqual('Please enter a password');
     });
   });
 
-  Expect.describe('settings', function () {
-    itp('uses default title', function () {
-      return setup().then(function (test) {
+  Expect.describe('settings', function() {
+    itp('uses default title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toEqual('Sign In');
       });
     });
-    itp('uses default for username label', function () {
-      return setup().then(function (test) {
+    itp('uses default for username label', function() {
+      return setup().then(function(test) {
         const $usernameLabel = test.form.usernameLabel();
 
         expect($usernameLabel.text().trim()).toEqual('Username');
       });
     });
-    itp('sets autocomplete on username', function () {
-      return setup().then(function (test) {
+    itp('sets autocomplete on username', function() {
+      return setup().then(function(test) {
         expect(test.form.getUsernameFieldAutocomplete()).toBe('username');
       });
     });
-    itp('sets autocomplete on password', function () {
-      return setup().then(function (test) {
+    itp('sets autocomplete on password', function() {
+      return setup().then(function(test) {
         expect(test.form.getPasswordFieldAutocomplete()).toBe('current-password');
       });
     });
-    itp('uses default for password label', function () {
-      return setup().then(function (test) {
+    itp('uses default for password label', function() {
+      return setup().then(function(test) {
         const $passwordLabel = test.form.passwordLabel();
 
         expect($passwordLabel.text().trim()).toEqual('Password');
       });
     });
-    itp('uses default for rememberMe', function () {
-      return setup({ 'features.rememberMe': true }).then(function (test) {
+    itp('uses default for rememberMe', function() {
+      return setup({ 'features.rememberMe': true }).then(function(test) {
         const label = test.form.rememberMeLabelText();
 
         expect(label).toEqual('Remember me');
       });
     });
-    itp('uses default for unlock account', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('uses default for unlock account', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         const label = test.form.unlockLabel();
 
         expect(label.trim()).toBe('Unlock account?');
       });
     });
-    itp('overrides rememberMe from settings', function () {
+    itp('overrides rememberMe from settings', function() {
       const options = { 'features.rememberMe': true };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const label = test.form.rememberMeLabelText();
 
         expect(label).toEqual('Remember me');
       });
     });
-    itp('username field does not have explain by default', function () {
-      return setup().then(function (test) {
+    itp('username field does not have explain by default', function() {
+      return setup().then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.length).toBe(0);
@@ -374,7 +374,7 @@ Expect.describe('PrimaryAuth', function () {
           });
       });
     });
-    itp('username field does not have explain when only label is customized', function () {
+    itp('username field does not have explain when only label is customized', function() {
       const options = {
         language: 'en',
         i18n: {
@@ -384,13 +384,13 @@ Expect.describe('PrimaryAuth', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('username field does have explain when is customized', function () {
+    itp('username field does have explain when is customized', function() {
       const options = {
         language: 'en',
         i18n: {
@@ -400,20 +400,20 @@ Expect.describe('PrimaryAuth', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.text()).toEqual('Custom Username Explain');
       });
     });
-    itp('password field does not have explain by default', function () {
-      return setup().then(function (test) {
+    itp('password field does not have explain by default', function() {
+      return setup().then(function(test) {
         const explain = test.form.passwordExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('password field does not have explain when only label is customized', function () {
+    itp('password field does not have explain when only label is customized', function() {
       const options = {
         language: 'en',
         i18n: {
@@ -423,13 +423,13 @@ Expect.describe('PrimaryAuth', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.passwordExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('password field does have explain when is customized', function () {
+    itp('password field does have explain when is customized', function() {
       const options = {
         language: 'en',
         i18n: {
@@ -439,24 +439,24 @@ Expect.describe('PrimaryAuth', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.passwordExplain();
 
         expect(explain.text()).toEqual('Custom Password Explain');
       });
     });
-    itp('focuses on username field in browsers other than IE', function () {
+    itp('focuses on username field in browsers other than IE', function() {
       spyOn(BrowserFeatures, 'isIE').and.returnValue(false);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         const $username = test.form.usernameField();
 
         // Focused element would be username DOM element
         expect($username[0]).toBe(document.activeElement);
       });
     });
-    itp('does not focus on username field in IE', function () {
+    itp('does not focus on username field in IE', function() {
       spyOn(BrowserFeatures, 'isIE').and.returnValue(true);
-      return setup().then(function (test) {
+      return setup().then(function(test) {
         const $username = test.form.usernameField();
 
         // Focused element would be body element
@@ -465,24 +465,24 @@ Expect.describe('PrimaryAuth', function () {
     });
   });
 
-  Expect.describe('elements', function () {
-    itp('has a security beacon if features.securityImage is true', function () {
-      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function (test) {
+  Expect.describe('elements', function() {
+    itp('has a security beacon if features.securityImage is true', function() {
+      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function(test) {
         expect(test.beacon.isSecurityBeacon()).toBe(true);
       });
     });
-    itp('beacon could be minimized if it is a security beacon', function () {
-      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function (test) {
+    itp('beacon could be minimized if it is a security beacon', function() {
+      return setup({ features: { securityImage: true } }, [resSecurityImage]).then(function(test) {
         expect(test.authContainer.canBeMinimized()).toBe(true);
       });
     });
-    itp('does not show a beacon if features.securityImage is false', function () {
-      return setup().then(function (test) {
+    itp('does not show a beacon if features.securityImage is false', function() {
+      return setup().then(function(test) {
         expect(test.beacon.beacon().length).toBe(0);
       });
     });
-    itp('has a username field', function () {
-      return setup().then(function (test) {
+    itp('has a username field', function() {
+      return setup().then(function(test) {
         const username = test.form.usernameField();
 
         expect(username.length).toBe(1);
@@ -491,8 +491,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(username.prop('required')).toEqual(true);
       });
     });
-    itp('has a password field', function () {
-      return setup().then(function (test) {
+    itp('has a password field', function() {
+      return setup().then(function(test) {
         const password = test.form.passwordField();
 
         expect(password.length).toBe(1);
@@ -501,8 +501,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(password.prop('required')).toEqual(true);
       });
     });
-    itp('has a sign in button', function () {
-      return setup().then(function (test) {
+    itp('has a sign in button', function() {
+      return setup().then(function(test) {
         const signInButton = test.form.signInButton();
 
         expect(signInButton.length).toBe(1);
@@ -511,123 +511,123 @@ Expect.describe('PrimaryAuth', function () {
       });
     });
 
-    itp('has a rememberMe checkbox if features.rememberMe is true', function () {
-      return setup().then(function (test) {
+    itp('has a rememberMe checkbox if features.rememberMe is true', function() {
+      return setup().then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(1);
       });
     });
-    itp('does not have a rememberMe checkbox if features.rememberMe is false', function () {
-      return setup({ 'features.rememberMe': false }).then(function (test) {
+    itp('does not have a rememberMe checkbox if features.rememberMe is false', function() {
+      return setup({ 'features.rememberMe': false }).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
       });
     });
-    itp('has helpFooter with right aria-attributes and default values', function () {
-      return setup().then(function (test) {
+    itp('has helpFooter with right aria-attributes and default values', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('false');
         expect(test.form.helpFooter().attr('aria-controls')).toBe('help-links-container');
       });
     });
-    itp('sets aria-expanded attribute correctly when clicking help', function () {
-      return setup().then(function (test) {
+    itp('sets aria-expanded attribute correctly when clicking help', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('false');
         test.form.helpFooter().click();
         expect(test.form.helpFooter().attr('aria-expanded')).toBe('true');
       });
     });
-    itp('has "Need help?" link', function () {
-      return setup().then(function (test) {
+    itp('has "Need help?" link', function() {
+      return setup().then(function(test) {
         expect(test.form.helpFooterLabel().trim()).toBe('Need help signing in?');
       });
     });
-    itp('has a help link', function () {
-      return setup().then(function (test) {
+    itp('has a help link', function() {
+      return setup().then(function(test) {
         expect(test.form.helpLinkLabel().trim()).toBe('Help');
       });
     });
-    itp('has the correct help link url', function () {
-      return setup().then(function (test) {
+    itp('has the correct help link url', function() {
+      return setup().then(function(test) {
         spyOn(SharedUtil, 'redirect');
         expect(test.form.helpLinkHref()).toBe('https://foo.com/help/login');
       });
     });
-    itp('has the correct rel attributes for help link', function () {
-      return setup().then(function (test) {
+    itp('has the correct rel attributes for help link', function() {
+      return setup().then(function(test) {
         expect(test.form.helpLink().attr('rel')).toBe('noopener noreferrer');
       });
     });
-    itp('has a custom help link url when available', function () {
-      return setup({ 'helpLinks.help': 'https://bar.com' }).then(function (test) {
+    itp('has a custom help link url when available', function() {
+      return setup({ 'helpLinks.help': 'https://bar.com' }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         expect(test.form.helpLinkHref()).toBe('https://bar.com');
       });
     });
-    itp('has a forgot password link', function () {
-      return setup().then(function (test) {
+    itp('has a forgot password link', function() {
+      return setup().then(function(test) {
         expect(test.form.forgotPasswordLabel().trim()).toBe('Forgot password?');
       });
     });
-    itp('forgot password link is not visible on load', function () {
-      return setup().then(function (test) {
+    itp('forgot password link is not visible on load', function() {
+      return setup().then(function(test) {
         expect(test.form.forgotPasswordLinkVisible()).toBe(false);
       });
     });
-    itp('shows forgot password link when clicking help', function () {
-      return setup().then(function (test) {
+    itp('shows forgot password link when clicking help', function() {
+      return setup().then(function(test) {
         test.form.helpFooter().click();
         expect(test.form.forgotPasswordLinkVisible()).toBe(true);
       });
     });
-    itp('does not show forgot password link when disabled and clicked', function () {
+    itp('does not show forgot password link when disabled and clicked', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           expect(test.form.forgotPasswordLinkVisible()).not.toBe(true);
         });
     });
-    itp('navigates to forgot password page when click forgot password link', function () {
-      return setup().then(function (test) {
+    itp('navigates to forgot password page when click forgot password link', function() {
+      return setup().then(function(test) {
         test.form.helpFooter().click();
         test.form.forgotPasswordLink().click();
         expect(test.router.navigate).toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
       });
     });
-    itp('does not navigate to forgot password page when link disabled and clicked', function () {
+    itp('does not navigate to forgot password page when link disabled and clicked', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
           expect(test.router.navigate).not.toHaveBeenCalledWith('signin/forgot-password', { trigger: true });
         });
     });
-    itp('navigates to custom forgot password page when available', function () {
-      return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function (test) {
+    itp('navigates to custom forgot password page when available', function() {
+      return setup({ 'helpLinks.forgotPassword': 'https://foo.com' }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         test.form.helpFooter().click();
         test.form.forgotPasswordLink().click();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
       });
     });
-    itp('does not navigate to custom forgot password page when link disabled and clicked', function () {
+    itp('does not navigate to custom forgot password page when link disabled and clicked', function() {
       return setup({ 'helpLinks.forgotPassword': 'https://foo.com' })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(SharedUtil, 'redirect');
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -635,62 +635,62 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.forgotPasswordLink().click();
           expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
         });
     });
-    itp('unlock link is hidden on load', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('unlock link is hidden on load', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         expect(test.form.unlockLinkVisible()).toBe(false);
       });
     });
-    itp('shows unlock link when clicking help', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('shows unlock link when clicking help', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         test.form.helpFooter().click();
         expect(test.form.unlockLinkVisible()).toBe(true);
       });
     });
-    itp('navigates to unlock page when click unlock link', function () {
-      return setup({ 'features.selfServiceUnlock': true }).then(function (test) {
+    itp('navigates to unlock page when click unlock link', function() {
+      return setup({ 'features.selfServiceUnlock': true }).then(function(test) {
         test.form.helpFooter().click();
         test.form.unlockLink().click();
         expect(test.router.navigate).toHaveBeenCalledWith('signin/unlock', { trigger: true });
       });
     });
-    itp('does not navigate to unlock page when link disabled and clicked', function () {
+    itp('does not navigate to unlock page when link disabled and clicked', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.unlockLink().click();
           expect(test.router.navigate).not.toHaveBeenCalledWith('signin/unlock', { trigger: true });
         });
     });
-    itp('navigates to custom unlock page when available', function () {
+    itp('navigates to custom unlock page when available', function() {
       return setup({
         'helpLinks.unlock': 'https://foo.com',
         'features.selfServiceUnlock': true,
-      }).then(function (test) {
+      }).then(function(test) {
         spyOn(SharedUtil, 'redirect');
         test.form.helpFooter().click();
         test.form.unlockLink().click();
         expect(SharedUtil.redirect).toHaveBeenCalledWith('https://foo.com');
       });
     });
-    itp('does not navigate to custom unlock page when link disabled and clicked', function () {
+    itp('does not navigate to custom unlock page when link disabled and clicked', function() {
       return setup({
         'helpLinks.unlock': 'https://foo.com',
         'features.selfServiceUnlock': true,
       })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(SharedUtil, 'redirect');
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -698,64 +698,64 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.helpFooter().click();
           test.form.unlockLink().click();
           expect(SharedUtil.redirect).not.toHaveBeenCalledWith('https://foo.com');
         });
     });
-    itp('does not show unlock link if feature is off', function () {
-      return setup().then(function (test) {
+    itp('does not show unlock link if feature is off', function() {
+      return setup().then(function(test) {
         expect(test.form.unlockLink().length).toBe(0);
       });
     });
-    itp('does not show custom links if they do not exist', function () {
-      return setup().then(function (test) {
+    itp('does not show custom links if they do not exist', function() {
+      return setup().then(function(test) {
         expect(test.form.customLinks().length).toBe(0);
       });
     });
-    itp('shows custom links if they exist', function () {
+    itp('shows custom links if they exist', function() {
       const customLinks = [
         { text: 'github', href: 'https://github.com', rel: 'noopener noreferrer' },
         { text: 'google', href: 'https://google.com', rel: 'noopener noreferrer' },
       ];
 
-      return setup({ 'helpLinks.custom': customLinks }).then(function (test) {
+      return setup({ 'helpLinks.custom': customLinks }).then(function(test) {
         const links = test.form.customLinks();
 
         expect(links).toEqual(customLinks);
       });
     });
-    itp('shows custom links with target attribute', function () {
+    itp('shows custom links with target attribute', function() {
       const customLinks = [
         { text: 'github', href: 'https://github.com', rel: 'noopener noreferrer', target: '_blank' },
         { text: 'google', href: 'https://google.com', rel: 'noopener noreferrer' },
         { text: 'okta', href: 'https://okta.com', rel: 'noopener noreferrer', target: '_custom' },
       ];
 
-      return setup({ 'helpLinks.custom': customLinks }).then(function (test) {
+      return setup({ 'helpLinks.custom': customLinks }).then(function(test) {
         const links = test.form.customLinks();
 
         expect(links).toEqual(customLinks);
       });
     });
-    itp('toggles "focused-input" css class on focus in and focus out', function () {
-      return setup().then(function (test) {
+    itp('toggles "focused-input" css class on focus in and focus out', function() {
+      return setup().then(function(test) {
         test.form.usernameField().focus();
         expect(test.form.usernameField()[0].parentElement).toHaveClass('focused-input');
         test.form.usernameField().focusout();
         expect(test.form.usernameField()[0].parentElement).not.toHaveClass('focused-input');
       });
     });
-    itp('Does not show the password toggle button if features.showPasswordToggleOnSignInPage is not set', function () {
-      return setup({ 'features.showPasswordToggleOnSignInPage': false }).then(function (test) {
+    itp('Does not show the password toggle button if features.showPasswordToggleOnSignInPage is not set', function() {
+      return setup({ 'features.showPasswordToggleOnSignInPage': false }).then(function(test) {
         test.form.setPassword('testpass');
         test.form.setUsername('testuser');
         expect(test.form.passwordToggleContainer().length).toBe(0);
       });
     });
-    itp('Show the password toggle button if features.showPasswordToggleOnSignInPage is set', function () {
-      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function (test) {
+    itp('Show the password toggle button if features.showPasswordToggleOnSignInPage is set', function() {
+      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function(test) {
         test.form.setPassword('testpass');
         test.form.setUsername('testuser');
         expect(test.form.passwordToggleContainer().length).toBe(1);
@@ -763,8 +763,8 @@ Expect.describe('PrimaryAuth', function () {
     });
     itp(
       'Toggles icon when the password toggle button with features.showPasswordToggleOnSignInPage is clicked',
-      function () {
-        return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function (test) {
+      function() {
+        return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function(test) {
           test.form.setPassword('testpass');
           test.form.setUsername('testuser');
           expect(test.form.passwordToggleContainer().length).toBe(1);
@@ -780,8 +780,8 @@ Expect.describe('PrimaryAuth', function () {
         });
       }
     );
-    itp('Toggles password field from text to password after 30 seconds', function () {
-      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function (test) {
+    itp('Toggles password field from text to password after 30 seconds', function() {
+      return setup({ 'features.showPasswordToggleOnSignInPage': true }).then(function(test) {
         jasmine.clock().uninstall();
         const originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
@@ -809,8 +809,8 @@ Expect.describe('PrimaryAuth', function () {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
       });
     });
-    itp('show username validation error when username field is dirty', function () {
-      return setup().then(function (test) {
+    itp('show username validation error when username field is dirty', function() {
+      return setup().then(function(test) {
         test.form.usernameField().focus();
         test.form.setUsername('testuser');
         const msg1 = test.router.controller.model.validateField('username');
@@ -823,8 +823,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(msg2).toEqual('Please enter a username');
       });
     });
-    itp('does not show username validation error when username field is not dirty', function () {
-      return setup().then(function (test) {
+    itp('does not show username validation error when username field is not dirty', function() {
+      return setup().then(function(test) {
         test.form.usernameField().focus();
         expect(test.form.usernameField()[0].parentElement).toHaveClass('focused-input');
         test.form.usernameField().focusout();
@@ -833,8 +833,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(test.router.controller.model.validate).not.toHaveBeenCalled();
       });
     });
-    itp('show password validation error when password field is dirty', function () {
-      return setup().then(function (test) {
+    itp('show password validation error when password field is dirty', function() {
+      return setup().then(function(test) {
         test.form.passwordField().focus();
         test.form.setPassword('Abcd1234');
 
@@ -848,8 +848,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(msg2).toEqual('Please enter a password');
       });
     });
-    itp('does not show password validation error when password field is not dirty', function () {
-      return setup({ username: 'abc' }).then(function (test) {
+    itp('does not show password validation error when password field is not dirty', function() {
+      return setup({ username: 'abc' }).then(function(test) {
         spyOn(test.router.controller.model, 'validate');
         test.form.passwordField().focus();
         expect(test.form.passwordField()[0].parentElement).toHaveClass('focused-input');
@@ -860,10 +860,10 @@ Expect.describe('PrimaryAuth', function () {
     });
   });
 
-  Expect.describe('transform username', function () {
-    itp('calls the transformUsername function with the right parameters', function () {
+  Expect.describe('transform username', function() {
+    itp('calls the transformUsername function with the right parameters', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'transformUsername');
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -871,28 +871,28 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.settings.transformUsername.calls.count()).toBe(1);
           expect(test.router.settings.transformUsername.calls.argsFor(0)).toEqual(['testuser', 'PRIMARY_AUTH']);
         });
     });
-    itp('does not call transformUsername while loading security image', function () {
+    itp('does not call transformUsername while loading security image', function() {
       return setup({ features: { securityImage: true }, transformUsername: transformUsername })
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'transformUsername');
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.settings.transformUsername.calls.count()).toBe(0);
           expect(Util.numAjaxRequests()).toBe(1);
           expect(Util.getAjaxRequest(0).url).toBe('https://foo.com/login/getimage?username=testuser');
         });
     });
-    itp('adds the suffix to the username if the username does not have it', function () {
+    itp('adds the suffix to the username if the username does not have it', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -900,7 +900,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -915,16 +915,16 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('adds the suffix to the inital username if it is provided', function () {
+    itp('adds the suffix to the inital username if it is provided', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -939,9 +939,9 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('does not add the suffix to the username if the username already has it', function () {
+    itp('does not add the suffix to the username if the username already has it', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser@example.com');
           test.form.setPassword('pass');
@@ -949,7 +949,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -964,9 +964,9 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('does not add the suffix to the username if "PRIMARY_AUTH" operation is not handled', function () {
+    itp('does not add the suffix to the username if "PRIMARY_AUTH" operation is not handled', function() {
       return setupWithTransformUsernameOnUnlock()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -974,7 +974,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -991,21 +991,21 @@ Expect.describe('PrimaryAuth', function () {
     });
   });
 
-  Expect.describe('Typing biometrics', function () {
-    itp('does not contain typing pattern header in primary auth request if feature is disabled', function () {
+  Expect.describe('Typing biometrics', function() {
+    itp('does not contain typing pattern header in primary auth request if feature is disabled', function() {
       return setup({ features: { trackTypingPattern: false } })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
-          spyOn(TypingUtil, 'track').and.callFake(function (target) {
+          spyOn(TypingUtil, 'track').and.callFake(function(target) {
             expect(target).toBe('okta-signin-username');
           });
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(TypingUtil.track).not.toHaveBeenCalled();
           expect(Util.numAjaxRequests()).toBe(1);
           const ajaxArgs = Util.getAjaxRequest(0);
@@ -1014,23 +1014,23 @@ Expect.describe('PrimaryAuth', function () {
         });
     });
 
-    itp('contains typing pattern header in primary auth request if feature is enabled', function () {
+    itp('contains typing pattern header in primary auth request if feature is enabled', function() {
       return setup({ features: { trackTypingPattern: true } })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
-          spyOn(TypingUtil, 'track').and.callFake(function (targetId) {
+          spyOn(TypingUtil, 'track').and.callFake(function(targetId) {
             expect(targetId).toBe('okta-signin-username');
           });
-          spyOn(TypingUtil, 'getTypingPattern').and.callFake(function () {
+          spyOn(TypingUtil, 'getTypingPattern').and.callFake(function() {
             return typingPattern;
           });
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           const ajaxArgs = Util.getAjaxRequest(0);
 
@@ -1038,20 +1038,20 @@ Expect.describe('PrimaryAuth', function () {
         });
     });
 
-    itp('continues with primary auth if typing pattern cannot be computed', function () {
+    itp('continues with primary auth if typing pattern cannot be computed', function() {
       return setup({ features: { trackTypingPattern: true } })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
-          spyOn(TypingUtil, 'getTypingPattern').and.callFake(function () {
+          spyOn(TypingUtil, 'getTypingPattern').and.callFake(function() {
             return;
           });
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           const ajaxArgs = Util.getAjaxRequest(0);
 
@@ -1060,11 +1060,11 @@ Expect.describe('PrimaryAuth', function () {
     });
   });
 
-  Expect.describe('Device Fingerprint', function () {
+  Expect.describe('Device Fingerprint', function() {
     itp(
       `is not computed if securityImage is off, deviceFingerprinting is true
         and useDeviceFingerprintForSecurityImage is true`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({
           features: {
@@ -1073,13 +1073,13 @@ Expect.describe('PrimaryAuth', function () {
             useDeviceFingerprintForSecurityImage: true,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             spyOn(PrimaryAuthController.prototype, 'shouldComputeDeviceFingerprint').and.callThrough();
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return Expect.waitForSpyCall(PrimaryAuthController.prototype.shouldComputeDeviceFingerprint, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(0);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
           });
@@ -1088,20 +1088,20 @@ Expect.describe('PrimaryAuth', function () {
     itp(
       `contains fingerprint header in get security image request if deviceFingerprinting
         is true (useDeviceFingerprintForSecurityImage defaults to true)`,
-      function () {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+      function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
           const deferred = Q.defer();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
         return setup({ features: { securityImage: true, deviceFingerprinting: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -1113,8 +1113,8 @@ Expect.describe('PrimaryAuth', function () {
     itp(
       `contains fingerprint header in get security image request if both features
         deviceFingerprinting and useDeviceFingerprintForSecurityImage) are enabled`,
-      function () {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+      function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
           const deferred = Q.defer();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
@@ -1127,12 +1127,12 @@ Expect.describe('PrimaryAuth', function () {
             useDeviceFingerprintForSecurityImage: true,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -1144,7 +1144,7 @@ Expect.describe('PrimaryAuth', function () {
     itp(
       `does not contain fingerprint header in get security image request if deviceFingerprinting
           is enabled but useDeviceFingerprintForSecurityImage is disabled`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({
           features: {
@@ -1153,12 +1153,12 @@ Expect.describe('PrimaryAuth', function () {
             useDeviceFingerprintForSecurityImage: false,
           },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -1170,15 +1170,15 @@ Expect.describe('PrimaryAuth', function () {
     itp(
       `does not contain fingerprint header in get security image request if deviceFingerprinting
         is disabled and useDeviceFingerprintForSecurityImage is enabled`,
-      function () {
+      function() {
         spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
         return setup({ features: { securityImage: true, useDeviceFingerprintForSecurityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -1187,10 +1187,10 @@ Expect.describe('PrimaryAuth', function () {
           });
       }
     );
-    itp('does not contain device fingerprint header in primaryAuth if feature is disabled', function () {
+    itp('does not contain device fingerprint header in primaryAuth if feature is disabled', function() {
       spyOn(DeviceFingerprint, 'generateDeviceFingerprint');
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -1198,7 +1198,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
           const ajaxArgs = Util.getAjaxRequest(0);
@@ -1206,15 +1206,15 @@ Expect.describe('PrimaryAuth', function () {
           expect(ajaxArgs.requestHeaders['x-device-fingerprint']).toBeUndefined();
         });
     });
-    itp('contains device fingerprint header in primaryAuth if feature is enabled', function () {
-      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+    itp('contains device fingerprint header in primaryAuth if feature is enabled', function() {
+      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
         const deferred = Q.defer();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;
       });
       return setup({ features: { deviceFingerprinting: true } })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -1222,7 +1222,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
           const ajaxArgs = Util.getAjaxRequest(0);
@@ -1230,15 +1230,15 @@ Expect.describe('PrimaryAuth', function () {
           expect(ajaxArgs.requestHeaders['x-device-fingerprint']).toBe('thisIsTheDeviceFingerprint');
         });
     });
-    itp('continues with primary auth if there is an error getting fingerprint when feature is enabled', function () {
-      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+    itp('continues with primary auth if there is an error getting fingerprint when feature is enabled', function() {
+      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
         const deferred = Q.defer();
 
         deferred.reject('there was an error');
         return deferred.promise;
       });
       return setup({ features: { deviceFingerprinting: true } })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -1246,7 +1246,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
           const ajaxArgs = Util.getAjaxRequest(0);
@@ -1267,21 +1267,21 @@ Expect.describe('PrimaryAuth', function () {
     });
     itp(
       'contains device fingerprint and typing pattern header in primaryAuth if both features are enabled',
-      function () {
-        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+      function() {
+        spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
           const deferred = Q.defer();
 
           deferred.resolve('thisIsTheDeviceFingerprint');
           return deferred.promise;
         });
-        spyOn(TypingUtil, 'track').and.callFake(function (target) {
+        spyOn(TypingUtil, 'track').and.callFake(function(target) {
           expect(target).toBe('okta-signin-username');
         });
-        spyOn(TypingUtil, 'getTypingPattern').and.callFake(function () {
+        spyOn(TypingUtil, 'getTypingPattern').and.callFake(function() {
           return typingPattern;
         });
         return setup({ features: { deviceFingerprinting: true, trackTypingPattern: true } })
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
@@ -1289,7 +1289,7 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             expect(DeviceFingerprint.generateDeviceFingerprint).toHaveBeenCalled();
             const ajaxArgs = Util.getAjaxRequest(0);
@@ -1299,22 +1299,22 @@ Expect.describe('PrimaryAuth', function () {
           });
       }
     );
-    itp('does not load deviceFingerprint when username field looses focus if username is empty', function () {
-      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+    itp('does not load deviceFingerprint when username field looses focus if username is empty', function() {
+      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
         const deferred = Q.defer();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
         return deferred.promise;
       });
-      return setup({ features: { securityImage: true, deviceFingerprinting: true } }).then(function (test) {
+      return setup({ features: { securityImage: true, deviceFingerprinting: true } }).then(function(test) {
         test.setNextResponse(resSecurityImage);
         test.form.setUsername('');
         test.form.usernameField().focusout();
         expect(DeviceFingerprint.generateDeviceFingerprint).not.toHaveBeenCalled();
       });
     });
-    itp('disables the "sign in" button while fetching fingerprint before model.save', function () {
-      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function () {
+    itp('disables the "sign in" button while fetching fingerprint before model.save', function() {
+      spyOn(DeviceFingerprint, 'generateDeviceFingerprint').and.callFake(function() {
         const deferred = Q.defer();
 
         deferred.resolve('thisIsTheDeviceFingerprint');
@@ -1323,20 +1323,20 @@ Expect.describe('PrimaryAuth', function () {
       return setup({
         features: { securityImage: true, deviceFingerprinting: true, useDeviceFingerprintForSecurityImage: false },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.securityBeacon = test.router.header.currentBeacon.$el;
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           spyOn(PrimaryAuthController.prototype, 'toggleButtonState').and.callThrough();
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           const spyCalls = PrimaryAuthController.prototype.toggleButtonState.calls;
 
           expect(spyCalls.count()).toBe(3);
@@ -1350,24 +1350,24 @@ Expect.describe('PrimaryAuth', function () {
     });
   });
 
-  Expect.describe('events', function () {
-    Expect.describe('beacon loading', function () {
-      itp('shows beacon-loading animation when primaryAuth is submitted', function () {
+  Expect.describe('events', function() {
+    Expect.describe('beacon loading', function() {
+      itp('shows beacon-loading animation when primaryAuth is submitted', function() {
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resSuccess);
             test.form.setPassword('pass');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.count()).toBe(2);
@@ -1387,24 +1387,24 @@ Expect.describe('PrimaryAuth', function () {
             );
           });
       });
-      itp('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', function () {
+      itp('shows beacon-loading animation when primaryAuth is submitted (with deviceFingerprint)', function() {
         return setup({
           features: { securityImage: true, deviceFingerprinting: true, useDeviceFingerprintForSecurityImage: false },
         })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resSuccess);
             test.form.setPassword('pass');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.count()).toBe(4);
@@ -1416,15 +1416,15 @@ Expect.describe('PrimaryAuth', function () {
             expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
-      itp('does not show beacon-loading animation when primaryAuth fails', function () {
+      itp('does not show beacon-loading animation when primaryAuth fails', function() {
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resUnauthorized);
@@ -1432,22 +1432,22 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.afterErrorHandler, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
             expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
-      itp('does not show beacon-loading animation when password expires', function () {
+      itp('does not show beacon-loading animation when password expires', function() {
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             test.setNextResponse(resPwdExpired);
@@ -1455,22 +1455,22 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.securityBeacon.toggleClass, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
             expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
-      itp('does not show beacon-loading animation on CORS error', function () {
+      itp('does not show beacon-loading animation on CORS error', function() {
         return setup({ features: { securityImage: true } })
-          .then(function (test) {
+          .then(function(test) {
             test.securityBeacon = test.router.header.currentBeacon.$el;
             test.setNextResponse(resSecurityImage);
             test.form.setUsername('testuser');
             return waitForBeaconChange(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             spyOn(test.securityBeacon, 'toggleClass');
             spyOn(test.router.settings, 'callGlobalError');
@@ -1479,29 +1479,29 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             const spyCalls = test.securityBeacon.toggleClass.calls;
 
             expect(spyCalls.argsFor(0)).toEqual([BEACON_LOADING_CLS, true]);
             expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
           });
       });
-      itp('shows beacon-loading animation when primaryAuth is submitted (no security image)', function () {
+      itp('shows beacon-loading animation when primaryAuth is submitted (no security image)', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resSuccess);
             test.form.setUsername('testuser');
             test.form.setPassword('pass');
             test.form.submit();
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(true);
           });
       });
-      itp('does not show beacon-loading animation when primaryAuth fails (no security image)', function () {
+      itp('does not show beacon-loading animation when primaryAuth fails (no security image)', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             test.setNextResponse(resUnauthorized);
             test.form.setUsername('testuser');
@@ -1509,14 +1509,14 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.afterErrorHandler, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(false);
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
-      itp('does not show beacon-loading animation when password expires (no security image)', function () {
+      itp('does not show beacon-loading animation when password expires (no security image)', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             Q.stopUnhandledRejectionTracking();
             test.setNextResponse(resPwdExpired);
             test.form.setUsername('testuser');
@@ -1524,14 +1524,14 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForPasswordExpired(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(false);
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
-      itp('does not show beacon-loading animation on CORS error (no security image)', function () {
+      itp('does not show beacon-loading animation on CORS error (no security image)', function() {
         return setup()
-          .then(function (test) {
+          .then(function(test) {
             spyOn(test.router.settings, 'callGlobalError');
             Q.stopUnhandledRejectionTracking();
             test.setNextResponse({ status: 0, response: {} });
@@ -1540,25 +1540,25 @@ Expect.describe('PrimaryAuth', function () {
             test.form.submit();
             return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.beacon.isLoadingBeacon()).toBe(false);
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
     });
-    itp('does not make securityImage requests if features.securityImage is false', function () {
+    itp('does not make securityImage requests if features.securityImage is false', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(PrimaryAuthController.prototype, 'shouldComputeDeviceFingerprint').and.callThrough();
           test.form.setUsername('testuser');
           return Expect.waitForSpyCall(PrimaryAuthController.prototype.shouldComputeDeviceFingerprint, test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(0);
         });
     });
-    itp('has default security image on page load and no rememberMe', function () {
-      return setup({ features: { securityImage: true } }).then(function (test) {
+    itp('has default security image on page load and no rememberMe', function() {
+      return setup({ features: { securityImage: true } }).then(function(test) {
         expect(test.form.securityBeacon()[0].className).toMatch('undefined-user');
         expect(test.form.securityBeacon()[0].className).not.toMatch('new-device');
         expect(test.form.securityBeacon().css('background-image')).toMatch(
@@ -1566,16 +1566,16 @@ Expect.describe('PrimaryAuth', function () {
         );
       });
     });
-    itp('shows beacon-loading animation while loading security image (with deviceFingerprint)', function () {
+    itp('shows beacon-loading animation while loading security image (with deviceFingerprint)', function() {
       return setup({ features: { securityImage: true, deviceFingerprinting: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.securityBeacon = test.router.header.currentBeacon.$el;
           spyOn(test.securityBeacon, 'toggleClass');
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const spyCalls = test.securityBeacon.toggleClass.calls;
 
           expect(spyCalls.count()).toBe(2);
@@ -1583,14 +1583,14 @@ Expect.describe('PrimaryAuth', function () {
           expect(spyCalls.mostRecent().args).toEqual([BEACON_LOADING_CLS, false]);
         });
     });
-    itp('updates security beacon when user enters correct username', function () {
+    itp('updates security beacon when user enters correct username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           test.form.setUsername('test+user');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(Util.numAjaxRequests()).toBe(1);
           // reserved characters in the username (like "+") should be escaped, since it's in the query
           expect(Util.getAjaxRequest(0).url).toEqual('https://foo.com/login/getimage?username=test%2Buser');
@@ -1598,27 +1598,27 @@ Expect.describe('PrimaryAuth', function () {
           expect(test.form.accessibilityText()).toBe('a single pixel');
         });
     });
-    itp('waits for username field to lose focus before fetching the security image', function () {
+    itp('waits for username field to lose focus before fetching the security image', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImage);
           test.form.editingUsername('te');
           test.form.editingUsername('testu');
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('updates security beacon to show the new user image when user enters unfamiliar username', function () {
+    itp('updates security beacon to show the new user image when user enters unfamiliar username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityBeacon()[0].className).toMatch('new-user');
           expect(test.form.securityBeacon()[0].className).not.toMatch('undefined-user');
           expect(test.form.securityBeacon().css('background-image')).toMatch(
@@ -1626,22 +1626,22 @@ Expect.describe('PrimaryAuth', function () {
           );
         });
     });
-    itp('shows an unknown user message when user enters unfamiliar username', function () {
+    itp('shows an unknown user message when user enters unfamiliar username', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityImageTooltipText()).toEqual(
             'This is the first time you are connecting to foo.com from this browser×'
           );
         });
     });
-    itp('does not show anti-phishing message if security image is hidden', function () {
+    itp('does not show anti-phishing message if security image is hidden', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.securityBeaconContainer().hide();
           spyOn($.qtip.prototype, 'toggle').and.callThrough();
@@ -1649,70 +1649,70 @@ Expect.describe('PrimaryAuth', function () {
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function () {
+        .then(function() {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
         });
     });
-    itp('show anti-phishing message if security image become visible', function () {
+    itp('show anti-phishing message if security image become visible', function() {
       return setup({ features: { securityImage: true } })
-        .then(function (test) {
+        .then(function(test) {
           spyOn($.qtip.prototype, 'toggle').and.callThrough();
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().hide();
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
           return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
         })
-        .then(function () {
+        .then(function() {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
         });
     });
-    itp('guards against XSS when showing the anti-phishing message', function () {
+    itp('guards against XSS when showing the anti-phishing message', function() {
       return setup({
         baseUrl: 'http://foo<i>xss</i>bar.com?bar=<i>xss</i>',
         features: { securityImage: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.securityImageTooltipText()).toEqual(
             'This is the first time you are connecting to foo<i>xss< from this browser×'
           );
         });
     });
-    itp('removes anti-phishing message if help link is clicked', function () {
+    itp('removes anti-phishing message if help link is clicked', function() {
       return setup({
         baseUrl: 'http://foo<i>xss</i>bar.com?bar=<i>xss</i>',
         features: { securityImage: true, selfServiceUnlock: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resSecurityImageFail);
           test.form.setUsername('testuser');
           return waitForBeaconChange(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Tooltip exists
           expect(test.form.isSecurityImageTooltipDestroyed()).toBe(false);
           test.form.helpFooter().click();
@@ -1722,7 +1722,7 @@ Expect.describe('PrimaryAuth', function () {
           expect(test.form.isSecurityImageTooltipDestroyed()).toBe(true);
         });
     });
-    itp('updates security beacon immediately if rememberMe is available', function () {
+    itp('updates security beacon immediately if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         features: {
@@ -1732,22 +1732,22 @@ Expect.describe('PrimaryAuth', function () {
       };
 
       return setup(options, [resSecurityImage])
-        .then(function (test) {
-          return Expect.wait(function () {
+        .then(function(test) {
+          return Expect.wait(function() {
             return test.form.accessibilityText() === 'a single pixel';
           }, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect($.fn.css).toHaveBeenCalledWith('background-image', 'url(/base/test/unit/assets/1x1.gif)');
           expect(test.form.accessibilityText()).toBe('a single pixel');
         });
     });
-    itp('calls globalErrorFn if cors is not enabled and security image request is made', function () {
+    itp('calls globalErrorFn if cors is not enabled and security image request is made', function() {
       spyOn(BrowserFeatures, 'corsIsNotEnabled').and.returnValue(true);
       return setup({
         features: { securityImage: true },
       })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse({
             responseType: 'json',
             response: '',
@@ -1757,7 +1757,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.setUsername('testuser');
           return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
 
           expect(err instanceof Errors.UnsupportedBrowserError).toBe(true);
@@ -1765,112 +1765,112 @@ Expect.describe('PrimaryAuth', function () {
           expect(err.message).toEqual('There was an error sending the request - have you enabled CORS?');
         });
     });
-    itp('has username in field if rememberMe is available', function () {
+    itp('has username in field if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.usernameField().val()).toBe('testuser');
       });
     });
-    itp('has rememberMe checked if rememberMe is available', function () {
+    itp('has rememberMe checked if rememberMe is available', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
       });
     });
-    itp('unchecks rememberMe if username is changed', function () {
+    itp('unchecks rememberMe if username is changed', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
         test.form.setUsername('new-user');
         expect(test.form.rememberMeCheckboxStatus()).toBe('unchecked');
       });
     });
-    itp('does not re-render rememberMe checkbox on changes', function () {
+    itp('does not re-render rememberMe checkbox on changes', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         'features.rememberMe': true,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const orig = test.form.rememberMeCheckbox().get(0);
 
         test.form.setUsername('new-user');
         expect(test.form.rememberMeCheckbox().get(0)).toBe(orig);
       });
     });
-    itp('populates username if username is available', function () {
+    itp('populates username if username is available', function() {
       const options = {
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('populates username if username is available and when features.rememberMe is false', function () {
+    itp('populates username if username is available and when features.rememberMe is false', function() {
       const options = {
         username: 'testuser@ABC.com',
         'features.rememberMe': false,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('ignores lastUsername and hides rememberMe if features.rememberMe is false and cookie is set', function () {
+    itp('ignores lastUsername and hides rememberMe if features.rememberMe is false and cookie is set', function() {
       Util.mockGetCookie('ln', 'testuser@ABC.com');
       const options = {
         'features.rememberMe': false,
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const cb = test.form.rememberMeCheckbox();
 
         expect(cb.length).toBe(0);
         expect(test.form.usernameField().val().length).toBe(0);
       });
     });
-    itp('unchecks rememberMe if username is populated and lastUsername is different from username', function () {
+    itp('unchecks rememberMe if username is populated and lastUsername is different from username', function() {
       Util.mockGetCookie('ln', 'testuser');
       const options = {
         'features.rememberMe': true,
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('unchecked');
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('checks rememberMe if username is populated and lastUsername is same as username', function () {
+    itp('checks rememberMe if username is populated and lastUsername is same as username', function() {
       Util.mockGetCookie('ln', 'testuser@ABC.com');
       const options = {
         'features.rememberMe': true,
         username: 'testuser@ABC.com',
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         expect(test.form.rememberMeCheckboxStatus()).toBe('checked');
         expect(test.form.usernameField().val()).toBe('testuser@ABC.com');
       });
     });
-    itp('shows an error if username is empty and submitted', function () {
-      return setup().then(function (test) {
+    itp('shows an error if username is empty and submitted', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(test.form.usernameErrorField().length).toBe(1);
@@ -1882,8 +1882,8 @@ Expect.describe('PrimaryAuth', function () {
         expect(Util.numAjaxRequests()).toBe(0);
       });
     });
-    itp('shows an error if password is empty and submitted', function () {
-      return setup().then(function (test) {
+    itp('shows an error if password is empty and submitted', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.submit();
         expect(test.form.passwordErrorField().length).toBe(1);
@@ -1895,9 +1895,9 @@ Expect.describe('PrimaryAuth', function () {
         expect(Util.numAjaxRequests()).toBe(0);
       });
     });
-    itp('reenables button and fields after a CORS error', function () {
+    itp('reenables button and fields after a CORS error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -1905,7 +1905,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForAjaxRequest(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const button = test.form.submitButton();
           const buttonClass = button.attr('class');
 
@@ -1944,9 +1944,9 @@ Expect.describe('PrimaryAuth', function () {
     //       expect(test.form.isDisabled()).toBe(false);
     //     });
     // });
-    itp('calls authClient primaryAuth with form values when submitted', function () {
+    itp('calls authClient primaryAuth with form values when submitted', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.successSpy.calls.reset();
           test.form.setUsername('testuser');
@@ -1955,7 +1955,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // Form is kept disabling until `globalSuccessFn` does something else,
           // change the DOM or redirect. Widget will not re-enable form when success.
           expect(test.form.isDisabled()).toBe(true);
@@ -1973,9 +1973,9 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('calls authentication with stateToken if status is UNAUTHENTICATED', function () {
+    itp('calls authentication with stateToken if status is UNAUTHENTICATED', function() {
       return setupUnauthenticated()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           Util.resetAjaxRequests();
@@ -1983,7 +1983,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.isDisabled()).toBe(true);
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2000,13 +2000,13 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('calls processCreds function before saving a model', function () {
+    itp('calls processCreds function before saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCreds');
 
       return setup({
         processCreds: processCredsSpy,
       })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -2014,7 +2014,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith({
             username: 'testuser',
@@ -2023,15 +2023,15 @@ Expect.describe('PrimaryAuth', function () {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('calls async processCreds function before saving a model', function () {
+    itp('calls async processCreds function before saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCreds');
       return setup({
-        processCreds: function (creds, callback) {
+        processCreds: function(creds, callback) {
           processCredsSpy(creds, callback);
           callback();
         },
       })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -2039,7 +2039,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith(
             {
@@ -2051,15 +2051,15 @@ Expect.describe('PrimaryAuth', function () {
           expect(Util.numAjaxRequests()).toBe(1);
         });
     });
-    itp('calls async processCreds function and can prevent saving a model', function () {
+    itp('calls async processCreds function and can prevent saving a model', function() {
       const processCredsSpy = jasmine.createSpy('processCreds');
 
       return setup({
-        processCreds: function (creds, callback) {
+        processCreds: function(creds, callback) {
           processCredsSpy(creds, callback);
         },
       })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
@@ -2067,7 +2067,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(processCredsSpy);
         })
-        .then(function () {
+        .then(function() {
           expect(processCredsSpy.calls.count()).toBe(1);
           expect(processCredsSpy).toHaveBeenCalledWith(
             {
@@ -2079,16 +2079,16 @@ Expect.describe('PrimaryAuth', function () {
           expect(Util.numAjaxRequests()).toBe(0);
         });
     });
-    itp('calls authClient with multiOptionalFactorEnroll=true if feature is true', function () {
+    itp('calls authClient with multiOptionalFactorEnroll=true if feature is true', function() {
       return setup({ 'features.multiOptionalFactorEnroll': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.isDisabled()).toBe(true);
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -2104,11 +2104,11 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('sets rememberMe cookie if rememberMe is enabled and checked on submit', function () {
+    itp('sets rememberMe cookie if rememberMe is enabled and checked on submit', function() {
       const cookieSpy = Util.mockSetCookie();
 
       return setup({ 'features.rememberMe': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.form.setRememberMe(true);
@@ -2116,19 +2116,19 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(cookieSpy).toHaveBeenCalledWith('ln', 'testuser', {
             expires: 365,
             path: '/',
           });
         });
     });
-    itp('removes rememberMe cookie if called with existing username and unchecked', function () {
+    itp('removes rememberMe cookie if called with existing username and unchecked', function() {
       Util.mockGetCookie('ln', 'testuser');
       const removeCookieSpy = Util.mockRemoveCookie();
 
       return setup({ 'features.rememberMe': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.form.setRememberMe(false);
@@ -2136,15 +2136,15 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function () {
+        .then(function() {
           expect(removeCookieSpy).toHaveBeenCalledWith('ln', { path: '/' });
         });
     });
-    itp('removes rememberMe cookie if Authentication failed (401)', function () {
+    itp('removes rememberMe cookie if Authentication failed (401)', function() {
       const removeCookieSpy = Util.mockRemoveCookie();
 
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('invalidUser');
           test.form.setPassword('anyPwd');
           test.form.setRememberMe(true);
@@ -2152,114 +2152,114 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
-        .then(function () {
+        .then(function() {
           expect(removeCookieSpy).toHaveBeenCalledWith('ln', { path: '/' });
         });
     });
-    itp('shows an error if authClient returns with an error', function () {
+    itp('shows an error if authClient returns with an error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resUnauthorized);
           test.form.setUsername('testuser');
           test.form.setPassword('invalidpass');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Unable to sign in');
         });
     });
-    itp('shows the right throttle error message', function () {
+    itp('shows the right throttle error message', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resThrottle);
           test.form.setUsername('testuser');
           test.form.setPassword('testpass');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('You exceeded the maximum number of requests. Try again in a while.');
           expectErrorEvent(test, 429, 'API call exceeded rate limit due to too many requests.');
         });
     });
-    itp('shows the correct error if authClient returns with a correct error object', function () {
+    itp('shows the correct error if authClient returns with a correct error object', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resErrorValid);
           test.form.setUsername('testuser');
           test.form.setPassword('invalidpass');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Unable to sign in');
           expectErrorEvent(test, 401, 'Authentication failed');
         });
     });
-    itp('shows a form error if authClient returns with an error that is plain text', function () {
+    itp('shows a form error if authClient returns with an error that is plain text', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resNonJson);
           test.form.setUsername('testuser');
           test.form.setPassword('invalidpass');
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Unable to sign in');
           expectErrorEvent(test, 401, 'Authentication failed');
         });
     });
-    itp('shows a form error if authClient returns with an error that is plain text and not a valid json', function () {
+    itp('shows a form error if authClient returns with an error that is plain text and not a valid json', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('invalidpass');
           test.setNextResponse(resInvalidText);
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Could not parse server response');
           expectErrorEvent(test, 401, 'Could not parse server response');
         });
     });
-    itp('shows an error if authClient returns with LOCKED_OUT response and selfServiceUnlock is off', function () {
+    itp('shows an error if authClient returns with LOCKED_OUT response and selfServiceUnlock is off', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resLockedOut);
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe('Your account is locked. Please contact your administrator.');
         });
     });
-    itp('redirects to "unlock" if authClient returns with LOCKED_OUT response and selfServiceUnlock is on', function () {
+    itp('redirects to "unlock" if authClient returns with LOCKED_OUT response and selfServiceUnlock is on', function() {
       return setup({ 'features.selfServiceUnlock': true })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resLockedOut);
           test.form.submit();
           return Expect.waitForSpyCall(test.router.navigate, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.navigate).toHaveBeenCalledWith('signin/unlock', { trigger: true });
         });
     });
-    itp('calls globalErrorFn if authClient returns with a cors enabled error', function () {
+    itp('calls globalErrorFn if authClient returns with a cors enabled error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           spyOn(test.router.settings, 'callGlobalError');
           test.setNextResponse({
             responseType: 'json',
@@ -2271,7 +2271,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForSpyCall(test.router.settings.callGlobalError, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const err = test.router.settings.callGlobalError.calls.mostRecent().args[0];
 
           expect(err instanceof Errors.UnsupportedBrowserError).toBe(true);
@@ -2280,7 +2280,7 @@ Expect.describe('PrimaryAuth', function () {
         });
     });
 
-    itp('shows an error if redirect is required for MFA', function () {
+    itp('shows an error if redirect is required for MFA', function() {
       const serverMessage = 'The client specified not to prompt, but the client app requires re-authentication or MFA.';
       const error = new OAuthError('login_required', serverMessage);
       const clientMessage = 'MFA means need redirect';
@@ -2298,7 +2298,7 @@ Expect.describe('PrimaryAuth', function () {
           }
         }
       })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser');
           test.form.setPassword('pass');
           test.setNextResponse(resSuccess);
@@ -2306,30 +2306,30 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorMessage()).toBe(clientMessage);
         });
     });
   });
 
-  Expect.describe('Passwordless Auth', function () {
-    itp('does not have a password field', function () {
-      return setupPasswordlessAuth().then(function (test) {
+  Expect.describe('Passwordless Auth', function() {
+    itp('does not have a password field', function() {
+      return setupPasswordlessAuth().then(function(test) {
         const password = test.form.passwordField();
 
         expect(password.length).toBe(0);
       });
     });
-    itp('calls authClient.signIn with username only', function () {
+    itp('calls authClient.signIn with username only', function() {
       return setupPasswordlessAuth()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn',
@@ -2343,29 +2343,29 @@ Expect.describe('PrimaryAuth', function () {
           });
         });
     });
-    itp('shows MfaVerify view after authClient.signIn returns with UNAUTHENTICATED', function () {
+    itp('shows MfaVerify view after authClient.signIn returns with UNAUTHENTICATED', function() {
       return setupPasswordlessAuth()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.el('factor-question').length).toEqual(1);
         });
     });
 
     itp(
       'calls transaction.authenticate with the same stateToken that the widget was bootstrapped with, in the config object',
-      function () {
+      function() {
         return setupPasswordlessAuth(null, true)
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setUsername('testuser@test.com');
             test.form.submit();
             return Expect.waitForMfaVerify(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.okta.com/api/v1/authn',
@@ -2382,22 +2382,22 @@ Expect.describe('PrimaryAuth', function () {
       }
     );
 
-    itp('can sign in again when sign out is clicked on mfa and no Idx state token', function () {
+    itp('can sign in again when sign out is clicked on mfa and no Idx state token', function() {
       return setupPasswordlessAuth(null, true, false)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // log out when prompted for first factor in UNAUTHENTICATED state
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           test.setNextResponse(resCancel);
           $(test.form.el('signout-link')).click();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // try to log back in
           expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           Expect.isPrimaryAuth(test.router.controller);
@@ -2407,7 +2407,7 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // should see prompt for factor
           expect(test.form.el('factor-question').length).toEqual(1);
         });
@@ -2415,15 +2415,15 @@ Expect.describe('PrimaryAuth', function () {
 
     itp(
       'calls transaction.login with the same stateToken that the widget was bootstrapped with, in the config object',
-      function () {
+      function() {
         return setupPasswordlessAuth(null, true, true)
-          .then(function (test) {
+          .then(function(test) {
             Util.resetAjaxRequests();
             test.form.setUsername('testuser@test.com');
             test.form.submit();
             return Expect.waitForMfaVerify(test);
           })
-          .then(function () {
+          .then(function() {
             expect(Util.numAjaxRequests()).toBe(1);
             Expect.isJsonPost(Util.getAjaxRequest(0), {
               url: 'https://foo.okta.com/api/v1/authn',
@@ -2440,22 +2440,22 @@ Expect.describe('PrimaryAuth', function () {
       }
     );
 
-    itp('can sign in again when sign out is clicked on mfa and there is Idx state token', function () {
+    itp('can sign in again when sign out is clicked on mfa and there is Idx state token', function() {
       return setupPasswordlessAuth(null, true, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.form.setUsername('testuser@test.com');
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // log out when prompted for first factor in UNAUTHENTICATED state
           spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
           test.setNextResponse(resCancel);
           $(test.form.el('signout-link')).click();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // try to log back in
           expect(test.router.controller.options.appState.clearLastAuthResponse).toHaveBeenCalled();
           Expect.isPrimaryAuth(test.router.controller);
@@ -2465,21 +2465,21 @@ Expect.describe('PrimaryAuth', function () {
           test.form.submit();
           return Expect.waitForMfaVerify(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           // should see prompt for factor
           expect(test.form.el('factor-question').length).toEqual(1);
         });
     });
   });
 
-  Expect.describe('Social Auth', function () {
-    itp('does not show the divider or buttons if no idps are passed in', function () {
-      return setup().then(function (test) {
+  Expect.describe('Social Auth', function() {
+    itp('does not show the divider or buttons if no idps are passed in', function() {
+      return setup().then(function(test) {
         expect(test.form.hasSocialAuthDivider()).toBe(false);
         expect(test.form.socialAuthButtons()).toHaveLength(0);
       });
     });
-    itp('shows a divider and a button for each idp that is passed in', function () {
+    itp('shows a divider and a button for each idp that is passed in', function() {
       const settings = {
         idps: [
           {
@@ -2493,14 +2493,14 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.hasSocialAuthDivider()).toBe(true);
         expect(test.form.socialAuthButtons()).toHaveLength(2);
         expect(test.form.facebookButton()).toHaveLength(1);
         expect(test.form.googleButton()).toHaveLength(1);
       });
     });
-    itp('shows idps in the order specified', function () {
+    itp('shows idps in the order specified', function() {
       const settings = {
         idps: [
           {
@@ -2526,7 +2526,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.eq(0)).toHaveClass('social-auth-linkedin-button');
@@ -2536,7 +2536,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(buttons.eq(4)).toHaveClass('social-auth-microsoft-button');
       });
     });
-    itp('optionally adds a class for idp buttons', function () {
+    itp('optionally adds a class for idp buttons', function() {
       const settings = {
         idps: [
           {
@@ -2556,7 +2556,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.eq(0)).toHaveClass('social-auth-google-button');
@@ -2575,7 +2575,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(buttons.eq(2)).toHaveClass('other-class');
       });
     });
-    itp('displays generic idp buttons for unknown types', function () {
+    itp('displays generic idp buttons for unknown types', function() {
       const settings = {
         idps: [
           {
@@ -2585,7 +2585,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.size()).toBe(1);
@@ -2598,7 +2598,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(buttons.eq(0)).toHaveClass('social-auth-general-idp-button');
       });
     });
-    itp('type is optional for generic idp buttons', function () {
+    itp('type is optional for generic idp buttons', function() {
       const settings = {
         idps: [
           {
@@ -2607,7 +2607,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.size()).toBe(1);
@@ -2619,7 +2619,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(buttons.eq(0)).toHaveClass('social-auth-general-idp-button');
       });
     });
-    itp('sets the text for generic idp buttons', function () {
+    itp('sets the text for generic idp buttons', function() {
       const settings = {
         idps: [
           {
@@ -2629,13 +2629,13 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.eq(0)).toHaveText('Not default text');
       });
     });
-    itp('gives default text if no text provided for generic idp buttons', function () {
+    itp('gives default text if no text provided for generic idp buttons', function() {
       const settings = {
         idps: [
           {
@@ -2644,13 +2644,13 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         const buttons = test.form.socialAuthButtons();
 
         expect(buttons.eq(0)).toHaveText('{ Please provide a text value }');
       });
     });
-    itp('shows the buttons below the primary auth form by default', function () {
+    itp('shows the buttons below the primary auth form by default', function() {
       const settings = {
         idps: [
           {
@@ -2676,7 +2676,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.primaryAuthForm().index()).toBe(0);
         expect(test.form.primaryAuthContainer().index()).toBe(1);
         expect(test.form.socialAuthButtons().length).toBe(5);
@@ -2687,7 +2687,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(test.form.microsoftButton().length).toBe(1);
       });
     });
-    itp('shows the buttons above the primary auth form when "idpDisplay" is passed as "PRIMARY"', function () {
+    itp('shows the buttons above the primary auth form when "idpDisplay" is passed as "PRIMARY"', function() {
       const settings = {
         idpDisplay: 'PRIMARY',
         idps: [
@@ -2706,7 +2706,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.primaryAuthContainer().index()).toBe(0);
         expect(test.form.primaryAuthForm().index()).toBe(1);
         expect(test.form.socialAuthButtons().length).toBe(3);
@@ -2715,7 +2715,7 @@ Expect.describe('PrimaryAuth', function () {
         expect(test.form.appleButton().length).toBe(1);
       });
     });
-    itp('shows the buttons below the primary auth form when "idpDisplay" is passed as "SECONDARY"', function () {
+    itp('shows the buttons below the primary auth form when "idpDisplay" is passed as "SECONDARY"', function() {
       const settings = {
         idpDisplay: 'SECONDARY',
         idps: [
@@ -2734,7 +2734,7 @@ Expect.describe('PrimaryAuth', function () {
         ],
       };
 
-      return setup(settings).then(function (test) {
+      return setup(settings).then(function(test) {
         expect(test.form.primaryAuthForm().index()).toBe(0);
         expect(test.form.primaryAuthContainer().index()).toBe(1);
         expect(test.form.socialAuthButtons().length).toBe(3);
@@ -2743,13 +2743,13 @@ Expect.describe('PrimaryAuth', function () {
         expect(test.form.appleButton().length).toBe(1);
       });
     });
-    itp('opens a popup with the correct url when an idp button is clicked', function () {
+    itp('opens a popup with the correct url when an idp button is clicked', function() {
       return setupSocial()
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForSpyCall(window.open);
         })
-        .then(function () {
+        .then(function() {
           expect(window.open.calls.count()).toBe(1);
           expect(window.open).toHaveBeenCalledWith(
             'https://foo.com/oauth2/v1/authorize?' +
@@ -2771,13 +2771,13 @@ Expect.describe('PrimaryAuth', function () {
           );
         });
     });
-    itp('navigate to "/sso/idp/:id" at none OIDC mode when an idp button is clicked', function () {
+    itp('navigate to "/sso/idp/:id" at none OIDC mode when an idp button is clicked', function() {
       spyOn(SharedUtil, 'redirect');
       const opt = {
         relayState: '/oauth2/v1/authorize/redirect?okta_key=FTAUUQK8XbZi0h2MyEDnBFTLnTFpQGqfNjVnirCXE0U',
       };
 
-      return setupSocialNoneOIDCMode(opt).then(function (test) {
+      return setupSocialNoneOIDCMode(opt).then(function(test) {
         test.form.facebookButton().click();
         expect(SharedUtil.redirect.calls.count()).toBe(1);
         expect(SharedUtil.redirect).toHaveBeenCalledWith(
@@ -2786,13 +2786,13 @@ Expect.describe('PrimaryAuth', function () {
         );
       });
     });
-    itp('opens a popup with the correct url when an idp button is clicked and asking for an accessToken', function () {
+    itp('opens a popup with the correct url when an idp button is clicked and asking for an accessToken', function() {
       return setupSocial({ 'authParams.responseType': 'token' })
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForSpyCall(window.open);
         })
-        .then(function () {
+        .then(function() {
           expect(window.open.calls.count()).toBe(1);
           expect(window.open).toHaveBeenCalledWith(
             'https://foo.com/oauth2/v1/authorize?' +
@@ -2816,13 +2816,13 @@ Expect.describe('PrimaryAuth', function () {
     });
     itp(
       'opens a popup with the correct url when an idp button is clicked and asking for an accessToken and idToken',
-      function () {
+      function() {
         return setupSocial({ 'authParams.responseType': ['id_token', 'token'] })
-          .then(function (test) {
+          .then(function(test) {
             test.form.facebookButton().click();
             return Expect.waitForSpyCall(window.open);
           })
-          .then(function () {
+          .then(function() {
             expect(window.open.calls.count()).toBe(1);
             expect(window.open).toHaveBeenCalledWith(
               'https://foo.com/oauth2/v1/authorize?' +
@@ -2847,7 +2847,7 @@ Expect.describe('PrimaryAuth', function () {
     );
     itp(
       'calls the global success function with the idToken and user data when the popup sends a message with idToken',
-      function () {
+      function() {
         Util.loadWellKnownAndKeysCache();
         spyOn(window, 'addEventListener');
 
@@ -2855,11 +2855,11 @@ Expect.describe('PrimaryAuth', function () {
         // Mock the date to 10 seconds after token was issued.
         jasmine.clock().mockDate(new Date(AUTH_TIME + 10000));
         return setupSocial()
-          .then(function (test) {
+          .then(function(test) {
             test.form.facebookButton().click();
             return Expect.waitForWindowListener('message', test);
           })
-          .then(function (test) {
+          .then(function(test) {
             jasmine.clock().mockDate(new Date(AUTH_TIME + 10000));
             const args = window.addEventListener.calls.mostRecent().args;
             const callback = args[1];
@@ -2872,7 +2872,7 @@ Expect.describe('PrimaryAuth', function () {
             });
             return Expect.waitForSpyCall(test.successSpy, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.successSpy.calls.count()).toBe(1);
             const data = test.successSpy.calls.argsFor(0)[0];
 
@@ -2900,12 +2900,12 @@ Expect.describe('PrimaryAuth', function () {
               ver: 1,
             });
           })
-          .finally(function () {
+          .finally(function() {
             jasmine.clock().uninstall();
           });
       }
     );
-    itp('calls the global success function with the idToken and accessToken', function () {
+    itp('calls the global success function with the idToken and accessToken', function() {
       Util.loadWellKnownAndKeysCache();
       spyOn(window, 'addEventListener');
 
@@ -2913,11 +2913,11 @@ Expect.describe('PrimaryAuth', function () {
       // Mock the date to 10 seconds after token was issued.
       jasmine.clock().mockDate(new Date(AUTH_TIME + 10000));
       return setupSocial({ 'authParams.responseType': ['id_token', 'token'] })
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
           const callback = args[1];
           callback.call(null, {
@@ -2933,7 +2933,7 @@ Expect.describe('PrimaryAuth', function () {
           });
           return Expect.waitForSpyCall(test.successSpy, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.successSpy.calls.count()).toBe(1);
           const data = test.successSpy.calls.argsFor(0)[0];
 
@@ -2944,18 +2944,18 @@ Expect.describe('PrimaryAuth', function () {
           expect(data.tokens.accessToken.scopes).toEqual(['openid', 'email', 'profile']);
           expect(data.tokens.accessToken.tokenType).toBe('Bearer');
         })
-        .finally(function () {
+        .finally(function() {
           jasmine.clock().uninstall();
         });
     });
-    itp('triggers the afterError event if there is no valid id token returned', function () {
+    itp('triggers the afterError event if there is no valid id token returned', function() {
       spyOn(window, 'addEventListener');
       return setupSocial()
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
           const callback = args[1];
           callback.call(null, {
@@ -2968,7 +2968,7 @@ Expect.describe('PrimaryAuth', function () {
           });
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
           expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
             {
@@ -2983,18 +2983,18 @@ Expect.describe('PrimaryAuth', function () {
     });
 
     // TODO: add test to verify the behavior when missing `state` in the data
-    itp('ignores messages with the wrong origin', function () {
+    itp('ignores messages with the wrong origin', function() {
       const successSpy = jasmine.createSpy('successSpy');
       const errorSpy = jasmine.createSpy('errorSpy');
 
       spyOn(window, 'addEventListener');
 
       return setupSocial({ globalErrorFn: errorSpy, globalSuccessFn: successSpy })
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
           const callback = args[1];
           callback.call(null, {
@@ -3006,7 +3006,7 @@ Expect.describe('PrimaryAuth', function () {
           });
           return Expect.waitForSpyCall(test.afterErrorHandler, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(successSpy.calls.count()).toBe(0);
           expect(errorSpy.calls.count()).toBe(0);
           expect(test.afterErrorHandler).toHaveBeenCalledWith(
@@ -3020,16 +3020,16 @@ Expect.describe('PrimaryAuth', function () {
           );
         });
     });
-    itp('closes the popup after receiving the idToken message', function () {
+    itp('closes the popup after receiving the idToken message', function() {
       const successSpy = jasmine.createSpy('successSpy');
 
       spyOn(window, 'addEventListener');
       return setupSocial({ globalSuccessFn: successSpy })
-        .then(function (test) {
+        .then(function(test) {
           test.form.facebookButton().click();
           return Expect.waitForWindowListener('message', test);
         })
-        .then(function (test) {
+        .then(function(test) {
           const args = window.addEventListener.calls.mostRecent().args;
           const callback = args[1];
           callback.call(null, {
@@ -3041,7 +3041,7 @@ Expect.describe('PrimaryAuth', function () {
           });
           return Expect.waitForSpyCall(test.oidcWindow.close, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.oidcWindow.close).toHaveBeenCalled();
         });
     });
@@ -3054,37 +3054,37 @@ Expect.describe('PrimaryAuth', function () {
   });
 });
 
-Expect.describe('Additional Auth Button', function () {
-  itp('does not show the divider and buttons if settings.customButtons is not set', function () {
-    return setup().then(function (test) {
+Expect.describe('Additional Auth Button', function() {
+  itp('does not show the divider and buttons if settings.customButtons is not set', function() {
+    return setup().then(function(test) {
       expect(test.form.authDivider().length).toBe(0);
       expect(test.form.additionalAuthButton().length).toBe(0);
     });
   });
-  itp('show the divider and buttons if settings.customButtons is not empty', function () {
-    return setupWithCustomButtons().then(function (test) {
+  itp('show the divider and buttons if settings.customButtons is not empty', function() {
+    return setupWithCustomButtons().then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.additionalAuthButton().length).toBe(1);
     });
   });
-  itp('sets text with property passed', function () {
-    return setupWithCustomButtons().then(function (test) {
+  itp('sets text with property passed', function() {
+    return setupWithCustomButtons().then(function(test) {
       expect(test.form.additionalAuthButton().text()).toEqual('test text');
     });
   });
-  itp('sets class with property passed', function () {
-    return setupWithCustomButtons().then(function (test) {
+  itp('sets class with property passed', function() {
+    return setupWithCustomButtons().then(function(test) {
       expect(test.form.additionalAuthButton().hasClass('test-class')).toBe(true);
     });
   });
-  itp('clickHandler is called when button is clicked', function () {
-    return setupWithCustomButtons().then(function (test) {
+  itp('clickHandler is called when button is clicked', function() {
+    return setupWithCustomButtons().then(function(test) {
       expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(false);
       test.form.additionalAuthButton().click();
       expect(test.form.additionalAuthButton().hasClass('new-class')).toBe(true);
     });
   });
-  itp('displays custom button translation', function () {
+  itp('displays custom button translation', function() {
     const settings = {
       i18n: {
         en: {
@@ -3098,11 +3098,11 @@ Expect.describe('Additional Auth Button', function () {
       ],
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.additionalAuthButton().text()).toEqual('Custom Translated Title');
     });
   });
-  itp('ignores custom button translation if title is passed', function () {
+  itp('ignores custom button translation if title is passed', function() {
     const settings = {
       i18n: {
         en: {
@@ -3117,17 +3117,17 @@ Expect.describe('Additional Auth Button', function () {
       ],
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.additionalAuthButton().text()).toEqual('Title Overrides i18n');
     });
   });
-  itp('displays social auth and custom buttons', function () {
+  itp('displays social auth and custom buttons', function() {
     const settings = {
       customButtons: [
         {
           title: 'test text',
           className: 'test-class',
-          click: function (e) {
+          click: function(e) {
             $(e.target).addClass('new-class');
           },
         },
@@ -3140,13 +3140,13 @@ Expect.describe('Additional Auth Button', function () {
       ],
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.additionalAuthButton().length).toBe(1);
       expect(test.form.facebookButton().length).toBe(1);
     });
   });
-  itp('does not display custom buttons when it is undefined', function () {
+  itp('does not display custom buttons when it is undefined', function() {
     const settings = {
       customButtons: undefined,
       idps: [
@@ -3157,19 +3157,19 @@ Expect.describe('Additional Auth Button', function () {
       ],
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.additionalAuthButton().length).toBe(0);
       expect(test.form.facebookButton().length).toBe(1);
     });
   });
-  itp('does not display social auth when it is undefined', function () {
+  itp('does not display social auth when it is undefined', function() {
     const settings = {
       customButtons: [
         {
           title: 'test text',
           className: 'test-class',
-          click: function (e) {
+          click: function(e) {
             $(e.target).addClass('new-class');
           },
         },
@@ -3177,19 +3177,19 @@ Expect.describe('Additional Auth Button', function () {
       idps: undefined,
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.additionalAuthButton().length).toBe(1);
       expect(test.form.facebookButton().length).toBe(0);
     });
   });
-  itp('does not display any additional buttons when social auth and customButtons are undefined', function () {
+  itp('does not display any additional buttons when social auth and customButtons are undefined', function() {
     const settings = {
       customButtons: undefined,
       idps: undefined,
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(0);
       expect(test.form.additionalAuthButton().length).toBe(0);
       expect(test.form.facebookButton().length).toBe(0);
@@ -3197,53 +3197,53 @@ Expect.describe('Additional Auth Button', function () {
   });
 });
 
-Expect.describe('PIV Button', function () {
-  itp('does not show the divider and buttons if certAuthUrl is not defined', function () {
-    return setupPIV(false).then(function (test) {
+Expect.describe('PIV Button', function() {
+  itp('does not show the divider and buttons if certAuthUrl is not defined', function() {
+    return setupPIV(false).then(function(test) {
       expect(test.form.authDivider().length).toBe(0);
       expect(test.form.pivButton().length).toBe(0);
     });
   });
-  itp('does not show the divider and buttons if settings.piv is not set', function () {
-    return setup().then(function (test) {
+  itp('does not show the divider and buttons if settings.piv is not set', function() {
+    return setup().then(function(test) {
       expect(test.form.authDivider().length).toBe(0);
       expect(test.form.pivButton().length).toBe(0);
     });
   });
-  itp('show the divider and buttons if settings.piv is not empty', function () {
-    return setupPIV(true).then(function (test) {
+  itp('show the divider and buttons if settings.piv is not empty', function() {
+    return setupPIV(true).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.pivButton().length).toBe(1);
     });
   });
-  itp('shows default text if none passed', function () {
-    return setupPIV(true, true).then(function (test) {
+  itp('shows default text if none passed', function() {
+    return setupPIV(true, true).then(function(test) {
       expect(test.form.pivButton().text()).toEqual('Sign in with PIV / CAC card');
     });
   });
-  itp('sets text with property passed', function () {
-    return setupPIV(true).then(function (test) {
+  itp('sets text with property passed', function() {
+    return setupPIV(true).then(function(test) {
       expect(test.form.pivButton().text()).toEqual('piv test text');
     });
   });
-  itp('sets class with property passed', function () {
-    return setupPIV(true).then(function (test) {
+  itp('sets class with property passed', function() {
+    return setupPIV(true).then(function(test) {
       expect(test.form.pivButton().hasClass('piv-test-class')).toBe(true);
     });
   });
-  itp('navigates to piv login flow when button is clicked', function () {
-    return setupPIV(true).then(function (test) {
+  itp('navigates to piv login flow when button is clicked', function() {
+    return setupPIV(true).then(function(test) {
       test.form.pivButton().click();
       expect(test.router.navigate).toHaveBeenCalledWith('signin/verify/piv', { trigger: true });
     });
   });
-  itp('displays social auth, piv and custom buttons', function () {
+  itp('displays social auth, piv and custom buttons', function() {
     const settings = {
       customButtons: [
         {
           title: 'test text',
           className: 'test-class',
-          click: function (e) {
+          click: function(e) {
             $(e.target).addClass('new-class');
           },
         },
@@ -3261,14 +3261,14 @@ Expect.describe('PIV Button', function () {
       },
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.additionalAuthButton().length).toBe(1);
       expect(test.form.facebookButton().length).toBe(1);
       expect(test.form.pivButton().length).toBe(1);
     });
   });
-  itp('does not display piv button when certAuthUrl is not defined', function () {
+  itp('does not display piv button when certAuthUrl is not defined', function() {
     const settings = {
       idps: [
         {
@@ -3282,13 +3282,13 @@ Expect.describe('PIV Button', function () {
       },
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.pivButton().length).toBe(0);
       expect(test.form.facebookButton().length).toBe(1);
     });
   });
-  itp('does not display social auth when it is undefined', function () {
+  itp('does not display social auth when it is undefined', function() {
     const settings = {
       piv: {
         text: 'piv test text',
@@ -3298,20 +3298,20 @@ Expect.describe('PIV Button', function () {
       idps: undefined,
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(1);
       expect(test.form.pivButton().length).toBe(1);
       expect(test.form.facebookButton().length).toBe(0);
     });
   });
-  itp('does not display any additional buttons when social auth, piv and customButtons are undefined', function () {
+  itp('does not display any additional buttons when social auth, piv and customButtons are undefined', function() {
     const settings = {
       piv: undefined,
       customButtons: undefined,
       idps: undefined,
     };
 
-    return setup(settings).then(function (test) {
+    return setup(settings).then(function(test) {
       expect(test.form.authDivider().length).toBe(0);
       expect(test.form.additionalAuthButton().length).toBe(0);
       expect(test.form.pivButton().length).toBe(0);
@@ -3320,23 +3320,23 @@ Expect.describe('PIV Button', function () {
   });
 });
 
-Expect.describe('Registration Flow', function () {
-  itp('does not show the registration button if features.registration is not set', function () {
-    return setup().then(function (test) {
+Expect.describe('Registration Flow', function() {
+  itp('does not show the registration button if features.registration is not set', function() {
+    return setup().then(function(test) {
       expect(test.form.registrationContainer().length).toBe(0);
     });
   });
-  itp('does not show the registration button if features.registration is false', function () {
+  itp('does not show the registration button if features.registration is false', function() {
     const registration = {};
 
-    return setupRegistrationButton(null, registration).then(function (test) {
+    return setupRegistrationButton(null, registration).then(function(test) {
       expect(test.form.registrationContainer().length).toBe(0);
     });
   });
-  itp('show the registration button if settings.registration.enable is true', function () {
+  itp('show the registration button if settings.registration.enable is true', function() {
     const registration = {};
 
-    return setupRegistrationButton(true, registration).then(function (test) {
+    return setupRegistrationButton(true, registration).then(function(test) {
       expect(test.form.registrationContainer().length).toBe(1);
       expect(test.form.registrationLabel().length).toBe(1);
       expect(test.form.registrationLabel().text()).toBe('Don\'t have an account?');
@@ -3345,14 +3345,14 @@ Expect.describe('Registration Flow', function () {
       expect(typeof registration.click).toEqual('undefined');
     });
   });
-  itp('the registration button is a custom function', function () {
+  itp('the registration button is a custom function', function() {
     const registration = {
-      click: function () {
+      click: function() {
         window.location.href = 'http://www.test.com';
       },
     };
 
-    return setupRegistrationButton(true, registration).then(function (test) {
+    return setupRegistrationButton(true, registration).then(function(test) {
       expect(test.form.registrationContainer().length).toBe(1);
       expect(test.form.registrationLabel().length).toBe(1);
       expect(test.form.registrationLabel().text()).toBe('Don\'t have an account?');
@@ -3361,12 +3361,12 @@ Expect.describe('Registration Flow', function () {
       expect(typeof registration.click).toEqual('function');
     });
   });
-  itp('calls settings.registration.click if its a function and when the link is clicked', function () {
+  itp('calls settings.registration.click if its a function and when the link is clicked', function() {
     const registration = {
       click: jasmine.createSpy('registrationSpy'),
     };
 
-    return setupRegistrationButton(true, registration).then(function (test) {
+    return setupRegistrationButton(true, registration).then(function(test) {
       test.form.registrationLink().click();
       expect(registration.click).toHaveBeenCalled();
     });

--- a/test/unit/spec/RecoveryChallenge_spec.js
+++ b/test/unit/spec/RecoveryChallenge_spec.js
@@ -15,7 +15,7 @@ import $sandbox from 'sandbox';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-function setup (settings) {
+function setup(settings) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -53,24 +53,24 @@ function setup (settings) {
   return Expect.waitForRecoveryChallenge(testData);
 }
 
-Expect.describe('RecoveryChallenge', function () {
-  beforeEach(function () {
+Expect.describe('RecoveryChallenge', function() {
+  beforeEach(function() {
     const throttle = _.throttle;
 
-    spyOn(_, 'throttle').and.callFake(function (fn) {
+    spyOn(_, 'throttle').and.callFake(function(fn) {
       return throttle(fn, 0);
     });
     this.originalDelay = _.delay;
     spyOn(_, 'delay');
   });
-  itp('displays the security beacon', function () {
-    return setup().then(function (test) {
+  itp('displays the security beacon', function() {
+    return setup().then(function(test) {
       expect(test.beacon.isSecurityBeacon()).toBe(true);
     });
   });
-  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
@@ -80,7 +80,7 @@ Expect.describe('RecoveryChallenge', function () {
         $link.click();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -93,17 +93,17 @@ Expect.describe('RecoveryChallenge', function () {
       });
   });
 
-  itp('does not show back link if hideBackToSignInForReset is true', function () {
-    return setup({ 'features.hideBackToSignInForReset': true }).then(function (test) {
+  itp('does not show back link if hideBackToSignInForReset is true', function() {
+    return setup({ 'features.hideBackToSignInForReset': true }).then(function(test) {
       const $link = test.form.signoutLink();
 
       expect($link.length).toBe(0);
     });
   });
 
-  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function () {
+  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function() {
     return setup({ signOutLink: 'http://www.goodbye.com' })
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
@@ -114,7 +114,7 @@ Expect.describe('RecoveryChallenge', function () {
         $link.click();
         return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -126,18 +126,18 @@ Expect.describe('RecoveryChallenge', function () {
         expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
       });
   });
-  itp('has a text field to enter the recovery sms code', function () {
-    return setup().then(function (test) {
+  itp('has a text field to enter the recovery sms code', function() {
+    return setup().then(function(test) {
       Expect.isTextField(test.form.codeField());
     });
   });
-  itp('does not allow autocomplete', function () {
-    return setup().then(function (test) {
+  itp('does not allow autocomplete', function() {
+    return setup().then(function(test) {
       expect(test.form.getAutocompleteCodeField()).toBe('off');
     });
   });
-  itp('has a disabled "Sent" button on initialize', function () {
-    return setup().then(function (test) {
+  itp('has a disabled "Sent" button on initialize', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       spyOn(test.router.controller.model, 'resendCode').and.callThrough();
       const button = test.form.resendButton();
@@ -148,24 +148,24 @@ Expect.describe('RecoveryChallenge', function () {
       expect(Util.numAjaxRequests()).toBe(0);
     });
   });
-  itp('has a "Re-send" button after a short delay', function () {
+  itp('has a "Re-send" button after a short delay', function() {
     const delay = this.originalDelay;
 
-    _.delay.and.callFake(function (func, wait, args) {
+    _.delay.and.callFake(function(func, wait, args) {
       return delay(func, 0, args);
     });
-    return setup().then(function (test) {
+    return setup().then(function(test) {
       expect(test.form.resendButton().text()).toBe('Re-send code');
     });
   });
-  itp('"Re-send" button will resend the code and then be disabled', function () {
+  itp('"Re-send" button will resend the code and then be disabled', function() {
     const delay = this.originalDelay;
 
-    _.delay.and.callFake(function (func, wait, args) {
+    _.delay.and.callFake(function(func, wait, args) {
       return delay(func, 0, args);
     });
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.setNextResponse(resChallenge);
         test.button = test.form.resendButton();
@@ -174,7 +174,7 @@ Expect.describe('RecoveryChallenge', function () {
         expect(test.button.attr('class')).toMatch('link-button-disabled');
         return Expect.waitForAjaxRequest();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/factors/SMS/resend',
@@ -184,14 +184,14 @@ Expect.describe('RecoveryChallenge', function () {
         });
       });
   });
-  itp('displays only one error block when a resend button clicked several time and got error resp', function () {
+  itp('displays only one error block when a resend button clicked several time and got error resp', function() {
     const delay = this.originalDelay;
 
-    _.delay.and.callFake(function (func, wait, args) {
+    _.delay.and.callFake(function(func, wait, args) {
       return delay(func, 0, args);
     });
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.model, 'resendCode').and.callThrough();
         Util.resetAjaxRequests();
         test.setNextResponse(resResendError);
@@ -199,7 +199,7 @@ Expect.describe('RecoveryChallenge', function () {
         expect(test.router.controller.model.resendCode.calls.count()).toBe(1);
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox().length).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -216,7 +216,7 @@ Expect.describe('RecoveryChallenge', function () {
         test.form.resendButton().click();
         return Expect.waitForAjaxRequest(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox().length).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
@@ -227,16 +227,16 @@ Expect.describe('RecoveryChallenge', function () {
         });
       });
   });
-  itp('makes the right auth request when form is submitted', function () {
+  itp('makes the right auth request when form is submitted', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setCode('1234');
         test.setNextResponse(resSuccess);
         test.form.submit();
         return Expect.waitForAjaxRequest(test);
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/factors/SMS/verify',
@@ -247,27 +247,27 @@ Expect.describe('RecoveryChallenge', function () {
         });
       });
   });
-  itp('validates that the code is not empty before submitting', function () {
-    return setup().then(function (test) {
+  itp('validates that the code is not empty before submitting', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.submit();
       expect(Util.numAjaxRequests()).toBe(0);
       expect(test.form.hasErrors()).toBe(true);
     });
   });
-  itp('shows an error msg if there is an error re-sending the code', function () {
+  itp('shows an error msg if there is an error re-sending the code', function() {
     const delay = this.originalDelay;
 
-    _.delay.and.callFake(function (func, wait, args) {
+    _.delay.and.callFake(function(func, wait, args) {
       return delay(func, 0, args);
     });
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resResendError);
         test.form.resendButton().click();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -295,15 +295,15 @@ Expect.describe('RecoveryChallenge', function () {
         ]);
       });
   });
-  itp('shows an error msg if there is an error submitting the code', function () {
+  itp('shows an error msg if there is an error submitting the code', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resVerifyError);
         test.form.setCode('1234');
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('You do not have permission to perform the requested action');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/RecoveryLoading_spec.js
+++ b/test/unit/spec/RecoveryLoading_spec.js
@@ -13,7 +13,7 @@ import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 
-function setup (settings, callRecoveryLoading, fail = false) {
+function setup(settings, callRecoveryLoading, fail = false) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -58,13 +58,13 @@ function setup (settings, callRecoveryLoading, fail = false) {
   return Q(testData);
 }
 
-Expect.describe('Recovery Loading', function () {
-  itp('makes a request with correct token passed in url', function () {
+Expect.describe('Recovery Loading', function() {
+  itp('makes a request with correct token passed in url', function() {
     return setup({}, true)
       .then(test => {
         return Expect.waitForRecoveryQuestion(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/token',
@@ -76,12 +76,12 @@ Expect.describe('Recovery Loading', function () {
       });
   });
 
-  itp('makes a request with correct token passed in settings', function () {
+  itp('makes a request with correct token passed in settings', function() {
     return setup({ recoveryToken: 'SETTINGSTOKEN' }, false)
       .then(test => {
         return Expect.waitForRecoveryQuestion(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/token',
@@ -95,7 +95,7 @@ Expect.describe('Recovery Loading', function () {
         test.router.navigate('', { trigger: true });
         return Expect.waitForPrimaryAuth();
       })
-      .then(function () {
+      .then(function() {
         const form = new PrimaryAuthFormView($sandbox);
 
         expect(form.isPrimaryAuth()).toBe(true);
@@ -109,7 +109,7 @@ Expect.describe('Recovery Loading', function () {
   // it('calls a callback function if no token passed in settings');
   // ======
 
-  itp('triggers an afterError event when a request with a stale token passed in settings', function () {
+  itp('triggers an afterError event when a request with a stale token passed in settings', function() {
     return setup({ recoveryToken: 'foo' }, false, true)
       .then(test => {
         return Expect.waitForRecoveryLoading(test);
@@ -117,7 +117,7 @@ Expect.describe('Recovery Loading', function () {
       .then(test => {
         return Expect.waitForSpyCall(test.afterErrorHandler, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/token',

--- a/test/unit/spec/RecoveryQuestion_spec.js
+++ b/test/unit/spec/RecoveryQuestion_spec.js
@@ -15,7 +15,7 @@ import $sandbox from 'sandbox';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-function setup (settings, res) {
+function setup(settings, res) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -56,15 +56,15 @@ function setup (settings, res) {
 
 const setupOIDC = _.partial(setup, { clientId: 'someClientId' });
 
-Expect.describe('RecoveryQuestion', function () {
-  itp('displays the security beacon', function () {
-    return setup().then(function (test) {
+Expect.describe('RecoveryQuestion', function() {
+  itp('displays the security beacon', function() {
+    return setup().then(function(test) {
       expect(test.beacon.isSecurityBeacon()).toBe(true);
     });
   });
-  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function () {
+  itp('has a signout link which cancels the current stateToken and navigates to primaryAuth', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
@@ -74,7 +74,7 @@ Expect.describe('RecoveryQuestion', function () {
         $link.click();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -86,9 +86,9 @@ Expect.describe('RecoveryQuestion', function () {
         Expect.isPrimaryAuth(test.router.controller);
       });
   });
-  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function () {
+  itp('has a signout link which cancels the current stateToken and redirects to the provided signout url', function() {
     return setup({ signOutLink: 'http://www.goodbye.com' })
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.router.controller.options.appState, 'clearLastAuthResponse').and.callThrough();
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
@@ -99,7 +99,7 @@ Expect.describe('RecoveryQuestion', function () {
         $link.click();
         return Expect.waitForSpyCall(SharedUtil.redirect, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/cancel',
@@ -111,45 +111,45 @@ Expect.describe('RecoveryQuestion', function () {
         expect(SharedUtil.redirect).toHaveBeenCalledWith('http://www.goodbye.com');
       });
   });
-  itp('does not show back link if hideBackToSignInForReset is true', function () {
-    return setup({ 'features.hideBackToSignInForReset': true }).then(function (test) {
+  itp('does not show back link if hideBackToSignInForReset is true', function() {
+    return setup({ 'features.hideBackToSignInForReset': true }).then(function(test) {
       const $link = test.form.signoutLink();
 
       expect($link.length).toBe(0);
     });
   });
-  itp('sets the correct title for a forgotten password flow', function () {
-    return setup().then(function (test) {
+  itp('sets the correct title for a forgotten password flow', function() {
+    return setup().then(function(test) {
       expect(test.form.titleText()).toBe('Answer Forgotten Password Challenge');
     });
   });
-  itp('sets the correct submit button value for a forgotten password flow', function () {
-    return setup().then(function (test) {
+  itp('sets the correct submit button value for a forgotten password flow', function() {
+    return setup().then(function(test) {
       expect(test.form.submitButton().val()).toBe('Reset Password');
     });
   });
-  itp('sets the correct title for an unlock account flow', function () {
-    return setup({}, { recoveryType: 'UNLOCK' }).then(function (test) {
+  itp('sets the correct title for an unlock account flow', function() {
+    return setup({}, { recoveryType: 'UNLOCK' }).then(function(test) {
       expect(test.form.titleText()).toBe('Answer Unlock Account Challenge');
     });
   });
-  itp('sets the correct submit button value for an unlock account flow', function () {
-    return setup({}, { recoveryType: 'UNLOCK' }).then(function (test) {
+  itp('sets the correct submit button value for an unlock account flow', function() {
+    return setup({}, { recoveryType: 'UNLOCK' }).then(function(test) {
       expect(test.form.submitButton().val()).toBe('Unlock Account');
     });
   });
-  itp('sets the correct label based on the auth response', function () {
-    return setup().then(function (test) {
+  itp('sets the correct label based on the auth response', function() {
+    return setup().then(function(test) {
       expect(test.form.labelText('answer')).toBe('Last 4 digits of your social security number?');
     });
   });
-  itp('has a text field to enter the security question answer', function () {
-    return setup().then(function (test) {
+  itp('has a text field to enter the security question answer', function() {
+    return setup().then(function(test) {
       Expect.isPasswordField(test.form.answerField());
     });
   });
-  itp('has a show answer checkbox', function () {
-    return setup().then(function (test) {
+  itp('has a show answer checkbox', function() {
+    return setup().then(function(test) {
       const showAnswer = test.form.showAnswerCheckbox();
 
       expect(showAnswer.length).toBe(1);
@@ -160,8 +160,8 @@ Expect.describe('RecoveryQuestion', function () {
   itp(
     'the answer field type is "password" initially and is changed to text \
           when a "show answer" checkbox is checked',
-    function () {
-      return setup().then(function (test) {
+    function() {
+      return setup().then(function(test) {
         const answer = test.form.answerField();
 
         expect(test.form.showAnswerCheckboxStatus()).toEqual('unchecked');
@@ -173,16 +173,16 @@ Expect.describe('RecoveryQuestion', function () {
       });
     }
   );
-  itp('makes the right auth request when form is submitted', function () {
+  itp('makes the right auth request when form is submitted', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccess);
         test.form.submit();
         return Expect.waitForAjaxRequest();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/answer',
@@ -193,16 +193,16 @@ Expect.describe('RecoveryQuestion', function () {
         });
       });
   });
-  itp('shows unlock page when response is success with unlock recoveryType', function () {
+  itp('shows unlock page when response is success with unlock recoveryType', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccessUnlock);
         test.form.submit();
         return Expect.waitForAccountUnlocked(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/answer',
@@ -217,16 +217,16 @@ Expect.describe('RecoveryQuestion', function () {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
   });
-  itp('with OIDC configured, it shows unlock page when response is success with unlock recoveryType', function () {
+  itp('with OIDC configured, it shows unlock page when response is success with unlock recoveryType', function() {
     return setupOIDC()
-      .then(function (test) {
+      .then(function(test) {
         Util.resetAjaxRequests();
         test.form.setAnswer('4444');
         test.setNextResponse(resSuccessUnlock);
         test.form.submit();
         return Expect.waitForAccountUnlocked(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/recovery/answer',
@@ -241,23 +241,23 @@ Expect.describe('RecoveryQuestion', function () {
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
   });
-  itp('validates that the answer is not empty before submitting', function () {
-    return setup().then(function (test) {
+  itp('validates that the answer is not empty before submitting', function() {
+    return setup().then(function(test) {
       Util.resetAjaxRequests();
       test.form.submit();
       expect(Util.numAjaxRequests()).toBe(0);
       expect(test.form.hasErrors()).toBe(true);
     });
   });
-  itp('shows an error msg if there is an error submitting the answer', function () {
+  itp('shows an error msg if there is an error submitting the answer', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resError);
         test.form.setAnswer('4444');
         test.form.submit();
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('The recovery question answer did not match our records.');
         expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);

--- a/test/unit/spec/RefreshAuthState_spec.js
+++ b/test/unit/spec/RefreshAuthState_spec.js
@@ -10,7 +10,7 @@ import Q from 'q';
 import $sandbox from 'sandbox';
 const itp = Expect.itp;
 
-function setup (settings) {
+function setup(settings) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -42,27 +42,27 @@ function setup (settings) {
   });
 }
 
-Expect.describe('RefreshAuthState', function () {
-  itp('redirects to PrimaryAuth if authClient does not need a refresh', function () {
+Expect.describe('RefreshAuthState', function() {
+  itp('redirects to PrimaryAuth if authClient does not need a refresh', function() {
     return setup({}, true)
-      .then(function (test) {
+      .then(function(test) {
         spyOn(test.ac.tx, 'exists').and.returnValue(false);
         test.router.refreshAuthState();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         Expect.isPrimaryAuth(test.router.controller);
       });
   });
-  itp('refreshes auth state and picks token from cookie', function () {
+  itp('refreshes auth state and picks token from cookie', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         Util.mockSDKCookie(test.ac, null, 'a-token-in-cookie');
         test.setNextResponse(resEnroll);
         test.router.refreshAuthState();
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn',
@@ -72,14 +72,14 @@ Expect.describe('RefreshAuthState', function () {
         });
       });
   });
-  itp('calls status with token if initialized with token passed directly to controller via options', function () {
+  itp('calls status with token if initialized with token passed directly to controller via options', function() {
     return setup()
-      .then(function (test) {
+      .then(function(test) {
         test.setNextResponse(resEnroll);
         test.router.refreshAuthState('dummy-token');
         return Expect.waitForEnrollChoices();
       })
-      .then(function () {
+      .then(function() {
         expect(Util.numAjaxRequests()).toBe(1);
         Expect.isJsonPost(Util.getAjaxRequest(0), {
           url: 'https://foo.com/api/v1/authn/introspect',

--- a/test/unit/spec/RegistrationFormFactory_spec.js
+++ b/test/unit/spec/RegistrationFormFactory_spec.js
@@ -3,10 +3,10 @@ import { internal } from 'okta';
 import RegistrationFormFactory from 'util/RegistrationFormFactory';
 let { SchemaProperty } = internal.models;
 
-describe('RegistrationFormFactory', function () {
+describe('RegistrationFormFactory', function() {
   let testContext;
-  describe('string field', function () {
-    beforeEach(function () {
+  describe('string field', function() {
+    beforeEach(function() {
       testContext = {};
       const schemaProperty = new SchemaProperty.Model(
         {
@@ -21,25 +21,25 @@ describe('RegistrationFormFactory', function () {
       testContext.inputOptions = RegistrationFormFactory.createInputOptions(schemaProperty);
     });
 
-    it('type is text', function () {
+    it('type is text', function() {
       expect(testContext.inputOptions['type']).toEqual('text');
     });
 
-    it('no label', function () {
+    it('no label', function() {
       expect(testContext.inputOptions['label']).toBe(false);
     });
 
-    it('label-top is true', function () {
+    it('label-top is true', function() {
       expect(testContext.inputOptions['label-top']).toBe(true);
     });
 
-    it('placeholder is the title', function () {
+    it('placeholder is the title', function() {
       expect(testContext.inputOptions['placeholder']).toEqual('Test Property');
     });
   });
 
-  describe('enum field', function () {
-    beforeEach(function () {
+  describe('enum field', function() {
+    beforeEach(function() {
       const schemaProperty = new SchemaProperty.Model(
         {
           name: 'enumfield',
@@ -54,21 +54,21 @@ describe('RegistrationFormFactory', function () {
       testContext.inputOptions = RegistrationFormFactory.createInputOptions(schemaProperty);
     });
 
-    it('label is the title', function () {
+    it('label is the title', function() {
       expect(testContext.inputOptions['label']).toEqual('Flavor Fruit');
     });
 
-    it('label-top is not set', function () {
+    it('label-top is not set', function() {
       expect(testContext.inputOptions['label-top']).toBeUndefined();
     });
 
-    it('placeholder is not set', function () {
+    it('placeholder is not set', function() {
       expect(testContext.inputOptions['placeholder']).toBeUndefined();
     });
   });
 
-  describe('field name is userName', function () {
-    beforeEach(function () {
+  describe('field name is userName', function() {
+    beforeEach(function() {
       const schemaProperty = new SchemaProperty.Model(
         {
           name: 'userName',
@@ -80,13 +80,13 @@ describe('RegistrationFormFactory', function () {
       testContext.inputOptions = RegistrationFormFactory.createInputOptions(schemaProperty);
     });
 
-    it('icon is person-16-gray', function () {
+    it('icon is person-16-gray', function() {
       expect(testContext.inputOptions['params'].icon).toEqual('person-16-gray');
     });
   });
 
-  describe('field name is password', function () {
-    beforeEach(function () {
+  describe('field name is password', function() {
+    beforeEach(function() {
       const schemaProperty = new SchemaProperty.Model(
         {
           name: 'password',
@@ -98,17 +98,17 @@ describe('RegistrationFormFactory', function () {
       testContext.inputOptions = RegistrationFormFactory.createInputOptions(schemaProperty);
     });
 
-    it('type is password', function () {
+    it('type is password', function() {
       expect(testContext.inputOptions['type']).toEqual('password');
     });
 
-    it('icon is remote-lock-16', function () {
+    it('icon is remote-lock-16', function() {
       expect(testContext.inputOptions['params'].icon).toEqual('remote-lock-16');
     });
   });
 
-  describe('Get username parts', function () {
-    it('gives the right username parts', function () {
+  describe('Get username parts', function() {
+    it('gives the right username parts', function() {
       let result = RegistrationFormFactory.getUsernameParts('first-last.name@okta.com');
 
       expect(result).toEqual(['first', 'last', 'name', 'okta', 'com']);
@@ -145,12 +145,12 @@ describe('RegistrationFormFactory', function () {
     });
   });
 
-  describe('PasswordContainsFormField', function () {
-    it('returns false if password does not contain username or no username ', function () {
+  describe('PasswordContainsFormField', function() {
+    it('returns false if password does not contain username or no username ', function() {
       expect(RegistrationFormFactory.passwordContainsFormField('administrator1', 'Abcd1234')).toEqual(false);
       expect(RegistrationFormFactory.passwordContainsFormField(null, 'Abcd1234')).toEqual(false);
     });
-    it('returns true if password does contain username ', function () {
+    it('returns true if password does contain username ', function() {
       expect(RegistrationFormFactory.passwordContainsFormField('abcd@okta.com', 'Abcd1234')).toEqual(true);
       expect(RegistrationFormFactory.passwordContainsFormField('abc', 'abc')).toEqual(true);
       expect(RegistrationFormFactory.passwordContainsFormField('abc', 'abc@okta.com')).toEqual(true);

--- a/test/unit/spec/RegistrationSchema_spec.js
+++ b/test/unit/spec/RegistrationSchema_spec.js
@@ -2,18 +2,18 @@
 import RegistrationSchema from 'models/RegistrationSchema';
 import Settings from 'models/Settings';
 
-describe('RegistrationSchema', function () {
+describe('RegistrationSchema', function() {
   const getSettings = () => {
     return new Settings({
       baseUrl: 'http://localhost:3000',
-      parseSchema: function (response, onSuccess) {
+      parseSchema: function(response, onSuccess) {
         return onSuccess(response);
       },
     });
   };
-  describe('properties', function () {
-    describe('string field', function () {
-      beforeEach(function () {
+  describe('properties', function() {
+    describe('string field', function() {
+      beforeEach(function() {
         const jsonResponse = {
           profileSchema: {
             properties: {
@@ -32,37 +32,37 @@ describe('RegistrationSchema', function () {
         this.schema.parse(jsonResponse);
       });
 
-      it('only has one property', function () {
+      it('only has one property', function() {
         expect(this.schema.properties.length).toEqual(1);
       });
 
-      it('has a correct name', function () {
+      it('has a correct name', function() {
         expect(this.schema.properties.first().get('name')).toEqual('stringfield');
       });
 
-      it('is a string type', function () {
+      it('is a string type', function() {
         expect(this.schema.properties.first().get('type')).toEqual('string');
       });
 
-      it('has a correct description', function () {
+      it('has a correct description', function() {
         expect(this.schema.properties.first().get('description')).toEqual('The description');
       });
 
-      it('has a correct minLength', function () {
+      it('has a correct minLength', function() {
         expect(this.schema.properties.first().get('minLength')).toEqual(2);
       });
 
-      it('has a correct maxLength', function () {
+      it('has a correct maxLength', function() {
         expect(this.schema.properties.first().get('maxLength')).toEqual(10);
       });
 
-      it('does not have format', function () {
+      it('does not have format', function() {
         expect(this.schema.properties.first().get('format')).toBeUndefined();
       });
     });
 
-    describe('email field', function () {
-      beforeEach(function () {
+    describe('email field', function() {
+      beforeEach(function() {
         const jsonResponse = {
           profileSchema: {
             properties: {
@@ -80,17 +80,17 @@ describe('RegistrationSchema', function () {
       });
 
       // eslint-disable-next-line jasmine/no-spec-dupes
-      it('is a string type', function () {
+      it('is a string type', function() {
         expect(this.schema.properties.first().get('type')).toEqual('string');
       });
 
-      it('have a correct format', function () {
+      it('have a correct format', function() {
         expect(this.schema.properties.first().get('format')).toEqual('email');
       });
     });
 
-    describe('enum field', function () {
-      beforeEach(function () {
+    describe('enum field', function() {
+      beforeEach(function() {
         const jsonResponse = {
           profileSchema: {
             properties: {
@@ -108,17 +108,17 @@ describe('RegistrationSchema', function () {
       });
 
       // eslint-disable-next-line jasmine/no-spec-dupes
-      it('is a string type', function () {
+      it('is a string type', function() {
         expect(this.schema.properties.first().get('type')).toEqual('string');
       });
 
-      it('have a correct enum', function () {
+      it('have a correct enum', function() {
         expect(this.schema.properties.first().get('enum')).toEqual(['Apple', 'Banana', 'Cherry']);
       });
     });
 
-    describe('required fields', function () {
-      beforeEach(function () {
+    describe('required fields', function() {
+      beforeEach(function() {
         const jsonResponse = {
           policyId: '1234',
           profileSchema: {
@@ -142,31 +142,31 @@ describe('RegistrationSchema', function () {
         this.schema.parse(jsonResponse);
       });
 
-      it('has 3 properties', function () {
+      it('has 3 properties', function() {
         expect(this.schema.properties.length).toEqual(3);
       });
 
-      it('field1 is required', function () {
+      it('field1 is required', function() {
         expect(this.schema.properties.get('field1').get('required')).toBe(true);
         expect(this.schema.properties.createModelProperties()['field1'].required).toBe(true);
       });
 
-      it('field2 is not required', function () {
+      it('field2 is not required', function() {
         expect(this.schema.properties.get('field2').get('required')).toBe(false);
         expect(this.schema.properties.createModelProperties()['field2'].required).toBe(false);
       });
 
-      it('field3 is required', function () {
+      it('field3 is required', function() {
         expect(this.schema.properties.get('field3').get('required')).toBe(true);
       });
 
-      it('policyId is set', function () {
+      it('policyId is set', function() {
         expect(this.schema.properties.defaultPolicyId).toBe('1234');
       });
     });
 
-    describe('sorting order', function () {
-      beforeEach(function () {
+    describe('sorting order', function() {
+      beforeEach(function() {
         const jsonResponse = {
           profileSchema: {
             properties: {
@@ -195,11 +195,11 @@ describe('RegistrationSchema', function () {
         this.schema.parse(jsonResponse);
       });
 
-      it('has 5 properties', function () {
+      it('has 5 properties', function() {
         expect(this.schema.properties.length).toEqual(5);
       });
 
-      it('have a correct sort order', function () {
+      it('have a correct sort order', function() {
         const order = this.schema.properties.pluck('name');
 
         expect(order).toEqual(['field5', 'field2', 'field6', 'field3', 'field1']);

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -107,7 +107,7 @@ const testData = {
   },
 };
 
-function setup (settings) {
+function setup(settings) {
   settings || (settings = {});
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
@@ -132,7 +132,7 @@ function setup (settings) {
 
   Util.registerRouter(router);
   router.on('afterError', afterErrorHandler);
-  spyOn(RegSchema.prototype, 'fetch').and.callFake(function () {
+  spyOn(RegSchema.prototype, 'fetch').and.callFake(function() {
     this.set(this.parse(testData));
     return $.Deferred().resolve();
   });
@@ -148,14 +148,14 @@ function setup (settings) {
   });
 }
 
-Expect.describe('Registration', function () {
-  Expect.describe('settings', function () {
-    itp('uses default title', function () {
-      return setup().then(function (test) {
+Expect.describe('Registration', function() {
+  Expect.describe('settings', function() {
+    itp('uses default title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toEqual('Create Account');
       });
     });
-    itp('uses custom title', function () {
+    itp('uses custom title', function() {
       const config = {
         i18n: {
           en: {
@@ -164,16 +164,16 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(config).then(function (test) {
+      return setup(config).then(function(test) {
         expect(test.form.titleText()).toEqual('Custom Form Title');
       });
     });
-    itp('uses default for submit', function () {
-      return setup().then(function (test) {
+    itp('uses default for submit', function() {
+      return setup().then(function(test) {
         expect(test.form.submitButtonText()).toEqual('Register');
       });
     });
-    itp('uses custom text for submit', function () {
+    itp('uses custom text for submit', function() {
       const config = {
         i18n: {
           en: {
@@ -182,12 +182,12 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(config).then(function (test) {
+      return setup(config).then(function(test) {
         expect(test.form.submitButtonText()).toEqual('Custom Register Button');
       });
     });
-    itp('policyid is retrieved from default org policy', function () {
-      return setup().then(function (test) {
+    itp('policyid is retrieved from default org policy', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
         test.form.setFirstname('firstName');
@@ -202,8 +202,8 @@ Expect.describe('Registration', function () {
         expect(test.router.controller.model.settings.get('defaultPolicyId')).toContain('1234');
       });
     });
-    itp('policyid from form settings is used instead of default org policy', function () {
-      return setup().then(function (test) {
+    itp('policyid from form settings is used instead of default org policy', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
         test.form.setFirstname('firstName');
@@ -219,10 +219,10 @@ Expect.describe('Registration', function () {
         expect(test.router.controller.model.settings.get('policyId')).toContain('5678');
       });
     });
-    itp('sends relay state with registration post if set', function () {
+    itp('sends relay state with registration post if set', function() {
       return setup({
         relayState: '%2Fapp%2FUserHome',
-      }).then(function (test) {
+      }).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -232,8 +232,8 @@ Expect.describe('Registration', function () {
         expect(postData.relayState).toBe('%2Fapp%2FUserHome');
       });
     });
-    itp('sends relay state as undefined string with registration post if not set', function () {
-      return setup().then(function (test) {
+    itp('sends relay state as undefined string with registration post if not set', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -243,14 +243,14 @@ Expect.describe('Registration', function () {
         expect(postData.relayState).toBeUndefined();
       });
     });
-    itp('duplicate email address in org error message is localized by widget', function () {
+    itp('duplicate email address in org error message is localized by widget', function() {
       return setup({
         i18n: {
           en: {
             'registration.error.userName.notUniqueWithinOrg': 'Custom duplicate account error message',
           }
         }
-      }).then(function (test) {
+      }).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -261,71 +261,71 @@ Expect.describe('Registration', function () {
         test.form.submit();
 
         return Expect.waitForFormErrorBox(test.form, test);
-      }).then(function (test) {
+      }).then(function(test) {
         expect(test.form.errorBox().length).toBe(1);
         expect(test.form.errorBox().text().trim()).toBe('Custom duplicate account error message');
       });
     });
   });
 
-  Expect.describe('elements', function () {
-    itp('has a firstname field', function () {
-      return setup().then(function (test) {
+  Expect.describe('elements', function() {
+    itp('has a firstname field', function() {
+      return setup().then(function(test) {
         const firstname = test.form.firstnameField();
 
         expect(firstname.length).toBe(1);
         expect(firstname.attr('type')).toEqual('text');
       });
     });
-    itp('has a lastname field', function () {
-      return setup().then(function (test) {
+    itp('has a lastname field', function() {
+      return setup().then(function(test) {
         const lastname = test.form.lastnameField();
 
         expect(lastname.length).toBe(1);
         expect(lastname.attr('type')).toEqual('text');
       });
     });
-    itp('has a username field', function () {
-      return setup().then(function (test) {
+    itp('has a username field', function() {
+      return setup().then(function(test) {
         const userName = test.form.userNameField();
 
         expect(userName.length).toBe(1);
         expect(userName.attr('type')).toEqual('text');
       });
     });
-    itp('has a preferredLanguage field', function () {
-      return setup().then(function (test) {
+    itp('has a preferredLanguage field', function() {
+      return setup().then(function(test) {
         const preferredLanguage = test.form.input('preferredLanguage');
 
         expect(preferredLanguage.length).toBe(1);
         expect(preferredLanguage.attr('type')).toEqual('text');
       });
     });
-    itp('has a countryCode field', function () {
-      return setup().then(function (test) {
+    itp('has a countryCode field', function() {
+      return setup().then(function(test) {
         const countryCode = test.form.input('countryCode');
 
         expect(countryCode.length).toBe(1);
         expect(countryCode.attr('type')).toEqual('text');
       });
     });
-    itp('has a password field', function () {
-      return setup().then(function (test) {
+    itp('has a password field', function() {
+      return setup().then(function(test) {
         const password = test.form.passwordField();
 
         expect(password.length).toBe(1);
         expect(password.attr('type')).toEqual('password');
       });
     });
-    itp('shows label for required field', function () {
-      return setup().then(function (test) {
+    itp('shows label for required field', function() {
+      return setup().then(function(test) {
         const requiredLabel = test.form.requiredFieldLabel();
 
         expect(requiredLabel).toBe('* indicates required field');
       });
     });
-    itp('shows * next to placeholder for required field', function () {
-      return setup().then(function (test) {
+    itp('shows * next to placeholder for required field', function() {
+      return setup().then(function(test) {
         const firstNamePlaceholder = test.form.fieldPlaceholder('firstName');
 
         expect(firstNamePlaceholder).toContain('*');
@@ -348,15 +348,15 @@ Expect.describe('Registration', function () {
     });
   });
 
-  Expect.describe('events', function () {
-    itp('shows an error if email is empty and register', function () {
-      return setup().then(function (test) {
+  Expect.describe('events', function() {
+    itp('shows an error if email is empty and register', function() {
+      return setup().then(function(test) {
         test.form.submit();
         expect(test.form.userNameErrorField().length).toBe(1);
       });
     });
-    itp('shows an error if firstname is too long', function () {
-      return setup().then(function (test) {
+    itp('shows an error if firstname is too long', function() {
+      return setup().then(function(test) {
         test.form.setFirstname(Util.LoremIpsum);
         test.form.submit();
         expect(test.form.firstnameErrorField().length).toBe(1);
@@ -364,9 +364,9 @@ Expect.describe('Registration', function () {
     });
   });
 
-  Expect.describe('password complexity', function () {
-    itp('Does not show password complexity error on load', function () {
-      return setup().then(function (test) {
+  Expect.describe('password complexity', function() {
+    itp('Does not show password complexity error on load', function() {
+      return setup().then(function(test) {
         expect(test.form.hasPasswordComplexityUnsatisfied('0')).toBe(false);
         expect(test.form.hasPasswordComplexityUnsatisfied('1')).toBe(false);
         expect(test.form.hasPasswordComplexityUnsatisfied('2')).toBe(false);
@@ -374,8 +374,8 @@ Expect.describe('Registration', function () {
         expect(test.form.hasPasswordComplexityUnsatisfied('4')).toBe(false);
       });
     });
-    itp('shows password complexity satisfied if it is satisfied', function () {
-      return setup().then(function (test) {
+    itp('shows password complexity satisfied if it is satisfied', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd');
         test.form.focusOutPassword();
@@ -386,8 +386,8 @@ Expect.describe('Registration', function () {
         expect(test.form.hasPasswordComplexitySatisfied('4')).toBe(true);
       });
     });
-    itp('shows password complexity error if focus out and not satisfied', function () {
-      return setup().then(function (test) {
+    itp('shows password complexity error if focus out and not satisfied', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('12345678');
         test.form.focusOutPassword();
@@ -405,8 +405,8 @@ Expect.describe('Registration', function () {
         );
       });
     });
-    itp('shows no password complexity error if focus out and satisfied all conditions', function () {
-      return setup().then(function (test) {
+    itp('shows no password complexity error if focus out and satisfied all conditions', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
@@ -417,8 +417,8 @@ Expect.describe('Registration', function () {
         expect(test.form.hasPasswordComplexitySatisfied('4')).toBe(true);
       });
     });
-    itp('shows no password complexity section if no password entered', function () {
-      return setup().then(function (test) {
+    itp('shows no password complexity section if no password entered', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('');
         test.form.focusOutPassword();
@@ -429,8 +429,8 @@ Expect.describe('Registration', function () {
         expect(test.form.isPasswordComplexitySectionHidden('4')).toBe(true);
       });
     });
-    itp('shows password complexity section if password entered', function () {
-      return setup().then(function (test) {
+    itp('shows password complexity section if password entered', function() {
+      return setup().then(function(test) {
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
@@ -441,8 +441,8 @@ Expect.describe('Registration', function () {
         expect(test.form.isPasswordComplexitySectionHidden('4')).toBe(false);
       });
     });
-    itp('shows error if password contains part of the username:testing', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of the username:testing', function() {
+      return setup().then(function(test) {
         test.form.setUserName('testing');
         test.form.setPassword('Testing1234');
         test.form.focusOutPassword();
@@ -470,8 +470,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(false);
       });
     });
-    itp('shows error if password contains part of username:testing1234@okta.com', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of username:testing1234@okta.com', function() {
+      return setup().then(function(test) {
         test.form.setUserName('testing1234@okta.com');
         test.form.setPassword('Testing1234');
         test.form.focusOutPassword();
@@ -496,8 +496,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('shows error if password contains part of the username:testing_123', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of the username:testing_123', function() {
+      return setup().then(function(test) {
         test.form.setUserName('testing_123');
         test.form.setPassword('testing');
         test.form.focusOutPassword();
@@ -519,8 +519,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('shows error if password contains part of username:first-last.name@okta.com', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of username:first-last.name@okta.com', function() {
+      return setup().then(function(test) {
         test.form.setUserName('first-last.name@okta.com');
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
@@ -536,8 +536,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('shows error if password contains part of email:testing1234@okta.com', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of email:testing1234@okta.com', function() {
+      return setup().then(function(test) {
         test.form.setEmail('testing1234@okta.com');
         test.form.setPassword('Testing1234');
         test.form.focusOutPassword();
@@ -562,8 +562,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('shows error if password contains part of email:first-last.name@okta.com', function () {
-      return setup().then(function (test) {
+    itp('shows error if password contains part of email:first-last.name@okta.com', function() {
+      return setup().then(function(test) {
         test.form.setEmail('first-last.name@okta.com');
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
@@ -579,8 +579,8 @@ Expect.describe('Registration', function () {
         expect(test.form.passwordContainsUsernameError()).toBe(true);
       });
     });
-    itp('hides password complexity error if password does not contain part of the username', function () {
-      return setup().then(function (test) {
+    itp('hides password complexity error if password does not contain part of the username', function() {
+      return setup().then(function(test) {
         test.form.setUserName('user@example.com');
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
@@ -588,8 +588,8 @@ Expect.describe('Registration', function () {
       });
     });
 
-    itp('shows password complexity error if username is entered after password', function () {
-      return setup().then(function (test) {
+    itp('shows password complexity error if username is entered after password', function() {
+      return setup().then(function(test) {
         test.form.setPassword('Abcd1234');
         test.form.focusOutPassword();
         test.form.setUserName('abcd@example.com');
@@ -598,7 +598,7 @@ Expect.describe('Registration', function () {
     });
   });
 
-  const expectRegCallbackError = function (test, callback, message) {
+  const expectRegCallbackError = function(test, callback, message) {
     const errMsg = callback + ':' + message;
 
     expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
@@ -613,7 +613,7 @@ Expect.describe('Registration', function () {
     ]);
   };
 
-  const expectRegApiError = function (test, message) {
+  const expectRegApiError = function(test, message) {
     expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
     expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
       {
@@ -626,25 +626,25 @@ Expect.describe('Registration', function () {
     ]);
   };
 
-  Expect.describe('Registration callback hooks', function () {
+  Expect.describe('Registration callback hooks', function() {
     const DEFAULT_CALLBACK_ERROR = 'We could not process your registration at this time. Please try again later.';
 
-    itp('calls parseSchema if registration.parseSchema defined in config', function () {
+    itp('calls parseSchema if registration.parseSchema defined in config', function() {
       const setting = {
         registration: {
           parseSchema: jasmine.createSpy('parseSchemaSpy'),
         },
       };
 
-      return setup(setting).then(function () {
+      return setup(setting).then(function() {
         expect(setting.registration.parseSchema).toHaveBeenCalled();
       });
     });
-    itp('calls parseSchema if registration.parseSchema is defined and parseSchema calls onSuccess', function () {
+    itp('calls parseSchema if registration.parseSchema is defined and parseSchema calls onSuccess', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onSuccess(resp);
           },
@@ -652,7 +652,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -664,11 +664,11 @@ Expect.describe('Registration', function () {
         expect(setting.registration.preSubmit).toHaveBeenCalled();
       });
     });
-    itp('parseSchema updates the schema correctly and calls onSuccess', function () {
+    itp('parseSchema updates the schema correctly and calls onSuccess', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const setting = {
         registration: {
-          parseSchema: function (schema, onSuccess, onFailure) {
+          parseSchema: function(schema, onSuccess, onFailure) {
             parseSchemaSpy(schema, onSuccess, onFailure);
             schema.profileSchema.properties.zip = {
               type: 'string',
@@ -683,17 +683,17 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         expect(test.form.getFieldByName('zip').length).toBe(1);
         expect(test.form.fieldPlaceholder('zip')).toBe('Zip');
       });
     });
-    itp(' does not call preSubmit if parseSchema calls onFailure with default error', function () {
+    itp(' does not call preSubmit if parseSchema calls onFailure with default error', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onFailure();
           },
@@ -701,7 +701,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -713,11 +713,11 @@ Expect.describe('Registration', function () {
         expectRegCallbackError(test, 'parseSchema', DEFAULT_CALLBACK_ERROR);
       });
     });
-    itp(' does not call preSubmit if parseSchema calls onFailure with custom form level error', function () {
+    itp(' does not call preSubmit if parseSchema calls onFailure with custom form level error', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             const errorObject = {
               errorSummary: 'Custom form level parseSchema error message',
@@ -729,7 +729,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -742,12 +742,12 @@ Expect.describe('Registration', function () {
         expectRegCallbackError(test, 'parseSchema', 'Custom form level parseSchema error message');
       });
     });
-    itp('preSubmit modifies postData correctly before submit', function () {
+    itp('preSubmit modifies postData correctly before submit', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
       const setting = {
         registration: {
-          parseSchema: function (schema, onSuccess, onFailure) {
+          parseSchema: function(schema, onSuccess, onFailure) {
             parseSchemaSpy(schema, onSuccess, onFailure);
             schema.profileSchema.properties.zip = {
               type: 'string',
@@ -766,7 +766,7 @@ Expect.describe('Registration', function () {
             };
             onSuccess(schema);
           },
-          preSubmit: function (postData, onSuccess, onFailure) {
+          preSubmit: function(postData, onSuccess, onFailure) {
             preSubmitSpy(postData, onSuccess, onFailure);
             postData.userName += '@example.com';
             onSuccess(postData);
@@ -775,7 +775,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         expect(test.form.getFieldByName('zip').length).toBe(1);
         expect(test.form.fieldPlaceholder('zip')).toBe('Zip');
@@ -802,16 +802,16 @@ Expect.describe('Registration', function () {
         expect(setting.registration.postSubmit).toHaveBeenCalled();
       });
     });
-    itp('calls postSubmit when parseSchema and preSubmit call onSuccess', function () {
+    itp('calls postSubmit when parseSchema and preSubmit call onSuccess', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onSuccess(resp);
           },
-          preSubmit: function (postData, onSuccess, onFailure) {
+          preSubmit: function(postData, onSuccess, onFailure) {
             preSubmitSpy(postData, onSuccess, onFailure);
             onSuccess(postData);
           },
@@ -819,7 +819,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -832,21 +832,21 @@ Expect.describe('Registration', function () {
         expect(setting.registration.postSubmit).toHaveBeenCalled();
       });
     });
-    itp('calls postSubmit call onSuccess assert username is same as email', function () {
+    itp('calls postSubmit call onSuccess assert username is same as email', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
       const postSubmitSpy = jasmine.createSpy('postSubmitSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onSuccess(resp);
           },
-          preSubmit: function (postData, onSuccess, onFailure) {
+          preSubmit: function(postData, onSuccess, onFailure) {
             preSubmitSpy(postData, onSuccess, onFailure);
             onSuccess(postData);
           },
-          postSubmit: function (postData, onSuccess, onFailure) {
+          postSubmit: function(postData, onSuccess, onFailure) {
             postSubmitSpy(postData, onSuccess, onFailure);
             onSuccess(postData);
           },
@@ -854,7 +854,7 @@ Expect.describe('Registration', function () {
       };
 
       return setup(setting)
-        .then(function (test) {
+        .then(function(test) {
           spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
           Util.resetAjaxRequests();
           test.form.setUserName('test@example.com');
@@ -865,23 +865,23 @@ Expect.describe('Registration', function () {
           test.form.submit();
           return Expect.waitForRegistrationComplete(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.navigate).toHaveBeenCalledWith('signin/register-complete', { trigger: true });
           expect(postSubmitSpy).toHaveBeenCalled();
           expect($('div.registration-complete .title').text()).toBe('Verification email sent');
           expect($('div.registration-complete .desc').text()).toBe('To finish signing in, check your email.');
         });
     });
-    itp('does not call postSubmit if registration.postSubmit is defined and preSubmit calls onFailure', function () {
+    itp('does not call postSubmit if registration.postSubmit is defined and preSubmit calls onFailure', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onSuccess(resp);
           },
-          preSubmit: function (postData, onSuccess, onFailure) {
+          preSubmit: function(postData, onSuccess, onFailure) {
             preSubmitSpy(postData, onSuccess, onFailure);
             onFailure();
           },
@@ -889,7 +889,7 @@ Expect.describe('Registration', function () {
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test@example.com');
         test.form.setPassword('Abcd1234');
@@ -902,28 +902,28 @@ Expect.describe('Registration', function () {
         expectRegCallbackError(test, 'preSubmit', DEFAULT_CALLBACK_ERROR);
       });
     });
-    itp('triggers the afterError event when registration API throws an error', function () {
+    itp('triggers the afterError event when registration API throws an error', function() {
       const parseSchemaSpy = jasmine.createSpy('parseSchemaSpy');
       const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
       const postSubmitSpy = jasmine.createSpy('postSubmitSpy');
       const setting = {
         registration: {
-          parseSchema: function (resp, onSuccess, onFailure) {
+          parseSchema: function(resp, onSuccess, onFailure) {
             parseSchemaSpy(resp, onSuccess, onFailure);
             onSuccess(resp);
           },
-          preSubmit: function (postData, onSuccess, onFailure) {
+          preSubmit: function(postData, onSuccess, onFailure) {
             preSubmitSpy(postData, onSuccess, onFailure);
             onSuccess();
           },
-          postSubmit: function (response, onSuccess, onFailure) {
+          postSubmit: function(response, onSuccess, onFailure) {
             postSubmitSpy(response, onSuccess, onFailure);
             onSuccess(response);
           },
         },
       };
 
-      return setup(setting).then(function (test) {
+      return setup(setting).then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUserName('test');
         test.form.setPassword('Abcd1234');

--- a/test/unit/spec/Spinner_spec.js
+++ b/test/unit/spec/Spinner_spec.js
@@ -2,8 +2,8 @@ import { BaseModel } from 'okta';
 import Expect from 'helpers/util/Expect';
 import Spinner from 'views/shared/Spinner';
 
-Expect.describe('Spinner', function () {
-  it('does not have "hide" class if "visible" option is undefined', function () {
+Expect.describe('Spinner', function() {
+  it('does not have "hide" class if "visible" option is undefined', function() {
     this.spinner = new Spinner({
       model: new BaseModel(),
     });
@@ -11,7 +11,7 @@ Expect.describe('Spinner', function () {
     expect(this.spinner.$el.hasClass('hide')).toBe(false);
   });
 
-  it('has "hide" class if "visible" option is false', function () {
+  it('has "hide" class if "visible" option is false', function() {
     this.spinner = new Spinner({
       model: new BaseModel(),
       visible: false,
@@ -20,8 +20,8 @@ Expect.describe('Spinner', function () {
     expect(this.spinner.$el.hasClass('hide')).toBe(true);
   });
 
-  Expect.describe('modelEvents', function () {
-    beforeEach(function () {
+  Expect.describe('modelEvents', function() {
+    beforeEach(function() {
       this.spinner = new Spinner({
         model: new BaseModel(),
       });
@@ -29,12 +29,12 @@ Expect.describe('Spinner', function () {
       this.spinner.render();
     });
 
-    it('removes "hide" class after "spinner:show" model event', function () {
+    it('removes "hide" class after "spinner:show" model event', function() {
       this.spinner.model.trigger('spinner:show');
       expect(this.spinner.$el.hasClass('hide')).toBe(false);
     });
 
-    it('adds "hide" class after "spinner:hide" model event', function () {
+    it('adds "hide" class after "spinner:hide" model event', function() {
       this.spinner.model.trigger('spinner:show');
       expect(this.spinner.$el.hasClass('hide')).toBe(false);
 

--- a/test/unit/spec/TextBox_spec.js
+++ b/test/unit/spec/TextBox_spec.js
@@ -3,8 +3,8 @@ import Expect from 'helpers/util/Expect';
 import $sandbox from 'sandbox';
 import TextBox from 'views/shared/TextBox';
 
-Expect.describe('TextBox', function () {
-  it('the value of aria-label is same as the placeholder', function () {
+Expect.describe('TextBox', function() {
+  it('the value of aria-label is same as the placeholder', function() {
     const placeHolderValue = 'Test Value 123';
     const textbox = new TextBox({
       model: new BaseModel(),
@@ -16,7 +16,7 @@ Expect.describe('TextBox', function () {
     expect(textbox.$('#' + textbox.options.inputId).attr('aria-label')).toEqual(placeHolderValue);
   });
 
-  it('has appropriate attributes for type="number"', function () {
+  it('has appropriate attributes for type="number"', function() {
     const textbox = new TextBox({
       model: new BaseModel(),
       id: _.uniqueId('textbox'),

--- a/test/unit/spec/TimeUtil_spec.js
+++ b/test/unit/spec/TimeUtil_spec.js
@@ -1,8 +1,8 @@
 import TimeUtil from 'util/TimeUtil';
 
-describe('util/TimeUtil', function () {
-  describe('getTimeInHighestRelevantUnit', function () {
-    it('converts millisends', function () {
+describe('util/TimeUtil', function() {
+  describe('getTimeInHighestRelevantUnit', function() {
+    it('converts millisends', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(0, 'milliseconds')).toEqual({
         time: 0,
         unit: 'MILLISECOND',
@@ -21,7 +21,7 @@ describe('util/TimeUtil', function () {
       });
     });
 
-    it('converts seconds', function () {
+    it('converts seconds', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(0, 'minutes')).toEqual({
         time: 0,
         unit: 'MINUTE',
@@ -40,7 +40,7 @@ describe('util/TimeUtil', function () {
       });
     });
 
-    it('converts minutes', function () {
+    it('converts minutes', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(0, 'minutes')).toEqual({
         time: 0,
         unit: 'MINUTE',
@@ -59,7 +59,7 @@ describe('util/TimeUtil', function () {
       });
     });
 
-    it('converts hours', function () {
+    it('converts hours', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(0, 'hours')).toEqual({
         time: 0,
         unit: 'HOUR',
@@ -78,7 +78,7 @@ describe('util/TimeUtil', function () {
       });
     });
 
-    it('keep days', function () {
+    it('keep days', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(0, 'days')).toEqual({
         time: 0,
         unit: 'DAY',
@@ -97,7 +97,7 @@ describe('util/TimeUtil', function () {
       });
     });
 
-    it('no runtime error when unknow time unit', function () {
+    it('no runtime error when unknow time unit', function() {
       expect(TimeUtil.getTimeInHighestRelevantUnit(10, 'foo')).toEqual({
         time: 10,
         unit: 'foo',

--- a/test/unit/spec/UnlockAccount_spec.js
+++ b/test/unit/spec/UnlockAccount_spec.js
@@ -14,7 +14,7 @@ import $sandbox from 'sandbox';
 
 const itp = Expect.itp;
 
-function setup (settings, startRouter) {
+function setup(settings, startRouter) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -49,13 +49,13 @@ function setup (settings, startRouter) {
   });
 }
 
-function transformUsername (name) {
+function transformUsername(name) {
   const suffix = '@example.com';
 
   return name.indexOf(suffix) !== -1 ? name : name + suffix;
 }
 
-function expectError (test, controller) {
+function expectError(test, controller) {
   const message = 'You do not have permission to perform the requested action';
 
   expect(test.form.hasErrors()).toBe(true);
@@ -99,33 +99,33 @@ const setupWithSmsWithoutEmail = _.partial(setup, { 'features.smsRecovery': true
 
 const setupWithCallWithoutEmail = _.partial(setup, { 'features.callRecovery': true, 'features.emailRecovery': false });
 
-Expect.describe('UnlockAccount', function () {
-  Expect.describe('settings', function () {
-    itp('has correct title', function () {
-      return setup().then(function (test) {
+Expect.describe('UnlockAccount', function() {
+  Expect.describe('settings', function() {
+    itp('has correct title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toEqual('Unlock account');
       });
     });
-    itp('has correct username label', function () {
-      return setup().then(function (test) {
+    itp('has correct username label', function() {
+      return setup().then(function(test) {
         const $usernameLabel = test.form.usernameLabel();
 
         expect($usernameLabel.text().trim()).toEqual('Email or username');
       });
     });
-    itp('does not allow autocomplete', function () {
-      return setup().then(function (test) {
+    itp('does not allow autocomplete', function() {
+      return setup().then(function(test) {
         expect(test.form.getUsernameAutocomplete()).toBe('off');
       });
     });
-    itp('username field does not have explain by default', function () {
-      return setup().then(function (test) {
+    itp('username field does not have explain by default', function() {
+      return setup().then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.length).toBe(0);
       });
     });
-    itp('username field does have explain when is customized', function () {
+    itp('username field does have explain when is customized', function() {
       const options = {
         i18n: {
           en: {
@@ -134,7 +134,7 @@ Expect.describe('UnlockAccount', function () {
         },
       };
 
-      return setup(options).then(function (test) {
+      return setup(options).then(function(test) {
         const explain = test.form.usernameExplain();
 
         expect(explain.text()).toEqual('Custom Username Explain');
@@ -142,127 +142,127 @@ Expect.describe('UnlockAccount', function () {
     });
   });
 
-  Expect.describe('elements', function () {
-    itp('has a username field', function () {
-      return setup().then(function (test) {
+  Expect.describe('elements', function() {
+    itp('has a username field', function() {
+      return setup().then(function(test) {
         Expect.isTextField(test.form.usernameField());
       });
     });
-    itp('doesn\'t have an sms option by default', function () {
-      return setup().then(function (test) {
+    itp('doesn\'t have an sms option by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(false);
       });
     });
-    itp('doesn\'t have Voice Call option by default', function () {
-      return setup().then(function (test) {
+    itp('doesn\'t have Voice Call option by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasCallButton()).toBe(false);
       });
     });
-    itp('supports sms', function () {
-      return setupWithSms().then(function (test) {
+    itp('supports sms', function() {
+      return setupWithSms().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
       });
     });
-    itp('has sms hint', function () {
-      return setupWithSms().then(function (test) {
+    itp('has sms hint', function() {
+      return setupWithSms().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'SMS can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('does not have sms hint if sms is not enabled', function () {
-      return setup().then(function (test) {
+    itp('does not have sms hint if sms is not enabled', function() {
+      return setup().then(function(test) {
         expect(test.form.hasSmsHint()).toBe(false);
       });
     });
-    itp('supports Voice Call', function () {
-      return setupWithCall().then(function (test) {
+    itp('supports Voice Call', function() {
+      return setupWithCall().then(function(test) {
         expect(test.form.hasCallButton()).toBe(true);
         expect(test.form.hasSmsButton()).toBe(false);
       });
     });
-    itp('has Voice Call hint', function () {
-      return setupWithCall().then(function (test) {
+    itp('has Voice Call hint', function() {
+      return setupWithCall().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'Voice Call can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('supports SMS and Voice Call unlock factors together', function () {
-      return setupWithSmsAndCall().then(function (test) {
+    itp('supports SMS and Voice Call unlock factors together', function() {
+      return setupWithSmsAndCall().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
         expect(test.form.hasCallButton()).toBe(true);
       });
     });
-    itp('has SMS and Voice Call hint if both features are enabled', function () {
-      return setupWithSmsAndCall().then(function (test) {
+    itp('has SMS and Voice Call hint if both features are enabled', function() {
+      return setupWithSmsAndCall().then(function(test) {
         expect(test.form.hasMobileRecoveryHint()).toBe(true);
         expect(test.form.mobileRecoveryHintText()).toEqual(
           'SMS or Voice Call can only be used if a mobile phone number has been configured.'
         );
       });
     });
-    itp('shows a link to contact support when a help number is given', function () {
-      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function (test) {
+    itp('shows a link to contact support when a help number is given', function() {
+      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(true);
       });
     });
-    itp('shows no link to contact support by default', function () {
-      return setup().then(function (test) {
+    itp('shows no link to contact support by default', function() {
+      return setup().then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(false);
       });
     });
-    itp('does not show email recovery button if emailRecovery is false', function () {
-      return setupWithoutEmail().then(function (test) {
+    itp('does not show email recovery button if emailRecovery is false', function() {
+      return setupWithoutEmail().then(function(test) {
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
-    itp('shows email recovery button if emailRecovery is true', function () {
-      return setup().then(function (test) {
+    itp('shows email recovery button if emailRecovery is true', function() {
+      return setup().then(function(test) {
         expect(test.form.hasEmailButton()).toBe(true);
       });
     });
-    itp('shows error if no recovery factors are enabled', function () {
-      return setupWithoutEmail().then(function (test) {
+    itp('shows error if no recovery factors are enabled', function() {
+      return setupWithoutEmail().then(function(test) {
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorMessage()).toBe('No unlock options available. Please contact your administrator.');
       });
     });
-    itp('supports SMS without email', function () {
-      return setupWithSmsWithoutEmail().then(function (test) {
+    itp('supports SMS without email', function() {
+      return setupWithSmsWithoutEmail().then(function(test) {
         expect(test.form.hasSmsButton()).toBe(true);
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
-    itp('supports Voice Call without email', function () {
-      return setupWithCallWithoutEmail().then(function (test) {
+    itp('supports Voice Call without email', function() {
+      return setupWithCallWithoutEmail().then(function(test) {
         expect(test.form.hasCallButton()).toBe(true);
         expect(test.form.hasEmailButton()).toBe(false);
       });
     });
   });
 
-  Expect.describe('events', function () {
-    itp('shows an error if username is empty and request email', function () {
-      return setup().then(function (test) {
+  Expect.describe('events', function() {
+    itp('shows an error if username is empty and request email', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.sendEmail();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('shows an error if username is too long', function () {
-      return setup().then(function (test) {
+    itp('shows an error if username is too long', function() {
+      return setup().then(function(test) {
         test.form.setUsername(Util.LoremIpsum);
         test.form.sendEmail();
         expect(test.form.usernameErrorField().length).toBe(1);
         expect(test.form.usernameErrorField().text()).toBe('Please check your username');
       });
     });
-    itp('shows an error if username is empty', function () {
-      return setup().then(function (test) {
+    itp('shows an error if username is empty', function() {
+      return setup().then(function(test) {
         Util.resetAjaxRequests();
         test.form.setUsername(' ');
         test.form.sendEmail();
@@ -271,16 +271,16 @@ Expect.describe('UnlockAccount', function () {
         expect(test.form.usernameErrorField().text()).toBe('This field cannot be left blank');
       });
     });
-    itp('sends email', function () {
+    itp('sends email', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -291,16 +291,16 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('sends email when pressing enter if Email is the only factor', function () {
+    itp('sends email when pressing enter if Email is the only factor', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForUnlockEmailSent();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -311,8 +311,8 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('calls the transformUsername function with the right parameters', function () {
-      return setupWithTransformUsername().then(function (test) {
+    itp('calls the transformUsername function with the right parameters', function() {
+      return setupWithTransformUsername().then(function(test) {
         spyOn(test.router.settings, 'transformUsername');
         test.setNextResponse(resChallengeEmail);
         test.form.setUsername('foo');
@@ -321,16 +321,16 @@ Expect.describe('UnlockAccount', function () {
         expect(test.router.settings.transformUsername.calls.argsFor(0)).toEqual(['foo', 'UNLOCK_ACCOUNT']);
       });
     });
-    itp('appends the suffix returned by the transformUsername function to the username', function () {
+    itp('appends the suffix returned by the transformUsername function to the username', function() {
       return setupWithTransformUsername()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -341,28 +341,28 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('updates appState username after sending email', function () {
+    itp('updates appState username after sending email', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('foo');
           expect(test.router.appState.get('username')).toBeUndefined();
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows email sent confirmation screen, and has a button that navigates back', function () {
+    itp('shows email sent confirmation screen, and has a button that navigates back', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('foo@bar');
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.titleText()).toBe('Email sent!');
           expect(test.form.getEmailSentConfirmationText().indexOf('foo@bar') >= 0).toBe(true);
           expect(test.form.backToLoginButton().length).toBe(1);
@@ -370,53 +370,53 @@ Expect.describe('UnlockAccount', function () {
           expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
         });
     });
-    itp('calls globalSuccessFn when an email has been sent', function () {
+    itp('calls globalSuccessFn when an email has been sent', function() {
       const successSpy = jasmine.createSpy('successSpy');
 
       return setup({ globalSuccessFn: successSpy })
-        .then(function (test) {
+        .then(function(test) {
           test.form.setUsername('foo@bar');
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(successSpy).toHaveBeenCalledWith({
             status: 'UNLOCK_ACCOUNT_EMAIL_SENT',
             username: 'foo@bar',
           });
         });
     });
-    itp('shows an error if sending email results in an error', function () {
+    itp('shows an error if sending email results in an error', function() {
       return setup()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendEmail();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectError(test);
         });
     });
-    itp('shows an error if username is empty and request sms', function () {
-      return setupWithSms().then(function (test) {
+    itp('shows an error if username is empty and request sms', function() {
+      return setupWithSms().then(function(test) {
         Util.resetAjaxRequests();
         test.form.sendSms();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('sends sms', function () {
+    itp('sends sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -427,9 +427,9 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('sends sms without email enabled', function () {
+    itp('sends sms without email enabled', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
           Util.resetAjaxRequests();
@@ -438,7 +438,7 @@ Expect.describe('UnlockAccount', function () {
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -449,16 +449,16 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('sends sms when pressing enter if SMS is the only factor', function () {
+    itp('sends sms when pressing enter if SMS is the only factor', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -469,9 +469,9 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('sends sms when pressing enter if SMS is the first factor of the list', function () {
+    itp('sends sms when pressing enter if SMS is the first factor of the list', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSmsButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
           Util.resetAjaxRequests();
@@ -480,7 +480,7 @@ Expect.describe('UnlockAccount', function () {
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -491,9 +491,9 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('updates appState username after sending sms', function () {
+    itp('updates appState username after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
@@ -501,39 +501,39 @@ Expect.describe('UnlockAccount', function () {
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows an error if sending sms results in an error', function () {
+    itp('shows an error if sending sms results in an error', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectError(test);
         });
     });
-    itp('does not have a problem with sending email after sending sms', function () {
+    itp('does not have a problem with sending email after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectError(test);
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.sendEmail();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -544,24 +544,24 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('shows an error if username is empty and request Voice Call', function () {
-      return setupWithCall().then(function (test) {
+    itp('shows an error if username is empty and request Voice Call', function() {
+      return setupWithCall().then(function(test) {
         Util.resetAjaxRequests();
         test.form.makeCall();
         expect(Util.numAjaxRequests()).toBe(0);
         expect(test.form.usernameErrorField().length).toBe(1);
       });
     });
-    itp('makes a Voice Call', function () {
+    itp('makes a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -572,9 +572,9 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('makes a Voice Call without email enabled', function () {
+    itp('makes a Voice Call without email enabled', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(false);
           Util.resetAjaxRequests();
@@ -583,7 +583,7 @@ Expect.describe('UnlockAccount', function () {
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -594,16 +594,16 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('makes a Voice Call when pressing enter if Voice Call is the only factor', function () {
+    itp('makes a Voice Call when pressing enter if Voice Call is the only factor', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -614,9 +614,9 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('makes a Voice Call when pressing enter if Voice Call is the first factor of the list', function () {
+    itp('makes a Voice Call when pressing enter if Voice Call is the first factor of the list', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasCallButton()).toBe(true);
           expect(test.form.hasEmailButton()).toBe(true);
           Util.resetAjaxRequests();
@@ -625,7 +625,7 @@ Expect.describe('UnlockAccount', function () {
           test.form.pressEnter();
           return Expect.waitForRecoveryChallenge();
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -636,95 +636,95 @@ Expect.describe('UnlockAccount', function () {
           });
         });
     });
-    itp('updates appState username after making a Voice Call', function () {
+    itp('updates appState username after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.router.appState.get('username')).toBe('foo');
         });
     });
-    itp('shows an error if making a Voice Call results in an error', function () {
+    itp('shows an error if making a Voice Call results in an error', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resError);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expectError(test);
         });
     });
-    itp('goes back', function () {
-      return setup().then(function (test) {
+    itp('goes back', function() {
+      return setup().then(function(test) {
         test.form.goBack();
         expect(test.router.navigate).toHaveBeenCalledWith('', { trigger: true });
       });
     });
-    itp('returns to primary auth when browser\'s back button is clicked', function () {
+    itp('returns to primary auth when browser\'s back button is clicked', function() {
       return setup(null, true)
-        .then(function (test) {
+        .then(function(test) {
           Util.triggerBrowserBackButton();
           return Expect.waitForPrimaryAuth(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isPrimaryAuth(test.router.controller);
           Util.stopRouter();
         });
     });
-    itp('shows an org\'s contact form when user clicks no email access link', function () {
-      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function (test) {
+    itp('shows an org\'s contact form when user clicks no email access link', function() {
+      return setup({ helpSupportNumber: '(999) 123-4567' }).then(function(test) {
         expect(test.form.hasCantAccessEmailLink()).toBe(true);
         test.form.clickCantAccessEmail();
         expect(test.form.contactSupportText()).toMatch(/\(999\) 123-4567/);
         expect(test.form.hasCantAccessEmailLink()).toBe(false);
       });
     });
-    itp('shows the "Unlock via email" link after sending sms', function () {
+    itp('shows the "Unlock via email" link after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Unlock via email');
         });
     });
-    itp('does not show the "Unlock via email" link after sending sms if emailRecovery is false', function () {
+    itp('does not show the "Unlock via email" link after sending sms if emailRecovery is false', function() {
       return setupWithSmsWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(false);
         });
     });
-    itp('sends an email when user clicks the "Unlock via email" link, after sending sms', function () {
+    itp('sends an email when user clicks the "Unlock via email" link, after sending sms', function() {
       return setupWithSms()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeSms);
           test.form.setUsername('foo@bar');
           test.form.sendSms();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.clickSendEmailLink();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -737,20 +737,20 @@ Expect.describe('UnlockAccount', function () {
     });
     itp(
       'shows email sent confirmation screen when user clicks the "Unlock via email" link, after sending sms',
-      function () {
+      function() {
         return setupWithSms()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeSms);
             test.form.setUsername('foo@bar');
             test.form.sendSms();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForUnlockEmailSent(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.titleText()).toBe('Email sent!');
             expect(test.form.getEmailSentConfirmationText().indexOf('foo@bar') >= 0).toBe(true);
             expect(test.form.backToLoginButton().length).toBe(1);
@@ -759,65 +759,65 @@ Expect.describe('UnlockAccount', function () {
     );
     itp(
       'shows an error if sending email via "Unlock via email" link results in an error, after sending sms',
-      function () {
+      function() {
         return setupWithSms()
-          .then(function (test) {
+          .then(function(test) {
             Expect.allowUnhandledPromiseRejection();
             test.setNextResponse(resChallengeSms);
             test.form.setUsername('foo');
             test.form.sendSms();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resError);
             test.form.clickSendEmailLink();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(test, 'recovery-challenge');
           });
       }
     );
-    itp('shows the "Unlock via email" link after making a Voice Call', function () {
+    itp('shows the "Unlock via email" link after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(true);
           expect(test.form.sendEmailLink().trimmedText()).toEqual('Didn\'t receive a code? Unlock via email');
         });
     });
-    itp('does not show the "Unlock via email" link after making a Voice Call if emailRecovery is false', function () {
+    itp('does not show the "Unlock via email" link after making a Voice Call if emailRecovery is false', function() {
       return setupWithCallWithoutEmail()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasSendEmailLink()).toBe(false);
         });
     });
-    itp('sends an email when user clicks the "Unlock via email" link, after making a Voice Call', function () {
+    itp('sends an email when user clicks the "Unlock via email" link, after making a Voice Call', function() {
       return setupWithCall()
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse(resChallengeCall);
           test.form.setUsername('foo@bar');
           test.form.makeCall();
           return Expect.waitForRecoveryChallenge(test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Util.resetAjaxRequests();
           test.setNextResponse(resChallengeEmail);
           test.form.clickSendEmailLink();
           return Expect.waitForUnlockEmailSent(test);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(1);
           Expect.isJsonPost(Util.getAjaxRequest(0), {
             url: 'https://foo.com/api/v1/authn/recovery/unlock',
@@ -830,20 +830,20 @@ Expect.describe('UnlockAccount', function () {
     });
     itp(
       'shows email sent confirmation when user clicks "Unlock via email" link, after making a Voice Call',
-      function () {
+      function() {
         return setupWithCall()
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeCall);
             test.form.setUsername('foo@bar');
             test.form.makeCall();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resChallengeEmail);
             test.form.clickSendEmailLink();
             return Expect.waitForUnlockEmailSent(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expect(test.form.titleText()).toBe('Email sent!');
             expect(test.form.getEmailSentConfirmationText().indexOf('foo@bar') >= 0).toBe(true);
             expect(test.form.backToLoginButton().length).toBe(1);
@@ -852,21 +852,21 @@ Expect.describe('UnlockAccount', function () {
     );
     itp(
       'shows an error if sending email via "Unlock via email" link results in an error, after making a Voice Call',
-      function () {
+      function() {
         return setupWithCall()
-          .then(function (test) {
+          .then(function(test) {
             Expect.allowUnhandledPromiseRejection();
             test.setNextResponse(resChallengeCall);
             test.form.setUsername('foo');
             test.form.makeCall();
             return Expect.waitForRecoveryChallenge(test);
           })
-          .then(function (test) {
+          .then(function(test) {
             test.setNextResponse(resError);
             test.form.clickSendEmailLink();
             return Expect.waitForFormError(test.form, test);
           })
-          .then(function (test) {
+          .then(function(test) {
             expectError(test, 'recovery-challenge');
           });
       }

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -4,9 +4,9 @@ import $sandbox from 'sandbox';
 import Logger from 'util/Logger';
 import Util from 'util/Util';
 
-describe('util/Util', function () {
-  describe('transformErrorXHR', function () {
-    it('errorSummary shows network connection error when status is 0', function () {
+describe('util/Util', function() {
+  describe('transformErrorXHR', function() {
+    it('errorSummary shows network connection error when status is 0', function() {
       const xhr = {
         status: 0,
       };
@@ -16,7 +16,7 @@ describe('util/Util', function () {
         'Unable to connect to the server. Please check your network connection.'
       );
     });
-    it('errorSummary shows internal error when there are no responseJSON and no responseText', function () {
+    it('errorSummary shows internal error when there are no responseJSON and no responseText', function() {
       const xhr = {
         status: 400,
       };
@@ -24,7 +24,7 @@ describe('util/Util', function () {
       Util.transformErrorXHR(xhr);
       expect(xhr.responseJSON.errorSummary).toEqual('There was an unexpected internal error. Please try again.');
     });
-    it('errorSummary is set from responseText when there is no responseJSON', function () {
+    it('errorSummary is set from responseText when there is no responseJSON', function() {
       const responseText = { errorSummary: 'errorSummary from responseText' };
       const xhr = {
         status: 400,
@@ -34,7 +34,7 @@ describe('util/Util', function () {
       Util.transformErrorXHR(xhr);
       expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from responseText');
     });
-    it('If there is an errorCauses array and there is no error code, get errorSummary from errorCauses array', function () {
+    it('If there is an errorCauses array and there is no error code, get errorSummary from errorCauses array', function() {
       const errorCauses = [
         {
           errorSummary: 'errorSummary from errorCauses',
@@ -51,7 +51,7 @@ describe('util/Util', function () {
       expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
       expect(xhr.responseJSON.errorCauses).toBe(errorCauses);
     });
-    it('If there is an errorCauses array and there is an invalid error code, get errorSummary from errorCauses array', function () {
+    it('If there is an errorCauses array and there is an invalid error code, get errorSummary from errorCauses array', function() {
       const errorCauses = [
         {
           errorSummary: 'errorSummary from errorCauses',
@@ -69,7 +69,7 @@ describe('util/Util', function () {
       expect(xhr.responseJSON.errorSummary).toEqual('errorSummary from errorCauses');
       expect(xhr.responseJSON.errorCauses).toBe(errorCauses);
     });
-    it('If there is a valid error code, get errorSummary from that and delete errorCauses array', function () {
+    it('If there is a valid error code, get errorSummary from that and delete errorCauses array', function() {
       const errorCauses = [
         {
           errorSummary: 'errorSummary from errorCauses',
@@ -89,44 +89,44 @@ describe('util/Util', function () {
     });
   });
 
-  describe('expandLanguages', function () {
-    it('works with an empty array', function () {
+  describe('expandLanguages', function() {
+    it('works with an empty array', function() {
       const languages = [];
       const expected = [];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('works in the default "en" case', function () {
+    it('works in the default "en" case', function() {
       const languages = ['en'];
       const expected = ['en'];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('expands with 2 parts (regions) in the correct order', function () {
+    it('expands with 2 parts (regions) in the correct order', function() {
       const languages = ['pt-BR'];
       const expected = ['pt-BR', 'pt'];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('expands when there are 3 parts (regions+dialects) in the correct order', function () {
+    it('expands when there are 3 parts (regions+dialects) in the correct order', function() {
       const languages = ['de-DE-bavarian'];
       const expected = ['de-DE-bavarian', 'de-DE', 'de'];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('returns a flattened array with multiple languages', function () {
+    it('returns a flattened array with multiple languages', function() {
       const languages = ['en', 'pt-BR', 'ja', 'zh-CN'];
       const expected = ['en', 'pt-BR', 'pt', 'ja', 'zh-CN', 'zh'];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('filters out any duplicates that are generated', function () {
+    it('filters out any duplicates that are generated', function() {
       const languages = ['en-US', 'en'];
       const expected = ['en-US', 'en'];
 
       expect(Util.expandLanguages(languages)).toEqual(expected);
     });
-    it('filters out duplicates that are passed in (correct order)', function () {
+    it('filters out duplicates that are passed in (correct order)', function() {
       const languages = ['en-US', 'ja', 'en'];
       const expected = ['en-US', 'en', 'ja'];
 
@@ -134,8 +134,8 @@ describe('util/Util', function () {
     });
   });
 
-  describe('toLower', function () {
-    it('lowercases all string entries in a given array', function () {
+  describe('toLower', function() {
+    it('lowercases all string entries in a given array', function() {
       const arr = ['Hi', 'THERE', 'i', 'wOUld'];
       const expected = ['hi', 'there', 'i', 'would'];
 
@@ -143,8 +143,8 @@ describe('util/Util', function () {
     });
   });
 
-  describe('debugMessage', function () {
-    it('formats template literal strings into a consistent format', function () {
+  describe('debugMessage', function() {
+    it('formats template literal strings into a consistent format', function() {
       spyOn(Logger, 'warn');
       const debugMessage = `
           Multi-line
@@ -157,33 +157,33 @@ describe('util/Util', function () {
     });
   });
 
-  describe('redirect', function () {
-    beforeEach(function () {
+  describe('redirect', function() {
+    beforeEach(function() {
       spyOn(Logger, 'error');
     });
-    it('should load the URL', function () {
+    it('should load the URL', function() {
       const win = jasmine.createSpyObj('window', { location: 'href' });
       Util.redirect('http://example.com/idp/123', win);
       expect(win.location.href).toEqual('http://example.com/idp/123');
     });
-    it('should not load an empty URL', function () {
+    it('should not load an empty URL', function() {
       Util.redirect('');
       expect(Logger.error.calls.count()).toBe(1);
       expect(Logger.error).toHaveBeenCalledWith('Cannot redirect to empty URL: ()');
     });
   });
 
-  describe('redirectWithFormGet', function () {
-    beforeEach(function () {
+  describe('redirectWithFormGet', function() {
+    beforeEach(function() {
       spyOn(Logger, 'error');
       spyOn(HTMLFormElement.prototype, 'submit');
       $sandbox.append('<div id="okta-sign-in"></div>');
     });
-    afterEach(function () {
+    afterEach(function() {
       $sandbox.empty();
     });
 
-    it('shall submit a plain URL', function () {
+    it('shall submit a plain URL', function() {
       Util.redirectWithFormGet('http://example.com/idp/123');
 
       expect($('#okta-sign-in form')[0].submit.calls.count()).toBe(1);
@@ -191,7 +191,7 @@ describe('util/Util', function () {
         '<form method="get" style="display: none;" action="http://example.com/idp/123">' + '</form>'
       );
     });
-    it('shall submit URL that has query pamaters', function () {
+    it('shall submit URL that has query pamaters', function() {
       Util.redirectWithFormGet('http://example.com/idp/123?foo=aaa&bar=bbb');
 
       expect($('#okta-sign-in form')[0].submit.calls.count()).toBe(1);
@@ -202,7 +202,7 @@ describe('util/Util', function () {
           '</form>'
       );
     });
-    it('shall submit URL that has query pamaters and fragement', function () {
+    it('shall submit URL that has query pamaters and fragement', function() {
       Util.redirectWithFormGet('http://example.com/idp/123?redirectURI=https%3A%2F%2Ffoo.com#hello=okta');
 
       expect($('#okta-sign-in form')[0].submit.calls.count()).toBe(1);
@@ -212,7 +212,7 @@ describe('util/Util', function () {
           '</form>'
       );
     });
-    it('shall submit URL that encoded XSS value', function () {
+    it('shall submit URL that encoded XSS value', function() {
       Util.redirectWithFormGet(
         'http://example.com/idp/123?foo=a%22%2F%3E%3Cimg%20error%3D%22alert(11)%22%20src%3D%22xx%22%2F%3E'
       );
@@ -224,7 +224,7 @@ describe('util/Util', function () {
           '</form>'
       );
     });
-    it('shall submit URL that XSS value', function () {
+    it('shall submit URL that XSS value', function() {
       Util.redirectWithFormGet('http://example.com/idp/123?foo=%22/><img error="alert(2)" src="yy"/>');
 
       expect($('#okta-sign-in form')[0].submit.calls.count()).toBe(1);
@@ -234,14 +234,14 @@ describe('util/Util', function () {
           '</form>'
       );
     });
-    it('shall not submit anything if the okta-sign-in container doesnot exists', function () {
+    it('shall not submit anything if the okta-sign-in container doesnot exists', function() {
       $('#okta-sign-in').remove();
       Util.redirectWithFormGet('http://example.com/idp/123');
       expect($('#okta-sign-in form').length).toBe(0);
       expect(Logger.error.calls.count()).toBe(1);
       expect(Logger.error).toHaveBeenCalledWith('Cannot find okta-sign-in container append to which a form');
     });
-    it('shall not submit an empty URL', function () {
+    it('shall not submit an empty URL', function() {
       Util.redirectWithFormGet('');
       expect($('#okta-sign-in form').length).toBe(0);
       expect(Logger.error.calls.count()).toBe(1);

--- a/test/unit/spec/VerifyPIV_spec.js
+++ b/test/unit/spec/VerifyPIV_spec.js
@@ -14,7 +14,7 @@ import $sandbox from 'sandbox';
 const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
-function setup (errorResponse, pivConfig) {
+function setup(errorResponse, pivConfig) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl });
@@ -57,45 +57,45 @@ function setup (errorResponse, pivConfig) {
   });
 }
 
-function deepClone (res) {
+function deepClone(res) {
   return JSON.parse(JSON.stringify(res));
 }
 
-Expect.describe('PIV', function () {
-  Expect.describe('General', function () {
-    itp('displays the correct beacon', function () {
-      return setup().then(function (test) {
+Expect.describe('PIV', function() {
+  Expect.describe('General', function() {
+    itp('displays the correct beacon', function() {
+      return setup().then(function(test) {
         expect(test.beacon.isPIVBeacon()).toBe(true);
         expect(test.beacon.hasClass('smartcard')).toBe(true);
       });
     });
-    itp('displays the correct title', function () {
-      return setup().then(function (test) {
+    itp('displays the correct title', function() {
+      return setup().then(function(test) {
         expect(test.form.titleText()).toBe('PIV / CAC card');
       });
     });
-    itp('has a "back" link in the footer', function () {
-      return setup().then(function (test) {
+    itp('has a "back" link in the footer', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.backLink());
       });
     });
-    itp('has spinning wait icon', function () {
-      return setup().then(function (test) {
+    itp('has spinning wait icon', function() {
+      return setup().then(function(test) {
         Expect.isVisible(test.form.spinningIcon());
         Expect.isNotVisible(test.form.submitButton());
       });
     });
-    itp('displays the correct instructions', function () {
-      return setup().then(function (test) {
+    itp('displays the correct instructions', function() {
+      return setup().then(function(test) {
         expect(test.form.instructions()).toBe('Please insert your PIV / CAC card and select the user certificate.');
       });
     });
-    itp('makes ajax get and post calls with correct data', function () {
+    itp('makes ajax get and post calls with correct data', function() {
       return setup()
-        .then(function () {
+        .then(function() {
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
 
           const argsForGet = Util.getAjaxRequest(0);
@@ -113,17 +113,17 @@ Expect.describe('PIV', function () {
           });
         });
     });
-    itp('makes post call with correct data when isCustomDomain is false', function () {
+    itp('makes post call with correct data when isCustomDomain is false', function() {
       const config = {
         certAuthUrl: 'https://foo.com',
         isCustomDomain: false,
       };
 
       return setup(null, config)
-        .then(function () {
+        .then(function() {
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
           const argsForPost = Util.getAjaxRequest(1);
 
@@ -133,17 +133,17 @@ Expect.describe('PIV', function () {
           });
         });
     });
-    itp('makes post call with correct data when isCustomDomain is undefined', function () {
+    itp('makes post call with correct data when isCustomDomain is undefined', function() {
       const config = {
         certAuthUrl: 'https://foo.com',
         isCustomDomain: undefined,
       };
 
       return setup(null, config)
-        .then(function () {
+        .then(function() {
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(Util.numAjaxRequests()).toBe(2);
           const argsForPost = Util.getAjaxRequest(1);
 
@@ -152,67 +152,67 @@ Expect.describe('PIV', function () {
           });
         });
     });
-    itp('redirects on successful cert auth', function () {
+    itp('redirects on successful cert auth', function() {
       return setup()
-        .then(function () {
+        .then(function() {
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'https://rain.okta1.com/login/sessionCookieRedirect?redirectUrl=%2Fapp%2FUserHome&amp;token=token1'
           );
         });
     });
   });
-  Expect.describe('Error', function () {
+  Expect.describe('Error', function() {
     const pivError = deepClone(resError);
 
-    itp('shows error box with error response', function () {
+    itp('shows error box with error response', function() {
       return setup(pivError)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox()).toHaveLength(1);
           expect(test.form.errorMessage()).toEqual('Invalid certificate.');
         });
     });
-    itp('displays retry button', function () {
+    itp('displays retry button', function() {
       return setup(pivError)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           Expect.isVisible(test.form.submitButton());
           Expect.isNotVisible(test.form.spinningIcon());
         });
     });
-    itp('can retry authentication', function () {
+    itp('can retry authentication', function() {
       return setup(pivError)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           test.setNextResponse([resGet, resPost]);
           test.form.submit();
           return Expect.waitForSpyCall(SharedUtil.redirect);
         })
-        .then(function () {
+        .then(function() {
           expect(SharedUtil.redirect).toHaveBeenCalledWith(
             'https://rain.okta1.com/login/sessionCookieRedirect?redirectUrl=%2Fapp%2FUserHome&amp;token=token1'
           );
         });
     });
-    itp('shows generic error message for undefined error response', function () {
+    itp('shows generic error message for undefined error response', function() {
       const res = deepClone(resError);
 
       res.response = undefined;
       return setup(res)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox()).toHaveLength(1);
           expect(test.form.errorMessage()).toEqual(
@@ -220,16 +220,16 @@ Expect.describe('PIV', function () {
           );
         });
     });
-    itp('shows generic error message for empty text error response', function () {
+    itp('shows generic error message for empty text error response', function() {
       const res = deepClone(resError);
 
       res.responseType = 'text';
       res.response = '';
       return setup(res)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox()).toHaveLength(1);
           expect(test.form.errorMessage()).toEqual(
@@ -237,17 +237,17 @@ Expect.describe('PIV', function () {
           );
         });
     });
-    itp('shows correct error message for text error response', function () {
+    itp('shows correct error message for text error response', function() {
       const res = deepClone(resError);
 
       res.responseType = 'text';
       res.response =
         '{"errorCode":"E0000004","errorSummary":"Authentication failed","errorLink":"E0000004","errorId":"oaeDtg9knyJR7agwMN-70SYgw","errorCauses":[]}';
       return setup(res)
-        .then(function (test) {
+        .then(function(test) {
           return Expect.waitForFormError(test.form, test);
         })
-        .then(function (test) {
+        .then(function(test) {
           expect(test.form.hasErrors()).toBe(true);
           expect(test.form.errorBox()).toHaveLength(1);
           expect(test.form.errorMessage()).toEqual('Authentication failed');

--- a/test/unit/spec/VerifyWebauthn_spec.js
+++ b/test/unit/spec/VerifyWebauthn_spec.js
@@ -22,7 +22,7 @@ import LoginUtil from 'util/Util';
 import webauthn from 'util/webauthn';
 const itp = Expect.itp;
 
-function createRouter (baseUrl, authClient, successSpy, settings) {
+function createRouter(baseUrl, authClient, successSpy, settings) {
   const router = new Router(
     _.extend(
       {
@@ -70,11 +70,11 @@ const configWithCustomLinkNoHref = {
   }
 };
 
-function clickFactorInDropdown (test, factorName) {
+function clickFactorInDropdown(test, factorName) {
   test.beacon.getOptionsLinks().eq(Factors[factorName]).click();
 }
 
-function setup (options) {
+function setup(options) {
   const setNextResponse = Util.mockAjax();
   const baseUrl = 'https://foo.com';
   const authClient = createAuthClient({ issuer: baseUrl, transformErrorXHR: LoginUtil.transformErrorXHR });
@@ -86,7 +86,7 @@ function setup (options) {
   setNextResponse(options.multipleWebauthn ? [resMultipleWebauthnWithQuestion] : [resAllFactors]);
   router.refreshAuthState('dummy-token');
   return Expect.waitForMfaVerify()
-    .then(function () {
+    .then(function() {
       const responses = options.multipleWebauthn ? [resChallengeMultipleWebauthn] : [resChallengeWebauthn];
 
       if (options.signStatus === 'success') {
@@ -96,10 +96,10 @@ function setup (options) {
       router.verifyWebauthn();
       return Expect.waitForVerifyWebauthn();
     })
-    .then(function () {
+    .then(function() {
       const $forms = $sandbox.find('.o-form');
 
-      let forms = _.map($forms, function (form) {
+      let forms = _.map($forms, function(form) {
         return new MfaVerifyForm($(form));
       });
 
@@ -126,7 +126,7 @@ const testSignature = 'YWJjZGVmYXNkZmV3YWZrbm1hc2xqZWY=';
 const testCredentialId = 'vdCxImCygaKmXS3S_2WwgqF1LLZ4i_2MKYfAbrNByJOOmSyRD_STj6VfhLQsLdLrIdgvdP5EmO1n9Tuw5BawZw';
 const testChallenge = 'kygOUtSWURMv_t_Gj71Y';
 
-function mockWebauthn (options) {
+function mockWebauthn(options) {
   if (options.webauthnSupported) {
     navigator.credentials = {
       get: jasmine.createSpy('webauthn-spy'),
@@ -143,8 +143,8 @@ function mockWebauthn (options) {
   }
 }
 
-function mockWebauthnSignFailure () {
-  spyOn(navigator.credentials, 'get').and.callFake(function () {
+function mockWebauthnSignFailure() {
+  spyOn(navigator.credentials, 'get').and.callFake(function() {
     const deferred = Q.defer();
 
     deferred.reject({ message: 'something went wrong' });
@@ -152,8 +152,8 @@ function mockWebauthnSignFailure () {
   });
 }
 
-function mockWebauthnSignSuccess (rememberDevice) {
-  spyOn(navigator.credentials, 'get').and.callFake(function () {
+function mockWebauthnSignSuccess(rememberDevice) {
+  spyOn(navigator.credentials, 'get').and.callFake(function() {
     if (rememberDevice) {
       $('[name=rememberDevice]').prop('checked', true);
       $('[name=rememberDevice]').trigger('change');
@@ -171,11 +171,11 @@ function mockWebauthnSignSuccess (rememberDevice) {
   });
 }
 
-function mockWebauthnSignPending () {
+function mockWebauthnSignPending() {
   spyOn(navigator.credentials, 'get').and.returnValue(Q.defer().promise);
 }
 
-function setupWebauthnFactor (options) {
+function setupWebauthnFactor(options) {
   options || (options = {});
   spyOn(webauthn, 'isNewApiAvailable').and.returnValue(options.webauthnSupported === true);
   const isSafari = options.isSafari ? true : false;
@@ -184,7 +184,7 @@ function setupWebauthnFactor (options) {
   return setup(options);
 }
 
-function setupMultipleWebauthnOnly (options) {
+function setupMultipleWebauthnOnly(options) {
   options || (options = {});
   options.multipleWebauthn = true;
   spyOn(webauthn, 'isNewApiAvailable').and.returnValue(options.webauthnSupported === true);
@@ -205,10 +205,10 @@ function setupMultipleWebauthnOnly (options) {
   }
   setNextResponse(responses);
   router.refreshAuthState('dummy-token');
-  return Expect.waitForVerifyWebauthn().then(function () {
+  return Expect.waitForVerifyWebauthn().then(function() {
     const $forms = $sandbox.find('.o-form');
 
-    let forms = _.map($forms, function (form) {
+    let forms = _.map($forms, function(form) {
       return new MfaVerifyForm($(form));
     });
 
@@ -229,31 +229,31 @@ function setupMultipleWebauthnOnly (options) {
   });
 }
 
-function setupMultipleWebauthn (options) {
+function setupMultipleWebauthn(options) {
   options || (options = {});
   options.multipleWebauthn = true;
   return setupWebauthnFactor(options);
 }
 
-function expectHasRightBeaconImage (test, desiredClassName) {
+function expectHasRightBeaconImage(test, desiredClassName) {
   expect(test.beacon.isFactorBeacon()).toBe(true);
   expect(test.beacon.hasClass(desiredClassName)).toBe(true);
 }
 
-function expectTitleToBe (test, desiredTitle) {
+function expectTitleToBe(test, desiredTitle) {
   expect(test.form.titleText()).toBe(desiredTitle);
 }
 
-function testWebauthnFactor (setupFn, webauthnOnly) {
-  itp('shows the right beacon and title for webauthn', function () {
-    return setupFn({ webauthnSupported: true }).then(function (test) {
+function testWebauthnFactor(setupFn, webauthnOnly) {
+  itp('shows the right beacon and title for webauthn', function() {
+    return setupFn({ webauthnSupported: true }).then(function(test) {
       expectHasRightBeaconImage(test, 'mfa-webauthn');
       expectTitleToBe(test, 'Security Key or Biometric Authenticator');
     });
   });
 
-  itp('shows error if browser does not support webauthn', function () {
-    return setupFn({ webauthnSupported: false }).then(function (test) {
+  itp('shows error if browser does not support webauthn', function() {
+    return setupFn({ webauthnSupported: false }).then(function(test) {
       expect(test.form.el('o-form-error-html')).toHaveLength(1);
       const errorMessage = webauthnOnly
         ? 'Security key or biometric authenticator is not supported on this browser. ' +
@@ -265,61 +265,61 @@ function testWebauthnFactor (setupFn, webauthnOnly) {
     });
   });
 
-  itp('does not show error if browser supports webauthn', function () {
-    return setupFn({ webauthnSupported: true }).then(function (test) {
+  itp('does not show error if browser supports webauthn', function() {
+    return setupFn({ webauthnSupported: true }).then(function(test) {
       expect(test.form.el('o-form-error-html')).toHaveLength(0);
     });
   });
 
-  itp('shows verify button when webauthn challenge page is loaded when on safari', function () {
-    return setupFn({ webauthnSupported: true, isSafari: true }).then(function (test) {
+  itp('shows verify button when webauthn challenge page is loaded when on safari', function() {
+    return setupFn({ webauthnSupported: true, isSafari: true }).then(function(test) {
       expect(test.form.submitButton().css('display')).toBe('block');
       expect(test.form.submitButtonText()).toBe('Verify');
     });
   });
 
-  itp('does not show verify button when not on safari', function () {
-    return setupFn({ webauthnSupported: true }).then(function (test) {
+  itp('does not show verify button when not on safari', function() {
+    return setupFn({ webauthnSupported: true }).then(function(test) {
       return Expect.waitForSpyCall(navigator.credentials.get, test);
-    }).then(function (test) {
+    }).then(function(test) {
       Expect.isNotVisible(test.form.submitButton());
       expect(test.form.submitButtonText()).toBe('Verify');
     });
   });
 
-  itp('has remember device checkbox', function () {
-    return setupFn({ webauthnSupported: true }).then(function (test) {
+  itp('has remember device checkbox', function() {
+    return setupFn({ webauthnSupported: true }).then(function(test) {
       Expect.isVisible(test.form.rememberDeviceCheckbox());
     });
   });
 
-  itp('has a sign out link', function () {
-    return setupFn({ webauthnSupported: true }).then(function (test) {
+  itp('has a sign out link', function() {
+    return setupFn({ webauthnSupported: true }).then(function(test) {
       Expect.isVisible(test.form.signoutLink($sandbox));
     });
   });
-  itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function () {
-    return setupFn({ webauthnSupported: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function (test) {
+  itp('does not have sign out link if features.hideSignOutLinkInMFA is true', function() {
+    return setupFn({ webauthnSupported: true, settings: {'features.hideSignOutLinkInMFA': true} }).then(function(test) {
       expect(test.form.signoutLink($sandbox).length).toBe(0);
     });
   });
-  itp('does not have sign out link if features.mfaOnlyFlow is true', function () {
-    return setupFn({ webauthnSupported: true, settings: {'features.mfaOnlyFlow': true} }).then(function (test) {
+  itp('does not have sign out link if features.mfaOnlyFlow is true', function() {
+    return setupFn({ webauthnSupported: true, settings: {'features.mfaOnlyFlow': true} }).then(function(test) {
       expect(test.form.signoutLink($sandbox).length).toBe(0);
     });
   });
 }
 
-function testMultipleWebauthnFactor (setupFn) {
-  itp('calls navigator.credentials.get and verifies factor', function () {
+function testMultipleWebauthnFactor(setupFn) {
+  itp('calls navigator.credentials.get and verifies factor', function() {
     return setupFn({
       webauthnSupported: true,
       signStatus: 'success',
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(navigator.credentials.get).toHaveBeenCalledWith({
           publicKey: {
             allowCredentials: [
@@ -356,16 +356,16 @@ function testMultipleWebauthnFactor (setupFn) {
       });
   });
 
-  itp('calls navigator.credentials.get and verifies factor when rememberDevice set to true', function () {
+  itp('calls navigator.credentials.get and verifies factor when rememberDevice set to true', function() {
     return setupFn({
       webauthnSupported: true,
       signStatus: 'success',
       rememberDevice: true,
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(navigator.credentials.get).toHaveBeenCalledWith({
           publicKey: {
             allowCredentials: [
@@ -402,16 +402,16 @@ function testMultipleWebauthnFactor (setupFn) {
       });
   });
 
-  itp('shows an error if navigator.credentials.get fails and displays retry button', function () {
+  itp('shows an error if navigator.credentials.get fails and displays retry button', function() {
     Expect.allowUnhandledPromiseRejection();
     return setupFn({
       webauthnSupported: true,
       signStatus: 'fail',
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(navigator.credentials.get).toHaveBeenCalled();
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox()).toHaveLength(1);
@@ -437,18 +437,18 @@ function testMultipleWebauthnFactor (setupFn) {
   });
 }
 
-Expect.describe('Webauthn Factor', function () {
+Expect.describe('Webauthn Factor', function() {
   testWebauthnFactor(setupWebauthnFactor);
 
-  itp('calls navigator.credentials.get and verifies factor', function () {
+  itp('calls navigator.credentials.get and verifies factor', function() {
     return setupWebauthnFactor({
       webauthnSupported: true,
       signStatus: 'success',
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(test.successSpy, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(navigator.credentials.get).toHaveBeenCalledWith({
           publicKey: {
             allowCredentials: [
@@ -478,16 +478,16 @@ Expect.describe('Webauthn Factor', function () {
       });
   });
 
-  itp('calls navigator.credentials.get and verifies factor when rememberDevice set to true', function () {
+  itp('calls navigator.credentials.get and verifies factor when rememberDevice set to true', function() {
     return setupWebauthnFactor({
       webauthnSupported: true,
       signStatus: 'success',
       rememberDevice: true,
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(test.successSpy);
       })
-      .then(function () {
+      .then(function() {
         expect(navigator.credentials.get).toHaveBeenCalledWith({
           publicKey: {
             allowCredentials: [
@@ -516,16 +516,16 @@ Expect.describe('Webauthn Factor', function () {
       });
   });
 
-  itp('shows an error if navigator.credentials.get fails', function () {
+  itp('shows an error if navigator.credentials.get fails', function() {
     Expect.allowUnhandledPromiseRejection();
     return setupWebauthnFactor({
       webauthnSupported: true,
       signStatus: 'fail',
     })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForFormError(test.form, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(navigator.credentials.get).toHaveBeenCalled();
         expect(test.form.hasErrors()).toBe(true);
         expect(test.form.errorBox()).toHaveLength(1);
@@ -550,21 +550,21 @@ Expect.describe('Webauthn Factor', function () {
   });
 });
 
-Expect.describe('Only multiple Webauthn is setup', function () {
+Expect.describe('Only multiple Webauthn is setup', function() {
   testWebauthnFactor(setupMultipleWebauthnOnly, true);
   testMultipleWebauthnFactor(setupMultipleWebauthnOnly);
 });
 
-Expect.describe('Multiple Webauthn and one or more factors are setup', function () {
+Expect.describe('Multiple Webauthn and one or more factors are setup', function() {
   testWebauthnFactor(setupMultipleWebauthn);
   testMultipleWebauthnFactor(setupMultipleWebauthn);
 
-  itp('switching to another factor after initiating webauthn verify calls abort', function () {
+  itp('switching to another factor after initiating webauthn verify calls abort', function() {
     return setupMultipleWebauthn({ webauthnSupported: true })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.el('webauthn-waiting').length).toBe(1);
         const webauthnAbortController = test.router.controller.model.webauthnAbortController;
 
@@ -577,12 +577,12 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
       });
   });
 
-  itp('SignOut after initiating webauthn verify calls abort', function () {
+  itp('SignOut after initiating webauthn verify calls abort', function() {
     return setupMultipleWebauthn({ webauthnSupported: true })
-      .then(function (test) {
+      .then(function(test) {
         return Expect.waitForSpyCall(navigator.credentials.get, test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.form.el('webauthn-waiting').length).toBe(1);
         test.webauthnAbortController = test.router.controller.model.webauthnAbortController;
         expect(test.webauthnAbortController).toBeDefined();
@@ -591,33 +591,33 @@ Expect.describe('Multiple Webauthn and one or more factors are setup', function 
         test.form.signoutLink(test.router.el).click();
         return Expect.waitForPrimaryAuth(test);
       })
-      .then(function (test) {
+      .then(function(test) {
         expect(test.router.controller.model.webauthnAbortController).not.toBeDefined();
         expect(test.webauthnAbortController.abort).toHaveBeenCalled();
       });
   });
 });
 
-Expect.describe('Factor page custom link', function () {
-  itp('is visible if configured and has correct text and url', function () {
-    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLink }).then(function (test) {
+Expect.describe('Factor page custom link', function() {
+  itp('is visible if configured and has correct text and url', function() {
+    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLink }).then(function(test) {
       Expect.isVisible(test.form.factorPageCustomLink($sandbox));
       expect(test.form.factorPageCustomLinkLabel($sandbox).trim()).toBe('Need help with MFA?');
       expect(test.form.factorPageCustomLinkHref($sandbox).trim()).toBe('https://acme.com/mfa-help');
     });
   });
-  itp('is not visible if not configured', function () {
-    return setupWebauthnFactor({ webauthnSupported: true }).then(function (test) {
+  itp('is not visible if not configured', function() {
+    return setupWebauthnFactor({ webauthnSupported: true }).then(function(test) {
       expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
     });
   });
-  itp('is not visible if configured without text', function () {
-    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLinkNoText }).then(function (test) {
+  itp('is not visible if configured without text', function() {
+    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLinkNoText }).then(function(test) {
       expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
     });
   });
-  itp('is not visible if configured without url', function () {
-    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLinkNoHref }).then(function (test) {
+  itp('is not visible if configured without url', function() {
+    return setupWebauthnFactor({ webauthnSupported: true, settings: configWithCustomLinkNoHref }).then(function(test) {
       expect(test.form.factorPageCustomLink($sandbox).length).toBe(0);
     });
   });

--- a/test/unit/spec/v2/controllers/FormController_spec.js
+++ b/test/unit/spec/v2/controllers/FormController_spec.js
@@ -6,9 +6,9 @@ import AppState from 'v2/models/AppState';
 
 import FormController from 'v2/controllers/FormController';
 
-describe('v2/controllers/FormController', function () {
+describe('v2/controllers/FormController', function() {
   let testContext;
-  beforeEach(function () {
+  beforeEach(function() {
     testContext = {};
     testContext.init = (settings) => {
       const appState = new AppState({idx: {neededToProceed: []}});
@@ -20,11 +20,11 @@ describe('v2/controllers/FormController', function () {
     };
   });
 
-  afterEach(function () {
+  afterEach(function() {
     testContext.controller.options.appState.get('idx').proceed.mockReset();
   });
 
-  it('passes identifier to idx.proceed', function () {
+  it('passes identifier to idx.proceed', function() {
     const settings = new Settings({
       baseUrl: 'http://localhost:3000',
     });
@@ -36,10 +36,10 @@ describe('v2/controllers/FormController', function () {
     expect(testContext.controller.options.appState.get('idx').proceed.mock.calls[0][1].identifier).toEqual('foo');
   });
 
-  it('passes transformed identifier using settings.transformUsername to idx.proceed', function () {
+  it('passes transformed identifier using settings.transformUsername to idx.proceed', function() {
     const settings = new Settings({
       baseUrl: 'http://localhost:3000',
-      transformUsername: function (username, operation) {
+      transformUsername: function(username, operation) {
         if (operation === 'PRIMARY_AUTH') {
           return `${username}@okta.com`;
         }

--- a/test/unit/spec/v2/ion/IonResponseHelper_spec.js
+++ b/test/unit/spec/v2/ion/IonResponseHelper_spec.js
@@ -2,7 +2,7 @@ import { _ } from 'okta';
 import IonResponseHelper from 'v2/ion/IonResponseHelper';
 import Bundles from 'util/Bundles';
 
-describe('v2/ion/IonResponseHelper', function () {
+describe('v2/ion/IonResponseHelper', function() {
   let originalLoginBundle;
 
   beforeAll(() => {

--- a/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
+++ b/test/unit/spec/v2/ion/ViewClassNamesFactory_spec.js
@@ -1,8 +1,8 @@
 import { getClassNameMapping, getV1ClassName } from 'v2/ion/ViewClassNamesFactory';
 
-describe('v1/ion/ViewClassNamesFactory', function () {
-  describe('getClassNameMapping for v2 flow plus getV1ClassName', function () {
-    it('for identify form with password', function () {
+describe('v1/ion/ViewClassNamesFactory', function() {
+  describe('getClassNameMapping for v2 flow plus getV1ClassName', function() {
+    it('for identify form with password', function() {
       const v2Class = getClassNameMapping('identify', 'okta_password', null, false);
       expect(v2Class).toEqual(['identify--okta_password', 'primary-auth']);
 
@@ -10,7 +10,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('primary-auth');
     });
 
-    it('for identify form', function () {
+    it('for identify form', function() {
       const v2Class = getClassNameMapping('identify', null, null);
       expect(v2Class).toEqual(['identify', 'primary-auth']);
 
@@ -18,7 +18,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('primary-auth');
     });
 
-    it('for identify-recovery form', function () {
+    it('for identify-recovery form', function() {
       const v2Class = getClassNameMapping('identify-recovery', null, null);
       expect(v2Class).toEqual(['identify-recovery', 'forgot-password']);
 
@@ -26,7 +26,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('forgot-password');
     });
 
-    it('for select-authenticator-authenticate form', function () {
+    it('for select-authenticator-authenticate form', function() {
       const v2Class = getClassNameMapping('select-authenticator-authenticate', null, null);
       expect(v2Class).toEqual(['select-authenticator-authenticate']);
 
@@ -34,7 +34,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual(null);
     });
 
-    it('for select-authenticator-authenticate form with password', function () {
+    it('for select-authenticator-authenticate form with password', function() {
       const v2Class = getClassNameMapping('select-authenticator-authenticate', 'okta_password', null);
       expect(v2Class).toEqual(['select-authenticator-authenticate--okta_password', 'forgot-password']);
 
@@ -42,7 +42,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('forgot-password');
     });
 
-    it('for select-authenticator-enroll form', function () {
+    it('for select-authenticator-enroll form', function() {
       const v2Class = getClassNameMapping('select-authenticator-enroll', null, null);
       expect(v2Class).toEqual(['select-authenticator-enroll', 'enroll-choices']);
 
@@ -50,7 +50,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-choices');
     });
 
-    it('for challenge-authenticator form with email', function () {
+    it('for challenge-authenticator form with email', function() {
       const v2Class = getClassNameMapping('challenge-authenticator', 'okta_email', null);
       expect(v2Class).toEqual(['challenge-authenticator--okta_email', 'mfa-verify-passcode']);
 
@@ -58,7 +58,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('mfa-verify-passcode');
     });
 
-    it('for challenge-authenticator form with security_question', function () {
+    it('for challenge-authenticator form with security_question', function() {
       const v2Class = getClassNameMapping('challenge-authenticator', 'security_question', null);
       expect(v2Class).toEqual(['challenge-authenticator--security_question', 'mfa-verify-question']);
 
@@ -66,7 +66,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('mfa-verify-question');
     });
 
-    it('for enroll-authenticator form with security_question', function () {
+    it('for enroll-authenticator form with security_question', function() {
       const v2Class = getClassNameMapping('enroll-authenticator', 'security_question', null);
       expect(v2Class).toEqual(['enroll-authenticator--security_question', 'enroll-question']);
 
@@ -74,7 +74,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-question');
     });
 
-    it('for enroll-authenticator form with email', function () {
+    it('for enroll-authenticator form with email', function() {
       const v2Class = getClassNameMapping('enroll-authenticator', 'okta_email', null);
       expect(v2Class).toEqual(['enroll-authenticator--okta_email', 'enroll-email']);
 
@@ -82,7 +82,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-email');
     });
 
-    it('for enroll-authenticator form with password', function () {
+    it('for enroll-authenticator form with password', function() {
       const v2Class = getClassNameMapping('enroll-authenticator', 'okta_password', null);
       expect(v2Class).toEqual(['enroll-authenticator--okta_password', 'enroll-password']);
 
@@ -90,7 +90,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-password');
     });
 
-    it('for enroll-authenticator form with sms', function () {
+    it('for enroll-authenticator form with sms', function() {
       const v2Class = getClassNameMapping('enroll-authenticator', 'phone_number', 'sms', null);
       expect(v2Class).toEqual(['enroll-authenticator--phone_number', 'enroll-sms']);
 
@@ -98,7 +98,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-sms');
     });
 
-    it('for enroll-authenticator form with voice', function () {
+    it('for enroll-authenticator form with voice', function() {
       const v2Class = getClassNameMapping('enroll-authenticator', 'phone_number', 'voice', null);
       expect(v2Class).toEqual(['enroll-authenticator--phone_number', 'enroll-call']);
 
@@ -106,7 +106,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('enroll-call');
     });
 
-    it('for reenroll-authenticator form with voice', function () {
+    it('for reenroll-authenticator form with voice', function() {
       const v2Class = getClassNameMapping('reenroll-authenticator', 'okta_password', null);
       expect(v2Class).toEqual(['reenroll-authenticator--okta_password', 'password-expired']);
 
@@ -114,7 +114,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('password-expired');
     });
 
-    it('for reset-authenticator form with voice', function () {
+    it('for reset-authenticator form with voice', function() {
       const v2Class = getClassNameMapping('reset-authenticator', 'okta_password', null);
       expect(v2Class).toEqual(['reset-authenticator--okta_password', 'forgot-password']);
 
@@ -122,7 +122,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual('forgot-password');
     });
 
-    it('for success form', function () {
+    it('for success form', function() {
       const v2Class = getClassNameMapping('success-redirect', null, null);
       expect(v2Class).toEqual(['success-redirect']);
 
@@ -130,7 +130,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual(null);
     });
 
-    it('for terminal form', function () {
+    it('for terminal form', function() {
       const v2Class = getClassNameMapping('terminal', null, null);
       expect(v2Class).toEqual(['terminal']);
 
@@ -138,7 +138,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual(null);
     });
 
-    it('for authenticator-verification-data form wih email method sms', function () {
+    it('for authenticator-verification-data form wih email method sms', function() {
       const v2Class = getClassNameMapping('authenticator-verification-data', 'phone_number', 'sms');
       expect(v2Class).toEqual(['authenticator-verification-data--phone_number']);
 
@@ -146,7 +146,7 @@ describe('v1/ion/ViewClassNamesFactory', function () {
       expect(v1Class).toEqual(null);
     });
 
-    it('for authenticator-verification-data form wih email method voice', function () {
+    it('for authenticator-verification-data form wih email method voice', function() {
       const v2Class = getClassNameMapping('authenticator-verification-data', 'phone_number', 'voice');
       expect(v2Class).toEqual(['authenticator-verification-data--phone_number']);
 

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -3,7 +3,7 @@ import i18nTransformer from 'v2/ion/i18nTransformer';
 import { getMessageKey, getI18NParams } from 'v2/ion/i18nTransformer';
 import Bundles from 'util/Bundles';
 
-describe('v2/ion/i18nTransformer', function () {
+describe('v2/ion/i18nTransformer', function() {
   let originalLoginBundle;
 
   beforeAll(() => {

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -16,7 +16,7 @@ import XHRIdentifyWithThirdPartyIdps
   from '../../../../../playground/mocks/data/idp/idx/identify-with-third-party-idps.json';
 import XHRIdentifyButUnknownUser from '../../../../../playground/mocks/data/idp/idx/identify-unknown-user.json';
 
-describe('v2/ion/responseTransformer', function () {
+describe('v2/ion/responseTransformer', function() {
   let idps = [
     {
       type: 'FACEBOOK',

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -13,7 +13,7 @@ import XHRAuthenticatorEnrollOktaVerifyQr from '../../../../../playground/mocks/
 import XHRIdentifyResponse from '../../../../../playground/mocks/data/idp/idx/identify.json';
 import XHRIdentifyWithPasswordResponse from '../../../../../playground/mocks/data/idp/idx/identify-with-password.json';
 
-describe('v2/ion/uiSchemaTransformer', function () {
+describe('v2/ion/uiSchemaTransformer', function() {
   let testContext;
 
   beforeEach(() => {

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -1,7 +1,7 @@
 import AppState from 'v2/models/AppState';
 import { FORMS_WITHOUT_SIGNOUT, FORMS_FOR_VERIFICATION, FORMS } from 'v2/ion/RemediationConstants';
 
-describe('v2/models/AppState', function () {
+describe('v2/models/AppState', function() {
   beforeEach(() => {
     this.initAppState = (idxObj, currentFormName) => {
       const appStateData = idxObj || { idx: { actions: {} } };

--- a/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
@@ -3,7 +3,7 @@ import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
 import Link from 'v2/view-builder/components/Link';
 
-describe('v2/view-builder/internals/BaseFooter', function () {
+describe('v2/view-builder/internals/BaseFooter', function() {
   let testContext;
 
   const renderFooter = (links, shouldShowSignOutLink) => {
@@ -30,19 +30,19 @@ describe('v2/view-builder/internals/BaseFooter', function () {
     };
   });
 
-  it('adds nothing when links function return undefined', function () {
+  it('adds nothing when links function return undefined', function() {
     const fooFooter = renderFooter(() => {}, false);
 
     expect(fooFooter.add).not.toHaveBeenCalled();
   });
-  it('adds nothing when links function return empty array', function () {
+  it('adds nothing when links function return empty array', function() {
     const fooFooter = renderFooter(() => {
       return [];
     }, false);
 
     expect(fooFooter.add).not.toHaveBeenCalled();
   });
-  it('adds nothing when empty links array', function () {
+  it('adds nothing when empty links array', function() {
     const fooFooter = renderFooter([], false);
 
     expect(fooFooter.add).not.toHaveBeenCalled();

--- a/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
@@ -1,13 +1,13 @@
 import { BaseModel } from 'v2/view-builder/internals';
 
-describe('v2/view-builder/internals/BaseModel', function () {
+describe('v2/view-builder/internals/BaseModel', function() {
   const createModelAndVerifyPropsAndLocal = ({ uiSchema, optionUiSchemaConfig }, props, local = {}) => {
     const result = BaseModel.create({ uiSchema }, optionUiSchemaConfig);
     expect(result.prototype.props).toEqual(props);
     expect(result.prototype.local).toEqual(Object.assign({ formName: 'string' }, local));
   };
 
-  it('shall create Model - passcode', function () {
+  it('shall create Model - passcode', function() {
     const uiSchema = [
       {
         name: 'credentials.passcode',
@@ -29,7 +29,7 @@ describe('v2/view-builder/internals/BaseModel', function () {
     );
   });
 
-  it('shall create Model - profile enroll', function () {
+  it('shall create Model - profile enroll', function() {
     const uiSchema = [
       {
         name: 'userProfile.lastName',
@@ -64,7 +64,7 @@ describe('v2/view-builder/internals/BaseModel', function () {
     );
   });
 
-  it('shall create Model - identify', function () {
+  it('shall create Model - identify', function() {
     const uiSchema = [
       {
         name: 'identifier',
@@ -92,7 +92,7 @@ describe('v2/view-builder/internals/BaseModel', function () {
     );
   });
 
-  it('shall create Model - enroll phone', function () {
+  it('shall create Model - enroll phone', function() {
     const uiSchema = [
       {
         name: 'authenticator.id',
@@ -137,7 +137,7 @@ describe('v2/view-builder/internals/BaseModel', function () {
     );
   });
 
-  it('shall create Model - enroll security question', function () {
+  it('shall create Model - enroll security question', function() {
     const uiSchema = [
       {
         name: 'sub_schema_local_credentials',
@@ -245,7 +245,7 @@ describe('v2/view-builder/internals/BaseModel', function () {
     );
   });
 
-  it('shall create Model - authenticator list', function () {
+  it('shall create Model - authenticator list', function() {
     const uiSchema = [
       {
         name: 'authenticator',

--- a/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
@@ -3,8 +3,8 @@ import FormInputFactory from 'v2/view-builder/internals/FormInputFactory';
 import AuthenticatorVerifyOptions from 'v2/view-builder/components/AuthenticatorVerifyOptions';
 import AuthenticatorEnrollOptions from 'v2/view-builder/components/AuthenticatorEnrollOptions';
 
-describe('v2/view-builder/internals/FormInputFactory', function () {
-  it('handles authenticatorVerify Select type', function () {
+describe('v2/view-builder/internals/FormInputFactory', function() {
+  it('handles authenticatorVerify Select type', function() {
     const input = {
       name: 'authenticator',
       type: 'authenticatorVerifySelect',
@@ -325,7 +325,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
     expect(opt).toEqual(input);
   });
 
-  it('filters additional webauthn enrollments for authenticatorVerify Select type', function () {
+  it('filters additional webauthn enrollments for authenticatorVerify Select type', function() {
     const opt = {
       type: 'authenticatorVerifySelect',
       options: [
@@ -414,7 +414,7 @@ describe('v2/view-builder/internals/FormInputFactory', function () {
     });
   });
 
-  it('handles authenticatorEnrollSelect type', function () {
+  it('handles authenticatorEnrollSelect type', function() {
     // Create a copy of input object.
     const input = {
       name: 'authenticator',

--- a/test/unit/spec/v2/view-builder/utils/AuthenticatorUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/AuthenticatorUtil_spec.js
@@ -1,7 +1,7 @@
 import { removeRequirementsFromError, getAuthenticatorDisplayName } from 'v2/view-builder/utils/AuthenticatorUtil';
 
-describe('v2/utils/AuthenticatorUtil', function () {
-  it('filters requirements from password error', function () {
+describe('v2/utils/AuthenticatorUtil', function() {
+  it('filters requirements from password error', function() {
     const policy = {
       'complexity': {
         'minLength': 8,
@@ -45,7 +45,7 @@ describe('v2/utils/AuthenticatorUtil', function () {
     });
   });
 
-  it('does not change anything if there are no requirements in error message', function () {
+  it('does not change anything if there are no requirements in error message', function() {
     const policy = {
       'complexity': {
         'minLength': 8,
@@ -89,7 +89,7 @@ describe('v2/utils/AuthenticatorUtil', function () {
     });
   });
 
-  it('getAuthenticatorDisplayName returns displayName from remediation', function () {
+  it('getAuthenticatorDisplayName returns displayName from remediation', function() {
     const remediation = {
       'relatesTo': {
         'value': {

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -10,9 +10,9 @@ import Expect from 'helpers/util/Expect';
 import ChallengeWebauthnResponse
   from '../../../../../../playground/mocks/data/idp/idx/authenticator-verification-webauthn.json';
 
-describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
+describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
   let testContext;
-  beforeEach(function () {
+  beforeEach(function() {
     testContext = {};
     testContext.init = (
       currentAuthenticatorEnrollment = ChallengeWebauthnResponse.currentAuthenticatorEnrollment.value,
@@ -43,11 +43,11 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     };
   });
 
-  afterEach(function () {
+  afterEach(function() {
     $sandbox.empty();
   });
 
-  it('shows verify instructions and spinner when webauthn is supported and browser is not safari', function () {
+  it('shows verify instructions and spinner when webauthn is supported and browser is not safari', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isSafari').and.callFake(() => false);
     testContext.init();
@@ -60,7 +60,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
 
   });
 
-  it('shows verify instructions and button when browser supports webauthn on safari', function () {
+  it('shows verify instructions and button when browser supports webauthn on safari', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
     testContext.init();
@@ -72,7 +72,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(testContext.view.$('.webauthn-not-supported').length).toBe(0);
   });
 
-  it('updated button text to "Retry" on click on safari', function () {
+  it('updated button text to "Retry" on click on safari', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
     testContext.init();
@@ -86,7 +86,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(testContext.view.$('.retry-webauthn').text()).toBe('Retry');
   });
 
-  it('shows verify instructions if there are existing enrollments', function () {
+  it('shows verify instructions if there are existing enrollments', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isSafari').and.callFake(() => true);
     testContext.init(
@@ -101,7 +101,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(testContext.view.$('.webauthn-not-supported').length).toBe(0);
   });
 
-  it('shows error when browser does not support webauthn', function () {
+  it('shows error when browser does not support webauthn', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => false);
     testContext.init();
     expect(testContext.view.$('.idx-webauthn-verify-text').length).toBe(0);
@@ -113,7 +113,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     );
   });
 
-  it('shows UV required callout when userVerification is "required"', function () {
+  it('shows UV required callout when userVerification is "required"', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     const currentAuthenticatorEnrollment = JSON.parse(
       JSON.stringify(ChallengeWebauthnResponse.currentAuthenticatorEnrollment.value)
@@ -126,7 +126,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     );
   });
 
-  it('does not show UV required callout when userVerification is "discouraged"', function () {
+  it('does not show UV required callout when userVerification is "discouraged"', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     const currentAuthenticatorEnrollment = JSON.parse(
       JSON.stringify(ChallengeWebauthnResponse.currentAuthenticatorEnrollment.value)
@@ -136,7 +136,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
     expect(testContext.view.$('.uv-required-callout').length).toBe(0);
   });
 
-  it('saveForm is called with model when credentials.get succeeds', function (done) {
+  it('saveForm is called with model when credentials.get succeeds', function(done) {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     const assertion = {
       response: {
@@ -189,7 +189,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function () {
       .catch(done.fail);
   });
 
-  it('error is displayed when credentials.get fails', function (done) {
+  it('error is displayed when credentials.get fails', function(done) {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(navigator.credentials, 'get').and.returnValue(Promise.reject({ message: 'error from browser' }));
     testContext.init();

--- a/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
@@ -5,9 +5,9 @@ import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import xhrAuthenticatorEnrollOktaVerifyQr from '../../../../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
 
-describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function () {
+describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
   let testContext;
-  beforeEach(function () {
+  beforeEach(function() {
     testContext = {};
     testContext.init = (currentAuthenticator = xhrAuthenticatorEnrollOktaVerifyQr.currentAuthenticator.value) => {
       const currentViewState = {
@@ -32,11 +32,11 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function () {
     };
   });
 
-  afterEach(function () {
+  afterEach(function() {
     $sandbox.empty();
   });
 
-  it('triggers switchForm on appState when on ios device to select channel', function () {
+  it('triggers switchForm on appState when on ios device to select channel', function() {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => false);
     testContext.init();
@@ -45,7 +45,7 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function () {
     expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
   });
 
-  it('triggers switchForm on appState when on android device to select channel', function () {
+  it('triggers switchForm on appState when on android device to select channel', function() {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => false);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => true);
     testContext.init();
@@ -53,7 +53,7 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function () {
     expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
   });
 
-  it('renders QR code view when on desktop', function () {
+  it('renders QR code view when on desktop', function() {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => false);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => false);
     testContext.init();

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -9,9 +9,9 @@ import BrowserFeatures from 'util/BrowserFeatures';
 import Expect from 'helpers/util/Expect';
 import EnrollWebauthnResponse from '../../../../../../playground/mocks/data/idp/idx/authenticator-enroll-webauthn.json';
 
-describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
+describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
   let testContext;
-  beforeEach(function () {
+  beforeEach(function() {
     testContext = {};
     testContext.init = (
       currentAuthenticator = EnrollWebauthnResponse.currentAuthenticator.value,
@@ -40,11 +40,11 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     };
   });
 
-  afterEach(function () {
+  afterEach(function() {
     $sandbox.empty();
   });
 
-  it('shows enroll instructions and setup button when browser supports webauthn', function () {
+  it('shows enroll instructions and setup button when browser supports webauthn', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     testContext.init();
     expect(testContext.view.$('.idx-webauthn-enroll-text').text()).toBe(
@@ -56,7 +56,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     expect(testContext.view.$('.webauthn-not-supported').length).toBe(0);
   });
 
-  it('shows error when browser does not support webauthn', function () {
+  it('shows error when browser does not support webauthn', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => false);
     testContext.init();
     expect(testContext.view.$('.idx-webauthn-enroll-text').length).toBe(0);
@@ -66,7 +66,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     );
   });
 
-  it('shows additional enroll instructions for edge when browser is edge', function () {
+  it('shows additional enroll instructions for edge when browser is edge', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isEdge').and.callFake(() => true);
     testContext.init();
@@ -77,7 +77,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     expect(testContext.view.$('.webauthn-setup').length).toBe(1);
   });
 
-  it('shows UV required callout when userVerification is "required"', function () {
+  it('shows UV required callout when userVerification is "required"', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     const currentAuthenticator = JSON.parse(JSON.stringify(EnrollWebauthnResponse.currentAuthenticator.value));
     currentAuthenticator.contextualData.activationData.authenticatorSelection.userVerification = 'required';
@@ -88,7 +88,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     );
   });
 
-  it('does not show UV required callout when userVerification is "discouraged"', function () {
+  it('does not show UV required callout when userVerification is "discouraged"', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     const currentAuthenticator = JSON.parse(JSON.stringify(EnrollWebauthnResponse.currentAuthenticator.value));
     currentAuthenticator.contextualData.activationData.authenticatorSelection.userVerification = 'discouraged';
@@ -96,7 +96,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     expect(testContext.view.$('.uv-required-callout').length).toBe(0);
   });
 
-  it('click on setup hides the setup button and shows spinner', function () {
+  it('click on setup hides the setup button and shows spinner', function() {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     testContext.init();
     testContext.view.$('.webauthn-setup').click();
@@ -104,7 +104,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
     expect(testContext.view.$('.okta-waiting-spinner').css('display')).toBe('block');
   });
 
-  it('saveForm is called when credentials.get succeeds', function (done) {
+  it('saveForm is called when credentials.get succeeds', function(done) {
     const newCredential = {
       response: {
         clientDataJSON: 123,
@@ -177,7 +177,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function () {
       .catch(done.fail);
   });
 
-  it('error is displayed when credentials.create fails', function (done) {
+  it('error is displayed when credentials.create fails', function(done) {
     spyOn(webauthn, 'isNewApiAvailable').and.callFake(() => true);
     spyOn(navigator.credentials, 'create').and.returnValue(Promise.reject({ message: 'error from browser' }));
 

--- a/test/unit/spec/webauthn_spec.js
+++ b/test/unit/spec/webauthn_spec.js
@@ -2,10 +2,10 @@ import Expect from 'helpers/util/Expect';
 import Q from 'q';
 import webauthn from 'util/webauthn';
 
-Expect.describe('webauthn', function () {
-  function setupMsCredentials () {
+Expect.describe('webauthn', function() {
+  function setupMsCredentials() {
     window.msCredentials = {
-      makeCredential: function () /*accountInfo, cryptoParams, challenge*/ {
+      makeCredential: function() /*accountInfo, cryptoParams, challenge*/ {
         const result = Q.defer();
 
         result.resolve({
@@ -17,7 +17,7 @@ Expect.describe('webauthn', function () {
         return result.promise;
       },
 
-      getAssertion: function () /*challenge, filters*/ {
+      getAssertion: function() /*challenge, filters*/ {
         const result = Q.defer();
 
         result.resolve({
@@ -37,20 +37,20 @@ Expect.describe('webauthn', function () {
     spyOn(window.msCredentials, 'getAssertion').and.callThrough();
   }
 
-  afterEach(function () {
+  afterEach(function() {
     delete window.msCredentials;
   });
 
-  it('isAvailable returns false if window.msCredentials is undefined', function () {
+  it('isAvailable returns false if window.msCredentials is undefined', function() {
     expect(webauthn.isAvailable()).toBe(false);
   });
 
-  it('isAvailable returns true if window.msCredentials is not undefined', function () {
+  it('isAvailable returns true if window.msCredentials is not undefined', function() {
     setupMsCredentials();
     expect(webauthn.isAvailable()).toBe(true);
   });
 
-  it('msCredentials.makeCredential was called with correct parameters', function () {
+  it('msCredentials.makeCredential was called with correct parameters', function() {
     setupMsCredentials();
 
     webauthn.makeCredential({ userId: 'SomeUserId' }, [{ algorithm: 'RSASSA-PKCS1-v1_5' }]);
@@ -61,7 +61,7 @@ Expect.describe('webauthn', function () {
     );
   });
 
-  it('msCredentials.getAssertion was called with correct parameters', function () {
+  it('msCredentials.getAssertion was called with correct parameters', function() {
     setupMsCredentials();
 
     webauthn.getAssertion('SomeChallenge', [{ id: 'msCredentials_ID' }]);

--- a/test/unit/spec/widget/buildRenderOptions_spec.js
+++ b/test/unit/spec/widget/buildRenderOptions_spec.js
@@ -2,7 +2,7 @@ import buildRenderOptions from 'widget/buildRenderOptions';
 
 describe('widget/buildRenderOptions', () => {
 
-  function callBuildRenderOptions () {
+  function callBuildRenderOptions() {
     return buildRenderOptions.apply(null, arguments);
   }
 

--- a/test/unit/spec/widget/createRouter_spec.js
+++ b/test/unit/spec/widget/createRouter_spec.js
@@ -3,7 +3,7 @@ import createRouter from 'widget/createRouter';
 describe('widget/createRouter', () => {
   let MockRouter;
   beforeEach(() => {
-    MockRouter = function () {};
+    MockRouter = function() {};
     Object.assign(MockRouter.prototype, {
       start: jest.fn()
     });

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -6,7 +6,7 @@ var TARGET_JS = path.resolve(__dirname, 'target/js/');
 var LOCAL_PACKAGES = path.resolve(__dirname, 'packages/');
 
 // Return a function so that all consumers get a new copy of the config
-module.exports = function (outputFilename) {
+module.exports = function(outputFilename) {
   return {
     entry: [`${SRC}/widget/OktaSignIn.js`],
     devtool: 'source-map',
@@ -41,7 +41,7 @@ module.exports = function (outputFilename) {
         // Babel
         {
           test: /\.js$/,
-          exclude: function (filePath) {
+          exclude: function(filePath) {
             const filePathContains = (f) => filePath.indexOf(f) > 0;
             const npmRequiresTransform = [
               '/node_modules/parse-ms',

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -74,7 +74,7 @@ module.exports = {
       ],
       target: `http://localhost:${MOCK_SERVER_PORT}`
     }],
-    before () {
+    before() {
       const script = path.resolve(
         __dirname,
         'playground',


### PR DESCRIPTION
## Description:

The key change is in the root `.eslintrc` then run `yarn eslint . --fix`

```
'space-before-function-paren': [2, {
       'anonymous': 'never',
       'named': 'never',
       'asyncArrow': 'always'
     }],
```

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- OKTA-381970


