### PR TITLE
bug: Fixes auto-redirect for IdP and adds error messages for i18n

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -724,6 +724,10 @@ cert.authentication.title = Certificate authentication
 ##                       OIE strings            ##
 ##################################################
 
+## Generic
+oie.authenticator.enroll.error.fail = Unable to enroll authenticator. Try again or contact your admin for assistance.
+oie.authenticator.verify.error.fail = Unable to verify authenticator. Try again or contact your admin for assistance.
+
 ## Password
 oie.password.label = Password
 oie.password.authenticator.description = Choose a password for your account

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -725,8 +725,8 @@ cert.authentication.title = Certificate authentication
 ##################################################
 
 ## Generic
-oie.authenticator.enroll.error.fail = Unable to enroll authenticator. Try again or contact your admin for assistance.
-oie.authenticator.verify.error.fail = Unable to verify authenticator. Try again or contact your admin for assistance.
+oie.authenticator.enroll.error.fail = Unable to enroll authenticator. Try again.
+oie.authenticator.verify.error.fail = Unable to verify authenticator. Try again.
 
 ## Password
 oie.password.label = Password

--- a/playground/mocks/data/idp/idx/authenticator-verification-idp-single-remediation.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-idp-single-remediation.json
@@ -3,19 +3,6 @@
   "version": "1.0.0",
   "expiresAt": "2021-01-19T15:10:35.000Z",
   "intent": "LOGIN",
-  "messages": {
-    "type": "array",
-    "value": [
-      {
-        "message": "Unable to verify authenticator. Try again or contact your admin for assistance.",
-        "i18n": {
-          "key": "oie.authenticator.verify.error.fail",
-          "params": []
-        },
-        "class": "ERROR"
-      }
-    ]
-  },
   "remediation": {
     "type": "array",
     "value": [
@@ -29,45 +16,6 @@
         "href": "http://localhost:3000/sso/idps/0oa69chx4bZyx8O7l0g4?stateToken=02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
         "method": "GET",
         "relatesTo" : [ "$.currentAuthenticatorEnrollment" ]
-      },
-      {
-        "rel": [ "create-form" ],
-        "name": "select-authenticator-authenticate",
-        "href": "http://localhost:3000/idp/idx/challenge",
-        "method": "POST",
-        "accepts": "application/json; okta-version=1.0.0",
-        "produces": "application/ion+json; okta-version=1.0.0",
-        "value": [
-          {
-            "name": "authenticator",
-            "type": "object",
-            "options": [
-              {
-                "label": "IDP Authenticator",
-                "value": {
-                  "form": {
-                    "value": [
-                      {
-                        "name": "id",
-                        "required": true,
-                        "value": "aut4mhtS1b84AR0iQ0g4",
-                        "mutable": false
-                      }
-                    ]
-                  }
-                },
-                "relatesTo": "$.authenticatorEnrollments.value[0]"
-              }
-            ]
-          },
-          {
-            "name": "stateHandle",
-            "required": true,
-            "value": "02TptqPN4BOLIwMAGUVLPlZVJEnONAq7xkg19dy6Gk",
-            "visible": false,
-            "mutable": false
-          }
-        ]
       }
     ]
   },

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
@@ -7,7 +7,7 @@
     "type": "array",
     "value": [
       {
-        "message": "Unable to enroll authenticator. Try again or contact your admin for assistance.",
+        "message": "Unable to enroll authenticator. Try again.",
         "i18n": {
           "key": "oie.authenticator.enroll.error.fail",
           "params": []

--- a/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-enroll-idp.json
@@ -7,9 +7,9 @@
     "type": "array",
     "value": [
       {
-        "message": "Unable to enroll. Try again or contact your admin for assistance.",
+        "message": "Unable to enroll authenticator. Try again or contact your admin for assistance.",
         "i18n": {
-          "key": "",
+          "key": "oie.authenticator.enroll.error.fail",
           "params": []
         },
         "class": "ERROR"

--- a/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
+++ b/playground/mocks/data/idp/idx/error-authenticator-verification-idp.json
@@ -7,7 +7,7 @@
     "type": "array",
     "value": [
       {
-        "message": "Unable to verify authenticator. Try again or contact your admin for assistance.",
+        "message": "Unable to verify authenticator. Try again.",
         "i18n": {
           "key": "oie.authenticator.verify.error.fail",
           "params": []

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -228,8 +228,11 @@ const convert = (settings, idx = {}, lastResult = null) => {
     { idx }
   );
 
+  // Override the `result` to handle custom IdP login buttons
+  // and update the form for IdP Authenticators.
   injectIdPConfigButtonToRemediation(settings, result);
   modifyFormNameForIdPAuthenticator(result);
+
   if (!result.messages) {
     // Only redirect to the IdP if we are not in an error flow
     convertRedirectIdPToSuccessRedirectIffOneIdp(settings, result, lastResult);

--- a/src/v2/ion/responseTransformer.js
+++ b/src/v2/ion/responseTransformer.js
@@ -229,12 +229,11 @@ const convert = (settings, idx = {}, lastResult = null) => {
   );
 
   injectIdPConfigButtonToRemediation(settings, result);
+  modifyFormNameForIdPAuthenticator(result);
   if (!result.messages) {
     // Only redirect to the IdP if we are not in an error flow
     convertRedirectIdPToSuccessRedirectIffOneIdp(settings, result, lastResult);
   }
-
-  modifyFormNameForIdPAuthenticator(result);
 
   return result;
 };

--- a/test/testcafe/spec/AuthenticatorIdPView_spec.js
+++ b/test/testcafe/spec/AuthenticatorIdPView_spec.js
@@ -82,7 +82,7 @@ test
 
     await t.expect(pageObject.getPageTitle()).eql('Set up IDP Authenticator');
     await t.expect(pageObject.getPageSubtitle()).eql('Clicking below will redirect to enrollment in IDP Authenticator');
-    await t.expect(pageObject.getErrorFromErrorBox()).eql('Unable to enroll authenticator. Try again or contact your admin for assistance.');
+    await t.expect(pageObject.getErrorFromErrorBox()).eql('Unable to enroll authenticator. Try again.');
   });
 
 fixture('Verify IdP Authenticator');
@@ -118,5 +118,5 @@ test
 
     await t.expect(pageObject.getPageTitle()).eql('Verify with IDP Authenticator');
     await t.expect(pageObject.getPageSubtitle()).eql('You will be redirected to verify with IDP Authenticator');
-    await t.expect(pageObject.getErrorFromErrorBox()).eql('Unable to verify authenticator. Try again or contact your admin for assistance.');
+    await t.expect(pageObject.getErrorFromErrorBox()).eql('Unable to verify authenticator. Try again.');
   });


### PR DESCRIPTION
## Description:

- Fixes an issue where the Widget would auto-redirect when there was only **one** remediation form
- Adds i18n messages for IdP Authenticator flows

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added e2e tests

### Reviewers:

- @haishengwu-okta 

### Issue:

- [OKTA-380834](https://oktainc.atlassian.net/browse/OKTA-380834)
- [OKTA-386387](https://oktainc.atlassian.net/browse/OKTA-386387)
