### PR TITLE
When calling /challenge, if it timeout, the xhr.statusText === 'timeo…

### DIFF
--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -113,7 +113,12 @@ const Body = BaseFormWithPolling.extend(
               return this.trigger('save', this.model);
             }).fail((xhr) => {
               Logger.error(`OV challenge response with HTTP code ${xhr.status} ${xhr.responseText}`);
-              onPortFail();
+              if (xhr.statusText === 'timeout') {
+                foundPort = true;
+                return this.trigger('save', this.model);
+              } else {
+                onPortFail();
+              }
             });
           })
           .fail(onFailure);


### PR DESCRIPTION
## Description:
When calling /challenge, if it timeout, the xhr.statusText === 'timeout'.

When it is timeout, we should not cancel the polling.

some context about this fix:
We implemented the following probing logic:

SIW iterates the loopback ports with the following two calls

/probe - detect if the port is available

/challenge - send device challenge to OV

If both calls above for a particular port get success, we stop probing, start /poll to the server.

until we iterate all the loopback ports. 

If non of the port get success, we "cancel" the polling.

When a call to (/probe, /challenge) is successful, the xhr.status == 200.

timeout actually means fail (xhr.status==0)

In the case of /challenge, we have 3000 ms timeout, but for inline enrollment, OV will reply the /challenge after enrollment completes by the user. 

Usually it takes a few minutes. As a result, SIW will end up the following situation.

"non of the port get success, we "cancel" the polling."


The fix is that we should not treat timeout of /challenge as failure so that SIW will continue to poll the result until either user completes the enrollment or IdX transaction timeout(5 mintues).

Resolves: OKTA-384095

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
before fix, failure video:
https://okta.box.com/s/z16eqtkt78gigmfwmc77loumn3m1bay4

after fix, success video:
https://okta.box.com/s/lq3qxwyj26p60uv44m69ukupcc6sazko

### Reviewers:
@anatoliiboiarshchykov-okta @haishengwu-okta @magizh-okta 

### Issue:

- [OKTA-384095](https://oktainc.atlassian.net/browse/OKTA-384095)


