### PR TITLE
AppState render check should ignore 'stateHandle' data OKTA-384206

### DIFF
--- a/src/v2/mixins/mixins.js
+++ b/src/v2/mixins/mixins.js
@@ -1,17 +1,24 @@
 import { _ } from 'okta';
 
 _.mixin({
-  nestedOmit: function(obj, iteratee, context) {
-    var result = _.omit(obj, iteratee, context);
-          
+  nestedOmit: function(obj, names) {
+    var result = _.omit(obj, names);
+
+    if (names.includes(result.name)) {
+      result = _.omit(result, 'value');
+    }
+
     _.each(result, function(val, key) {
-      if (typeof(val) === 'object') {
-        result[key] = _.nestedOmit(val, iteratee, context);
+      if (Array.isArray(val)) {
+        result[key] = val.map((v) => {
+          return _.nestedOmit(v, names);
+        });
+      } else if (typeof val === 'object') {
+        result[key] = _.nestedOmit(val, names);
       }
     });
-          
     return result;
-  }
+  },
 });
 
 export { _ };

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -131,11 +131,13 @@ export default Model.extend({
 
   shouldReRenderView(transformedResponse) {
     const previousRawState = this.has('idx') ? this.get('idx').rawIdxState : null;
+    
     const identicalResponse = _.isEqual(
-      _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'refresh']),
-      _.nestedOmit(previousRawState, ['expiresAt', 'refresh']));
-    const isSameRefreshInterval = _.isEqual(_.omit(transformedResponse.idx.rawIdxState, 'expiresAt'),
-      _.omit(previousRawState, 'expiresAt') );
+      _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'refresh', 'stateHandle']),
+      _.nestedOmit(previousRawState, ['expiresAt', 'refresh', 'stateHandle']));
+    const isSameRefreshInterval = _.isEqual(
+      _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'stateHandle']),
+      _.nestedOmit(previousRawState, ['expiresAt', 'stateHandle']));
 
     if (identicalResponse && !isSameRefreshInterval) {
       this.set('dynamicRefreshInterval', this.getRefreshInterval(transformedResponse));

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -1,5 +1,5 @@
 import AppState from 'v2/models/AppState';
-import { FORMS_WITHOUT_SIGNOUT, FORMS_FOR_VERIFICATION, FORMS } from 'v2/ion/RemediationConstants';
+import {FORMS, FORMS_FOR_VERIFICATION, FORMS_WITHOUT_SIGNOUT} from 'v2/ion/RemediationConstants';
 
 describe('v2/models/AppState', function() {
   beforeEach(() => {
@@ -110,5 +110,74 @@ describe('v2/models/AppState', function() {
         expect(this.appState.isAuthenticatorChallenge()).toBe(true);
       });
     });
+  });
+
+  describe('shouldReRenderView', () => {
+    it('rerender view should be false if stateHandle are different', () => {
+
+      const transformedResponse = {
+        'idx': {
+          'rawIdxState':{
+            'version':'1.0.0',
+            'stateHandle':'12345',
+            'intent':'LOGIN',
+            'remediation':{
+              'type':'array',
+              'value':[
+                {
+                  'rel':[
+                    'create-form'
+                  ],
+                  'name':'device-challenge-poll',
+                  'relatesTo':[
+                    'authenticatorChallenge'
+                  ],
+                  'refresh':2000,
+                  'value':[
+                    {
+                      'name':'stateHandle',
+                      'required':true,
+                      'value':'12345'
+                    }
+                  ]
+                }
+              ]
+            }
+          }}};
+
+      const idxObj = {
+        'idx': {
+          'rawIdxState':{
+            'version':'1.0.0',
+            'stateHandle':'abcdf',
+            'intent':'LOGIN',
+            'remediation':{
+              'type':'array',
+              'value':[
+                {
+                  'rel':[
+                    'create-form'
+                  ],
+                  'name':'device-challenge-poll',
+                  'relatesTo':[
+                    'authenticatorChallenge'
+                  ],
+                  'refresh':2000,
+                  'value':[
+                    {
+                      'name':'stateHandle',
+                      'required':true,
+                      'value':'abcdf'
+                    }
+                  ]
+                }
+              ]
+            }
+          }}};
+
+      this.initAppState(idxObj, 'create-form');
+      expect(this.appState.shouldReRenderView(transformedResponse)).toBe(false);
+    });
+
   });
 });


### PR DESCRIPTION
- update shouldReRenderView() to ignore 'stateHandle' to match previous & current data
- add a unit test to check 'stateHandle' field is ignored

## Description:
Due to ticket [OKTA-384206](https://oktainc.atlassian.net/browse/OKTA-384206)([PR](https://github.com/okta/okta-core/pull/50800)) **'**stateHanler**'** field is now containing encrypted context. As result, its value is changed with each **'/poll'** or any other API call, causing **FormController** page to re-render(it is triggered once any changes between previous calls data and current detected). When **FormController** page is re-rendering it is recalling OV **'/deviceChallenge'**, causing pop-up spamming.

In the previous implementation, 'stateHandle' was only an ID for Redis and it was not immutable.
## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/80226149/113718672-8c4de080-96f5-11eb-910c-1135f7915067.mov

### Reviewers:
@santoshmale-okta , @sshen-okta , @vakaevich-okta  ,@haishengwu-okta , @pradeepdewda-okta 
@jane-kuang-okta - can you please take a look, since you worked with this code some time ago.

### Issue:

- [OKTA-384206](https://oktainc.atlassian.net/browse/OKTA-384206)