### PR TITLE
feat: Add lint rule to find missing i18n keys in mock files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,12 @@ module.exports = {
       'rules': {
         'local-rules/no-missing-keys': 2,
       }
+    },
+    {
+      'files': ['playground/**/*.json'],
+      'rules': {
+        'local-rules/no-missing-api-keys': 1,
+      }
     }
   ],
   'rules': {

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,7 +1,9 @@
 var noBareTemplates = require('./packages/@okta/eslint-plugin-okta-ui/lib/rules/no-bare-templates');
 var noMissingKeys = require('./packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-keys');
+var noMissingAPIKeys = require('./packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-api-keys');
 
 module.exports = {
   'no-bare-templates': noBareTemplates,
   'no-missing-keys': noMissingKeys,
+  'no-missing-api-keys': noMissingAPIKeys
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-readme": "node buildtools update-readme",
     "retirejs": "retire --jspath target/js --package",
     "lint:eslint": "eslint .",
-    "lint:eslint:report": "eslint -f checkstyle -o build2/OSW-eslint-checkstyle-result.xml .",
+    "lint:eslint:report": "eslint -f checkstyle -o build2/OSW-eslint-checkstyle-result.xml . --quiet",
     "lint:stylelint": "stylelint assets/sass/",
     "lint:stylelint:report": "stylelint --custom-formatter node_modules/stylelint-checkstyle-formatter assets/sass/ > build2/OSW-stylelint-checkstyle-result.xml",
     "lint": "grunt propertiesToJSON && mkdir -p build2 && run-p -c lint:eslint lint:stylelint",

--- a/packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-api-keys.js
+++ b/packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-api-keys.js
@@ -1,0 +1,54 @@
+const _ = require('underscore');
+const loginEnBundle = require('../../../i18n/src/json/login.json');
+const { readFileSync } = require('fs-extra');
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Detect missing i18n keys from json mock files',
+      category: 'i18n Issues',
+      recommended: true,
+    },
+    messages: {
+      missingApiKeysLoginBundle: '"{{i18nKey}}" is missing from login.properties.',
+      missingi18nKeyApiResponse: 'API mock "{{file}}" does not have an i18nKey. Avoid hard-coding English strings.'
+    },
+  },
+  create(context) {
+    return {
+      'Program': function (node) {
+        const fileName = context.getFilename();
+        const jsonContent = JSON.parse(readFileSync(fileName, 'utf8'));
+        const messages = jsonContent.messages;
+        if (!messages || !messages.value || !messages.value.length) { return; }
+        const value = messages.value && messages.value[0];
+        const i18nKey = value.i18n && value.i18n.key;
+        // check if i18n key exists in mocks
+        if (!i18nKey) {
+          const file = fileName.split('idp/idx/')[1];
+          context.report({
+            messageId: 'missingi18nKeyApiResponse',
+            data: {
+              file
+            },
+            loc: {
+              start: { line: 0, column: 0 }
+            },
+          });
+          return;
+        }
+        // check if i18n keys returned from API are added to login.properties
+        if (!loginEnBundle[i18nKey]) {
+          context.report({
+            messageId: 'missingApiKeysLoginBundle',
+            data: {
+              i18nKey,
+            },
+            loc: {
+              start: { line: 0, column: 0 }
+            },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Resolves: OKTA-380268

## Description:



## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Screenshot/Video:

```
/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/authenticator-expiry-warning-password.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.password.expiring.message to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-reject-push.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add api.authn.poll.error.push_rejected to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-403-security-access-denied.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add security.access_denied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-authenticator-verify-password.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add incorrectPassword to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-authenticator-webauthn-failure.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add authfactor.webauthn.error.assertion_validation_failure to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-email-verify.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add security.access_denied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-forgot-password.json
  1:2  warning  Missing i18n key in API mock error-forgot-password.json. Avoid using hard-coded strings returned and instead have the API return an i18n key and add that key to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-google-authenticator-otp.json
  1:2  warning  Missing i18n key in API mock error-google-authenticator-otp.json. Avoid using hard-coded strings returned and instead have the API return an i18n key and add that key to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-identify-access-denied.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add security.access_denied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-internal-server-error.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add E0000009 to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-invalid-device-code.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.invalid.device.code to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-okta-verify-totp.json
  1:2  warning  Missing i18n key in API mock error-okta-verify-totp.json. Avoid using hard-coded strings returned and instead have the API return an i18n key and add that key to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-pre-versioning-ff-session-expired.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.session.expired to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-safe-mode-polling.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add E0000010 to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-session-expired.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.session.expired to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-unlock-account.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add oie.selfservice.unlock_user.failed.message to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/error-user-is-not-assigned.json
  1:2  warning  Missing i18n key in API mock error-user-is-not-assigned.json. Avoid using hard-coded strings returned and instead have the API return an i18n key and add that key to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/identify-unknown-user.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.unknown.user to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/safe-mode-credential-enrollment-intent.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.error.server.safe.mode.cred.enroll to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/safe-mode-optional-enrollment.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.error.server.safe.mode.assurance.satisfied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/safe-mode-required-enrollment.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.error.server.safe.mode.assurance.not.satisfied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-device-activated.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.device.activated to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-device-not-activated-consent-denied.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.device.not.activated.consent.denied to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-device-not-activated-internal-error.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.device.not.activated.internal.error to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-enduser-email-consent-denied.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.operation.cancelled.by.user to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-polling-window-expired.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add E0000010 to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-registration.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.email.verification.required to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-email-consent-denied.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.operation.cancelled.on.other.device to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-email-consent.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.return.to.original.tab to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-email.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.return.to.original.tab to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-error-email.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.session.expired to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-expired-email.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.return.link.expired to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-return-stale-email.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.session.expired to login.properties to prevent english leaks  local-rules/no-missing-api-keys

/Users/nikhilvenkatraman/okta/okta-signin-widget/playground/mocks/data/idp/idx/terminal-transfered-email.json
  1:2  warning  Missing i18n key from login.properties returned from the API. Add idx.transferred.to.new.tab to login.properties to prevent english leaks  local-rules/no-missing-api-keys

✖ 34 problems (0 errors, 34 warnings)


```

Setting the rule to throw a warning, causes the lint suite to fail on bacon. Need to find a workaround to be able to throw a warning.


### Reviewers:

@jmelberg-okta @haishengwu-okta 

### Issue:

- [OKTA-380268](https://oktainc.atlassian.net/browse/OKTA-380268)


