### PR TITLE
Update underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "handlebars": "^4.5.3",
     "q": "1.4.1",
     "u2f-api-polyfill": "0.4.3",
-    "underscore": "1.8.3"
+    "underscore": "1.12.1"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/packages/@okta/courage-dist/okta.js
+++ b/packages/@okta/courage-dist/okta.js
@@ -84,7 +84,7 @@ var _underscore = _interopRequireDefault(__webpack_require__(37));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /* eslint @okta/okta-ui/no-specific-methods: 0, @okta/okta-ui/no-specific-modules: 0 */
-var _ = _underscore.default.noConflict();
+var _ = _underscore.default;
 
 _.mixin({
   resultCtx: function resultCtx(object, property, context, defaultValue) {

--- a/packages/@okta/courage-dist/okta.js
+++ b/packages/@okta/courage-dist/okta.js
@@ -84,7 +84,7 @@ var _underscore = _interopRequireDefault(__webpack_require__(37));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /* eslint @okta/okta-ui/no-specific-methods: 0, @okta/okta-ui/no-specific-modules: 0 */
-var _ = _underscore.default;
+var _ = _underscore.default.noConflict();
 
 _.mixin({
   resultCtx: function resultCtx(object, property, context, defaultValue) {

--- a/packages/@okta/courage-for-signin-widget/package.json
+++ b/packages/@okta/courage-for-signin-widget/package.json
@@ -12,6 +12,7 @@
     "@okta/eslint-plugin-okta-ui": "0.1.0-beta.4181.g1f38f27",
     "copy-webpack-plugin": "4.6.0",
     "webpack": "3.12.0",
-    "webpack-bundle-analyzer": "3.0.2"
+    "webpack-bundle-analyzer": "3.0.2",
+    "webpack-plugin-replace": "^1.2.0"
   }
 }

--- a/packages/@okta/courage-for-signin-widget/webpack.config.js
+++ b/packages/@okta/courage-for-signin-widget/webpack.config.js
@@ -118,10 +118,11 @@ const webpackConfig = {
         to: `${I18N_DIR}/dist/properties/`,
       }
     ]),
+    // TODO: OKTA-397756
     new ReplacePlugin({
       patterns: [{
-        regex: /underscore\.noConflict\(\)/,
-        value: 'underscore'
+        regex: /underscore\.default\.noConflict\(\)/,
+        value: 'underscore.default'
       }]
     })
   ]

--- a/packages/@okta/courage-for-signin-widget/webpack.config.js
+++ b/packages/@okta/courage-for-signin-widget/webpack.config.js
@@ -3,6 +3,7 @@ const { resolve } = require('path');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { BannerPlugin } = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ReplacePlugin = require('webpack-plugin-replace');
 const PACKAGE_JSON = require('./package.json');
 
 const EMPTY = resolve(__dirname, 'src/empty');
@@ -117,7 +118,12 @@ const webpackConfig = {
         to: `${I18N_DIR}/dist/properties/`,
       }
     ]),
-
+    new ReplacePlugin({
+      patterns: [{
+        regex: /underscore\.noConflict\(\)/,
+        value: 'underscore'
+      }]
+    })
   ]
 
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14301,14 +14301,15 @@ underscore.string@~3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+
 underscore@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
   integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
-
-underscore@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 underscore@>=1.7.0:
   version "1.9.1"


### PR DESCRIPTION
## Description:

Updated `underscore` 1.8.3 -> 1.12.1 to fix [vulnerability](https://snyk.io/test/npm/underscore/1.8.3)

**Note**: Since 1.10.0, `_.noConflict` is [not exported](https://github.com/jashkenas/underscore/commit/7043ce3581c4394802be670fed2b12bc8be9c21b)

**!** Need to [fix](https://github.com/okta/okta-signin-widget/pull/1812/files#diff-563f8e94ab62f12655040f13d4aa05bf9111fecde04b01c9f39d29c2ff03467dR87) this also in `@okta/courage`
 
## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-383163](https://oktainc.atlassian.net/browse/OKTA-383163)

https://github.com/okta/okta-signin-widget/issues/1792
