### PR TITLE
fix: hide forgot password link on identifier only view

### DIFF
--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -65,7 +65,12 @@ export default Model.extend({
       fn: function(recoveryAuthenticator = {}) {
         return recoveryAuthenticator?.type === 'password';
       }
-    }
+    },
+  },
+
+  isIdentifierOnlyView() {
+    return !this.get('remediations')?.find(({name}) => name === 'identify')
+      ?.uiSchema?.find(({name}) => name === 'credentials.passcode');
   },
 
   hasRemediationObject(formName) {

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -5,11 +5,13 @@ import { getForgotPasswordLink, getSignUpLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
   links() {
+    const { appState, settings } = this.options;
+
     let helpLinkHref;
-    if (this.options.settings.get('helpLinks.help')) {
-      helpLinkHref = this.options.settings.get('helpLinks.help');
+    if (settings.get('helpLinks.help')) {
+      helpLinkHref = settings.get('helpLinks.help');
     } else {
-      const baseUrl = this.options.settings.get('baseUrl');
+      const baseUrl = settings.get('baseUrl');
       helpLinkHref = baseUrl + '/help/login';
     }
 
@@ -21,14 +23,17 @@ export default BaseFooter.extend({
       },
     ];
 
-    const signUpLink = getSignUpLink(this.options.appState, this.options.settings);
+    const signUpLink = getSignUpLink(appState, settings);
 
-    const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
+    let forgotPasswordLink = [];
+    if (!appState.isIdentifierOnlyView()) {
+      forgotPasswordLink = getForgotPasswordLink(appState, settings);
+    }
 
     const customHelpLinks = [];
-    if (this.options.settings.get('helpLinks.custom')) {
+    if (settings.get('helpLinks.custom')) {
       //add custom helpLinks
-      this.options.settings.get('helpLinks.custom').forEach(customHelpLink => {
+      settings.get('helpLinks.custom').forEach(customHelpLink => {
         customHelpLink.name = 'custom';
         customHelpLink.label = customHelpLink.text;
         customHelpLinks.push(customHelpLink);
@@ -36,14 +41,14 @@ export default BaseFooter.extend({
     }
 
     const unlockAccountLink = [];
-    if (this.options.settings.get('helpLinks.unlock')) {
+    if (settings.get('helpLinks.unlock')) {
       unlockAccountLink.push({
         'type': 'link',
         'label': loc('unlockaccount', 'login'),
         'name' : 'unlock',
-        'href': this.options.settings.get('helpLinks.unlock'),
+        'href': settings.get('helpLinks.unlock'),
       });
-    } else if (this.options.appState.hasRemediationObject(RemediationForms.UNLOCK_ACCOUNT)) {
+    } else if (appState.hasRemediationObject(RemediationForms.UNLOCK_ACCOUNT)) {
       unlockAccountLink.push({
         'type': 'link',
         'label': loc('unlockaccount', 'login'),

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -238,6 +238,17 @@ test.requestHooks(identifyMock)('should render custom Unlock account link', asyn
   await t.expect(identityPage.getCustomUnlockAccountLink()).eql('http://unlockaccount');
 });
 
+test.requestHooks(identifyMock)('should not render custom forgot password link', async t => {
+  const identityPage = await setup(t);
+  await rerenderWidget({
+    helpLinks: {
+      forgotPassword: '/forgotpassword'
+    }
+  });
+
+  await t.expect(await identityPage.hasForgotPasswordLinkText()).notOk();
+});
+
 test.requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should compute device fingerprint and add to header', async t => {
   const identityPage = await setup(t);
 


### PR DESCRIPTION
## Description:
Hide "Forgot Password?" on Identifier only view. 
The forgot password link should only show on identify with password and a verify password views.

<img width="449" alt="Screenshot 2021-05-17 at 11 33 37 AM" src="https://user-images.githubusercontent.com/71431120/118542326-b8527d80-b707-11eb-8ae2-87c20c2dabba.png">
<img width="431" alt="Screenshot 2021-05-17 at 11 33 55 AM" src="https://user-images.githubusercontent.com/71431120/118542330-b983aa80-b707-11eb-9809-22777a327953.png">
<img width="424" alt="Screenshot 2021-05-17 at 11 43 57 AM" src="https://user-images.githubusercontent.com/71431120/118542334-bab4d780-b707-11eb-8c06-0c079fa32197.png">

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-395448](https://oktainc.atlassian.net/browse/OKTA-395448)


