### PR TITLE
Remove Verify with something else link from the Device poll page

### DIFF
--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -161,14 +161,6 @@ const Footer = BaseFooter.extend({
       Enums.UNIVERSAL_LINK_CHALLENGE
     ].includes(this.options.currentViewState.relatesTo.value.challengeMethod);
     if (isFallbackApproach) {
-      this.links = [
-        {
-          name: 'sign-in-options',
-          type: 'link',
-          label: loc('oie.verification.switch.authenticator', 'login'),
-          href: this.settings.get('baseUrl')
-        }
-      ];
       BaseFooter.prototype.initialize.apply(this, arguments);
     } else {
       this.add(Link, {

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -288,8 +288,6 @@ test
     await t.expect(content).contains('Don’t have Okta Verify?');
     await t.expect(content).contains('Download here');
     await t.expect(deviceChallengePollPageObject.getDownloadOktaVerifyLink()).eql('https://apps.apple.com/us/app/okta-verify/id490179405');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Verify with something else');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().getAttribute('href')).eql('http://localhost:3000');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
   });
 
@@ -321,7 +319,6 @@ test
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in using Okta Verify on this device');
     await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
     await t.expect(deviceChallengePollPageObject.getPrimiaryButtonText()).eql('Reopen Okta Verify');
-    await t.expect(deviceChallengePollPageObject.getFooterLink().innerText).eql('Verify with something else');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
     deviceChallengePollPageObject.clickUniversalLink();
     await t.expect(getPageUrl()).contains(mockHttpCustomUri);


### PR DESCRIPTION
This is the recreation of https://github.com/okta/okta-signin-widget/pull/1920 which was branched off master.

## Description:

Remove "Verify with something else" link from the Device poll page. In the Device poll page, the user has not been detected, so the link leads back to login page. But we should keep the link in the switch authenticator page, where the user is already detected.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

1. Before the change: the "Verify with something else" link shows up in the identify page
<img width="407" alt="Screen Shot 2021-05-06 at 4 48 31 PM" src="https://user-images.githubusercontent.com/82833791/117722216-a582fa80-b195-11eb-8c05-8321332c6777.png">

2. After the change: link is removed
<img width="405" alt="Screen Shot 2021-05-06 at 5 05 19 PM" src="https://user-images.githubusercontent.com/82833791/117722249-ac117200-b195-11eb-8e28-67a309f7489a.png">

3. We still need to keep the "Verify with something else" in the FastPass page during assurance stage
<img width="407" alt="Screen Shot 2021-05-10 at 12 19 59 PM" src="https://user-images.githubusercontent.com/82833791/117722324-c3505f80-b195-11eb-9e30-23d6ba085c26.png">

4. We still need to keep the "Verify with something else" in other factor page during assurance stage
<img width="404" alt="Screen Shot 2021-05-06 at 5 06 27 PM" src="https://user-images.githubusercontent.com/82833791/117722273-b59ada00-b195-11eb-9adf-751c749e7970.png">


### Reviewers:


### Issue:

- OKTA-387045


