### PR TITLE
fix: english leak authenticator-enroll-ov-via-email

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -804,6 +804,7 @@ oie.enroll.okta_verify.select.channel.qrcode.label = Scan a QR code
 oie.enroll.okta_verify.select.channel.email.label = Email me a setup link
 oie.enroll.okta_verify.select.channel.sms.label = Text me a setup link
 oie.enroll.okta_verify.select.channel.title = More options
+oie.enroll.okta_verify.channel.email.label = Email
 oie.enroll.okta_verify.enroll.channel.email.title = Set up Okta Verify via email link
 oie.enroll.okta_verify.enroll.channel.sms.title = Set up Okta Verify via SMS
 oie.enroll.okta_verify.channel.email.description = Make sure you can access the email on your mobile device.

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -643,6 +643,7 @@ oie.enroll.okta_verify.select.channel.qrcode.label = 》Šçåñ å ǪŔ çöð�
 oie.enroll.okta_verify.select.channel.email.label = 》Éɱåîļ ɱé å šéţûþ ļîñķ Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.okta_verify.select.channel.sms.label = 》Ţéẋţ ɱé å šéţûþ ļîñķ €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.okta_verify.select.channel.title = 》Ṁöŕé öþţîöñš ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.enroll.okta_verify.channel.email.label = 》Éɱåîļ 홝한Ӝฐโ《
 oie.enroll.okta_verify.enroll.channel.email.title = 》Šéţ ûþ Öķţå Ṽéŕîƒý ṽîå éɱåîļ ļîñķ Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.okta_verify.enroll.channel.sms.title = 》Šéţ ûþ Öķţå Ṽéŕîƒý ṽîå ŠṀŠ €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.enroll.okta_verify.channel.email.description = 》Ṁåķé šûŕé ýöû çåñ åççéšš ţĥé éɱåîļ öñ ýöûŕ ɱöƀîļé ðéṽîçé· ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/playground/mocks/data/idp/idx/authenticator-enroll-ov-via-email.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-ov-via-email.json
@@ -57,7 +57,7 @@
                   {
                     "name": "channel",
                     "required": true,
-                    "visible": false,
+                    "visible": true,
                     "mutable": false,
                     "options": [
                       {
@@ -67,6 +67,10 @@
                       {
                         "value": "sms",
                         "label": "SMS"
+                      },
+                      {
+                        "value": "email",
+                        "label": "Email"
                       }
                     ]
                   }

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -110,6 +110,8 @@ const I18N_OVERRIDE_MAPPINGS = {
   'enroll-authenticator.symantec_vip.credentials.passcode': 'enroll.symantecVip.passcode1.placeholder',
   'enroll-authenticator.symantec_vip.credentials.nextPasscode': 'enroll.symantecVip.passcode2.placeholder',
 
+  'enrollment-channel-data.email': 'oie.enroll.okta_verify.channel.email.label',
+
   'select-enrollment-channel.authenticator.channel.qrcode': 'oie.enroll.okta_verify.select.channel.qrcode.label',
   'select-enrollment-channel.authenticator.channel.email': 'oie.enroll.okta_verify.select.channel.email.label',
   'select-enrollment-channel.authenticator.channel.sms': 'oie.enroll.okta_verify.select.channel.sms.label',

--- a/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollementChannelDataOktaVerifyView.js
@@ -11,7 +11,11 @@ const Body = BaseForm.extend({
       loc('oie.enroll.okta_verify.enroll.channel.email.title', 'login'):
       loc('oie.enroll.okta_verify.enroll.channel.sms.title', 'login');
   },
-  save: loc('oie.enroll.okta_verify.setupLink', 'login'),
+
+  save() {
+    return loc('oie.enroll.okta_verify.setupLink', 'login');
+  },
+
   getUISchema() {
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     const phoneNumberUISchema = _.find(uiSchemas, ({ name }) => name === 'phoneNumber');

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -50,7 +50,6 @@ const ignoredMocks = [
   'authenticator-expired-password-no-complexity.json',
   'authenticator-enroll-phone.json',
   'authenticator-enroll-phone-voice.json',
-  'authenticator-enroll-ov-via-email.json',
   'authenticator-enroll-email.json',
   'authenticator-enroll-data-phone.json',
   'authenticator-enroll-data-phone-voice.json',

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -33,6 +33,8 @@ describe('v2/ion/i18nTransformer', function() {
       'mfa.challenge.password.placeholder': 'password',
       'oie.okta_verify.totp.enterCodeText': 'enter totp code',
       'oie.google_authenticator.otp.enterCodeText': 'enter passcode',
+      'oie.enroll.okta_verify.channel.email.label': 'email',
+
       'primaryauth.password.placeholder': 'password',
       'primaryauth.username.placeholder': 'username',
       'remember': 'remember me',
@@ -1639,6 +1641,50 @@ describe('v2/ion/i18nTransformer', function() {
           ]
         }
       ]
+    });
+  });
+
+  it('should get email label if it defined on enrollment-channel-data', () => {
+    const resp = {
+      remediations: [{
+        name: 'enrollment-channel-data',
+        value: [{
+          label: 'Email',
+          name: 'email',
+          required: true,
+          visible: true
+        }],
+        uiSchema: [{
+          label: 'Email',
+          name: 'email',
+          required: true,
+          visible: true,
+          'label-top': true,
+          'data-se': 'o-form-fieldset-email',
+          type: 'text'
+        }]
+      }],
+    };
+
+    expect(i18nTransformer(resp)).toEqual({
+      'remediations': [{
+        name: 'enrollment-channel-data',
+        'value': [{
+          'label': 'Email',
+          'name': 'email',
+          'required': true,
+          'visible': true
+        }],
+        'uiSchema': [{
+          'label': 'unit test - email',
+          'name': 'email',
+          'required': true,
+          'visible': true,
+          'label-top': true,
+          'data-se': 'o-form-fieldset-email',
+          'type': 'text'
+        }]
+      }],
     });
   });
 


### PR DESCRIPTION
## Description:
1. `save` as function
2. add i18n mapping for Email label for enrolling okta verify


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/47287459/116926806-b10f7800-ac0f-11eb-8f8d-db4b0ac6bb88.png)


### Reviewers:
@jmelberg-okta @nikhilvenkatraman-okta 

### Issue:

- [OKTA-389462](https://oktainc.atlassian.net/browse/OKTA-389462)


