### PR TITLE
feat[v1]: ignore settings.signOutLink if SMS Password Recovery flow

### DIFF
--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -244,6 +244,14 @@ export default Model.extend({
         return res.status === 'MFA_CHALLENGE' || res.status === 'FACTOR_CHALLENGE';
       },
     },
+    isSMSPasswordRecovery: {
+      deps: ['lastAuthResponse'],
+      fn: function({ status, factorType, recoveryType }) {
+        return status === 'RECOVERY_CHALLENGE' &&
+          factorType?.toLowerCase() === 'sms' &&
+          recoveryType?.toLowerCase() === 'password';
+      }
+    },
     isUnauthenticated: {
       deps: ['lastAuthResponse'],
       fn: function(res) {

--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -28,19 +28,20 @@ export default View.extend({
   },
   handleSignout: function(e) {
     e.preventDefault();
-    this.options.appState.trigger('signOut');
-    const self = this;
+
+    const appState = this.options.appState;
+    appState.trigger('signOut');
 
     this.model
       .doTransaction(function(transaction) {
         return transaction.cancel();
       })
-      .then(function() {
-        if (self.settings.get('signOutLink')) {
-          Util.redirect(self.settings.get('signOutLink'));
+      .then(() => {
+        if (this.settings.get('signOutLink') && !appState.get('isSMSPasswordRecovery')) {
+          Util.redirect(this.settings.get('signOutLink'));
         } else {
-          self.state.set('navigateDir', Enums.DIRECTION_BACK);
-          self.options.appState.trigger('navigate', '');
+          this.state.set('navigateDir', Enums.DIRECTION_BACK);
+          appState.trigger('navigate', '');
         }
       });
   },

--- a/test/unit/spec/ForgotPassword_spec.js
+++ b/test/unit/spec/ForgotPassword_spec.js
@@ -1,5 +1,5 @@
 /* eslint max-params: [2, 18], max-statements: 0 */
-import { _ } from 'okta';
+import { _, internal } from 'okta';
 import createAuthClient from 'widget/createAuthClient';
 import Router from 'LoginRouter';
 import AccountRecoveryForm from 'helpers/dom/AccountRecoveryForm';
@@ -15,6 +15,7 @@ import resError from 'helpers/xhr/RECOVERY_error';
 import resSuccess from 'helpers/xhr/SUCCESS';
 import Q from 'q';
 import $sandbox from 'sandbox';
+const SharedUtil = internal.util.Util;
 const itp = Expect.itp;
 
 function setup(settings, startRouter) {
@@ -239,6 +240,19 @@ Expect.describe('ForgotPassword', function() {
   });
 
   Expect.describe('events', function() {
+    itp('ignores signOutLink customization if SMS recovery challenge and returns to last screen when "Back to sign in" is clicked', function() {
+      return setupWithSms({ signOutLink: 'https://signout.com/' })
+        .then(function(test) {
+          spyOn(SharedUtil, 'redirect');
+          Util.resetAjaxRequests();
+          test.form.goBack();
+          return Expect.waitForPrimaryAuth(test);
+        })
+        .then(function(test) {
+          expect(SharedUtil.redirect).not.toHaveBeenCalled();
+          Expect.isPrimaryAuth(test.router.controller);
+        });
+    });
     itp('shows an error if username is empty and request email', function() {
       return setup().then(function(test) {
         Util.resetAjaxRequests();


### PR DESCRIPTION
## Description:
doing this for a customer issue where they need signOutLink customized but want "Back to sign in" to navigate back and not navigate to their signOutLink
<img width="426" alt="Screenshot 2021-05-04 at 2 30 58 PM" src="https://user-images.githubusercontent.com/71431120/117072519-67915c80-ace5-11eb-9e67-ff79949b64e7.png">


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-374204](https://oktainc.atlassian.net/browse/OKTA-374204)


