### PR TITLE
fix: checks for correct error code during enrollment of rsa / on-prem…

### DIFF
--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-passcode-change-on-prem.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-passcode-change-on-prem.json
@@ -7,10 +7,12 @@
     "type": "array",
     "value": [
       {
-        "message": "Wait for token to change, then enter the new tokencode.",
+        "message": "Pin accepted, Wait for token to change, then enter new passcode",
         "i18n": {
-          "key": "errors.E0000106",
-          "params": []
+          "key": "errors.E0000113",
+          "params": [
+            "Pin accepted, Wait for token to change, then enter new passcode"
+          ]
         },
         "class": "ERROR"
       }

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-passcode-change-rsa.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-passcode-change-rsa.json
@@ -7,10 +7,12 @@
     "type": "array",
     "value": [
       {
-        "message": "Wait for token to change, then enter the new tokencode.",
+        "message": "Pin accepted, Wait for token to change, then enter new passcode",
         "i18n": {
-          "key": "errors.E0000106",
-          "params": []
+          "key": "errors.E0000113",
+          "params": [
+            "Pin accepted, Wait for token to change, then enter new passcode"
+          ]
         },
         "class": "ERROR"
       }

--- a/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
@@ -2,7 +2,7 @@ import { loc } from 'okta';
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
-const ON_PREM_TOKEN_CHANGE_KEY = 'errors.E0000106';
+const ON_PREM_TOKEN_CHANGE_KEY = 'errors.E0000113';
 
 const Body = BaseForm.extend({
 

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -82,6 +82,6 @@ test
     await enrollOnPremPage.waitForErrorBox();
     const errorBox = enrollOnPremPage.getErrorBox();
     await t.expect(errorBox.innerText)
-      .contains('Wait for token to change, then enter the new tokencode.');
+      .contains('Pin accepted, Wait for token to change, then enter new passcode.');
     await t.expect(enrollOnPremPage.getPasscodeValue()).eql('');
   });

--- a/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
@@ -86,6 +86,6 @@ test
     await enrollRsaPage.waitForErrorBox();
     const errorBox = enrollRsaPage.getErrorBox();
     await t.expect(errorBox.innerText)
-      .contains('Wait for token to change, then enter the new tokencode.');
+      .contains('Pin accepted, Wait for token to change, then enter new passcode.');
     await t.expect(enrollRsaPage.getPasscodeValue()).eql('');
   });

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -27,7 +27,6 @@ describe('v2/ion/i18nTransformer', function() {
 
       'enroll.onprem.username.placeholder': 'enter {0} username',
       'enroll.onprem.passcode.placeholder': 'enter {0} passcode',
-      'errors.E0000106': 'token change mode',
       'errors.E0000113': '{0}',
 
       'factor.totpHard.rsaSecurId': 'rsa',
@@ -1123,55 +1122,6 @@ describe('v2/ion/i18nTransformer', function() {
               'key': 'idx.foo',
               'params': [
                 'Email'
-              ]
-            },
-            'class': 'INFO'
-          }
-        ]
-      }
-    });
-  });
-
-  it('converts errors.E0000106 message', () => {
-    const resp = {
-      messages: {
-        value: [
-          {
-            'message': 'Wait for token to change, then enter the new tokencode',
-            'i18n': {
-              'key': 'errors.E0000106'
-            },
-            'class': 'INFO'
-          },
-          {
-            'message': 'another {0} message',
-            'i18n': {
-              'key': 'idx.foo',
-              'params': [
-                'Atko custom on-prem'
-              ]
-            },
-            'class': 'INFO'
-          }
-        ]
-      }
-    };
-    expect(i18nTransformer(resp)).toEqual({
-      messages: {
-        value: [
-          {
-            'message': 'unit test - token change mode',
-            'i18n': {
-              'key': 'errors.E0000106'
-            },
-            'class': 'INFO'
-          },
-          {
-            'message': 'unit test - hello the Atko custom on-prem authenticator',
-            'i18n': {
-              'key': 'idx.foo',
-              'params': [
-                'Atko custom on-prem'
               ]
             },
             'class': 'INFO'


### PR DESCRIPTION
## Description:

- Update messaging for RSA/On-Prem errors
## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added e2e tests

### Screenshot/Video:

| RSA | On-Prem |
| ---- | --------- |
| ![RSA](http://g.recordit.co/fuXV0SS7VM.gif) | ![OnPrem](http://g.recordit.co/fCYEPrAxKa.gif) |

### Issue:

- [OKTA-386741](https://oktainc.atlassian.net/browse/OKTA-386741)


