### PR TITLE
fix: en leak "terminal-polling-window-expired"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,7 +114,6 @@ module.exports = {
             'playground/**/error-unlock-account.json',
             'playground/**/error-user-is-not-assigned.json',
             'playground/**/identify-unknown-user.json',
-            'playground/**/terminal-polling-window-expired.json',
             'playground/**/terminal-registration.json',
             'playground/**/terminal-return-error-email.json',
             'playground/**/terminal-return-stale-email.json'

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1001,3 +1001,4 @@ authfactor.challenge.soft_token.used_passcode = Each code can only be used once.
 
 # rate limit
 oie.tooManyRequests = Too many requests
+E0000010 = Server is unable to respond at the moment.

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -792,3 +792,4 @@ oie.browser.error.NotAllowedError = 》Ţĥé öþéŕåţîöñ éîţĥéŕ ţ
 authfactor.challenge.soft_token.invalid_passcode = 》Ýöûŕ çöðé ðöéšñ´ţ ɱåţçĥ öûŕ ŕéçöŕðš· Þļéåšé ţŕý åĝåîñ· €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 authfactor.challenge.soft_token.used_passcode = 》Éåçĥ çöðé çåñ öñļý ƀé ûšéð öñçé· Þļéåšé ŵåîţ ƒöŕ å ñéŵ çöðé åñð ţŕý åĝåîñ· 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.tooManyRequests = 》Ţöö ɱåñý ŕéǫûéšţš 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+E0000010 = 》Šéŕṽéŕ îš ûñåƀļé ţö ŕéšþöñð åţ ţĥé ɱöɱéñţ· ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -17,7 +17,6 @@ const ignoredMocks = [
   'terminal-return-expired-email.json',
   'terminal-return-error-email.json',
   'terminal-registration.json',
-  'terminal-polling-window-expired.json',
   'success-with-interaction-code.json',
   'identify-with-third-party-idps.json',
   'identify-with-no-sso-extension.json',

--- a/test/testcafe/spec/PollView_spec.js
+++ b/test/testcafe/spec/PollView_spec.js
@@ -55,6 +55,6 @@ test.requestHooks(requestLogger, identifyPollErrorMock)('not poll on error', asy
   await identityPage.fillPasswordField('password');
   await identityPage.clickNextButton();
   const pollingPageObject = new PollingPageObject();
-  await t.expect(pollingPageObject.getErrorMessages().getTextContent()).eql('Something went wrong, Try again later.');
+  await t.expect(pollingPageObject.getErrorMessages().getTextContent()).eql('Server is unable to respond at the moment.');
   await t.expect(pollingPageObject.getContent().length).eql(0);
 });


### PR DESCRIPTION
## Description:

<img width="423" alt="Screenshot 2021-05-05 at 9 33 01 AM" src="https://user-images.githubusercontent.com/71431120/117177078-77607d80-ad85-11eb-8e96-ab973933bf5c.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-388431](https://oktainc.atlassian.net/browse/OKTA-388431)


