### PR TITLE
fix: Re-use v1 keys

### DIFF
--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -98,7 +98,7 @@ const I18N_OVERRIDE_MAPPINGS = {
   'authenticator-enrollment-data.phone_number.authenticator.methodType.voice': 'oie.phone.enroll.voice.label',
 
   'enroll-authenticator.okta_password.credentials.passcode': 'oie.password.passwordLabel',
-  'enroll-authenticator.okta_email.credentials.passcode': 'email.enroll.enterCode',
+  'enroll-authenticator.okta_email.credentials.passcode': 'mfa.challenge.enterCode.placeholder',
   'enroll-authenticator.phone_number.credentials.passcode': 'mfa.challenge.enterCode.placeholder',
   'enroll-authenticator.security_question.sub_schema_local_credentials.0': 'oie.security.question.questionKey.label',
   'enroll-authenticator.security_question.sub_schema_local_credentials.1': 'oie.security.question.createQuestion.label',

--- a/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
+++ b/src/v2/view-builder/views/ov/SwitchEnrollChannelLinkView.js
@@ -7,7 +7,7 @@ export default View.extend({
   template: hbs `
     {{#if isQRcodeChannel}}
       <a href="#" class="switch-channel-link">
-        {{{i18n code="oie.enroll.okta_verify.qrcode.cannotScan" bundle="login"}}}</a>
+        {{i18n code="enroll.totp.cannotScan" bundle="login"}}</a>
     {{else}}
       {{{i18n code="oie.enroll.okta_verify.switch.channel.link.text" bundle="login"}}}
     {{/if}}`,


### PR DESCRIPTION
## Description:

- Re-use v1 keys in some flows
- We captured all the OIE screens with V1 strings customized https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2063106417/OIE+SIW+views+with+all+V1+i18n+keys+customized
- Out of this list these were some low hanging areas identified by PM to fix
https://docs.google.com/spreadsheets/d/1w1pCKaIZIGCE2OKQS731ut4l6W38mK20m_jRPma5TDs/edit#gid=0

## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Screenshot/Video:

### Reviewers:

@anipendakur-okta @sherizada-okta @pradeepdewda-okta 

### Issue:

- [OKTA-394653](https://oktainc.atlassian.net/browse/OKTA-394653)
