### PR TITLE
fix: Reflects error message change in okta-core for unknown user

### DIFF
--- a/playground/mocks/data/idp/idx/identify-unknown-user.json
+++ b/playground/mocks/data/idp/idx/identify-unknown-user.json
@@ -52,7 +52,7 @@
     "type": "array",
     "value": [
       {
-        "message": "There is no account with the email <strong> test@rain.com </strong>. <a href=\"#\" class=\"js-sign-up\"> Sign up </a> for an account",
+        "message": "There is no account with the email test@rain.com. Error: idx.unknown.user",
         "i18n": {
           "key": "idx.unknown.user",
           "params": []

--- a/playground/mocks/data/idp/idx/identify-unknown-user.json
+++ b/playground/mocks/data/idp/idx/identify-unknown-user.json
@@ -52,7 +52,7 @@
     "type": "array",
     "value": [
       {
-        "message": "There is no account with the email test@rain.com. Error: idx.unknown.user",
+        "message": "There is no account with the email test@rain.com.",
         "i18n": {
           "key": "idx.unknown.user",
           "params": []

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -33,7 +33,7 @@ test('should show messages callout for unknown user', async t => {
   await identityPage.fillIdentifierField('unknown');
   await identityPage.clickNextButton();
   await t.expect(identityPage.getUnknownUserCalloutContent())
-    .eql('There is no account with the email test@rain.com. Error: idx.unknown.user');
+    .eql('There is no account with the email test@rain.com.');
 });
 
 test('should remove messages callout for unknown user once successful', async t => {

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -33,7 +33,7 @@ test('should show messages callout for unknown user', async t => {
   await identityPage.fillIdentifierField('unknown');
   await identityPage.clickNextButton();
   await t.expect(identityPage.getUnknownUserCalloutContent())
-    .eql('There is no account with the email  test@rain.com .  Sign up  for an account');
+    .eql('There is no account with the email test@rain.com. Error: idx.unknown.user');
 });
 
 test('should remove messages callout for unknown user once successful', async t => {

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -206,7 +206,7 @@ describe('v2/ion/responseTransformer', function() {
         messages: {
           value: [
             {
-              message: 'There is no account with the email test@rain.com. Error: idx.unknown.user',
+              message: 'There is no account with the email test@rain.com.',
               i18n: {
                 key: 'idx.unknown.user',
                 params: [],

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -206,7 +206,7 @@ describe('v2/ion/responseTransformer', function() {
         messages: {
           value: [
             {
-              message: 'There is no account with the email <strong> test@rain.com </strong>. <a href="#" class="js-sign-up"> Sign up </a> for an account',
+              message: 'There is no account with the email test@rain.com. Error: idx.unknown.user',
               i18n: {
                 key: 'idx.unknown.user',
                 params: [],


### PR DESCRIPTION
## Description:

HTML tag is removed from the idx.unknown.user error message in [a PR in okta-core](https://github.com/okta/okta-core/pull/51872) because it is not desirable to return HTML tag in API return messages. 

This PR reflects the change in okta-core. Okta-core's change has green bacon regardless of this change, so I suspect this PR is not strictly necessary, i.e., the mocked output just need to match the test expectation. But adding this PR to make sure we are consistent. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
   - Run `yarn test -t jest`, which passes both before and after the change. (The test would fail if the mocked output does not match the test expectation.)
   - `yarn test -t testcafe` and `yarn test -t karma` both fail locally before and after for the same reasons that look unrelated to this change. 

- [ ] Added unit tests?
   no

- [ ] Added e2e tests
   no

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
    Yes 
### Screenshot/Video:


### Reviewers:

@haishengwu-okta 

### Issue:

- [OKTA-379880](https://oktainc.atlassian.net/browse/OKTA-379880)


