### PR TITLE
fix: Dynamic Polling For Email Authenticator After Error Trigger

### DIFF
--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -76,8 +76,6 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     triggerAfterError(model, error) {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
-      const currentRefreshInterval = this.options.appState.get('dynamicRefreshInterval')
-        || this.options.currentViewState.refresh;
 
       // Wait 1 min before polling again & do not show error message when encounter rate limit error
       if (error.responseJSON?.errorSummaryKeys?.includes('tooManyRequests') ||
@@ -86,14 +84,14 @@ const Body = BaseFormWithPolling.extend(Object.assign(
           model.trigger('clearFormError');
         }, 0);
         setTimeout(() => {
-          this.startPolling(currentRefreshInterval);
+          this.startPolling(this.options.appState.get('dynamicRefreshInterval'));
         }, 60000);
         return;
       }
 
       // Polling needs to be resumed if it's a form error and session is still valid
       if(!error.responseJSON?.errorSummaryKeys?.includes('idx.session.expired')) {
-        this.startPolling(currentRefreshInterval);
+        this.startPolling(this.options.appState.get('dynamicRefreshInterval'));
       }
     }
   },

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -76,7 +76,8 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     triggerAfterError(model, error) {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
-      let currentRefreshInterval = this.options.appState.get('dynamicRefreshInterval') || this.options.currentViewState.refresh;
+      const currentRefreshInterval = this.options.appState.get('dynamicRefreshInterval')
+        || this.options.currentViewState.refresh;
 
       // Wait 1 min before polling again & do not show error message when encounter rate limit error
       if (error.responseJSON?.errorSummaryKeys?.includes('tooManyRequests') ||

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -76,6 +76,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     triggerAfterError(model, error) {
       BaseForm.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
+      let currentRefreshInterval = this.options.appState.get('dynamicRefreshInterval') || this.options.currentViewState.refresh;
 
       // Wait 1 min before polling again & do not show error message when encounter rate limit error
       if (error.responseJSON?.errorSummaryKeys?.includes('tooManyRequests') ||
@@ -84,14 +85,14 @@ const Body = BaseFormWithPolling.extend(Object.assign(
           model.trigger('clearFormError');
         }, 0);
         setTimeout(() => {
-          this.startPolling();
+          this.startPolling(currentRefreshInterval);
         }, 60000);
         return;
       }
 
       // Polling needs to be resumed if it's a form error and session is still valid
       if(!error.responseJSON?.errorSummaryKeys?.includes('idx.session.expired')) {
-        this.startPolling();
+        this.startPolling(currentRefreshInterval);
       }
     }
   },

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -69,7 +69,7 @@ const invalidOTPMockContinuePoll = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(emailVerificationPollingShort)
+  .respond(emailVerificationPollingLong)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidOTP, 403);
 
@@ -226,7 +226,7 @@ test
     )).eql(2);
 
     await t.removeRequestHooks(dynamicRefreshShortIntervalMock);
-    await t.addRequestHooks(dynamicRefreshLongIntervalMock);
+    await t.addRequestHooks(invalidOTPMockContinuePoll);
 
     // 1 poll requests in 2 seconds at 2 sec interval (Cumulative Request: 3)
     await t.wait(2000);
@@ -235,16 +235,10 @@ test
         record.request.url.match(/poll/)
     )).eql(3);
 
-    await t.removeRequestHooks(dynamicRefreshLongIntervalMock);
-    await t.addRequestHooks(invalidOTPMock);
-
     await challengeEmailPageObject.verifyFactor('credentials.passcode', 'xyz');
     await challengeEmailPageObject.clickNextButton();
     await challengeEmailPageObject.waitForErrorBox();
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('Authentication failed');
-
-    await t.removeRequestHooks(invalidOTPMock);
-    await t.addRequestHooks(dynamicRefreshLongIntervalMock);
 
     // 2 poll requests in 4 seconds at 2 sec interval (Cumulative Request: 5)
     await t.wait(4000);

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -375,7 +375,7 @@ test
   });
 
 test
-  .requestHooks(logger, apiLimitExeededMock)('pause polling when encounter 429 api limit exeeded', async t => {
+  .requestHooks(logger, apiLimitExeededMock)('pause polling when encounter 429 api limit exceeded', async t => {
     await setup(t);
 
     // Encounter 429

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -218,7 +218,7 @@ test
     const challengeEmailPageObject = await setup(t);
     await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).ok();
 
-    // 2 poll requests in 2 seconds at 1 sec interval
+    // 2 poll requests in 2 seconds at 1 sec interval (Cumulative Request: 2)
     await t.wait(2000);
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
@@ -228,7 +228,7 @@ test
     await t.removeRequestHooks(dynamicRefreshShortIntervalMock);
     await t.addRequestHooks(dynamicRefreshLongIntervalMock);
 
-    // 1 poll requests in 2 seconds at 2 sec interval
+    // 1 poll requests in 2 seconds at 2 sec interval (Cumulative Request: 3)
     await t.wait(2000);
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&
@@ -246,7 +246,7 @@ test
     await t.removeRequestHooks(invalidOTPMock);
     await t.addRequestHooks(dynamicRefreshLongIntervalMock);
 
-    // 2 poll requests in 4 seconds at 2 sec interval
+    // 2 poll requests in 4 seconds at 2 sec interval (Cumulative Request: 5)
     await t.wait(4000);
     await t.expect(logger.count(
       record => record.response.statusCode === 200 &&

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -214,7 +214,7 @@ test
   });
 
 test
-  .requestHooks(logger, invalidOTPMockContinuePoll)('continue polling on form error with dynamic polling', async t => {
+  .requestHooks(logger, dynamicRefreshShortIntervalMock)('continue polling on form error with dynamic polling', async t => {
     const challengeEmailPageObject = await setup(t);
     await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).ok();
 


### PR DESCRIPTION
## Description:
- Fix Dynamic Polling For Email Authenticator After Error Trigger
  Previously, it would revert back to every 4 seconds from `this.options.currentViewState.refresh`


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Reached max 20 sec polling rate:
![Screen Shot 2021-05-11 at 4 22 49 PM](https://user-images.githubusercontent.com/39062268/117879670-3b418700-b275-11eb-887f-a9b283776518.png)

Polling timestamp after enter the wrong OTP:
![Screen Shot 2021-05-11 at 4 23 12 PM](https://user-images.githubusercontent.com/39062268/117879793-5c09dc80-b275-11eb-9b3d-76200534f80e.png)

And the one after that which is 20 sec apart:
![Screen Shot 2021-05-11 at 4 23 22 PM](https://user-images.githubusercontent.com/39062268/117879828-66c47180-b275-11eb-9f80-f1f77f3cf80e.png)



### Reviewers:
- @anipendakur-okta 
- @haishengwu-okta 
- @pradeepdewda-okta 
- @thomasmaslen-okta 

### Issue:

- [OKTA-394641](https://oktainc.atlassian.net/browse/OKTA-394641)


