### PR TITLE
fix(v1): prevent signOutLink customization on SMS Password Recovery

### DIFF
--- a/src/views/shared/FooterSignout.js
+++ b/src/views/shared/FooterSignout.js
@@ -31,13 +31,14 @@ export default View.extend({
 
     const appState = this.options.appState;
     appState.trigger('signOut');
+    const isSMSPasswordRecovery = appState.get('isSMSPasswordRecovery');
 
     this.model
       .doTransaction(function(transaction) {
         return transaction.cancel();
       })
       .then(() => {
-        if (this.settings.get('signOutLink') && !appState.get('isSMSPasswordRecovery')) {
+        if (this.settings.get('signOutLink') && !isSMSPasswordRecovery) {
           Util.redirect(this.settings.get('signOutLink'));
         } else {
           this.state.set('navigateDir', Enums.DIRECTION_BACK);


### PR DESCRIPTION
## Description:
If a user has `signOutLink` configured, don't use it when they click "Back to sign in" for v1 SMS Password Recovery (customer request).

This was originally supposed to be fixed by https://github.com/okta/okta-signin-widget/pull/1886.
However, that fix only works in SIW playground, not production.

![May-19-2021 10-20-26](https://user-images.githubusercontent.com/71431120/118857178-9a625580-b88c-11eb-9a5a-40f07d00560e.gif)



## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-374204](https://oktainc.atlassian.net/browse/OKTA-374204)


