### PR TITLE
Adds test for button state on Identify

### DIFF
--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -84,6 +84,10 @@ export default class IdentityPageObject extends BasePageObject {
     return await Selector('.password-toggle').count;
   }
 
+  getSaveButtonLabel() {
+    return this.form.getSaveButtonLabel();
+  }
+
   clickNextButton() {
     return this.form.clickSaveButton();
   }


### PR DESCRIPTION
## Description:

- Adds tests to verify the button state is toggled back to normal when errors occur on the Identify page

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

### Reviewers:


### Issue:

- [OKTA-386981](https://oktainc.atlassian.net/browse/OKTA-386981)


