### PR TITLE
fix(v2): support config['features.showPasswordToggleOnSignInPage']

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -171,7 +171,10 @@ export default Model.extend({
       fn: function() {
         // showPasswordToggle is for OIE only.
         // Used to default showPasswordToggleOnSignInPage to true.
-        return this.options?.features?.showPasswordToggleOnSignInPage !== false;
+        const defaultValue = true;
+        const customizedValue = this.options?.features?.showPasswordToggleOnSignInPage ??
+          this.options?.['features.showPasswordToggleOnSignInPage'];
+        return customizedValue ?? defaultValue;
       },
       cache: true,
     },

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -73,7 +73,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
 });
 
-test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password toggle if features.showPasswordToggleOnSignIn is true', async t => {
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password toggle if features.showPasswordToggleOnSignInPage is true', async t => {
   const identityPage = await setup(t);
   await rerenderWidget({
     features: { showPasswordToggleOnSignInPage: true },
@@ -81,10 +81,18 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
 });
 
-test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if features.showPasswordToggleOnSignIn is false', async t => {
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if features.showPasswordToggleOnSignInPage is false', async t => {
   const identityPage = await setup(t);
   await rerenderWidget({
     features: { showPasswordToggleOnSignInPage: false },
+  });
+  await t.expect(await identityPage.hasShowTogglePasswordIcon()).notOk();
+});
+
+test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if "features.showPasswordToggleOnSignInPage" is false', async t => {
+  const identityPage = await setup(t);
+  await rerenderWidget({
+    'features.showPasswordToggleOnSignInPage': false,
   });
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).notOk();
 });

--- a/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
+++ b/test/unit/spec/v2/ion/uiSchemaTransformer_spec.js
@@ -1401,12 +1401,9 @@ describe('v2/ion/uiSchemaTransformer', function() {
     });
   });
 
-  it('sets showPasswordToggle to true if features.showPasswordToggleOnSignInPage is true', done => {
+  it('sets showPasswordToggle to true by default', done => {
     testContext.settings = new Settings({
       baseUrl: 'http://localhost:3000',
-      features: {
-        showPasswordToggleOnSignInPage: true,
-      }
     });
 
     MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
@@ -1486,6 +1483,91 @@ describe('v2/ion/uiSchemaTransformer', function() {
       );
     });
   });
+
+  it('sets showPasswordToggle to false if "features.showPasswordToggleOnSignInPage" is false', done => {
+    testContext.settings = new Settings({
+      baseUrl: 'http://localhost:3000',
+      'features.showPasswordToggleOnSignInPage': false,
+    });
+
+    MockUtil.mockIntrospect(done, XHRIdentifyWithPasswordResponse, idxResp => {
+      const result = _.compose(uiSchemaTransformer.bind(null, testContext.settings), responseTransformer.bind(null, testContext.settings))(idxResp);
+      expect(result.remediations[0]).toEqual(
+        {
+          name: 'identify',
+          href: 'http://localhost:3000/idp/idx/identify',
+          rel: ['create-form'],
+          accepts: 'application/vnd.okta.v1+json',
+          method: 'POST',
+          action: jasmine.any(Function),
+          value: [
+            {
+              name: 'identifier',
+              label: 'Username',
+            },
+            {
+              'form':  {
+                'value': [
+                  {
+                    'label': 'Password',
+                    'name': 'passcode',
+                    'secret': true,
+                  },
+                ],
+              },
+              'name': 'credentials',
+              'required': true,
+              'type': 'object',
+            },
+
+            {
+              name: 'rememberMe',
+              label: 'Keep me signed in',
+              type: 'boolean',
+            },
+            {
+              name: 'stateHandle',
+              required: true,
+              value: jasmine.any(String),
+              visible: false,
+              mutable: false,
+            },
+          ],
+          uiSchema: [
+            {
+              name: 'identifier',
+              label: 'Username',
+              type: 'text',
+              'label-top': true,
+              'data-se': 'o-form-fieldset-identifier',
+            },
+            {
+              'label': 'Password',
+              'label-top': true,
+              'data-se': 'o-form-fieldset-credentials.passcode',
+              'name': 'credentials.passcode',
+              'params':  {
+                'showPasswordToggle': false,
+              },
+              'secret': true,
+              'type': 'password',
+            },
+            {
+              name: 'rememberMe',
+              label: false,
+              type: 'checkbox',
+              placeholder: 'Keep me signed in',
+              modelType: 'boolean',
+              required: false,
+              'label-top': true,
+              'data-se': 'o-form-fieldset-rememberMe',
+            },
+          ],
+        },
+      );
+    });
+  });
+
 
   it('sets showPasswordToggle to false if features.showPasswordToggleOnSignInPage is false', done => {
     testContext.settings = new Settings({


### PR DESCRIPTION
## Description:
For customizing SIW feature flags, both of the following methods should work:
- will work with this change: `config['features.showPasswordToggleOnSignInPage'] = boolean`
- already works: `config.features.showPasswordToggleOnSignInPage = boolean`


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-397629](https://oktainc.atlassian.net/browse/OKTA-397629)


