### PR TITLE
fix: always use interactionHandle from settings

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -110,7 +110,7 @@ export default Model.extend({
     state: 'string',
     scopes: 'array',
     codeChallenge: 'string',
-    codeChallengeMethod: ['string', false, 'S256'],
+    codeChallengeMethod: ['string', false],
     oAuthTimeout: ['number', false],
 
     authScheme: ['string', false, 'OAUTH2'],

--- a/src/v2/client/transactionMeta.js
+++ b/src/v2/client/transactionMeta.js
@@ -13,7 +13,7 @@
 import Logger from 'util/Logger';
 
 // Calculate new values
-export function createTransactionMeta(settings) {
+export async function createTransactionMeta(settings) {
   const authClient = settings.getAuthClient();
   return authClient.token.prepareTokenParams();
 }
@@ -40,7 +40,7 @@ export async function getTransactionMeta(settings) {
   let codeChallenge = settings.get('codeChallenge');
   let codeChallengeMethod = settings.get('codeChallengeMethod');
 
-  const meta = createTransactionMeta(settings);
+  const meta = await createTransactionMeta(settings);
   if (interactionHandle) {
     meta.interactionHandle = interactionHandle;
   }
@@ -85,6 +85,12 @@ export function isTransactionMetaValid(settings, meta) {
   // if `codeChallenge` option was provided, validate it against the meta
   const codeChallenge = settings.get('codeChallenge');
   if (codeChallenge && meta.codeChallenge !== codeChallenge) {
+    return false;
+  }
+
+  // if `codeChallengeMethod` option was provided, validate it against the meta
+  const codeChallengeMethod = settings.get('codeChallengeMethod');
+  if (codeChallengeMethod && meta.codeChallengeMethod !== codeChallengeMethod) {
     return false;
   }
 

--- a/test/unit/.eslintrc.js
+++ b/test/unit/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'complexity': 0,
     'max-params': 0,
     'max-statements': 0,
+    'jasmine/no-expect-in-setup-teardown': 0,
     'jasmine/new-line-before-expect': 0,
     'jasmine/new-line-between-declarations': 0,
     'jasmine/no-spec-dupes': [1, 'branch'],

--- a/test/unit/spec/v2/client/transactionMeta_spec.js
+++ b/test/unit/spec/v2/client/transactionMeta_spec.js
@@ -1,0 +1,249 @@
+import {
+  createTransactionMeta,
+  getTransactionMeta,
+  saveTransactionMeta,
+  clearTransactionMeta,
+  isTransactionMetaValid
+} from 'v2/client/transactionMeta';
+import { Model } from 'okta';
+
+jest.mock('util/Logger', () => {
+  return {
+    warn: () => {}
+  };
+});
+
+const mocked = {
+  Logger: require('util/Logger')
+};
+
+describe('v2/client/transactionMeta', () => {
+  let testContext;
+  beforeEach(() => {
+    const state = 'a-test-state';
+    const interactionHandle = 'a-test-interaction-handle';
+    const codeChallenge = 'a-test-code-challenge';
+    const codeChallengeMethod = 'test-code-challenge-method';
+    const transactionMeta = {
+      state,
+      interactionHandle,
+      codeChallenge,
+      codeChallengeMethod
+    };
+    const authParams = {};
+    const authClient = {
+      options: authParams,
+      transactionManager: {
+        exists: () => !!testContext.transactionMeta,
+        load: () => testContext.transactionMeta,
+        clear: () => {},
+        save: () => {}
+      },
+      token: {
+        prepareTokenParams: () => Promise.resolve()
+      }
+    };
+    const settings = new Model();
+    settings.getAuthClient = () => authClient;
+    testContext = {
+      interactionHandle,
+      codeChallenge,
+      codeChallengeMethod,
+      transactionMeta,
+      settings,
+      authParams,
+      authClient
+    };
+  });
+  
+  function assertIsPromise(res) {
+    expect(typeof res.then).toBe('function');
+    expect(typeof res.catch).toBe('function');
+    expect(typeof res.finally).toBe('function');
+  }
+
+  describe('createTransactionMeta', () => {
+    it('calls `authClient.token.prepareTokenParams`', async () => {
+      jest.spyOn(testContext.authClient.token, 'prepareTokenParams');
+      await createTransactionMeta(testContext.settings);
+      expect(testContext.authClient.token.prepareTokenParams).toHaveBeenCalled();
+    });
+    it('returns a promise', () => {
+      const res = createTransactionMeta(testContext.settings);
+      assertIsPromise(res);
+      return res;
+    });
+  });
+
+  describe('getTransactionMeta', () => {
+    it('returns a promise', () => {
+      const res = getTransactionMeta(testContext.settings);
+      assertIsPromise(res);
+      return res;
+    });
+    describe('no existing meta', () => {
+      beforeEach(() => {
+        testContext.transactionMeta = null;
+        expect(testContext.authClient.transactionManager.exists()).toBe(false);
+        testContext.newMeta = { foo: 'bar' };
+        jest.spyOn(testContext.authClient.token, 'prepareTokenParams').mockReturnValue(Promise.resolve(testContext.newMeta));
+      });
+      it('returns new meta', async () => {
+        const res = await getTransactionMeta(testContext.settings);
+        expect(res).toEqual(testContext.newMeta);
+      });
+      it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
+        testContext.settings.set('interactionHandle', testContext.interactionHandle);
+        testContext.settings.set('codeChallenge', testContext.codeChallenge);
+        testContext.settings.set('codeChallengeMethod', testContext.codeChallengeMethod);
+        const res = await getTransactionMeta(testContext.settings);
+        expect(res.foo).toBe('bar');
+        expect(res.interactionHandle).toBe(testContext.interactionHandle);
+        expect(res.codeChallenge).toBe(testContext.codeChallenge);
+        expect(res.codeChallengeMethod).toBe(testContext.codeChallengeMethod);
+      });
+    });
+
+    describe('with existing meta', () => {
+      describe('existing is valid', () => {
+        beforeEach(() => {
+          jest.spyOn(testContext.authClient.token, 'prepareTokenParams');
+        });
+        afterEach(() => {
+          expect(testContext.authClient.token.prepareTokenParams).not.toHaveBeenCalled();
+        });
+        it('returns existing meta', async () => {
+          const res = await getTransactionMeta(testContext.settings);
+          expect(res).toEqual(testContext.transactionMeta);
+        });
+        it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
+          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
+          testContext.settings.set('interactionHandle', interactionHandle);
+          testContext.settings.set('codeChallenge', codeChallenge);
+          testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
+          Object.assign(testContext.transactionMeta, {
+            interactionHandle,
+            codeChallenge,
+            codeChallengeMethod 
+          });
+
+          const res = await getTransactionMeta(testContext.settings);
+          expect(res).toEqual(testContext.transactionMeta);
+          expect(res.interactionHandle).toBe(interactionHandle);
+          expect(res.codeChallenge).toBe(codeChallenge);
+          expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
+        });
+      });
+
+      describe('existing is invalid', () => {
+        beforeEach(() => {
+          testContext.newMeta = { foo: 'bar' };
+          jest.spyOn(testContext.authClient.token, 'prepareTokenParams').mockReturnValue(Promise.resolve(testContext.newMeta));
+          testContext.authParams.clientId = 'fake'; // will cause transaction meta to be invalid
+        });
+        afterEach(() => {
+          expect(testContext.authClient.token.prepareTokenParams).toHaveBeenCalled();
+        });
+
+        it('returns new meta', async () => {
+          const res = await getTransactionMeta(testContext.settings);
+          expect(res).toEqual(testContext.newMeta);
+        });
+  
+        it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
+          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
+          testContext.settings.set('interactionHandle', interactionHandle);
+          testContext.settings.set('codeChallenge', codeChallenge);
+          testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
+  
+          const res = await getTransactionMeta(testContext.settings);
+          expect(res.foo).toBe('bar');
+          expect(res.interactionHandle).toBe(interactionHandle);
+          expect(res.codeChallenge).toBe(codeChallenge);
+          expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
+        });
+
+        it('prints a warning message', async () => {
+          jest.spyOn(mocked.Logger, 'warn');
+          await getTransactionMeta(testContext.settings);
+
+          expect(mocked.Logger.warn).toHaveBeenCalledWith(
+            'Saved transaction meta does not match the current configuration. ' + 
+            'This may indicate that two apps are sharing a storage key.'
+          );
+        });
+      });
+    });
+  });
+
+  describe('saveTransactionMeta', () => {
+    it('calls `authClient.transactionManager.save`', () => {
+      jest.spyOn(testContext.authClient.transactionManager, 'save');
+      saveTransactionMeta(testContext.settings, testContext.transactionMeta);
+      expect(testContext.authClient.transactionManager.save).toHaveBeenCalledWith(testContext.transactionMeta);
+    });
+  });
+
+  describe('clearTransactionMeta', () => {
+    it('calls `authClient.transactionManager.clear`', () => {
+      jest.spyOn(testContext.authClient.transactionManager, 'clear');
+      clearTransactionMeta(testContext.settings);
+      expect(testContext.authClient.transactionManager.clear).toHaveBeenCalledWith();
+    });
+  });
+
+
+  describe('isTransactionMetaValid', () => {
+    it('returns false if `clientId` does not match', () => {
+      testContext.transactionMeta.clientId = 'abc';
+      testContext.authParams.clientId = 'def';
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns false if `redirectUri` does not match', () => {
+      testContext.transactionMeta.redirectUri = 'abc';
+      testContext.authParams.redirectUri = 'def';
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns false if `interactionHandle` does not match', () => {
+      testContext.transactionMeta.interactionHandle = 'abc';
+      testContext.settings.set('interactionHandle', 'def');
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns false if `codeChallenge` does not match', () => {
+      testContext.transactionMeta.codeChallenge = 'abc';
+      testContext.settings.set('codeChallenge', 'def');
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns false if `codeChallengeMethod` does not match', () => {
+      testContext.transactionMeta.codeChallengeMethod = 'abc';
+      testContext.settings.set('codeChallengeMethod', 'def');
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns true if clientId and redirectId match, with empty settings', () => {
+      testContext.transactionMeta.clientId = 'abc';
+      testContext.authParams.clientId = 'abc';
+      testContext.transactionMeta.redirectUri = 'abc';
+      testContext.authParams.redirectUri = 'abc';
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(true);
+    });
+
+    it('returns true if clientId and redirectId from authParams and interactionHandle, codeChallenge, codeChallengeMethod from settings match', () => {
+      testContext.transactionMeta.clientId = 'abc';
+      testContext.authParams.clientId = 'abc';
+      testContext.transactionMeta.redirectUri = 'abc';
+      testContext.authParams.redirectUri = 'abc';
+      testContext.transactionMeta.interactionHandle = 'abc';
+      testContext.settings.set('interactionHandle', 'abc');
+      testContext.transactionMeta.codeChallenge = 'abc';
+      testContext.settings.set('codeChallenge', 'abc');
+      testContext.transactionMeta.codeChallengeMethod = 'abc';
+      testContext.settings.set('codeChallengeMethod', 'abc');
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Description:

A missing `await` keyword meant that an `interactionHandle` passed via config options was being ignored.

This is a fix for server-side web applications using the interaction code flow.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-392995](https://oktainc.atlassian.net/browse/OKTA-392995)


