### PR TITLE
Implement route for loading register page

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -927,6 +927,7 @@ oie.selfservice.unlock_user.success.message = You can log in using your existing
 
 ## Terminal errors
 oie.session.expired = The session has expired.
+oie.registeration.is.not.enabled = Sign up is not enabled for this organization.
 
 ## OIE Server-side errors
 api.authn.error.PASSCODE_INVALID = Invalid code. Try again.

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,19 +1,15 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>Okta Sign-in Widget Playground</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/css/okta-sign-in.css" type="text/css" rel="stylesheet" />
+  </head>
 
-<head>
-  <title>Okta Sign-in Widget Playground</title>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link href="css/okta-sign-in.css" type="text/css" rel="stylesheet"/>
-</head>
-
-<body>
-  <div id="okta-login-container"></div>
-
-  <script src="js/okta-sign-in.js"></script>
-
-  <script src="playground.bundle.js"></script>
-</body>
-
+  <body>
+    <div id="okta-login-container"></div>
+    <script src="/js/okta-sign-in.js"></script>
+    <script src="/playground.bundle.js"></script>
+  </body>
 </html>

--- a/playground/mocks/data/idp/idx/enroll-profile-new.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new.json
@@ -8,9 +8,7 @@
     "type": "array",
     "value": [
       {
-        "rel": [
-          "create-form"
-        ],
+        "rel": ["create-form"],
         "name": "enroll-profile",
         "href": "http://localhost:3000/idp/idx/enroll/new",
         "method": "POST",
@@ -46,11 +44,9 @@
         ]
       },
       {
-        "rel": [
-          "create-form"
-        ],
+        "rel": ["create-form"],
         "name": "select-identify",
-        "href": "http://localhost:3000/idp/idx",
+        "href": "http://localhost:3000/idp/idx/identify",
         "method": "POST",
         "accepts": "application/vnd.okta.v1+json",
         "value": [
@@ -68,9 +64,7 @@
     ]
   },
   "context": {
-    "rel": [
-      "create-form"
-    ],
+    "rel": ["create-form"],
     "name": "context",
     "href": "http://localhost:3000/idp/idx/context",
     "method": "POST",

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -16,6 +16,7 @@
 import { _, $, Backbone, Router, loc } from 'okta';
 import Settings from 'models/Settings';
 import Bundles from 'util/Bundles';
+import BrowserFeatures from 'util/BrowserFeatures';
 import ColorsUtil from 'util/ColorsUtil';
 import Enums from 'util/Enums';
 import Errors from 'util/Errors';
@@ -41,7 +42,7 @@ export default Router.extend({
     // Create a default success and/or error handler if
     // one is not provided.
     if (!options.globalSuccessFn) {
-      options.globalSuccessFn = function() {};
+      options.globalSuccessFn = function() { };
     }
     if (!options.globalErrorFn) {
       options.globalErrorFn = function(err) {
@@ -84,7 +85,7 @@ export default Router.extend({
     if (idxResponse.interactionCode) {
       return interactionCodeFlow(this.settings, idxResponse);
     }
-  
+
     // transform response
     const ionResponse = transformIdxResponse(this.settings, idxResponse);
 
@@ -219,6 +220,11 @@ export default Router.extend({
     this.listenTo(this.controller, 'all', this.trigger);
 
     this.controller.render();
+  },
+
+  start: function() {
+    const pushState = BrowserFeatures.supportsPushState();
+    Router.prototype.start.call(this, { pushState: pushState });
   },
 
   hide: function() {

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -105,13 +105,15 @@ export default Router.extend({
       const idxMessages = {
         messages: {
           type: 'array',
-          value: [{
-            message: error.error_description,
-            i18n: {
-              key: 'oie.feature.disabled'
-            },
-            class: 'ERROR'
-          }],
+          value: [
+            {
+              message: error.error_description,
+              i18n: {
+                key: 'oie.feature.disabled'
+              },
+              class: 'ERROR'
+            }
+          ],
         },
       };
 

--- a/src/v2/WidgetRouter.js
+++ b/src/v2/WidgetRouter.js
@@ -10,17 +10,21 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import FormController from './controllers/FormController';
 import BaseLoginRouter from './BaseLoginRouter';
+import FormController from './controllers/FormController';
+import RegistrationFormController from './controllers/RegistrationFormController';
 
 module.exports = BaseLoginRouter.extend({
   routes: {
     '': 'defaultAuth',
+    'signin/register': 'renderRegister',
     '*wildcard': 'defaultAuth',
   },
 
   defaultAuth: function() {
     this.render(FormController);
   },
-
+  renderRegister() {
+    this.render(RegistrationFormController);
+  }
 });

--- a/src/v2/WidgetRouter.js
+++ b/src/v2/WidgetRouter.js
@@ -24,6 +24,11 @@ module.exports = BaseLoginRouter.extend({
   defaultAuth: function() {
     this.render(FormController);
   },
+
+  /**
+   * In order to support rendering Registration form
+   * directly when navigate to '/signin/register'.
+   */
   renderRegister() {
     this.render(RegistrationFormController);
   }

--- a/src/v2/controllers/RegistrationFormController.js
+++ b/src/v2/controllers/RegistrationFormController.js
@@ -13,18 +13,26 @@
 import FormController from './FormController';
 import { FORMS } from '../ion/RemediationConstants';
 
+/**
+ * Render Registration Form (a.k.a profile enroll) immediately as long as
+ * the remediation form is available and default remediation is Identify.
+ * Otherwise show error messages that feature is not supported.
+ *
+ */
 export default FormController.extend({
+
+  // TODO: what if user navigate to this page but there is valid state token in session storage?
+  // The flow is like
+  // 1. User tries to sign-in
+  // 2. During the middle of sign-in, change URL to /signin/register/
+  //
+  // User probably expects to see sign-up page
+  // But user will continue sign-in flow due to the saved state token
   postRender() {
-    // TODO: what if user navigate to this page but there is valid state token in session storage?
-    // The flow is like
-    // 1. User tries to sign-in
-    // 2. During the middle of sign-in, change URL to /signin/register/
-    //
-    // User probably expects to see sign-up page
-    // But user will continue sign-in flow due to the saved state token
+    // Auto switch to porfile enroll (register) page
+    // basically mimic the flow that show identify page and click sign-up link.
+    // Or show error messages.
     if (this.options.appState.get('currentFormName') === FORMS.IDENTIFY) {
-      // 1. auto switch to porfile enroll (register) page
-      // basically mimic the flow that show identify page and click sign-up link.
       if (this.options.appState.hasRemediationObject(FORMS.SELECT_ENROLL_PROFILE)) {
         this.handleInvokeAction(FORMS.SELECT_ENROLL_PROFILE);
       } else {

--- a/src/v2/controllers/RegistrationFormController.js
+++ b/src/v2/controllers/RegistrationFormController.js
@@ -12,6 +12,7 @@
 
 import FormController from './FormController';
 import { FORMS } from '../ion/RemediationConstants';
+import { REGISTRATION_NOT_ENABLED } from '../view-builder/views/TerminalView';
 
 /**
  * Render Registration Form (a.k.a profile enroll) immediately as long as
@@ -40,9 +41,9 @@ export default FormController.extend({
           type: 'array',
           value: [
             {
-              message: 'The requested feature is not enabled in this environment.',
+              message: 'Sign up is not enabled for this organization.',
               i18n: {
-                key: 'oie.feature.disabled'
+                key: REGISTRATION_NOT_ENABLED,
               },
               class: 'ERROR',
             }

--- a/src/v2/controllers/RegistrationFormController.js
+++ b/src/v2/controllers/RegistrationFormController.js
@@ -15,12 +15,13 @@ import { FORMS } from '../ion/RemediationConstants';
 
 export default FormController.extend({
   postRender() {
-    // TODO: what if user navigate to this page but there is valid state token
-    // in session storage
-    // - try to sign-in
-    // - during at middle of sign-in, change URL to /signin/register/
-    // user probably expects to see sign-up page
-    // actually widget will continue show sign-in flow (because of the saved state token)
+    // TODO: what if user navigate to this page but there is valid state token in session storage?
+    // The flow is like
+    // 1. User tries to sign-in
+    // 2. During the middle of sign-in, change URL to /signin/register/
+    //
+    // User probably expects to see sign-up page
+    // But user will continue sign-in flow due to the saved state token
     if (this.options.appState.get('currentFormName') === FORMS.IDENTIFY) {
       // 1. auto switch to porfile enroll (register) page
       // basically mimic the flow that show identify page and click sign-up link.
@@ -28,10 +29,13 @@ export default FormController.extend({
         this.handleInvokeAction(FORMS.SELECT_ENROLL_PROFILE);
       } else {
         const messages = {
-          'type': 'array',
+          type: 'array',
           value: [
             {
-              message: 'registration is not supported',
+              message: 'The requested feature is not enabled in this environment.',
+              i18n: {
+                key: 'oie.feature.disabled'
+              },
               class: 'ERROR',
             }
           ]
@@ -47,7 +51,6 @@ export default FormController.extend({
             messages
           }
         };
-        // this.options.appState.setIonResponse(resp);
         this.options.appState.trigger('remediationSuccess', resp);
       }
     } else {

--- a/src/v2/controllers/RegistrationFormController.js
+++ b/src/v2/controllers/RegistrationFormController.js
@@ -45,10 +45,10 @@ export default FormController.extend({
           neededToProceed: [],
           // OKTA-382410 so bad that has to leverage rawIdxState
           rawIdxState: {
-            messages
+            messages,
           },
           context: {
-            messages
+            messages,
           }
         };
         this.options.appState.trigger('remediationSuccess', resp);

--- a/src/v2/controllers/RegistrationFormController.js
+++ b/src/v2/controllers/RegistrationFormController.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2020, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import FormController from './FormController';
+import { FORMS } from '../ion/RemediationConstants';
+
+export default FormController.extend({
+  postRender() {
+    // TODO: what if user navigate to this page but there is valid state token
+    // in session storage
+    // - try to sign-in
+    // - during at middle of sign-in, change URL to /signin/register/
+    // user probably expects to see sign-up page
+    // actually widget will continue show sign-in flow (because of the saved state token)
+    if (this.options.appState.get('currentFormName') === FORMS.IDENTIFY) {
+      // 1. auto switch to porfile enroll (register) page
+      // basically mimic the flow that show identify page and click sign-up link.
+      if (this.options.appState.hasRemediationObject(FORMS.SELECT_ENROLL_PROFILE)) {
+        this.handleInvokeAction(FORMS.SELECT_ENROLL_PROFILE);
+      } else {
+        const messages = {
+          'type': 'array',
+          value: [
+            {
+              message: 'registration is not supported',
+              class: 'ERROR',
+            }
+          ]
+        };
+
+        const resp = {
+          neededToProceed: [],
+          // OKTA-382410 so bad that has to leverage rawIdxState
+          rawIdxState: {
+            messages
+          },
+          context: {
+            messages
+          }
+        };
+        // this.options.appState.setIonResponse(resp);
+        this.options.appState.trigger('remediationSuccess', resp);
+      }
+    } else {
+      // otherwise behavior as default FormController to handle remediations.
+      FormController.prototype.postRender.apply(this, arguments);
+    }
+  }
+});

--- a/src/v2/view-builder/internals/FormInputFactory.js
+++ b/src/v2/view-builder/internals/FormInputFactory.js
@@ -2,7 +2,7 @@ import { Collection, _, loc, createButton } from 'okta';
 
 import AuthenticatorEnrollOptions from '../components/AuthenticatorEnrollOptions';
 import AuthenticatorVerifyOptions from '../components/AuthenticatorVerifyOptions';
-import { getAuthenticatorDataForEnroll, getAuthenticatorDataForVerification} from '../utils/AuthenticatorUtil';
+import { getAuthenticatorDataForEnroll, getAuthenticatorDataForVerification } from '../utils/AuthenticatorUtil';
 import { AUTHENTICATOR_KEY, FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import IDP from '../../../util/IDP';
 import AdminScopeList from '../../../views/admin-consent/ScopeList';
@@ -137,7 +137,7 @@ const createCustomButtons = (settings) => {
       attributes: {
         'data-se': customButton.dataAttr
       },
-      className: customButton.className  + ' default-custom-button',
+      className: customButton.className + ' default-custom-button',
       title: customButton.title,
       click: customButton.click
     };

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -124,7 +124,8 @@ const getBackToSignInLink = (settings) => {
       'type': 'link',
       'label': loc('backToSignin', 'login'),
       'name': 'go-back',
-      'href': baseUrl + '/login/login.htm'
+      // TODO: OKTA-381328 back to baseUrl only works for default login page
+      'href': baseUrl,
     },
   ];
 };

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -8,6 +8,7 @@ import { AUTHENTICATOR_KEY } from '../../ion/RemediationConstants';
 const RETURN_LINK_EXPIRED_KEY = 'idx.return.link.expired';
 const SAFE_MODE_KEY_PREFIX = 'idx.error.server.safe.mode';
 const UNLOCK_ACCOUNT_TERMINAL_KEY = 'oie.selfservice.unlock_user.success.message';
+export const REGISTRATION_NOT_ENABLED = 'oie.registeration.is.not.enabled';
 
 const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
   'idx.transferred.to.new.tab',
@@ -20,6 +21,7 @@ const EMAIL_AUTHENTICATOR_TERMINAL_KEYS = [
 
 const GET_BACK_TO_SIGN_LINK_FLOWS = [
   RETURN_LINK_EXPIRED_KEY,
+  REGISTRATION_NOT_ENABLED,
 ];
 
 const HeaderBeaconTerminal = HeaderBeacon.extend({

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -1,5 +1,5 @@
 import BaseFormObject from './components/BaseFormObject';
-import { Selector } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
 
 const SIGNOUT_LINK = '.auth-footer .js-cancel';
 const GO_BACK_LINK = '.auth-footer .js-go-back';
@@ -17,6 +17,11 @@ export default class BasePageObject {
 
   async navigateToPage() {
     await this.t.navigateTo(`http://localhost:3000${this.url}`);
+  }
+
+  async getPageUrl() {
+    const pageUrl = await ClientFunction(() => window.location.href)();
+    return pageUrl;
   }
 
   getFormTitle() {

--- a/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/IdPAuthenticatorPageObject.js
@@ -1,14 +1,8 @@
-import { ClientFunction } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class IdPAuthenticatorPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-  }
-
-  async getPageUrl() {
-    const pageUrl = await ClientFunction(() => window.location.href)();
-    return pageUrl;
   }
 
   getPageTitle() {

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -1,4 +1,4 @@
-import { Selector, ClientFunction } from 'testcafe';
+import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 const CALLOUT_SELECTOR = '.infobox-warning > div';
@@ -16,12 +16,6 @@ const SUB_LABEL_SELECTOR = '.o-form-explain';
 export default class IdentityPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-  }
-
-  async getPageUrl() {
-
-    const pageUrl = await ClientFunction(() => window.location.href)();
-    return pageUrl;
   }
 
   getPageTitle() {
@@ -101,7 +95,7 @@ export default class IdentityPageObject extends BasePageObject {
     return this.form.getErrorBoxText();
   }
 
-  waitForIdentifierError(){
+  waitForIdentifierError() {
     return this.form.waitForTextBoxError('identifier');
   }
 

--- a/test/testcafe/framework/page-objects/RegistrationPageObject.js
+++ b/test/testcafe/framework/page-objects/RegistrationPageObject.js
@@ -8,6 +8,7 @@ const EMAIL_FIELD = 'userProfile\\.email';
 export default class RegistrationPageObject extends BasePageObject {
   constructor(t) {
     super(t);
+    this.url = '/signin/register';
   }
 
   fillFirstNameField(value) {

--- a/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/SymantecAuthenticatorPageObject.js
@@ -1,14 +1,8 @@
-import { ClientFunction } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
 export default class SymantecAuthenticatorPageObject extends BasePageObject {
   constructor(t) {
     super(t);
-  }
-
-  async getPageUrl() {
-    const pageUrl = await ClientFunction(() => window.location.href)();
-    return pageUrl;
   }
 
   verifyFactor(name, value) {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 
 const TERMINAL_CONTENT = '.o-form-error-container .ion-messages-container';
-const FORM_INFOBOX_ERROR = '.o-form-error-container .infobox-error';
+const FORM_INFOBOX_ERROR = '[data-se="o-form-error-container"] .infobox-error';
 
 const SUBMIT_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="save"]';
 const CANCEL_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="cancel"]';

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -1,7 +1,7 @@
 import { Selector, ClientFunction } from 'testcafe';
 
 const TERMINAL_CONTENT = '.o-form-error-container .ion-messages-container';
-const FORM_INFOBOX_ERROR = '.okta-form-infobox-error';
+const FORM_INFOBOX_ERROR = '.o-form-error-container .infobox-error';
 
 const SUBMIT_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="save"]';
 const CANCEL_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="cancel"]';

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -1,6 +1,7 @@
-import { RequestLogger, RequestMock, ClientFunction, Selector } from 'testcafe';
+import { RequestLogger, RequestMock, Selector } from 'testcafe';
 import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
 import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
+import BasePageObject from '../framework/page-objects/BasePageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import identifyWithUserVerificationLoopback from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-loopback';
@@ -47,7 +48,7 @@ const loopbackFallbackMock = RequestMock()
   .respond(identifyWithUserVerificationCustomURI);
 
 const identifyWithLaunchAuthenticatorHttpCustomUri = JSON.parse(JSON.stringify(identifyWithUserVerificationCustomURI));
-const mockHttpCustomUri = 'http://localhost:3000/launch-okta-verify';
+const mockHttpCustomUri = 'http://localhost:6512/launch-okta-verify';
 // replace custom URI with http URL so that we can mock and verify
 identifyWithLaunchAuthenticatorHttpCustomUri.currentAuthenticator.value.contextualData.challenge.value.href = mockHttpCustomUri;
 
@@ -58,7 +59,9 @@ const customURIMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
   .respond(identifyWithUserVerificationCustomURI)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
-  .respond(identifyWithLaunchAuthenticatorHttpCustomUri);
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri)
+  .onRequestTo(mockHttpCustomUri)
+  .respond('<html><h1>open universal link</h1></html>');
 
 const identifyWithSSOExtensionFallbackWithoutLink = JSON.parse(JSON.stringify(identifyWithSSOExtensionFallback));
 // remove the universal link so that Util.redirect does not open a link and the rest of the flow can be verified
@@ -108,16 +111,16 @@ test
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Sign Out');
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-      record.request.url.match(/introspect|6512/)
+        record.request.url.match(/introspect|6512/)
     )).eql(3);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-      record.request.url.match(/challenge/) &&
-      record.request.body.match(/challengeRequest":"eyJraWQiOiJW/)
+        record.request.url.match(/challenge/) &&
+        record.request.body.match(/challengeRequest":"eyJraWQiOiJW/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 500 &&
-      record.request.url.match(/2000|6511/)
+        record.request.url.match(/2000|6511/)
     )).eql(2);
     probeSuccess = true;
     await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
@@ -144,7 +147,7 @@ test
     await t.expect(content).contains('to launch Okta Verify, or');
     await t.expect(content).contains('download & run Okta Verify.');
     await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().exists).notOk;
+    await t.expect(deviceChallengePollPageObject.getFooterLink().exists).notOk();
     await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Sign Out');
     await deviceChallengePollPageObject.clickSwitchAuthenticatorButton();
@@ -152,7 +155,6 @@ test
     await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
   });
 
-const getPageUrl = ClientFunction(() => window.location.href);
 test
   .requestHooks(customURILogger, customURIMock)('in custom URI approach, Okta Verify is launched', async t => {
     const deviceChallengePollPageObject = await setup(t);
@@ -185,8 +187,8 @@ test
     await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Sign Out');
     deviceChallengePollPageObject.clickUniversalLink();
-    await t.expect(getPageUrl()).contains(mockHttpCustomUri);
     await t.expect(Selector('h1').innerText).eql('open universal link');
+    await t.expect(await (new BasePageObject()).getPageUrl()).contains(mockHttpCustomUri);
   });
 
 test
@@ -199,6 +201,6 @@ test
         record.request.url.match(/introspect/)
     )).eql(1);
     deviceChallengeFalllbackPage.clickOktaVerifyButton();
-    await t.expect(getPageUrl()).contains(mockHttpCustomUri);
     await t.expect(Selector('h1').innerText).eql('open universal link');
+    await t.expect(await (new BasePageObject()).getPageUrl()).contains(mockHttpCustomUri);
   });

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -27,23 +27,27 @@ const loopbackSuccesskMock = RequestMock()
   .onRequestTo(/2000\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6511\/probe/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6511\/challenge/)
   .respond((req, res) => {
     res.statusCode = req.method !== 'POST' ? 204 : 403;
     res.headers = {
       'access-control-allow-origin': '*',
       'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-      'access-control-allow-methods': 'POST, GET, OPTIONS'};
+      'access-control-allow-methods': 'POST, GET, OPTIONS'
+    };
   })
   .onRequestTo(/6512\/probe/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6512\/challenge/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
@@ -58,30 +62,35 @@ const loopbackOVFallbackMock = RequestMock()
   .onRequestTo(/2000\/probe/)
   .respond(null, 500, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6511\/probe/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6511\/challenge/)
   .respond((req, res) => {
     res.statusCode = req.method !== 'POST' ? 204 : 401;
     res.headers = {
       'access-control-allow-origin': '*',
       'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-      'access-control-allow-methods': 'POST, GET, OPTIONS'};
+      'access-control-allow-methods': 'POST, GET, OPTIONS'
+    };
   })
   .onRequestTo(/6512\/probe/)
   .respond(null, 200, {
     'access-control-allow-origin': '*',
-    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'})
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
   .onRequestTo(/6512\/challenge/)
   .respond((req, res) => {
     res.statusCode = req.method !== 'POST' ? 204 : 500;
     res.headers = {
       'access-control-allow-origin': '*',
       'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
-      'access-control-allow-methods': 'POST, GET, OPTIONS'};
+      'access-control-allow-methods': 'POST, GET, OPTIONS'
+    };
   })
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond(identifyWithLaunchAuthenticator)
@@ -102,7 +111,7 @@ const loopbackFallbackMock = RequestMock()
   .respond(identifyWithLaunchAuthenticator);
 
 const identifyWithLaunchAuthenticatorHttpCustomUri = JSON.parse(JSON.stringify(identifyWithLaunchAuthenticator));
-const mockHttpCustomUri = 'http://localhost:3000/launch-okta-verify';
+const mockHttpCustomUri = 'http://localhost:6512/launch-okta-verify';
 // replace custom URI with http URL so that we can mock and verify
 identifyWithLaunchAuthenticatorHttpCustomUri.authenticatorChallenge.value.href = mockHttpCustomUri;
 
@@ -113,7 +122,9 @@ const customURIMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/authenticators\/okta-verify\/launch/)
   .respond(identifyWithLaunchAuthenticator)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
-  .respond(identifyWithLaunchAuthenticatorHttpCustomUri);
+  .respond(identifyWithLaunchAuthenticatorHttpCustomUri)
+  .onRequestTo(/6512\/launch-okta-verify/)
+  .respond('<html><h1>Launch Okta Verify Mock</h1></html>');
 
 const identifyWithSSOExtensionFallbackWithoutLink = JSON.parse(JSON.stringify(identifyWithSSOExtensionFallback));
 // remove the universal link so that Util.redirect does not open a link and the rest of the flow can be verified
@@ -162,29 +173,29 @@ test
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-      record.request.url.match(/introspect/)
+        record.request.url.match(/introspect/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-              record.request.url.match(/6512\/probe/)
+        record.request.url.match(/6512\/probe/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-      record.request.url.match(/6512\/challenge/) &&
-      record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
+        record.request.url.match(/6512\/challenge/) &&
+        record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
     )).eql(1);
     failureCount = 2;
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 500 &&
-      record.request.url.match(/2000/)
+        record.request.url.match(/2000/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 200 &&
-                record.request.url.match(/6511\/probe/)
+        record.request.url.match(/6511\/probe/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 403 &&
-                record.request.url.match(/6511\/challenge/)
+        record.request.url.match(/6511\/challenge/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
 
@@ -284,31 +295,31 @@ test
     setup(t);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 200 &&
-                record.request.url.match(/introspect/)
+        record.request.url.match(/introspect/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 500 &&
-                record.request.url.match(/2000\/probe/)
+        record.request.url.match(/2000\/probe/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 200 &&
-                record.request.url.match(/6511\/probe/)
+        record.request.url.match(/6511\/probe/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 401 &&
-                record.request.url.match(/6511\/challenge/)
+        record.request.url.match(/6511\/challenge/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 200 &&
-                record.request.url.match(/6512\/probe/)
+        record.request.url.match(/6512\/probe/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 500 &&
-                record.request.url.match(/6512\/challenge/)
+        record.request.url.match(/6512\/challenge/)
     )).eql(1);
     await t.expect(loopbackOVFallbackLogger.count(
-      record => record.response.statusCode ===200 &&
-                record.request.url.match(/\/idp\/idx\/authenticators\/poll/)
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/\/idp\/idx\/authenticators\/poll/)
     )).lte(3);
     await t.expect(loopbackOVFallbackLogger.count(
       record => record.response.statusCode === 200 &&

--- a/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
@@ -22,7 +22,7 @@ const logger = RequestLogger(
 );
 
 
-fixture('EnrollProfile');
+fixture('Registration Hooks');
 
 async function setup(t) {
   const registrationPage = new RegistrationPageObject(t);
@@ -38,7 +38,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
   await rerenderWidget({
     registration: {
       parseSchema: function(resp, onSuccess) {
-        resp.find(({name}) => name === 'userProfile.firstName').required = false;
+        resp.find(({ name }) => name === 'userProfile.firstName').required = false;
         onSuccess(resp);
       },
       preSubmit: function(postData, onSuccess) {
@@ -74,7 +74,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
   await t.expect(log.includes('made it to postSubmit email@email.com')).ok();
 });
 
-test.requestHooks(logger, mock)('should call settings.registration hooks onFailure handlers', async t=> {
+test.requestHooks(logger, mock)('should call settings.registration hooks onFailure handlers', async t => {
   logger.clear();
   const registrationPage = await setup(t);
 
@@ -113,7 +113,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onFailu
   await t.expect(logger.requests.length).eql(0);
 });
 
-test.requestHooks(logger, mock)('should call settings.registration.postSubmit hook\'s onFailure handler', async t=> {
+test.requestHooks(logger, mock)('should call settings.registration.postSubmit hook\'s onFailure handler', async t => {
   logger.clear();
   const registrationPage = await setup(t);
 

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -241,7 +241,8 @@ test.requestHooks(enrolProfileDisabledMock)('should shall terminal error when re
   ]);
 
   // expect terminal errors
-  await t.expect(registrationPage.form.getErrorBoxText()).eql('The requested feature is not enabled in this environment.');
+  await t.expect(registrationPage.form.getErrorBoxText()).eql('Sign up is not enabled for this organization.');
+  await t.expect(await registrationPage.goBackLinkExists()).ok();
 });
 
 test.requestHooks(mock)('should call settings.registration.click on "Sign Up" click, instead of moving to registration page', async t => {

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -58,6 +58,7 @@ module.exports = {
       path.join(TARGET, 'js'),
       path.join(TARGET, 'css'),
     ],
+    historyApiFallback: true,
     compress: true,
     port: DEV_SERVER_PORT,
     open: true,


### PR DESCRIPTION
## Description:

- Add route `/signin/register` and show registration form directly
- Show terminal error if registration is not supported.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Added unit tests?
- [ ] Added e2e tests
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
<img width="467" alt="Screen Shot 2021-03-31 at 1 45 21 PM" src="https://user-images.githubusercontent.com/13139863/113209332-c9aefb80-9227-11eb-94b0-1da9c66993aa.png">
<img width="463" alt="Screen Shot 2021-03-31 at 1 45 00 PM" src="https://user-images.githubusercontent.com/13139863/113209341-cae02880-9227-11eb-849b-08f41750ad23.png">


### Reviewers:


### Issue:

- okta-380941


