### PR TITLE
fix width of content in beacon views, add back .no-beacon

### DIFF
--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -18,14 +18,3 @@
 @import './number-challenge';
 @import './consent-email';
 @import './success-redirect';
-
-&:not(.no-beacon) {
-  // the following is to center the beacon vertically with the divider line
-  .siw-main-view {
-    float: left; // to prevent margin collapse which drags beacon down
-    width: 100%;
-  }
-  .siw-main-footer {
-    padding-bottom: 20px; // add back padding removed from float
-  }
-}

--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -23,6 +23,7 @@
   // the following is to center the beacon vertically with the divider line
   .siw-main-view {
     float: left; // to prevent margin collapse which drags beacon down
+    width: 100%;
   }
   .siw-main-footer {
     padding-bottom: 20px; // add back padding removed from float

--- a/assets/sass/v2/_beacon.scss
+++ b/assets/sass/v2/_beacon.scss
@@ -1,7 +1,7 @@
 .siw-main-header {
   position: relative;
   .beacon-container {
-    top: -160px;
+    top: -183px;
     z-index: 10;
     .auth-beacon-factor {
       cursor: initial;

--- a/src/v2/view-builder/internals/BaseHeader.js
+++ b/src/v2/view-builder/internals/BaseHeader.js
@@ -18,8 +18,7 @@ export default View.extend({
       mainContentContainer.removeClass('no-beacon');
 
       // animate beacon
-      const selector = '[data-type="beacon-container"]';
-      const beaconContainer = this.$el.find(selector);
+      const beaconContainer = this.$el.find('[data-type="beacon-container"]');
       Animations.explode(beaconContainer);
     } else {
       mainContentContainer.addClass('no-beacon');

--- a/src/v2/view-builder/internals/BaseHeader.js
+++ b/src/v2/view-builder/internals/BaseHeader.js
@@ -12,12 +12,17 @@ export default View.extend({
   },
 
   postRender() {
+    const mainContentContainer = $(`#${Enums.WIDGET_CONTAINER_ID}`);
+
     if (this.HeaderBeacon) {
-      $(`#${Enums.WIDGET_CONTAINER_ID}`).removeClass('no-beacon');
+      mainContentContainer.removeClass('no-beacon');
 
       // animate beacon
-      var selector = '[data-type="beacon-container"]', container = this.$el.find(selector);
-      Animations.explode(container);
+      const selector = '[data-type="beacon-container"]';
+      const beaconContainer = this.$el.find(selector);
+      Animations.explode(beaconContainer);
+    } else {
+      mainContentContainer.addClass('no-beacon');
     }
   },
 });

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -1,9 +1,10 @@
-import { _, View } from 'okta';
+import { _, View, $ } from 'okta';
 import BaseForm from './BaseForm';
 import BaseModel from './BaseModel';
 import BaseFooter from './BaseFooter';
 import hbs from 'handlebars-inline-precompile';
 import {getClassNameMapping} from '../../ion/ViewClassNamesFactory';
+import Enums from 'util/Enums';
 
 export default View.extend({
 
@@ -46,6 +47,8 @@ export default View.extend({
         selector: '.siw-main-header',
         options: this.options,
       });
+    } else {
+      $(`#${Enums.WIDGET_CONTAINER_ID}`).addClass('no-beacon');
     }
     this.renderForm();
     this.add(this.Footer, {

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -1,4 +1,4 @@
-import { _, View, $ } from 'okta';
+import { _, View } from 'okta';
 import BaseHeader from './BaseHeader';
 import BaseForm from './BaseForm';
 import BaseModel from './BaseModel';

--- a/src/v2/view-builder/internals/BaseView.js
+++ b/src/v2/view-builder/internals/BaseView.js
@@ -1,14 +1,14 @@
 import { _, View, $ } from 'okta';
+import BaseHeader from './BaseHeader';
 import BaseForm from './BaseForm';
 import BaseModel from './BaseModel';
 import BaseFooter from './BaseFooter';
 import hbs from 'handlebars-inline-precompile';
 import {getClassNameMapping} from '../../ion/ViewClassNamesFactory';
-import Enums from 'util/Enums';
 
 export default View.extend({
 
-  Header: null,
+  Header: BaseHeader,
 
   Body: BaseForm,
 
@@ -47,8 +47,6 @@ export default View.extend({
         selector: '.siw-main-header',
         options: this.options,
       });
-    } else {
-      $(`#${Enums.WIDGET_CONTAINER_ID}`).addClass('no-beacon');
     }
     this.renderForm();
     this.add(this.Footer, {


### PR DESCRIPTION
## Description:
2 things:
- center beacon vertically without float
- when switching from a view with a beacon to a view without, add .no-beacon to remove gap for beacon.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Before
![Apr-19-2021 12-04-45](https://user-images.githubusercontent.com/71431120/115290797-ce6d1e00-a108-11eb-84d4-66450a4f07bb.gif)
After
![Apr-19-2021 12-04-29](https://user-images.githubusercontent.com/71431120/115290802-d0cf7800-a108-11eb-8435-34bfb599e642.gif)

Before
<img width="430" alt="Screenshot 2021-04-19 at 11 49 32 AM" src="https://user-images.githubusercontent.com/71431120/115290857-e47ade80-a108-11eb-9708-0bfe1ff4b161.png">
After
<img width="421" alt="Screenshot 2021-04-19 at 11 57 24 AM" src="https://user-images.githubusercontent.com/71431120/115290860-e5ac0b80-a108-11eb-95f6-a256fd319afa.png">
Before
<img width="437" alt="Screenshot 2021-04-19 at 11 44 21 AM" src="https://user-images.githubusercontent.com/71431120/115290871-e93f9280-a108-11eb-8c88-17f0aed87630.png">
After
<img width="439" alt="Screenshot 2021-04-19 at 11 44 10 AM" src="https://user-images.githubusercontent.com/71431120/115290874-e9d82900-a108-11eb-8efa-36417f2a532a.png">

IE
<img width="462" alt="Screenshot 2021-04-19 at 12 24 20 PM" src="https://user-images.githubusercontent.com/71431120/115291940-35d79d80-a10a-11eb-9fa6-7352c5b1904a.png">

### Reviewers:


### Issue:

- [OKTA-388425](https://oktainc.atlassian.net/browse/OKTA-388425)


