### PR TITLE
Fix pseudo-loc script

### DIFF
--- a/scripts/buildtools/commands/pseudo-loc.js
+++ b/scripts/buildtools/commands/pseudo-loc.js
@@ -8,7 +8,7 @@ exports.handler = async () => {
   // IMPORTANT:
   //   This utility requires VPN access to our internal NPM registry
   //   This script will fail without a connection
-  const packagePath = resolve(__dirname, '../../packages/@okta/pseudo-loc');
+  const packagePath = resolve(__dirname, '../../../packages/@okta/pseudo-loc');
   const installCmd = 'yarn install --silent';
 
   console.log('======= Installing Package Dependencies =======');

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -34,7 +34,9 @@ const parseMockData = () => {
   console.log('================= Parsing mocks for en leaks automation =============');
   fs.readdirSync(mocksFolder).forEach(file => {
     const isIgnored = ignoredMocks.includes(file);
-    if (!isIgnored) {
+    //only allow json mock files
+    const isJsonMock = path.extname(file) === '.json';
+    if (!isIgnored && isJsonMock) {
       mocks.push(file);
     } else {
       test.skip(`Warning skipping mock ${file} from test english leaks test suite. This file may result in english leaks on the UI.`, () => { });


### PR DESCRIPTION
Resolves: OKTA-399804

## Description:

- Fixes incorrect path for pseudo-loc script. Should enable `grunt exec:pseudo-loc` to execute without failures now

## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Screenshot/Video:
Fix script 
![Screen Shot 2021-05-27 at 2 51 57 PM](https://user-images.githubusercontent.com/23267876/119901720-1b5bc580-befb-11eb-84f8-026137c89d6e.png)

Tested by adding a `test.js` file that got ignored 
![Screen Shot 2021-05-27 at 3 09 59 PM](https://user-images.githubusercontent.com/23267876/119903838-2a904280-befe-11eb-9a11-70ac4fb79ee4.png)


### Reviewers:

@jmelberg-okta @anipendakur-okta 

### Issue:

- [OKTA-399804](https://oktainc.atlassian.net/browse/OKTA-399804)


