### PR TITLE
Fix flakey mocks from en leaks test suite

### DIFF
--- a/LocaleUtils/index.js
+++ b/LocaleUtils/index.js
@@ -2,18 +2,18 @@
 export async function assertNoEnglishLeaks(mockFile, viewText, noTranslationContent) {
   const regEx = '(?<=\》).+?(?=\《)'; // eslint-disable-line no-useless-escape
   const pseudoLocSymbols = ['》', '《', '《 》', '《》'];
-
+  if (!viewText.length) {
+    return;
+  }
   // Exclude all elements with a class of no-translate. Example phone numbers
   if (noTranslationContent.length) {
     viewText = viewText.replace(noTranslationContent, '');
   }
-
   let extractedString = viewText.trim().replace(new RegExp(regEx, 'g'), ' ');
   extractedString = extractedString.split(' ');
   const enLeaks = extractedString.filter( item => {
     return item.length && !pseudoLocSymbols.includes(item.trim());
   });
-
   if (enLeaks.length) {
     const error = enLeaks.join(' ');
     throw new Error(`Unlocalized text found in mock ${mockFile}: ${error}`);


### PR DESCRIPTION
Resolves: OKTA-388473

## Description:

Unignores the following mocks from the en leaks test suite
Added some null checks and setup some mocks in the test to make sure these mocks are passing. Verified them locally.
- success.json
- success-with-app-user.json
- identify-with-only-one-third-party-idp-app-user.json
- identify-with-device-probing-loopback-2.json

We can un ignore the 2 mocks below after recent fixes were made to https://oktainc.atlassian.net/browse/OKTA-383531
- error-authenticator-enroll-idp.json
- error-authenticator-verification-idp.json

Added a couple of mocks that have english leaks caused from https://github.com/okta/okta-signin-widget/pull/1838
Checking to see how this commit made it to master

![Screen Shot 2021-04-19 at 11 53 16 AM](https://user-images.githubusercontent.com/23267876/115288086-e1322380-a105-11eb-9ef1-9057f662e307.png)
![Screen Shot 2021-04-19 at 11 53 23 AM](https://user-images.githubusercontent.com/23267876/115288092-e4c5aa80-a105-11eb-9840-fbcb4cbade77.png)



## PR Checklist

- [x] Have you verified the basic functionality for this change?


- [x] Added e2e tests


### Screenshot/Video:


### Reviewers:

@jmelberg-okta @haishengwu-okta 

### Issue:

- [OKTA-388473](https://oktainc.atlassian.net/browse/OKTA-388473)


