### PR TITLE
feat: allow web apps to pass codeChallenge without interactionHandle

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -45,12 +45,6 @@ export default Model.extend({
       value: 'auto',
     },
 
-    mode: {
-      type: 'string',
-      values: ['remediation', 'relying-party'],
-      value: 'relying-party',
-    },
-
     // Function to transform the username before passing it to the API
     // for Primary Auth, Forgot Password and Unlock Account.
     transformUsername: ['function', false],
@@ -116,7 +110,7 @@ export default Model.extend({
     state: 'string',
     scopes: 'array',
     codeChallenge: 'string',
-    codeChallengeMethod: 'string',
+    codeChallengeMethod: ['string', false, 'S256'],
     oAuthTimeout: ['number', false],
 
     authScheme: ['string', false, 'OAUTH2'],
@@ -234,6 +228,15 @@ export default Model.extend({
         return Object.keys(countries).includes(defaultCountryCode)
           ? defaultCountryCode : 'US';
       },
+    },
+    mode: {
+      deps: ['useInteractionCodeFlow', 'interactionHandle', 'codeChallenge'],
+      fn: function(useInteractionCodeFlow, interactionHandle, codeChallenge) {
+        if (interactionHandle || (useInteractionCodeFlow && codeChallenge)) {
+          return 'remediation';
+        }
+        return 'relying-party';
+      }
     },
     oauth2Enabled: {
       deps: ['clientId', 'authScheme'],

--- a/src/v2/client/interactionCodeFlow.js
+++ b/src/v2/client/interactionCodeFlow.js
@@ -24,6 +24,9 @@ export async function interactionCodeFlow(settings, idxResponse) {
 
   // In remediation mode the transaction is owned by another client.
   const isRemediationMode = settings.get('mode') === 'remediation';
+  if (isRemediationMode) {
+    clearTransactionMeta(settings);
+  }
   
   // server-side applications will want to received interaction_code as a query parameter
   // this option can also be used to force a redirect for client-side/SPA applications

--- a/test/unit/spec/v2/client/interactionCodeFlow_spec.js
+++ b/test/unit/spec/v2/client/interactionCodeFlow_spec.js
@@ -50,8 +50,8 @@ describe('v2/client/interactionCodeFlow', () => {
       authParams,
       authClient,
       redirectUri
-    }
-  })
+    };
+  });
   
   describe('redirect = always', () => {
     beforeEach(() => {
@@ -78,7 +78,7 @@ describe('v2/client/interactionCodeFlow', () => {
     it('redirects using interaction_code from response and state from saved transaction', async () => {
       await interactionCodeFlow(testContext.settings, testContext.idxResponse);
       expect(window.location.assign).toHaveBeenCalledWith(`${testContext.redirectUri}?interaction_code=a%20fake%20code&state=a%20fake%20state`);
-    })
+    });
 
     describe('with authParams.state', () => {
       beforeEach(() => {
@@ -88,7 +88,7 @@ describe('v2/client/interactionCodeFlow', () => {
       it('returns interaction_code and state from authParams.state', async () => {
         await interactionCodeFlow(testContext.settings, testContext.idxResponse);
         expect(window.location.assign).toHaveBeenCalledWith(`${testContext.redirectUri}?interaction_code=a%20fake%20code&state=state%20in%20authParams`);
-      })
+      });
     });
   });
 
@@ -116,7 +116,7 @@ describe('v2/client/interactionCodeFlow', () => {
         'interaction_code': testContext.interactionCode,
         state: testContext.transactionMeta.state
       });
-    })
+    });
 
     describe('with authParams.state', () => {
       beforeEach(() => {
@@ -130,7 +130,7 @@ describe('v2/client/interactionCodeFlow', () => {
           'interaction_code': testContext.interactionCode,
           state: testContext.authParams.state
         });
-      })
+      });
     });
   });
 

