### PR TITLE
Configurable loopback probe timeout (client-side)

### DIFF
--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -24,7 +24,8 @@ export function doChallenge(view) {
       className: 'loopback-content',
       template: hbs`<div class="spinner"></div>`
     }));
-    view.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest, deviceChallenge.probeTimeoutMillis);
+    view.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest,
+      deviceChallenge.probeTimeoutMillis);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:
     view.title = loc('customUri.title', 'login');

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -24,7 +24,7 @@ export function doChallenge(view) {
       className: 'loopback-content',
       template: hbs`<div class="spinner"></div>`
     }));
-    view.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
+    view.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest, deviceChallenge.probeTimeoutMillis);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:
     view.title = loc('customUri.title', 'login');

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -24,8 +24,7 @@ export function doChallenge(view) {
       className: 'loopback-content',
       template: hbs`<div class="spinner"></div>`
     }));
-    view.doLoopback(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest,
-      deviceChallenge.probeTimeoutMillis);
+    view.doLoopback(deviceChallenge);
     break;
   case Enums.CUSTOM_URI_CHALLENGE:
     view.title = loc('customUri.title', 'login');

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -51,7 +51,12 @@ const Body = BaseFormWithPolling.extend(
       return this.options.currentViewState.relatesTo.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = 100) {
+    doLoopback(deviceChallenge) {
+      let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
+      let ports = deviceChallenge.ports !== undefined ? deviceChallenge.ports : [];
+      let challengeRequest = deviceChallenge.challengeRequest !== undefined ? deviceChallenge.challengeRequest : '';
+      let probeTimeoutMillis = deviceChallenge.probeTimeoutMillis !== undefined ?
+        deviceChallenge.probeTimeoutMillis : 100;
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -51,7 +51,7 @@ const Body = BaseFormWithPolling.extend(
       return this.options.currentViewState.relatesTo.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = -1) {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -65,8 +65,10 @@ const Body = BaseFormWithPolling.extend(
           url: getAuthenticatorUrl('probe'),
           // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
-          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: BrowserFeatures.isAndroid() ? 3000 : 100
+          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
+          // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
+          // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          timeout: BrowserFeatures.isAndroid() ? 3000 : (probeTimeoutMillis > -1 ? probeTimeoutMillis : 100)
         });
       };
 

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -63,11 +63,14 @@ const Body = BaseFormWithPolling.extend(
       const checkPort = () => {
         return request({
           url: getAuthenticatorUrl('probe'),
-          // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
-          // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
-          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
-          // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
-          // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          /*
+          OKTA-278573 in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional
+          timeout however, increasing timeout is a temporary solution since user will need to wait much longer in
+          worst case.
+          TODO: Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
+          OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
+          customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          */
           timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
         });
       };

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -51,7 +51,7 @@ const Body = BaseFormWithPolling.extend(
       return this.options.currentViewState.relatesTo.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = -1) {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = 100) {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -68,7 +68,7 @@ const Body = BaseFormWithPolling.extend(
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
           // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
           // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
-          timeout: BrowserFeatures.isAndroid() ? 3000 : (probeTimeoutMillis > -1 ? probeTimeoutMillis : 100)
+          timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
         });
       };
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -47,7 +47,12 @@ const Body = BaseForm.extend(Object.assign(
       return this.options.currentViewState.relatesTo.value.contextualData.challenge.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = 100) {
+    doLoopback(deviceChallenge) {
+      let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
+      let ports = deviceChallenge.ports !== undefined ? deviceChallenge.ports : [];
+      let challengeRequest = deviceChallenge.challengeRequest !== undefined ? deviceChallenge.challengeRequest : '';
+      let probeTimeoutMillis = deviceChallenge.probeTimeoutMillis !== undefined ?
+        deviceChallenge.probeTimeoutMillis : 100;
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -47,7 +47,7 @@ const Body = BaseForm.extend(Object.assign(
       return this.options.currentViewState.relatesTo.value.contextualData.challenge.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = -1) {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = 100) {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -64,7 +64,7 @@ const Body = BaseForm.extend(Object.assign(
           // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
           // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
           // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
-          timeout: BrowserFeatures.isAndroid() ? 3000 : (probeTimeoutMillis > -1 ? probeTimeoutMillis : 100)
+          timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
         });
       };
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -59,11 +59,14 @@ const Body = BaseForm.extend(Object.assign(
       const checkPort = () => {
         return request({
           url: getAuthenticatorUrl('probe'),
-          // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
-          // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
-          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
-          // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
-          // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          /*
+          OKTA-278573 in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional
+          timeout however, increasing timeout is a temporary solution since user will need to wait much longer in
+          worst case.
+          TODO: Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
+          OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
+          customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          */
           timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
         });
       };

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -47,7 +47,7 @@ const Body = BaseForm.extend(Object.assign(
       return this.options.currentViewState.relatesTo.value.contextualData.challenge.value;
     },
 
-    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '') {
+    doLoopback(authenticatorDomainUrl = '', ports = [], challengeRequest = '', probeTimeoutMillis = -1) {
       let currentPort;
       let foundPort = false;
       let countFailedPorts = 0;
@@ -61,8 +61,10 @@ const Body = BaseForm.extend(Object.assign(
           url: getAuthenticatorUrl('probe'),
           // in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional timeout
           // however, increasing timeout is a temporary solution since user will need to wait much longer in worst case
-          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta
-          timeout: BrowserFeatures.isAndroid() ? 3000 : 100
+          // TODO: OKTA-278573 Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
+          // OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
+          // customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+          timeout: BrowserFeatures.isAndroid() ? 3000 : (probeTimeoutMillis > -1 ? probeTimeoutMillis : 100)
         });
       };
 

--- a/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
@@ -20,7 +20,7 @@ describe('v2/utils/ChallengeViewUtil', function() {
       'domain': 'test_domain',
       'ports': [12345, 22222],
       'challengerequest': 'abcdfg12345',
-      'probeTimeoutMillis': 101
+      'probeTimeoutMillis': 100
     };
     spyOn(testView, 'getDeviceChallengePayload').and.callFake(() => deviceChallenge);
     let expectedAddArg = {};

--- a/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
@@ -19,7 +19,8 @@ describe('v2/utils/ChallengeViewUtil', function() {
       'challengeMethod': Enums.LOOPBACK_CHALLENGE,
       'domain': 'test_domain',
       'ports': [12345, 22222],
-      'challengerequest': 'abcdfg12345'
+      'challengerequest': 'abcdfg12345',
+      'probeTimeoutMillis': 101
     };
     spyOn(testView, 'getDeviceChallengePayload').and.callFake(() => deviceChallenge);
     let expectedAddArg = {};
@@ -35,7 +36,7 @@ describe('v2/utils/ChallengeViewUtil', function() {
     expect(testView.title).toBe(loc('deviceTrust.sso.redirectText', 'login'));
     expect(expectedAddArg.className).toBe('loopback-content');
     expect(expectedAddArg.template.call()).toBe(hbs`<div class="spinner"></div>`.call());
-    expect(testView.doLoopback).toHaveBeenCalledWith(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest);
+    expect(testView.doLoopback).toHaveBeenCalledWith(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest, deviceChallenge.probeTimeoutMillis);
   });
 
 

--- a/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
@@ -36,7 +36,7 @@ describe('v2/utils/ChallengeViewUtil', function() {
     expect(testView.title).toBe(loc('deviceTrust.sso.redirectText', 'login'));
     expect(expectedAddArg.className).toBe('loopback-content');
     expect(expectedAddArg.template.call()).toBe(hbs`<div class="spinner"></div>`.call());
-    expect(testView.doLoopback).toHaveBeenCalledWith(deviceChallenge.domain, deviceChallenge.ports, deviceChallenge.challengeRequest, deviceChallenge.probeTimeoutMillis);
+    expect(testView.doLoopback).toHaveBeenCalledWith(deviceChallenge);
   });
 
 


### PR DESCRIPTION
## Description:
Enhancement to read an optional loopback probe timeout from `/idp/idx/introspect`. If not specified or -1, current default of 100ms is used. Note that currently this enhancement will not affect Android which has a probe timeout of 3000ms (due to keyless HTTPS). This PR is for SIW client-side changes.

Accompanies server-side changes: https://github.com/okta/okta-core/pull/51968

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests? Yes, amended `ChallengeViewUtil_spec.js`.

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-365427](https://oktainc.atlassian.net/browse/OKTA-365427)


