### PR TITLE
redirectWithFormGet if Android in OIE 

### DIFF
--- a/src/util/DeviceFingerprint.js
+++ b/src/util/DeviceFingerprint.js
@@ -16,9 +16,6 @@ export default {
   getUserAgent: function() {
     return navigator.userAgent;
   },
-  isAndroid: function() {
-    return /Android/i.test(this.getUserAgent());
-  },
   isMessageFromCorrectSource: function($iframe, event) {
     return event.source === $iframe[0].contentWindow;
   },

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -15,6 +15,8 @@
 import { _, loc } from 'okta';
 import Enums from './Enums';
 import Logger from './Logger';
+import BrowserFeatures from './BrowserFeatures';
+
 const Util = {};
 
 const buildInputForParameter = function(name, value) {
@@ -154,7 +156,11 @@ Util.redirect = function(url, win = window) {
     Logger.error(`Cannot redirect to empty URL: (${url})`);
     return;
   }
-  win.location.href = url;
+  if (BrowserFeatures.isAndroid()) {
+    Util.redirectWithFormGet(url);
+  } else {
+    win.location.href = url;
+  }
 };
 
 /**

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -3,7 +3,7 @@ import { $, loc } from 'okta';
 import { BaseHeader, BaseForm, BaseFormWithPolling, BaseFooter, BaseView } from '../../internals';
 import HeaderBeacon from '../../components/HeaderBeacon';
 import Logger from '../../../../util/Logger';
-import DeviceFingerprint from '../../../../util/DeviceFingerprint';
+import BrowserFeatures from '../../../../util/BrowserFeatures';
 import Enums from '../../../../util/Enums';
 import { CANCEL_POLLING_ACTION } from '../../utils/Constants';
 import Link from '../../components/Link';
@@ -69,7 +69,7 @@ const Body = BaseFormWithPolling.extend(
           // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: DeviceFingerprint.isAndroid() ? 3000 : 100
+          timeout: BrowserFeatures.isAndroid() ? 3000 : 100
         });
       };
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -2,7 +2,7 @@
 import { $ } from 'okta';
 import { BaseForm } from '../../internals';
 import Logger from '../../../../util/Logger';
-import DeviceFingerprint from '../../../../util/DeviceFingerprint';
+import BrowserFeatures from '../../../../util/BrowserFeatures';
 import polling from '../shared/polling';
 import {doChallenge} from '../../utils/ChallengeViewUtil';
 
@@ -63,7 +63,7 @@ const Body = BaseForm.extend(Object.assign(
           // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: DeviceFingerprint.isAndroid() ? 3000 : 100
+          timeout: BrowserFeatures.isAndroid() ? 3000 : 100
         });
       };
 


### PR DESCRIPTION
## Description:
In v1, the [redirect function](https://github.com/okta/okta-signin-widget/blob/master/src/models/Settings.js#L176-L180) is controlled by an internal flag `redirectByFormSubmit`, which is just okta-core checking the user agent for Android (see [this](https://github.com/okta/okta-core/blob/master/webapp/src/main/resources/META-INF/resources/WEB-INF/jsp/loginpage_backbone.jsp#L313)). 
We can do this check inside SIW. Either way, it needs to happen for v2 because Android does not respond to `window.location.href` navigation.

In v2, the following views are using `Util.redirect`:
- DeviceChallengePollView
- ChallengeOktaVerify
- SignInWithDeviceOption

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-373513](https://oktainc.atlassian.net/browse/OKTA-373513)


