### PR TITLE
fix: render password sub-label on verify password view

### DIFF
--- a/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/ChallengeAuthenticatorPasswordView.js
@@ -3,6 +3,7 @@ import { BaseForm } from '../../internals';
 import AuthenticatorFooter from '../../components/AuthenticatorFooter';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { getForgotPasswordLink } from '../../utils/LinksUtil';
+import { isCustomizedI18nKey } from '../../../ion/i18nTransformer';
 
 
 const Body = BaseForm.extend({
@@ -14,6 +15,27 @@ const Body = BaseForm.extend({
   save: function() {
     return loc('mfa.challenge.verify', 'login');
   },
+
+  /**
+   * Update UI schemas for customization from .widgetrc.js or Admin Customization settings page.
+   * @returns Array
+   */
+  getUISchema() {
+    const schemas = BaseForm.prototype.getUISchema.apply(this, arguments);
+
+    const { settings } = this.options;
+    const passwordExplainLabeli18nKey = 'primaryauth.password.tooltip';
+
+    const passwordSchema = schemas.find(({name}) => name === 'credentials.passcode');
+
+    if (passwordSchema && isCustomizedI18nKey(passwordExplainLabeli18nKey, settings)) {
+      passwordSchema.explain = loc(passwordExplainLabeli18nKey, 'login');
+      passwordSchema['explain-top'] = true;
+    }
+
+    return schemas;
+  },
+
 });
 
 const Footer = AuthenticatorFooter.extend({

--- a/test/testcafe/framework/page-objects/ChallengePasswordPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengePasswordPageObject.js
@@ -1,8 +1,11 @@
+import { Selector } from 'testcafe';
+
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 import FooterLinkObject from './components/FooterLinkObject';
 
 const FORGOT_PASSWORD_SELECTOR = '.auth-footer .js-forgot-password';
 const PASSWORD_FIELD = 'credentials\\.passcode';
+const SUB_LABEL_SELECTOR = '.o-form-explain';
 
 export default class ChallengePasswordPageObject extends ChallengeFactorPageObject {
   constructor(t) {
@@ -15,4 +18,7 @@ export default class ChallengePasswordPageObject extends ChallengeFactorPageObje
     return this.form.getTextBoxErrorMessage(PASSWORD_FIELD);
   }
 
+  getPasswordSubLabelValue() {
+    return Selector(SUB_LABEL_SELECTOR).nth(0).textContent;
+  }
 }

--- a/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock } from 'testcafe';
+import { RequestLogger, RequestMock, ClientFunction } from 'testcafe';
 import xhrAuthenticatorRequiredPassword from '../../../playground/mocks/data/idp/idx/authenticator-verification-password';
 import xhrInvalidPassword from '../../../playground/mocks/data/idp/idx/error-authenticator-verify-password';
 import xhrForgotPasswordError from '../../../playground/mocks/data/idp/idx/error-forgot-password';
@@ -39,6 +39,11 @@ const recoveryRequestLogger = RequestLogger(
     stringifyRequestBody: true,
   }
 );
+
+const rerenderWidget = ClientFunction((settings) => {
+  window.renderPlaygroundWidget(settings);
+});
+
 
 fixture('Challenge Authenticator Password');
 
@@ -142,4 +147,16 @@ test.requestHooks(recoveryRequestLogger, mockCannotForgotPassword)('can not reco
   });
   await t.expect(req1.method).eql('post');
   await t.expect(req1.url).eql('http://localhost:3000/idp/idx/recover');
+});
+
+test.requestHooks(mockChallengeAuthenticatorPassword)('should add sub labels for Password if i18n keys are defined', async t => {
+  const challengePasswordPage = await setup(t);
+  await rerenderWidget({
+    i18n: {
+      en: {
+        'primaryauth.password.tooltip': 'Your password goes here',
+      }
+    }
+  });
+  await t.expect(challengePasswordPage.getPasswordSubLabelValue()).eql('Your password goes here');
 });


### PR DESCRIPTION
## Description:
Show password sub-label, if customized, on Identifier-first flow. 
In this flow, the password form field is on the Verify Password view.
<img width="416" alt="Screenshot 2021-05-17 at 12 18 58 PM" src="https://user-images.githubusercontent.com/71431120/118546473-dc648d80-b70c-11eb-9be6-852d72b3e410.png">

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-392653](https://oktainc.atlassian.net/browse/OKTA-392653)


