### PR TITLE
add signup link in widget footer

### DIFF
--- a/assets/sass/v2/_footer.scss
+++ b/assets/sass/v2/_footer.scss
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     .link {
-      width: max-content;
+      width: fit-content;
       padding: 0.3rem 0;
       word-wrap: break-word;
     }

--- a/assets/sass/v2/_footer.scss
+++ b/assets/sass/v2/_footer.scss
@@ -1,12 +1,35 @@
 .siw-main-footer {
   .auth-footer {
     max-width: 100%;
-    width: max-content;
     display: flex;
     flex-direction: column;
     .link {
+      width: max-content;
       padding: 0.3rem 0;
       word-wrap: break-word;
+    }
+  }
+
+  .footer-info {
+    border-top: 1px solid $border-color-default;
+    padding-top: 1rem;
+    margin-top: 1rem;
+    display: flex;
+
+    .signup-info {
+      margin: 0 auto;
+
+      span {
+        padding: 0.3rem 0;
+      }
+
+      .signup-link {
+        padding-left: 0.3rem;
+
+        .link {
+          color: $primary-color;
+        }
+      }
     }
   }
 }

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -1,9 +1,28 @@
-import { loc } from 'okta';
+import { loc, View } from 'okta';
 import { BaseFooter } from '../internals';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { getForgotPasswordLink, getSignUpLink } from '../utils/LinksUtil';
