### PR TITLE
Add support for processCreds for SIW v2

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -147,6 +147,7 @@ const authn = {
     // 'mfa-required-email',
     // 'unauthenticated',
     'admin-consent-required',
+    // 'password-expired',
   ],
   '/api/v1/authn': [
     'unauthenticated',

--- a/playground/mocks/data/api/v1/authn/password-expired.json
+++ b/playground/mocks/data/api/v1/authn/password-expired.json
@@ -1,0 +1,47 @@
+{
+    "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+    "expiresAt": "2015-11-03T10:15:57.000Z",
+    "status": "PASSWORD_EXPIRED",
+    "relayState": "/myapp/some/deep/link/i/want/to/return/to",
+    "_embedded": {
+        "user": {
+        "id": "00ub0oNGTSWTBKOLGLNR",
+        "passwordChanged": "2015-09-08T20:14:45.000Z",
+        "profile": {
+            "login": "dade.murphy@example.com",
+            "firstName": "Dade",
+            "lastName": "Murphy",
+            "locale": "en_US",
+            "timeZone": "America/Los_Angeles"
+        }
+        },
+        "policy": {
+        "complexity": {
+            "minLength": 8,
+            "minLowerCase": 1,
+            "minUpperCase": 1,
+            "minNumber": 1,
+            "minSymbol": 0
+        }
+        }
+    },
+    "_links": {
+        "next": {
+        "name": "changePassword",
+        "href": "http://localhost:3000/api/v1/authn/credentials/change_password",
+        "hints": {
+            "allow": [
+            "POST"
+            ]
+        }
+        },
+        "cancel": {
+        "href": "http://localhost:3000/api/v1/authn/cancel",
+        "hints": {
+            "allow": [
+            "POST"
+            ]
+        }
+        }
+    }
+}

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -31,6 +31,11 @@ const rerenderWidget = ClientFunction((settings) => {
   window.renderPlaygroundWidget(settings);
 });
 
+const fakeProcessCreds = ({ username, password }) => {
+  // eslint-disable-next-line no-console
+  console.log(`processCreds called with ${username} and ${password}`);
+};
+
 fixture('Identify + Password');
 
 async function setup(t) {
@@ -113,4 +118,13 @@ test.requestHooks(identifyMock)('should show errors when forgot password is not 
   await page.navigateToPage();
   await t.expect(page.form.getTitle()).eql('Reset your password');
   await t.expect(page.form.getErrorBoxText()).eql('Forgot password is not enabled for this organization.');
+});
+test.requestHooks(identifyWithPasswordMock)('call processCreds with the credentials', async t => {
+  const identityPage = await setup(t, true);
+  await rerenderWidget({ processCreds: fakeProcessCreds });
+  await identityPage.fillIdentifierField('abc@gmail.com');
+  await identityPage.fillPasswordField('123');
+  await identityPage.clickNextButton();
+  const { log } = await t.getBrowserConsoleMessages();
+  await t.expect(log).contains('processCreds called with abc@gmail.com and 123');
 });


### PR DESCRIPTION
## Description:

This PR adds support for processCreds in an IDX sign in widget. Not every view has access to the current user's login. Some views contain only a password input, and the server response contains a user that looks like this:
```
  "user": {
    "type": "object",
    "value": {
      "id": "00uwb8GLwf1HED5Xs0g3"
    }
  },
```

If we want those views to call `processCreds`, we will need to have the backend send something like this:
```
  "user": {
    "type": "object",
    "value": {
      "id": "I9bvFiq01cRFgbn",
      "passwordChanged": "2019-05-03T19:00:00.000Z",
      "profile": {
        "login": "foo@example.com",
        "firstName": "Foo",
        "lastName": "Bar",
        "locale": "en-us",
        "timeZone": "UTC"
      }
    }
  },
```
I'm guessing the user's profile is not being sent over for security reasons.

These views will call processCreds
- IdentifierView (with a password)
- EnrollAuthenticatorPasswordView

These views will not call processCreds because the FE doesn't have access to the user's username:
- ChallengeAuthenticatorPasswordView
- ReEnrollAuthenticatorPasswordView
- ReEnrollAuthenticatorWarningPasswordView
- ResetAuthenticatorPasswordView

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-314099](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


