### PR TITLE
Change label to Email as per API labels

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -963,7 +963,7 @@ oie.registration.form.title = Sign up
 oie.registration.form.submit = Sign Up
 oie.user.profile.lastname= Last name
 oie.user.profile.firstname= First name
-oie.user.profile.primary.email= Primary email
+oie.user.profile.primary.email= Email
 oie.selfservice.unlock_user.success.message = You can log in using your existing username and password.
 oie.selfservice.unlock_user.failed.message = We are unable to unlock your account at this time, please contact your administrator
 

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-no-profile.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-no-profile.json
@@ -52,7 +52,7 @@
             "type":"object",
             "options":[
               {
-                "label":"Primary Email Address",
+                "label":"Email",
                 "value":{
                   "form":{
                     "value":[
@@ -129,7 +129,7 @@
       "type":"email",
       "key": "okta_email",
       "id":"eae1d4u7aVB3VBbI70g4",
-      "displayName":"Primary Email Address",
+      "displayName":"Email",
       "methods":[
         {
           "type":"email"
@@ -144,7 +144,7 @@
         "type":"email",
         "key": "okta_email",
         "id":"eae1d4u7aVB3VBbI70g4",
-        "displayName":"Primary Email Address",
+        "displayName":"Email",
         "methods":[
           {
             "type":"email"

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-polling-long.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-polling-long.json
@@ -52,7 +52,7 @@
             "type":"object",
             "options":[
               {
-                "label":"Primary Email Address",
+                "label":"Email",
                 "value":{
                   "form":{
                     "value":[
@@ -129,7 +129,7 @@
       "type":"email",
       "key": "okta_email",
       "id":"eae1d4u7aVB3VBbI70g4",
-      "displayName":"Primary Email Address",
+      "displayName":"Email",
       "methods":[
         {
           "type":"email"
@@ -147,7 +147,7 @@
         "type":"email",
         "key": "okta_email",
         "id":"eae1d4u7aVB3VBbI70g4",
-        "displayName":"Primary Email Address",
+        "displayName":"Email",
         "methods":[
           {
             "type":"email"

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-polling-short.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-polling-short.json
@@ -52,7 +52,7 @@
             "type":"object",
             "options":[
               {
-                "label":"Primary Email Address",
+                "label":"Email",
                 "value":{
                   "form":{
                     "value":[
@@ -129,7 +129,7 @@
       "type":"email",
       "key": "okta_email",
       "id":"eae1d4u7aVB3VBbI70g4",
-      "displayName":"Primary Email Address",
+      "displayName":"Email",
       "methods":[
         {
           "type":"email"
@@ -147,7 +147,7 @@
         "type":"email",
         "key": "okta_email",
         "id":"eae1d4u7aVB3VBbI70g4",
-        "displayName":"Primary Email Address",
+        "displayName":"Email",
         "methods":[
           {
             "type":"email"

--- a/playground/mocks/data/idp/idx/authenticator-verification-email-polling.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email-polling.json
@@ -52,7 +52,7 @@
             "type":"object",
             "options":[
               {
-                "label":"Primary Email Address",
+                "label":"Email",
                 "value":{
                   "form":{
                     "value":[
@@ -111,7 +111,7 @@
       "type":"email",
       "key": "okta_email",
       "id":"eae1d4u7aVB3VBbI70g4",
-      "displayName":"Primary Email Address",
+      "displayName":"Email",
       "methods":[
         {
           "type":"email"
@@ -129,7 +129,7 @@
         "type":"email",
         "key": "okta_email",
         "id":"eae1d4u7aVB3VBbI70g4",
-        "displayName":"Primary Email Address",
+        "displayName":"Email",
         "methods":[
           {
             "type":"email"

--- a/playground/mocks/data/idp/idx/authenticator-verification-email.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-email.json
@@ -52,7 +52,7 @@
             "type":"object",
             "options":[
               {
-                "label":"Primary Email Address",
+                "label":"Email",
                 "value":{
                   "form":{
                     "value":[
@@ -129,7 +129,7 @@
       "type":"email",
       "key": "okta_email",
       "id":"eae1d4u7aVB3VBbI70g4",
-      "displayName":"Primary Email Address",
+      "displayName":"Email",
       "methods":[
         {
           "type":"email"
@@ -147,7 +147,7 @@
         "type":"email",
         "key": "okta_email",
         "id":"eae1d4u7aVB3VBbI70g4",
-        "displayName":"Primary Email Address",
+        "displayName":"Email",
         "methods":[
           {
             "type":"email"

--- a/playground/mocks/data/idp/idx/enroll-profile-new-custom-labels.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new-custom-labels.json
@@ -20,42 +20,21 @@
               "value": [
                 {
                   "name": "lastName",
-                  "label": "Last name",
+                  "label": "Please enter your last name",
                   "required": true
                 },
                 {
                   "name": "firstName",
-                  "label": "First name",
+                  "label": "Please enter your first name",
                   "required": true
                 },
                 {
                   "name": "email",
-                  "label": "Email",
+                  "label": "This is your awesome email address",
                   "required": true
                 }
               ]
             }
-          },
-          {
-            "name": "captchaVerify",
-            "form": {
-              "value": [
-                {
-                  "name": "captchaId",
-                  "required": true,
-                  "value": "capzomKHvPhLF7lrR0g3",
-                  "visible": false,
-                  "mutable": false
-                },
-                {
-                  "name": "captchaToken",
-                  "required": true,
-                  "visible": false,
-                  "hint": "captcha"
-                }
-              ]
-            },
-            "relatesTo": "$.captcha"
           },
           {
             "name": "stateHandle",
@@ -97,14 +76,5 @@
         "visible": false
       }
     ]
-  },
-  "captcha": {
-    "type": "object",
-    "value": {
-      "id": "4321dcba",
-      "name": "reCaptcha",
-      "siteKey": "abcd12345",
-      "type": "RECAPTCHA_V2"
-    }
   }
 }

--- a/playground/mocks/data/idp/idx/enroll-profile-new-with-hcaptcha.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new-with-hcaptcha.json
@@ -30,7 +30,7 @@
                 },
                 {
                   "name": "email",
-                  "label": "Primary email",
+                  "label": "Email",
                   "required": true
                 }
               ]

--- a/playground/mocks/data/idp/idx/enroll-profile-new.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new.json
@@ -30,7 +30,7 @@
                 },
                 {
                   "name": "email",
-                  "label": "Primary email",
+                  "label": "Email",
                   "required": true
                 }
               ]

--- a/playground/mocks/data/idp/idx/enroll-profile.json
+++ b/playground/mocks/data/idp/idx/enroll-profile.json
@@ -32,7 +32,7 @@
                 },
                 {
                   "name": "email",
-                  "label": "Primary email",
+                  "label": "Email",
                   "required": true
                 }
               ]

--- a/playground/mocks/data/idp/idx/error-forgot-password.json
+++ b/playground/mocks/data/idp/idx/error-forgot-password.json
@@ -63,7 +63,7 @@
         "type": "email",
         "key": "okta_email",
         "id": "eae1bkjVCPwRqshkf0g4",
-        "displayName": "Primary Email Address",
+        "displayName": "Email",
         "methods": [
           {
             "type": "email"

--- a/playground/mocks/data/idp/idx/error-new-signup-email.json
+++ b/playground/mocks/data/idp/idx/error-new-signup-email.json
@@ -32,7 +32,7 @@
                 },
                 {
                   "name": "email",
-                  "label": "Primary Email",
+                  "label": "Email",
                   "required": true,
                   "messages": {
                     "type": "array",

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -267,6 +267,9 @@ const getI18nKey = (i18nPath) => {
  */
 const getI18NValue = (i18nPath, defaultValue, params = []) => {
   const i18nKey = getI18nKey(i18nPath);
+  // TODO : OKTA-397225
+  // here defaultValue is uiSchema label or placeholders, some lables may be customized by 
+  // admin to anything string. We should not localize and replace these customized labels even if i18nkey exists
   if (i18nKey) {
     return loc(i18nKey, 'login', params);
   } else {

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -36,6 +36,10 @@ export default class BasePageObject {
     return this.form.getTitle();
   }
 
+  getFormFieldLabel(field) {
+    return this.form.getFormFieldLabel(field);
+  }
+
   getSaveButtonLabel() {
     return this.form.getElement('.button-primary').value;
   }

--- a/test/testcafe/framework/page-objects/RegistrationPageObject.js
+++ b/test/testcafe/framework/page-objects/RegistrationPageObject.js
@@ -5,6 +5,7 @@ const FIRSTNAME_FIELD = 'userProfile\\.firstName';
 const LASTNAME_FIELD = 'userProfile\\.lastName';
 const EMAIL_FIELD = 'userProfile\\.email';
 
+const BACK = 'a[data-se="back"]';
 export default class RegistrationPageObject extends BasePageObject {
   constructor(t) {
     super(t);
@@ -96,7 +97,7 @@ export default class RegistrationPageObject extends BasePageObject {
   }
 
   getHaveAccountLabel() {
-    return Selector('a[data-se="back"]').textContent;
+    return Selector(BACK).textContent;
   }
 
   getTerminalContent() {

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -7,6 +7,8 @@ import enrollProfileNew from '../../../playground/mocks/data/idp/idx/enroll-prof
 import enrollProfileError from '../../../playground/mocks/data/idp/idx/error-new-signup-email';
 import enrollProfileFinish from '../../../playground/mocks/data/idp/idx/terminal-registration';
 import enrollProfileNewError from '../../../playground/mocks/data/idp/idx/error-new-signup-email-exists';
+// import enrollProfileNewCustomLabel from '../../../playground/mocks/data/idp/idx/enroll-profile-new-custom-labels';
+
 
 const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -85,6 +87,10 @@ test.requestHooks(mock)('should have editable fields and have account label', as
   /* i18n tests */
   await t.expect(registrationPage.getHaveAccountLabel()).eql('Already have an account?');
   await t.expect(await registrationPage.signoutLinkExists()).notOk();
+
+  await t.expect(await registrationPage.getFormFieldLabel('userProfile.email')).eql('Email');
+  await t.expect(await registrationPage.getFormFieldLabel('userProfile.firstName')).eql('First name');
+  await t.expect(await registrationPage.getFormFieldLabel('userProfile.lastName')).eql('Last name');
 
   await registrationPage.fillFirstNameField('Test First Name');
   await registrationPage.fillLastNameField('Test Last Name');
@@ -326,3 +332,14 @@ test.requestHooks(mock)('should call settings.registration.click on "Sign Up" cl
   // will not navigate to register page
   await t.expect(identityPage.getPageTitle()).eql('Sign In');
 });
+
+// TODO : OKTA-397225
+// Uncomment once we support custom labels
+// test.requestHooks(enrollProfileNewCustomLabelMock)('should show custom labels', async t => {
+//   const registrationPage = await setup(t);
+
+//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.email')).eql('This is your awesome email address');
+//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.firstName')).eql('Please enter your first name');
+//   await t.expect(await registrationPage.getFormFieldLabel('userProfile.lastName')).eql('Please enter your last name');
+
+// });

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -114,7 +114,7 @@ describe('v2/ion/responseTransformer', function() {
                 type: 'object',
                 options: [
                   {
-                    label: 'Primary Email Address',
+                    label: 'Email',
                     value: {
                       form: {
                         value: [

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -53,7 +53,7 @@ describe('v2/ion/uiSchemaTransformer', function() {
                     },
                     {
                       name: 'email',
-                      label: 'Primary email',
+                      label: 'Email',
                       required: true,
                     },
                   ],
@@ -84,7 +84,7 @@ describe('v2/ion/uiSchemaTransformer', function() {
               },
               {
                 name: 'userProfile.email',
-                label: 'Primary email',
+                label: 'Email',
                 'label-top': true,
                 'data-se': 'o-form-fieldset-userProfile.email',
                 required: true,
@@ -194,7 +194,7 @@ describe('v2/ion/uiSchemaTransformer', function() {
                 type: 'object',
                 options: [
                   {
-                    label: 'Primary Email Address',
+                    label: 'Email',
                     value: {
                       form: {
                         value: [
@@ -233,7 +233,7 @@ describe('v2/ion/uiSchemaTransformer', function() {
                 'data-se': 'o-form-fieldset-authenticator',
                 options: [
                   {
-                    label: 'Primary Email Address',
+                    label: 'Email',
                     value: {
                       id: 'aut1bospdDFs7q3vc0g4',
                     },

--- a/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseModel_spec.js
@@ -53,7 +53,7 @@ describe('v2/view-builder/internals/BaseModel', function() {
       },
       {
         name: 'userProfile.email',
-        label: 'Primary email',
+        label: 'Email',
         'label-top': true,
         required: true,
         type: 'text',


### PR DESCRIPTION
## Description:

1. from Primary Email to Email
2. removed other instances of `Primary Email` references from mocks that can cause confusion

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2021-05-17 at 3 25 41 PM](https://user-images.githubusercontent.com/38230587/118565601-57d33880-b727-11eb-8793-6fee4537744e.png)


### Reviewers:


### Issue:

- [OKTA-394156](https://oktainc.atlassian.net/browse/OKTA-394156)


