### PR TITLE
Added call to callGlobalError when an error occurs during sign in. #1741 (copy)

### DIFF
--- a/src/util/OAuth2Util.js
+++ b/src/util/OAuth2Util.js
@@ -65,6 +65,7 @@ util.getTokens = function (settings, params, controller) {
     }
 
     Util.triggerAfterError(controller, new Errors.OAuthError(error.message), settings);
+    settings.callGlobalError(error);
   }
 
   const authClient = settings.getAuthClient();

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -2983,7 +2983,7 @@ Expect.describe('PrimaryAuth', function () {
     });
 
     // TODO: add test to verify the behavior when missing `state` in the data
-    itp('ignores messages with the wrong origin', function () {
+    itp('Rejects messages with the wrong origin', function () {
       const successSpy = jasmine.createSpy('successSpy');
       const errorSpy = jasmine.createSpy('errorSpy');
 
@@ -3008,7 +3008,7 @@ Expect.describe('PrimaryAuth', function () {
         })
         .then(function (test) {
           expect(successSpy.calls.count()).toBe(0);
-          expect(errorSpy.calls.count()).toBe(0);
+          expect(errorSpy.calls.count()).toBe(1);
           expect(test.afterErrorHandler).toHaveBeenCalledWith(
             {
               controller: 'primary-auth',


### PR DESCRIPTION
## Description:

Copy of https://github.com/okta/okta-signin-widget/pull/1815

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


