### PR TITLE
fix: remove webpack-dev-server open arg to open browser on yarn start

### DIFF
--- a/buildtools/commands/start.js
+++ b/buildtools/commands/start.js
@@ -12,16 +12,11 @@ exports.builder = {
       'mockDuo',
     ],
   },
-  open: {
-    description: 'Open the browser after the server starts',
-    type: 'boolean',
-    default: true,
-  },
 };
 
 exports.handler = async (argv) => {
   const buildDevCmd = 'grunt build:dev';
-  const startDevServer = `webpack-dev-server --config webpack.playground.config.js --open ${argv.open}`;
+  const startDevServer = 'webpack-dev-server --config webpack.playground.config.js';
   const mock = argv.mock ? `--env.${argv.mock}` : '';
 
   let cmd;


### PR DESCRIPTION
## Description:
- removing the `open` arg passed to webpack-dev-server because it's preventing the browser from opening
- the browser opens without this `open` arg because `open` is already defined in the `config` arg - [webpack.playground.config.js](https://github.com/okta/okta-signin-widget/blob/szada-fix-start-open-browser/webpack.playground.config.js#L67:L67)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