--- a/test/unit/spec/v2/client/interactionCodeFlow_spec.js
+++ b/test/unit/spec/v2/client/interactionCodeFlow_spec.js
@@ -1,0 +1,172 @@
+import { interactionCodeFlow } from 'v2/client/interactionCodeFlow';
+import { Model } from 'okta';
+
+jest.mock('v2/client/transactionMeta', () => {
+  return {
+    clearTransactionMeta: () => {}
+  };
+});
+
+const mocked = {
+  transactionMeta: require('v2/client/transactionMeta')
+};
+
+describe('v2/client/interactionCodeFlow', () => {
+  let testContext;
+  beforeEach(() => {
+    const state = 'a fake state'; // spaces to test URL encoding
+    const interactionCode = 'a fake code'; // spaces to test URL encoding
+    const codeVerifier = 'code verifier';
+    const idxResponse = {
+      interactionCode
+    };
+    const transactionMeta = {
+      state,
+      codeVerifier
+    };
+    const authParams = {};
+    const authClient = {
+      options: authParams,
+      transactionManager: {
+        load: () => transactionMeta
+      },
+      token: {
+        exchangeCodeForTokens: () => Promise.resolve()
+      }
+    };
+    const redirectUri = 'fake';
+    const settings = new Model();
+    settings.set('redirectUri', redirectUri);
+    settings.getAuthClient = () => authClient;
+    settings.callGlobalSuccess = () => {};
+    settings.callGlobalError = () => {};
+    testContext = {
+      state,
+      interactionCode,
+      codeVerifier,
+      idxResponse,
+      transactionMeta,
+      settings,
+      authParams,
+      authClient,
+      redirectUri
+    }
+  })
+  
+  describe('redirect = always', () => {
+    beforeEach(() => {
+      testContext.settings.set('redirect', 'always');
+      testContext.origLocation = window.location;
+      delete window.location;
+      window.location = {
+        assign: jest.fn()
+      };
+    });
+    afterEach(() => {
+      window.location = testContext.origLocation;
+    });
+
+    it('throws if redirectUri is not set', async () => {
+      testContext.settings.set('redirectUri', null);
+      try {
+        await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      } catch (e) {
+        expect(e.toString()).toBe('CONFIG_ERROR: "redirectUri" is required');
+      }
+    });
+
+    it('redirects using interaction_code from response and state from saved transaction', async () => {
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(window.location.assign).toHaveBeenCalledWith(`${testContext.redirectUri}?interaction_code=a%20fake%20code&state=a%20fake%20state`);
+    })
+
+    describe('with authParams.state', () => {
+      beforeEach(() => {
+        testContext.authParams.state = 'state in authParams';
+      });
+
+      it('returns interaction_code and state from authParams.state', async () => {
+        await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+        expect(window.location.assign).toHaveBeenCalledWith(`${testContext.redirectUri}?interaction_code=a%20fake%20code&state=state%20in%20authParams`);
+      })
+    });
+  });
+
+  describe('remediation mode', () => {
+    beforeEach(() => {
+      testContext.settings.set('mode', 'remediation');
+    });
+
+    it('clears transaction meta', async () => {
+      jest.spyOn(mocked.transactionMeta, 'clearTransactionMeta');
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(mocked.transactionMeta.clearTransactionMeta).toHaveBeenCalled();
+    });
+
+    it('does not exchange code for tokens', async () => {
+      jest.spyOn(testContext.authClient.token, 'exchangeCodeForTokens');
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(testContext.authClient.token.exchangeCodeForTokens).not.toHaveBeenCalled();
+    });
+
+    it('calls global success fn with interaction_code from response and state from saved transaction', async () => {
+      jest.spyOn(testContext.settings, 'callGlobalSuccess');
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(testContext.settings.callGlobalSuccess).toHaveBeenCalledWith('SUCCESS', {
+        'interaction_code': testContext.interactionCode,
+        state: testContext.transactionMeta.state
+      });
+    })
+
+    describe('with authParams.state', () => {
+      beforeEach(() => {
+        testContext.authParams.state = 'an auth param state';
+      });
+
+      it('calls global success fn with interaction_code and state from authParams.state', async () => {
+        jest.spyOn(testContext.settings, 'callGlobalSuccess');
+        await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+        expect(testContext.settings.callGlobalSuccess).toHaveBeenCalledWith('SUCCESS', {
+          'interaction_code': testContext.interactionCode,
+          state: testContext.authParams.state
+        });
+      })
+    });
+  });
+
+  describe('relying-party mode', () => {
+    it('exchanges code for tokens using the codeVerifier from saved transaction', async () => {
+      jest.spyOn(testContext.authClient.token, 'exchangeCodeForTokens');
+      const { interactionCode, codeVerifier } = testContext;
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(testContext.authClient.token.exchangeCodeForTokens).toHaveBeenCalledWith({
+        interactionCode,
+        codeVerifier
+      });
+    });
+
+    it('clears transaction meta', async () => {
+      jest.spyOn(mocked.transactionMeta, 'clearTransactionMeta');
+      await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+      expect(mocked.transactionMeta.clearTransactionMeta).toHaveBeenCalled();
+    });
+
+    describe('if exchangeCodeForTokens throws error', () => {
+      beforeEach(() => {
+        testContext.error = new Error('exchange code error');
+        jest.spyOn(testContext.authClient.token, 'exchangeCodeForTokens').mockReturnValue(Promise.reject(testContext.error));
+      });
+      it('calls the global error handler', async () => {
+        jest.spyOn(testContext.settings, 'callGlobalError');
+        await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+        expect(testContext.settings.callGlobalError).toHaveBeenCalled();
+      });
+
+      it('clears transaction meta', async () => {
+        jest.spyOn(mocked.transactionMeta, 'clearTransactionMeta');
+        await interactionCodeFlow(testContext.settings, testContext.idxResponse);
+        expect(mocked.transactionMeta.clearTransactionMeta).toHaveBeenCalled();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description:
Enhancement to interaction code flow for web applications who do not want to call `/interact` or manage the interactionHandle. Web apps can provide only a codeChallenge and the widget will retrieve and store an interactionHandle. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-389010](https://oktainc.atlassian.net/browse/OKTA-389010)


