### PR TITLE
fix: handle rate limit for email authenticator

### DIFF
--- a/playground/mocks/data/idp/idx/error-429-api-limit-exceeded.json
+++ b/playground/mocks/data/idp/idx/error-429-api-limit-exceeded.json
@@ -1,0 +1,7 @@
+{
+  "errorCode": "E0000047",
+  "errorSummary": "API call exceeded rate limit due to too many requests.",
+  "errorLink": "E0000047",
+  "errorId": "oaeD09ai4xzT4WpXsSwHn0Pxw",
+  "errorCauses": []
+}

--- a/playground/mocks/data/idp/idx/error-429-too-many-request.json
+++ b/playground/mocks/data/idp/idx/error-429-too-many-request.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "messages": {
+    "type": "array",
+    "value": [{
+      "message": "Too many requests",
+      "i18n": {
+        "key": "tooManyRequests"
+      },
+      "class": "ERROR"
+    }]
+  }
+}

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -77,6 +77,18 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
 
+      // Wait 1 min before polling again & do not show error message when encounter rate limit error
+      if (error.responseJSON?.errorSummaryKeys?.includes('tooManyRequests') ||
+        error.responseJSON?.errorCode === 'E0000047') {
+        setTimeout(() => {
+          model.trigger('clearFormError');
+        }, 0);
+        setTimeout(() => {
+          this.startPolling();
+        }, 60000);
+        return;
+      }
+
       // Polling needs to be resumed if it's a form error and session is still valid
       if(!error.responseJSON?.errorSummaryKeys?.includes('idx.session.expired')) {
         this.startPolling();


### PR DESCRIPTION
## Description:

- Add 60 seconds delay before restart polling when encounter rate limit error
- Hide error message when encounter rate limit error

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Before:
![Screen Shot 2021-04-14 at 3 51 41 PM](https://user-images.githubusercontent.com/39062268/114770393-664dbf00-9d39-11eb-8118-f31e04214791.png)
![Screen Shot 2021-04-14 at 3 51 37 PM](https://user-images.githubusercontent.com/39062268/114770398-66e65580-9d39-11eb-834a-2e982fe86708.png)
![Screen Shot 2021-04-14 at 3 51 29 PM](https://user-images.githubusercontent.com/39062268/114770399-66e65580-9d39-11eb-832d-23dafbb09abf.png)
![Screen Shot 2021-04-14 at 3 51 23 PM](https://user-images.githubusercontent.com/39062268/114770400-66e65580-9d39-11eb-96aa-093f70676e9c.png)

After:
![Screen Shot 2021-04-14 at 3 54 15 PM](https://user-images.githubusercontent.com/39062268/114770678-b2006880-9d39-11eb-9483-9319fd08d743.png)

https://user-images.githubusercontent.com/39062268/114920207-31a03d00-9df7-11eb-9101-8d86e0d69e3a.mov


### Reviewers:
- @pradeepdewda-okta 
- @anipendakur-okta 
- @haishengwu-okta 

### Issue:

- [OKTA-384169](https://oktainc.atlassian.net/browse/OKTA-384169)


