### PR TITLE
fix: Can remove router if not yet rendered

### DIFF
--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -305,7 +305,9 @@ export default Router.extend({
   },
 
   remove: function() {
-    this.controller.remove();
+    if (this.controller) {
+      this.controller.remove();
+    }
     this.header.$el.remove();
     Bundles.remove();
     Backbone.history.stop();

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1180,7 +1180,7 @@ Expect.describe('LoginRouter', function() {
           test.router.remove();
         };
         expect(fn).not.toThrowError();
-      })
+      });
   });
 
   Expect.describe('OIDC - okta is the idp and oauth2 is enabled', function() {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1173,6 +1173,15 @@ Expect.describe('LoginRouter', function() {
         });
       });
   });
+  itp('can call remove if not rendered', function() {
+    return setup()
+      .then(function(test) {
+        const fn = function() {
+          test.router.remove();
+        };
+        expect(fn).not.toThrowError();
+      })
+  });
 
   Expect.describe('OIDC - okta is the idp and oauth2 is enabled', function() {
     function expectAuthorizeUrl(url, options) {


### PR DESCRIPTION
## Description:

Fix potential error if widget's `remove` method called before render.
See issue https://github.com/okta/okta-signin-widget/issues/1150

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-296941](https://oktainc.atlassian.net/browse/OKTA-296941)

https://github.com/okta/okta-signin-widget/issues/1150
