### PR TITLE
fix: wrap footer help links

### DIFF
--- a/assets/sass/v2/_footer.scss
+++ b/assets/sass/v2/_footer.scss
@@ -1,10 +1,12 @@
 .siw-main-footer {
   .auth-footer {
+    max-width: 100%;
     width: max-content;
     display: flex;
     flex-direction: column;
     .link {
       padding: 0.3rem 0;
+      word-wrap: break-word;
     }
   }
 }


### PR DESCRIPTION
## Description:
Chrome:
<img width="421" alt="Screenshot 2021-05-12 at 2 22 02 PM" src="https://user-images.githubusercontent.com/71431120/118046053-a0f14a00-b32d-11eb-8e30-24aec718ce91.png">
IE:
<img width="276" alt="Screenshot 2021-05-12 at 2 21 50 PM" src="https://user-images.githubusercontent.com/71431120/118046060-a3ec3a80-b32d-11eb-993c-33297838a83b.png">
Before:
<img width="433" alt="Screenshot 2021-05-12 at 12 24 38 PM" src="https://user-images.githubusercontent.com/71431120/118033597-daba5480-b31d-11eb-97e2-73230c267b8d.png">


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-395123](https://oktainc.atlassian.net/browse/OKTA-395123)


