### PR TITLE
Fixing the spacing in the social auth links when displaying multiple IDPs

### DIFF
--- a/assets/sass/v2/_identify.scss
+++ b/assets/sass/v2/_identify.scss
@@ -15,6 +15,16 @@
   }
 }
 
+.sign-in-with-idp {
+  .okta-idps-container {
+    .social-auth-button.link-button {
+      &:last-of-type {
+        margin-bottom: 0px;
+      }   
+    }   
+  }
+}
+
 .sign-in-with-device-option,
 .sign-in-with-idp,
 .custom-buttons {

--- a/assets/sass/v2/_identify.scss
+++ b/assets/sass/v2/_identify.scss
@@ -19,9 +19,9 @@
   .okta-idps-container {
     .social-auth-button.link-button {
       &:last-of-type {
-        margin-bottom: 0px;
-      }   
-    }   
+        margin-bottom: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description:

- When we have multiple IDPs enabled, the spacing between the footer links and the IDP buttons is more than it should be. Please refer to the images below. 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

Before:
<img width="408" alt="Before" src="https://user-images.githubusercontent.com/77295104/118884377-5db25080-b8c4-11eb-99d7-07c88e282659.png">

After:
<img width="406" alt="After" src="https://user-images.githubusercontent.com/77295104/118884373-5d19ba00-b8c4-11eb-8d9e-9cd8d9a74b4d.png">

### Reviewers:


### Issue:

- [OKTA-396709](https://oktainc.atlassian.net/browse/OKTA-396709)