+import Link from './Link';
+import hbs from 'handlebars-inline-precompile';
 
 export default BaseFooter.extend({
+  footerInfo() {
+    const signUpLinkData = getSignUpLink(this.options.appState, this.options.settings);
+    //Build sign up link view appended with a text. Link class can only build anchor tags
+    const SignUpLinkWithText = View.extend({
+      className: 'signup-info',
+      template: hbs`
+        <span>{{i18n code="registration.signup.label" bundle="login"}}</span><span class="signup-link"></span>
+        `,
+      initialize() {
+        this.add(Link, '.signup-link', {
+          options: signUpLinkData[0]
+        }, );
+      }
+    });
+    return SignUpLinkWithText;
+  },
+
   links() {
     const { appState, settings } = this.options;
 
@@ -22,8 +41,6 @@ export default BaseFooter.extend({
         'href': helpLinkHref,
       },
     ];
-
-    const signUpLink = getSignUpLink(appState, settings);
 
     let forgotPasswordLink = [];
     if (!appState.isIdentifierOnlyView()) {
@@ -59,7 +76,6 @@ export default BaseFooter.extend({
 
     return forgotPasswordLink
       .concat(unlockAccountLink)
-      .concat(signUpLink)
       .concat(helpLink)
       .concat(customHelpLinks);
   }

--- a/src/v2/view-builder/components/IdentifierFooter.js
+++ b/src/v2/view-builder/components/IdentifierFooter.js
@@ -8,18 +8,21 @@ import hbs from 'handlebars-inline-precompile';
 export default BaseFooter.extend({
   footerInfo() {
     const signUpLinkData = getSignUpLink(this.options.appState, this.options.settings);
+    let SignUpLinkWithText;
     //Build sign up link view appended with a text. Link class can only build anchor tags
-    const SignUpLinkWithText = View.extend({
-      className: 'signup-info',
-      template: hbs`
-        <span>{{i18n code="registration.signup.label" bundle="login"}}</span><span class="signup-link"></span>
-        `,
-      initialize() {
-        this.add(Link, '.signup-link', {
-          options: signUpLinkData[0]
-        }, );
-      }
-    });
+    if(signUpLinkData.length) {
+      SignUpLinkWithText = View.extend({
+        className: 'signup-info',
+        template: hbs`
+          <span>{{i18n code="registration.signup.label" bundle="login"}}</span><span class="signup-link"></span>
+          `,
+        initialize() {
+          this.add(Link, '.signup-link', {
+            options: signUpLinkData[0]
+          });
+        }
+      });
+    }
     return SignUpLinkWithText;
   },
 

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -1,4 +1,4 @@
-import { View, _, $ } from 'okta';
+import { View, _, $} from 'okta';
 import Link from '../components/Link';
 import { getSignOutLink } from '../utils/LinksUtil';
 
@@ -27,8 +27,22 @@ export default View.extend({
    */
   links: [],
 
+  /**
+   * View
+   * adds any view to the footer in footer info section
+   */ 
+  footerInfo: null,
+
+  /**
+   * Boolean
+   * If true then 'Back to sign in' does not get added
+   */
+  noBackToSignInLink: false,
+
   initialize() {
     let links = _.resultCtx(this, 'links', this);
+    const footerInfo = _.resultCtx(this, 'footerInfo', this);
+    const noBackToSignInLink = _.resultCtx(this, 'noBackToSignInLink', this);
 
     // safe check
     // 1. avoid none array from override
@@ -39,10 +53,11 @@ export default View.extend({
       links = links.filter(l => $.isPlainObject(l));
     }
 
-    // add cancel/signout link if the form qualifies for it
+    // add 'back to sign in' link if the form qualifies for it by default.
+    // Previously called cancel/Sign Out links
     if (this.options.appState.shouldShowSignOutLinkInCurrentForm(
       this.options.settings.get('features.hideSignOutLinkInMFA') ||
-      this.settings.get('features.mfaOnlyFlow'))) {
+      this.settings.get('features.mfaOnlyFlow')) && !noBackToSignInLink) {
       links = links.concat(getSignOutLink(this.options.settings));
     }
 
@@ -51,5 +66,13 @@ export default View.extend({
         options: link,
       });
     });
+
+    if(footerInfo) {
+      this.add(View.extend({
+        className: 'footer-info',
+      }));
+
+      this.add(footerInfo, '.footer-info');
+    }
   }
 });

--- a/src/v2/view-builder/internals/BaseFooter.js
+++ b/src/v2/view-builder/internals/BaseFooter.js
@@ -35,14 +35,14 @@ export default View.extend({
 
   /**
    * Boolean
-   * If true then 'Back to sign in' does not get added
+   * If false then 'Back to sign in' does not get added to the view
    */
-  noBackToSignInLink: false,
+  hasBackToSignInLink: true,
 
   initialize() {
     let links = _.resultCtx(this, 'links', this);
     const footerInfo = _.resultCtx(this, 'footerInfo', this);
-    const noBackToSignInLink = _.resultCtx(this, 'noBackToSignInLink', this);
+    const hasBackToSignInLink = _.resultCtx(this, 'hasBackToSignInLink', this);
 
     // safe check
     // 1. avoid none array from override
@@ -57,7 +57,7 @@ export default View.extend({
     // Previously called cancel/Sign Out links
     if (this.options.appState.shouldShowSignOutLinkInCurrentForm(
       this.options.settings.get('features.hideSignOutLinkInMFA') ||
-      this.settings.get('features.mfaOnlyFlow')) && !noBackToSignInLink) {
+      this.settings.get('features.mfaOnlyFlow')) && hasBackToSignInLink) {
       links = links.concat(getSignOutLink(this.options.settings));
     }
 
@@ -67,7 +67,7 @@ export default View.extend({
       });
     });
 
-    if(footerInfo) {
+    if (footerInfo) {
       this.add(View.extend({
         className: 'footer-info',
       }));

--- a/src/v2/view-builder/views/device/SignInDeviceView.js
+++ b/src/v2/view-builder/views/device/SignInDeviceView.js
@@ -1,8 +1,7 @@
-import { $, _, loc } from 'okta';
+import { loc } from 'okta';
 import { BaseForm, BaseView } from '../../internals';
 import IdentifierFooter from '../../components/IdentifierFooter';
 import SignInWithDeviceOption from '../signin/SignInWithDeviceOption';
-import Link from '../../components/Link';
 
 const Body = BaseForm.extend({
 
@@ -28,23 +27,10 @@ const Body = BaseForm.extend({
 // override the footer to add all the supported links except the sign out link
 // no session is granted at this point
 const Footer = IdentifierFooter.extend({
-  initialize() {
-    let links = _.resultCtx(this, 'links', this);
-    if (!Array.isArray(links)) {
-      links = [];
-    } else {
-      links = links.filter(l => $.isPlainObject(l));
-    }
-
-    links.forEach(link => {
-      this.add(Link, {
-        options: link,
-      });
-    });
-  }
+  noBackToSignInLink: true
 });
 
 export default BaseView.extend({
   Body,
-  Footer,
+  Footer: Footer
 });

--- a/src/v2/view-builder/views/device/SignInDeviceView.js
+++ b/src/v2/view-builder/views/device/SignInDeviceView.js
@@ -27,7 +27,7 @@ const Body = BaseForm.extend({
 // override the footer to add all the supported links except the sign out link
 // no session is granted at this point
 const Footer = IdentifierFooter.extend({
-  noBackToSignInLink: true
+  hasBackToSignInLink: false
 });
 
 export default BaseView.extend({

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -13,6 +13,7 @@ const CUSTOM_BUTTON = '.custom-buttons .okta-custom-buttons-container .default-c
 const UNLOCK_ACCOUNT = '.auth-footer .js-unlock';
 const SUB_LABEL_SELECTOR = '.o-form-explain';
 const IDPS_CONTAINER = '.okta-idps-container';
+const FOOTER_INFO_SELECTOR = '.footer-info';
 
 export default class IdentityPageObject extends BasePageObject {
   constructor(t) {
@@ -146,6 +147,10 @@ export default class IdentityPageObject extends BasePageObject {
 
   getCustomHelpLinksLabel(index) {
     return Selector(CUSTOM_HELP_LINKS_SELECTOR).nth(index).textContent;
+  }
+
+  getFooterInfo() {
+    return Selector(FOOTER_INFO_SELECTOR).textContent;
   }
 
   async clickCustomButtonLink(index) {

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -149,6 +149,7 @@ test.requestHooks(identifyMock)('should have correct display text', async t => {
 
   const signupLinkText = identityPage.getSignupLinkText();
   await t.expect(signupLinkText).eql('Sign up');
+  await t.expect(identityPage.getFooterInfo()).eql('Don\'t have an account?Sign up');
 
   const needhelpLinkText = identityPage.getNeedhelpLinkText();
   await t.expect(needhelpLinkText).eql('Help');


### PR DESCRIPTION
## Description:
Before this change widget bundle the `Sign Up` link into the pack of links and show all of them stacked. To be parity with legacy, adding footer info section where extra data can be supplemented by any view.

1. added ability for BaseFooter to create an info section
2. added sign up link with text inline
3. minor css changes
4. add hasBackToSignIn to BaseFooter to provide optionality to hide back to sign in link


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2021-05-21 at 5 55 26 PM](https://user-images.githubusercontent.com/38230587/119209826-c7b22d80-ba5d-11eb-8ea6-61302503aaf4.png)

![Screen Shot 2021-05-21 at 5 56 12 PM](https://user-images.githubusercontent.com/38230587/119209839-dbf62a80-ba5d-11eb-8094-87baa855f6d7.png)

When profile enrollment is enabled configured to Denied, don't show Sign up section.
![Screen Shot 2021-05-24 at 11 58 42 AM](https://user-images.githubusercontent.com/38230587/119394807-7c7b6300-bc87-11eb-8439-50ef22ec08f5.png)

Long labels
![Screen Shot 2021-05-24 at 12 47 32 PM](https://user-images.githubusercontent.com/38230587/119400356-ec411c00-bc8e-11eb-8339-5edde68eee38.png)


### Reviewers:


### Issue:

- [OKTA-395646](https://oktainc.atlassian.net/browse/OKTA-395646)


