### PR TITLE
bug fix

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -32,8 +32,6 @@ const Body = BaseForm.extend({
       element: this.$el,
     };
 
-    this.model.trigger('request');
-
     DeviceFingerprinting.generateDeviceFingerprint(fingerprintData)
       .then(fingerprint => {
         this.options.appState.set('deviceFingerprint', fingerprint);


### PR DESCRIPTION
## Description:

1. remove unnecessary trigger that caused 'Next' button on widget to remain in loading state when `deviceFingerprinting` is true
2. Happens when provide invalid credentials

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
https://okta.box.com/s/e9zq69konw0dq9ecbcqlyce1s8m42tz2

### Reviewers:


### Issue:

- [OKTA-385460](https://oktainc.atlassian.net/browse/OKTA-385460)


