### PR TITLE
Remove Verify with something else link from the Device poll page

### DIFF
--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -156,14 +156,6 @@ const Footer = BaseFooter.extend({
       Enums.UNIVERSAL_LINK_CHALLENGE
     ].includes(this.options.currentViewState.relatesTo.value.challengeMethod);
     if (isFallbackApproach) {
-      this.links = [
-        {
-          name: 'sign-in-options',
-          type: 'link',
-          label: loc('oie.verification.switch.authenticator', 'login'),
-          href: this.settings.get('baseUrl')
-        }
-      ];
       BaseFooter.prototype.initialize.apply(this, arguments);
     } else {
       this.add(Link, {

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -231,7 +231,6 @@ test
     await t.expect(content).contains('Don’t have Okta Verify?');
     await t.expect(content).contains('Download here');
     await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
   });
@@ -264,7 +263,6 @@ test
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in using Okta Verify on this device');
     await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
     await t.expect(deviceChallengePollPageObject.getPrimiaryButtonText()).eql('Reopen Okta Verify');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
     deviceChallengePollPageObject.clickUniversalLink();
     await t.expect(getPageUrl()).contains(mockHttpCustomUri);

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -231,7 +231,6 @@ test
     await t.expect(content).contains('Don’t have Okta Verify?');
     await t.expect(content).contains('Download here');
     await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
   });
 


### PR DESCRIPTION
## Description:
Remove "Verify with something else" link from the Device poll page. In the Device poll page, the user has not been detected, so the link leads back to login page. But we should keep the link in the switch authenticator page, where the user is already detected.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


1. Before the change: the "Verify with something else" link shows up in the Device poll page
<img width="407" alt="Screen Shot 2021-05-06 at 4 48 31 PM" src="https://user-images.githubusercontent.com/82833791/117380026-ac57f780-ae8d-11eb-87b0-e32660ddb332.png">


2. After the change: link is removed
<img width="405" alt="Screen Shot 2021-05-06 at 5 05 19 PM" src="https://user-images.githubusercontent.com/82833791/117380148-f4771a00-ae8d-11eb-9793-717020d7323f.png">


3. We still need to keep the "Verify with something else" in the fastpass assurance page
<img width="407" alt="Screen Shot 2021-05-10 at 12 19 59 PM" src="https://user-images.githubusercontent.com/82833791/117724548-c567ed80-b198-11eb-8f08-fdbd2931db97.png">







### Reviewers:


### Issue:

- [OKTA-387045](https://oktainc.atlassian.net/browse/OKTA-387045)



