### PR TITLE
test: Another round of fixes for en leaks suite

### DIFF
--- a/playground/LocaleUtils/index.js
+++ b/playground/LocaleUtils/index.js
@@ -1,13 +1,16 @@
 
-export async function assertNoEnglishLeaks(mockFile, viewText, noTranslationContent) {
+export async function assertNoEnglishLeaks(mockFile, viewText, noTranslationContents) {
   const regEx = '(?<=\》).+?(?=\《)'; // eslint-disable-line no-useless-escape
   const pseudoLocSymbols = ['》', '《', '《 》', '《》'];
   if (!viewText.length) {
     return;
   }
-  // Exclude all elements with a class of no-translate. Example phone numbers
-  if (noTranslationContent.length) {
-    viewText = viewText.split(noTranslationContent).join('');
+  // Exclude all elements with a class of no-translate. Example phone numbers, urls, vendor names
+  if (noTranslationContents.length) {
+    //replace each item in noTranslationContents
+    noTranslationContents.forEach(noTranslationContent => {
+      viewText = viewText.split(noTranslationContent).join('');
+    });
   }
   let extractedString = viewText.trim().replace(new RegExp(regEx, 'g'), ' ');
   /*

--- a/playground/main.js
+++ b/playground/main.js
@@ -2,7 +2,7 @@
 /* eslint no-console: 0 */
 
 import signinWidgetOptions from '../.widgetrc.js';
-import { assertNoEnglishLeaks } from '../LocaleUtils';
+import { assertNoEnglishLeaks } from '../playground/LocaleUtils';
 
 let signIn;
 
@@ -85,15 +85,19 @@ const renderPlaygroundWidget = (options = {}) => {
 
     // assert english leaks if locale set to ok-PL
     if (signinWidgetOptions.language === 'ok-PL') {
-      // wait for view to finish rendering
-      const viewText = document.getElementById('okta-sign-in').textContent;
+      //Use innerText to avoid including hidden elements
+      let viewText = document.getElementById('okta-sign-in').innerText;
+      viewText = viewText.split('\n').join(' ');
+
       const noTranslationContentExists = document.getElementsByClassName('no-translate').length;
-      let noTranslationContent = '';
+
+      let noTranslationContent = [];
       /* eslint max-depth: [2, 3] */
       if (noTranslationContentExists) {
         const noTranslateElems = document.getElementsByClassName('no-translate');
         for (var i = 0; i < noTranslateElems.length; i++) {
-          noTranslationContent += noTranslateElems[i].textContent;
+          //build array of noTranslationContent
+          noTranslationContent.push(noTranslateElems[i].textContent);
         }
       }
       assertNoEnglishLeaks(null, viewText, noTranslationContent);

--- a/src/v2/view-builder/views/consent/AdminConsentViewHeader.js
+++ b/src/v2/view-builder/views/consent/AdminConsentViewHeader.js
@@ -21,10 +21,10 @@ const AdminConsentViewHeader = View.extend({
     {{/if}}
     <h1>
       <span class="title-text">
-        <b>{{appName}}</b>&nbsp;{{titleText}}
+        <b class="no-translate">{{appName}}</b>&nbsp;{{titleText}}
       </span>
       {{#if issuer}}
-        <div class="issuer"><span>{{issuer}}</span></div>
+        <div class="issuer no-translate"><span>{{issuer}}</span></div>
       {{/if}}
     </h1>`,
   getTemplateData: function() {

--- a/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
@@ -37,7 +37,7 @@ const Body = BaseForm.extend({
         {
           type: 'label',
           label: `+${this.model.get('phoneCode')}`,
-          className: 'country-code-label',
+          className: 'country-code-label no-translate',
         },
         Object.assign({}, phoneNumberUISchema),
       ],

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -33,7 +33,7 @@ const Body = BaseForm.extend(
         : loc('oie.phone.verify.call.sendText', 'login');
       const extraCssClasses =
         this.model.get('phoneNumber') !== loc('oie.phone.alternate.title', 'login') ?
-          'strong' : '';
+          'strong no-translate' : '';
       // Courage doesn't support HTML, hence creating a subtitle here.
       this.add(`<div class="okta-form-subtitle" data-se="o-form-explain">${sendText}
         <span ${ extraCssClasses ? 'class="' + extraCssClasses + '"' : ''}>${this.model.escape('phoneNumber')}</span>

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -1,7 +1,7 @@
 import { RequestMock, Selector } from 'testcafe';
 import PageObject from '../framework/page-objects/IdentityPageObject';
 import { renderWidget } from '../framework/shared';
-import { assertNoEnglishLeaks } from '../../../LocaleUtils';
+import { assertNoEnglishLeaks } from '../../../playground/LocaleUtils';
 const fs = require('fs');
 const path = require('path');
 
@@ -24,11 +24,9 @@ const ignoredMocks = [
   'safe-mode-optional-enrollment.json',
   'safe-mode-credential-enrollment-intent.json',
   'identify-with-third-party-idps.json',
-  'identify-with-only-one-third-party-idp.json',
   'identify-with-no-sso-extension.json',
   'identify-with-device-probing-loopback.json',
   'identify-with-device-probing-loopback-3.json',
-  'identify-with-device-launch-authenticator.json',
   'identify-with-apple-redirect-sso-extension.json', // flaky on bacon
   'identify-unknown-user.json',
   'error-user-is-not-assigned.json',
@@ -47,14 +45,9 @@ const ignoredMocks = [
   'error-authenticator-enroll-custom-otp.json',
   'error-403-security-access-denied.json',
   'consent-enduser.json',
-  'consent-admin.json',
   'authenticator-verification-select-authenticator.json',
   'authenticator-verification-okta-verify-signed-nonce-loopback.json',
-  'authenticator-verification-okta-verify-signed-nonce-custom-uri.json',
   'authenticator-verification-okta-verify-reject-push.json',
-  'authenticator-verification-data-phone-voice-then-sms.json',
-  'authenticator-verification-data-phone-voice-only.json',
-  'authenticator-verification-data-phone-sms-then-voice.json',
   'authenticator-reset-password.json',
   'authenticator-expiry-warning-password.json',
   'authenticator-expired-password.json',
@@ -64,9 +57,7 @@ const ignoredMocks = [
   'authenticator-enroll-select-authenticator.json',
   'authenticator-enroll-phone.json',
   'authenticator-enroll-phone-voice.json',
-  'authenticator-enroll-ov-via-sms.json',
   'authenticator-enroll-ov-via-email.json',
-  'authenticator-enroll-google-authenticator.json',
   'authenticator-enroll-email.json',
   'authenticator-enroll-data-phone.json',
   'authenticator-enroll-data-phone-voice.json',
@@ -154,13 +145,18 @@ const testEnglishLeaks = (mockIdxResponse, fileName, locale) => {
   test.requestHooks(mockIdxResponse)(`${fileName} should not have english leaks`, async t => {
     await setup(t, locale);
     const viewTextExists = await Selector('#okta-sign-in').exists;
-    const viewText = viewTextExists && await Selector('#okta-sign-in').textContent;
+    //Use innerText to avoid including hidden elements
+    let viewText = viewTextExists && await Selector('#okta-sign-in').innerText;
+    viewText = viewText && viewText.split('\n').join(' ');
+
     const noTranslationContentExists = await Selector('.no-translate').exists;
-    let noTranslationContent = '';
+    let noTranslationContent = [];
     if (noTranslationContentExists) {
+      //build array of noTranslationContent
       const noTranslateElems = await Selector('.no-translate').count;
       for (var i = 0; i < noTranslateElems; i++) {
-        noTranslationContent += await Selector('.no-translate').nth(i).textContent;
+        const noTranslateContent = await Selector('.no-translate').nth(i).textContent;
+        noTranslationContent.push(noTranslateContent);
       }
     }
     await assertNoEnglishLeaks(fileName, viewText, noTranslationContent);


### PR DESCRIPTION
Resolves: OKTA-389024

## Description:

- Improved logic to exclude multiple no translate sections from UI 
- Use `innerText` instead of `textContent` to avoid including elements with display:none attributes on UI 
- Unignore few more mocks 
- We have over 100 test passing now 🎉 

## PR Checklist

- [x] Have you verified the basic functionality for this change?


- [x] Added e2e tests

### Screenshot/Video:

![Screen Shot 2021-04-21 at 11 51 51 AM](https://user-images.githubusercontent.com/23267876/115605969-00f95100-a298-11eb-8a76-0548486e1109.png)



### Reviewers:

@haishengwu-okta @jmelberg-okta 

### Issue:

- [OKTA-389024](https://oktainc.atlassian.net/browse/OKTA-389024)


