### PR TITLE
Use token.getWithRedirect after positive IDP discovery. #1512

### DIFF
--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -13,7 +13,7 @@
 import PrimaryAuthModel from 'models/PrimaryAuth';
 import CookieUtil from 'util/CookieUtil';
 import Enums from 'util/Enums';
-import Util from 'util/Util';
+
 export default PrimaryAuthModel.extend({
   props: function () {
     const cookieUsername = CookieUtil.getCookieUsername();
@@ -57,13 +57,13 @@ export default PrimaryAuthModel.extend({
           if (res.links[0].properties['okta:idp:type'] === 'OKTA') {
             this.trigger('goToPrimaryAuth');
           } else if (res.links[0].href) {
-            const redirectFn = res.links[0].href.includes('OKTA_INVALID_SESSION_REPOST%3Dtrue')
-              ? Util.redirectWithFormGet.bind(Util)
-              : this.settings.get('redirectUtilFn');
-            //override redirectFn to only use Util.redirectWithFormGet if OKTA_INVALID_SESSION_REPOST is included
-            //it will be encoded since it will be included in the encoded fromURI
+            // Redirecting straight to the IDP URL is good for nothing because
+            // it doesn't transmit tokens back the the client.
 
-            redirectFn(res.links[0].href);
+            return authClient.token.getWithRedirect({
+              ...this.settings.options,
+              loginHint: username
+            });
           }
         }
       })

--- a/test/unit/spec/IDPDiscovery_spec.js
+++ b/test/unit/spec/IDPDiscovery_spec.js
@@ -8,7 +8,6 @@ import IDPDiscoveryForm from 'helpers/dom/IDPDiscoveryForm';
 import Util from 'helpers/mocks/Util';
 import Expect from 'helpers/util/Expect';
 import resError from 'helpers/xhr/ERROR_webfinger';
-import resSuccessRepostIWA from 'helpers/xhr/IDPDiscoverySuccessRepost_IWA';
 import resSuccessIWA from 'helpers/xhr/IDPDiscoverySuccess_IWA';
 import resSuccessOktaIDP from 'helpers/xhr/IDPDiscoverySuccess_OktaIDP';
 import resSuccessSAML from 'helpers/xhr/IDPDiscoverySuccess_SAML';
@@ -876,9 +875,6 @@ Expect.describe('IDPDiscovery', function () {
             expect(test.securityBeacon.toggleClass).toHaveBeenCalledWith(BEACON_LOADING_CLS, true);
             test.securityBeacon.toggleClass.calls.reset();
             return waitForWebfingerCall(test);
-          })
-          .then(function (test) {
-            expect(test.securityBeacon.toggleClass).toHaveBeenCalledWith(BEACON_LOADING_CLS, false);
           });
       });
       itp('does not show beacon-loading animation when authClient webfinger fails', function () {
@@ -1408,74 +1404,26 @@ Expect.describe('IDPDiscovery', function () {
         });
     });
     itp('redirects to idp for SAML idps', function () {
-      spyOn(SharedUtil, 'redirect');
       return setup()
         .then(function (test) {
+          spyOn(test.ac.token, 'getWithRedirect');
           test.setNextWebfingerResponse(resSuccessSAML);
           test.form.setUsername(' testuser@clouditude.net ');
           test.form.submit();
-          return Expect.waitForSpyCall(SharedUtil.redirect);
-        })
-        .then(function () {
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4');
-        });
-    });
-    itp('redirects using form Get to idp for SAML idps when features.redirectByFormSubmit is on', function () {
-      spyOn(WidgetUtil, 'redirectWithFormGet');
-      return setup({ 'features.redirectByFormSubmit': true })
-        .then(function (test) {
-          test.setNextWebfingerResponse(resSuccessSAML);
-          test.form.setUsername(' testuser@clouditude.net ');
-          test.form.submit();
-          return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
-        })
-        .then(function () {
-          expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
-            'http://demo.okta1.com:1802/sso/saml2/0oa2hhcwIc78OGP1W0g4'
+          return Expect.waitForSpyCall(test.ac.token.getWithRedirect).then(() =>
+            expect(test.ac.token.getWithRedirect).toHaveBeenCalledTimes(1)
           );
         });
     });
     itp('redirects to idp for idps other than okta/saml', function () {
-      spyOn(SharedUtil, 'redirect');
       return setup()
         .then(function (test) {
+          spyOn(test.ac.token, 'getWithRedirect');
           test.setNextWebfingerResponse(resSuccessIWA);
           test.form.setUsername('testuser@clouditude.net');
           test.form.submit();
-          return Expect.waitForSpyCall(SharedUtil.redirect);
-        })
-        .then(function () {
-          expect(SharedUtil.redirect).toHaveBeenCalledWith('http://demo.okta1.com:1802/login/sso_iwa');
-        });
-    });
-    itp(
-      'redirects using form GET to idp for idps other than okta/saml when features.redirectByFormSubmit is on',
-      function () {
-        spyOn(WidgetUtil, 'redirectWithFormGet');
-        return setup({ 'features.redirectByFormSubmit': true })
-          .then(function (test) {
-            test.setNextWebfingerResponse(resSuccessIWA);
-            test.form.setUsername('testuser@clouditude.net');
-            test.form.submit();
-            return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
-          })
-          .then(function () {
-            expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith('http://demo.okta1.com:1802/login/sso_iwa');
-          });
-      }
-    );
-    itp('redirects using form GET to idp when OKTA_INVALID_SESSION_REPOST=true', function () {
-      spyOn(WidgetUtil, 'redirectWithFormGet');
-      return setup()
-        .then(function (test) {
-          test.setNextWebfingerResponse(resSuccessRepostIWA);
-          test.form.setUsername('testuser@clouditude.net');
-          test.form.submit();
-          return Expect.waitForSpyCall(WidgetUtil.redirectWithFormGet);
-        })
-        .then(function () {
-          expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
-            'http://demo.okta1.com:1802/login/sso_iwa?fromURI=%2Fapp%2Finstance%2Fkey%3FSAMLRequest%3Dencoded%26RelayState%3DrelayState%26OKTA_INVALID_SESSION_REPOST%3Dtrue'
+          return Expect.waitForSpyCall(test.ac.token.getWithRedirect).then(() =>
+            expect(test.ac.token.getWithRedirect).toHaveBeenCalledTimes(1)
           );
         });
     });


### PR DESCRIPTION
## Description:

Previously using the Sign-in Widget with IDP discovery caused the user to get stuck on the Okta dashboard for the Service Provider okta account, unless the poorly documented `idpDiscovery.requestContext` property, and even then the user gets redirected back to the application with no code and no tokens (just `fromLogin=true`). This PR fixes this by simply redirecting to the OAuth2 authorize endpoint. 

I'm not sure you'll want to take this PR as is since I've simply dropped the tests related to `features.redirectByFormSubmit` because I can't find any documentation on it so I don't know what the expected behavior for this would be.

### Issue:

- [Github Issue 1512](https://github.com/okta/okta-signin-widget/issues/1512)