### PR TITLE
fix: match webauthn authenticator by key instead of type

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-enroll-webauthn.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-webauthn.json
@@ -217,6 +217,17 @@
         "authenticatorId": "aidwboITrg4b4yAYd0g3"
       },
       {
+        "type": "security_key",
+        "key": "custom_otp",
+        "id": "chf1k6lWANK11wvVk0g4",
+        "displayName": "Custom OTP",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
         "displayName": "yubikey",
         "type": "security_key",
         "key": "webauthn",

--- a/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-webauthn.json
@@ -240,6 +240,17 @@
         "authenticatorId": "aidwboITrg4b4yAYd0g3"
       },
       {
+        "type": "security_key",
+        "key": "custom_otp",
+        "id": "chf1k6lWANK11wvVk0g4",
+        "displayName": "Custom OTP",
+        "methods": [
+          {
+            "type": "otp"
+          }
+        ]
+      },
+      {
         "displayName": "yubikey",
         "type": "security_key",
         "key": "webauthn",

--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -67,7 +67,7 @@ const Body = BaseForm.extend({
     const allowCredentials = [];
     const authenticatorEnrollments = this.options.appState.get('authenticatorEnrollments').value || [];
     authenticatorEnrollments.forEach((enrollement) => {
-      if (enrollement.type === 'security_key') {
+      if (enrollement.key === 'webauthn') {
         allowCredentials.push({
           type: 'public-key',
           id: CryptoUtil.strToBin(enrollement.credentialId),

--- a/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/EnrollWebauthnView.js
@@ -9,7 +9,7 @@ import { getMessageFromBrowserError } from '../../../ion/i18nTransformer';
 function getExcludeCredentials(authenticatorEnrollments = []) {
   const credentials = [];
   authenticatorEnrollments.forEach((enrollement) => {
-    if (enrollement.type === 'security_key') {
+    if (enrollement.key === 'webauthn') {
       credentials.push({
         type: 'public-key',
         id: CryptoUtil.strToBin(enrollement.credentialId),

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -7,8 +7,7 @@ import BrowserFeatures from 'util/BrowserFeatures';
 import CryptoUtil from 'util/CryptoUtil';
 import $sandbox from 'sandbox';
 import Expect from 'helpers/util/Expect';
-import ChallengeWebauthnResponse
-  from '../../../../../../playground/mocks/data/idp/idx/authenticator-verification-webauthn.json';
+import ChallengeWebauthnResponse from '../../../../../../playground/mocks/data/idp/idx/authenticator-verification-webauthn';
 
 describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
   let testContext;


### PR DESCRIPTION
## Description:
match webauthn authenticator by key instead of type, otherwise, it will throw a NPE error if other security_key type authenticators in enrolled by don't have `credentialId`


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Enroll:
![webauthn_enroll](https://user-images.githubusercontent.com/47287459/117365559-5034a980-ae74-11eb-8f6b-ac845ce7d6fa.gif)

Verify:
![webauthn_verification](https://user-images.githubusercontent.com/47287459/117365565-52970380-ae74-11eb-8ca0-915d71e136e8.gif)



### Reviewers:
@magizh-okta @nikhilvenkatraman-okta @jmelberg-okta 

### Issue:
- [OKTA-389233](https://oktainc.atlassian.net/browse/OKTA-389233)


