### PR TITLE
feat: Expose ability to hide "Back to sign in" link for all MFA views

### DIFF
--- a/docs/interaction_code_flow.md
+++ b/docs/interaction_code_flow.md
@@ -506,4 +506,4 @@ Enable or disable widget functionality with the following options.
 #### features.hideSignOutLinkInMFA
 
   Defaults to `false`.
-  Hides the "Back to sign-in" link for MFA challenge flows.
+  Hides the "Back to sign in" link for authenticator enrollment and challenge flows.

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -194,18 +194,15 @@ export default Model.extend({
       transformedResponse.currentAuthenticator?.poll?.refresh;
   },
 
-  // Sign Out link will be displayed in the footer of a form, unless
-  // - widget config hideSignOutLinkInMFA=true or mfaOnlyFlow=true
-  // and form is for identity verification (FORMS_FOR_VERIFICATION)
+  // Sign Out link will be displayed in the footer of a form, unless:
+  // - widget configuration set hideSignOutLinkInMFA or mfaOnlyFlow to true
   // - cancel remediation form is not present in the response
   // - form is part of our list FORMS_WITHOUT_SIGNOUT
   shouldShowSignOutLinkInCurrentForm(hideSignOutLinkInMFA) {
     const idxActions = this.get('idx') && this.get('idx').actions;
     const currentFormName = this.get('currentFormName');
-    const hideSignOutConfigOverride = hideSignOutLinkInMFA
-      && FORMS_FOR_VERIFICATION.includes(currentFormName);
 
-    return !hideSignOutConfigOverride
+    return !hideSignOutLinkInMFA
       && _.isFunction(idxActions?.cancel)
       && !FORMS_WITHOUT_SIGNOUT.includes(currentFormName);
   },

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock, RequestLogger } from 'testcafe';
+import { renderWidget } from '../framework/shared';
 import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 
 import xhrSelectMethodOktaVerify from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method';
@@ -49,6 +50,17 @@ test.requestHooks(mockChallengeOVSelectMethod)('should load select method list w
   // signout link at enroll page
   await t.expect(await selectAuthenticatorPage.signoutLinkExists()).ok();
   await t.expect(selectAuthenticatorPage.getSignoutLinkText()).eql('Back to sign in');
+});
+
+test.requestHooks(mockChallengeOVSelectMethod)('should load select method list with okta verify and no sign-out link', async t => {
+  const selectAuthenticatorPage = await setup(t);
+  await renderWidget({
+    features: { hideSignOutLinkInMFA: true },
+  });
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+
+  // signout link is not visible
+  await t.expect(await selectAuthenticatorPage.signoutLinkExists()).notOk();
 });
 
 test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when fastpass is selected', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -1,6 +1,6 @@
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengePhonePageObject from '../framework/page-objects/ChallengePhonePageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import { RequestMock, RequestLogger } from 'testcafe';
 import phoneVerificationSMSThenVoice from '../../../playground/mocks/data/idp/idx/authenticator-verification-data-phone-sms-then-voice';
 import phoneVerificationVoiceThenSMS from '../../../playground/mocks/data/idp/idx/authenticator-verification-data-phone-voice-then-sms';
@@ -131,6 +131,18 @@ test
 
     await t.expect(await challengePhonePageObject.signoutLinkExists()).ok();
     await t.expect(challengePhonePageObject.getSignoutLinkText()).eql('Back to sign in');
+  });
+
+test
+  .requestHooks(smsPrimaryMock)('SMS primary mode - can render with no sign-out link', async t => {
+    const challengePhonePageObject = await setup(t);
+    await renderWidget({
+      features: { hideSignOutLinkInMFA: true },
+    });
+
+    await t.expect(challengePhonePageObject.getFormTitle()).contains('Verify with your phone');
+    // signout link is not visible
+    await t.expect(await challengePhonePageObject.signoutLinkExists()).notOk();
   });
 
 test

--- a/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
+++ b/test/testcafe/spec/DeviceEnrollmentTerminalView_spec.js
@@ -1,4 +1,5 @@
-import {ClientFunction, RequestLogger, RequestMock} from 'testcafe';
+import {RequestLogger, RequestMock} from 'testcafe';
+import { renderWidget as rerenderWidget } from '../framework/shared';
 import DeviceEnrollmentTerminalPageObject from '../framework/page-objects/DeviceEnrollmentTerminalPageObject';
 import IOSOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-ios';
 import AndroidOdaEnrollment from '../../../playground/mocks/data/idp/idx/oda-enrollment-android';
@@ -15,11 +16,6 @@ const androidOdaMock = RequestMock()
 const mdmMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(MdmEnrollment);
-
-const rerenderWidget = ClientFunction((settings) => {
-  // function `renderPlaygroundWidget` is defined in playground/main.js
-  window.renderPlaygroundWidget(settings);
-});
 
 fixture('Device enrollment terminal view for ODA and MDM');
 

--- a/test/testcafe/spec/EnrollAuthenticatorDuo_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDuo_spec.js
@@ -1,4 +1,5 @@
 import { RequestMock } from 'testcafe';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import DuoPageObject from '../framework/page-objects/DuoPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import xhrAuthenticatorEnrollDuo from '../../../playground/mocks/data/idp/idx/authenticator-enroll-duo';
@@ -16,12 +17,7 @@ fixture('Authenticator Enroll Duo')
 async function setup(t) {
   const enrollDuoPage = new DuoPageObject(t);
   await enrollDuoPage.navigateToPage();
-
-  const { log } = await t.getBrowserConsoleMessages();
-  await t.expect(log.length).eql(3);
-  await t.expect(log[0]).eql('===== playground widget ready event received =====');
-  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-  await t.expect(JSON.parse(log[2])).eql({
+  await checkConsoleMessages({
     controller: 'enroll-duo',
     formName: 'enroll-authenticator',
     authenticatorKey: 'duo',
@@ -42,6 +38,19 @@ test('should render an iframe for duo', async t => {
   await t.expect(await enrollDuoPage.switchAuthenticatorLinkExists()).ok();
   await t.expect(enrollDuoPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
   await t.expect(await enrollDuoPage.signoutLinkExists()).ok();
+});
+
+test('should render an iframe for duo without sign-out link', async t => {
+  const enrollDuoPage = await setup(t);
+  await renderWidget({
+    features: { hideSignOutLinkInMFA: true },
+  });
+
+  // Check title
+  await t.expect(enrollDuoPage.getFormTitle()).eql('Set up Duo Security');
+
+  // signout link is not visible
+  await t.expect(await enrollDuoPage.signoutLinkExists()).notOk();
 });
 
 test('enrolls successfully', async t => {

--- a/test/testcafe/spec/FailureRedirect_spec.js
+++ b/test/testcafe/spec/FailureRedirect_spec.js
@@ -1,4 +1,5 @@
-import { ClientFunction, RequestMock } from 'testcafe';
+import { RequestMock } from 'testcafe';
+import { renderWidget } from '../framework/shared';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 import PlaygroundErrorPageObject from '../framework/page-objects/PlaygroundErrorPageObject';
 import xhrErrorWithFailureRedirect from '../../../playground/mocks/data/idp/idx/error-with-failure-redirect';
@@ -8,11 +9,6 @@ const userNotAssignedMock = RequestMock()
   .respond(xhrErrorWithFailureRedirect);
 
 fixture('Failure with redirect');
-
-const renderWidget = ClientFunction((settings) => {
-  // function `renderPlaygroundWidget` is defined in playground/main.js
-  window.renderPlaygroundWidget(settings);
-});
 
 test.requestHooks(userNotAssignedMock)('generic case: redirects', async t => {
   const terminalPage = new TerminalPageObject(t);

--- a/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationHooks_spec.js
@@ -1,4 +1,5 @@
-import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
+import { RequestMock, RequestLogger } from 'testcafe';
+import { renderWidget } from '../framework/shared';
 import RegistrationPageObject from '../framework/page-objects/RegistrationPageObject';
 import enrollProfile from '../../../playground/mocks/data/idp/idx/enroll-profile';
 import success from '../../../playground/mocks/data/idp/idx/terminal-registration';
@@ -8,10 +9,6 @@ const mock = RequestMock()
   .respond(enrollProfile)
   .onRequestTo('http://localhost:3000/idp/idx/enroll/new')
   .respond(success);
-
-const rerenderWidget = ClientFunction((settings) => {
-  window.renderPlaygroundWidget(settings);
-});
 
 const logger = RequestLogger(
   /enroll/,
@@ -35,7 +32,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onSucce
   logger.clear();
   const registrationPage = await setup(t);
 
-  await rerenderWidget({
+  await renderWidget({
     registration: {
       parseSchema: function(resp, onSuccess) {
         resp.find(({ name }) => name === 'userProfile.firstName').required = false;
@@ -78,7 +75,7 @@ test.requestHooks(logger, mock)('should call settings.registration hooks onFailu
   logger.clear();
   const registrationPage = await setup(t);
 
-  await rerenderWidget({
+  await renderWidget({
     registration: {
       parseSchema: function(resp, onSuccess, onFailure) {
         const error = {
@@ -117,7 +114,7 @@ test.requestHooks(logger, mock)('should call settings.registration.postSubmit ho
   logger.clear();
   const registrationPage = await setup(t);
 
-  await rerenderWidget({
+  await renderWidget({
     registration: {
       postSubmit: function(postData, onSuccess, onFailure) {
         const error = {

--- a/test/testcafe/spec/IdentifyRegistration_spec.js
+++ b/test/testcafe/spec/IdentifyRegistration_spec.js
@@ -1,5 +1,5 @@
-import { RequestMock, ClientFunction, RequestLogger } from 'testcafe';
-import { checkConsoleMessages } from '../framework/shared';
+import { RequestMock, RequestLogger } from 'testcafe';
+import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import RegistrationPageObject from '../framework/page-objects/RegistrationPageObject';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
@@ -51,10 +51,6 @@ const logger = RequestLogger(
 const enrolProfileDisabledMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(identifyWithoutEnrollProfile);
-
-const rerenderWidget = ClientFunction((settings) => {
-  window.renderPlaygroundWidget(settings);
-});
 
 fixture('Registration');
 

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -1,7 +1,7 @@
-import { ClientFunction, RequestMock, RequestLogger } from 'testcafe';
+import { RequestMock, RequestLogger } from 'testcafe';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
 import IdentityRecoverPageObject from '../framework/page-objects/IdentifyRecoverPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
 import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
 import xhrIdentifyRecover from '../../../playground/mocks/data/idp/idx/identify-recovery';
@@ -26,10 +26,6 @@ const identifyRequestLogger = RequestLogger(
     stringifyRequestBody: true,
   }
 );
-
-const rerenderWidget = ClientFunction((settings) => {
-  window.renderPlaygroundWidget(settings);
-});
 
 fixture('Identify + Password');
 
@@ -75,7 +71,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
 
 test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have password toggle if features.showPasswordToggleOnSignInPage is true', async t => {
   const identityPage = await setup(t);
-  await rerenderWidget({
+  await renderWidget({
     features: { showPasswordToggleOnSignInPage: true },
   });
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).ok();
@@ -83,7 +79,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should have 
 
 test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if features.showPasswordToggleOnSignInPage is false', async t => {
   const identityPage = await setup(t);
-  await rerenderWidget({
+  await renderWidget({
     features: { showPasswordToggleOnSignInPage: false },
   });
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).notOk();
@@ -91,7 +87,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not h
 
 test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not have password toggle if "features.showPasswordToggleOnSignInPage" is false', async t => {
   const identityPage = await setup(t);
-  await rerenderWidget({
+  await renderWidget({
     'features.showPasswordToggleOnSignInPage': false,
   });
   await t.expect(await identityPage.hasShowTogglePasswordIcon()).notOk();
@@ -99,7 +95,7 @@ test.requestHooks(identifyRequestLogger, identifyWithPasswordMock)('should not h
 
 test.requestHooks(identifyWithPasswordMock)('should add sub labels for Username and Password if i18n keys are defined', async t => {
   const identityPage = await setup(t);
-  await rerenderWidget({
+  await renderWidget({
     i18n: {
       en: {
         'primaryauth.username.tooltip': 'Your username goes here',

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -1,7 +1,7 @@
-import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
+import { RequestMock, RequestLogger } from 'testcafe';
 import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
 import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
 import xhrAuthenticatorVerifySelect from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator';
@@ -71,10 +71,6 @@ const identifyRequestLogger = RequestLogger(
     logRequestHeaders: true,
   }
 );
-
-const rerenderWidget = ClientFunction((settings) => {
-  window.renderPlaygroundWidget(settings);
-});
 
 fixture('Identify');
 

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -1,5 +1,6 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 
+import { renderWidget } from '../framework/shared';
 import SelectFactorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import ChallengeFactorPageObject from '../framework/page-objects/ChallengeFactorPageObject';
 
@@ -209,7 +210,16 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   // signout link at enroll page
   await t.expect(await selectFactorPage.signoutLinkExists()).ok();
   await t.expect(selectFactorPage.getSignoutLinkText()).eql('Back to sign in');
+});
 
+test.requestHooks(mockChallengePassword)('should load select authenticator list with no sign-out link', async t => {
+  const selectFactorPage = await setup(t);
+  await renderWidget({
+    features: { hideSignOutLinkInMFA: true },
+  });
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  // signout link is not visible
+  await t.expect(await selectFactorPage.signoutLinkExists()).notOk();
 });
 
 test.requestHooks(mockAuthenticatorListNoNumber)('should not display phone number in description if not available', async t => {

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -1,5 +1,5 @@
 import AppState from 'v2/models/AppState';
-import {FORMS, FORMS_FOR_VERIFICATION, FORMS_WITHOUT_SIGNOUT} from 'v2/ion/RemediationConstants';
+import { FORMS_FOR_VERIFICATION, FORMS_WITHOUT_SIGNOUT } from 'v2/ion/RemediationConstants';
 
 describe('v2/models/AppState', function() {
   beforeEach(() => {
@@ -25,21 +25,21 @@ describe('v2/models/AppState', function() {
       this.initAppState({ idx: { actions: { cancel: 'invalid' } } });
       expect(this.appState.shouldShowSignOutLinkInCurrentForm()).toBe(false);
     });
+    it('returns false if param hideSignOutLinkInMFA is false but there is no remediation action', () => {
+      this.initAppState({ idx: { actions: { } } });
+      expect(this.appState.shouldShowSignOutLinkInCurrentForm(false)).toBe(false);
+    });
+    it('returns false if param hideSignOutLinkInMFA is true', () => {
+      this.initAppState({ idx: { actions: { cancel: () => {} } } });
+      expect(this.appState.shouldShowSignOutLinkInCurrentForm(true)).toBe(false);
+    });
+    it('returns true if param hideSignOutLinkInMFA is false', () => {
+      this.initAppState({ idx: { actions: { cancel: () => {} } } });
+      expect(this.appState.shouldShowSignOutLinkInCurrentForm(false)).toBe(true);
+    });
     it('returns false if the currentFormName is in FORMS_WITHOUT_SIGNOUT', () => {
       this.initAppState({ idx: { actions: { cancel: () => {} } } }, FORMS_WITHOUT_SIGNOUT[0]);
       expect(this.appState.shouldShowSignOutLinkInCurrentForm()).toBe(false);
-    });
-    it('returns false if param hideSignOutLinkInMFA is true currentFormName is part of FORMS_FOR_VERIFICATION', () => {
-      this.initAppState({ idx: { actions: { cancel: () => {} } } }, FORMS_FOR_VERIFICATION[0]);
-      expect(this.appState.shouldShowSignOutLinkInCurrentForm(true)).toBe(false);
-    });
-    it('returns true if all conditions are met', () => {
-      this.initAppState({ idx: { actions: { cancel: () => {} } } }, FORMS_FOR_VERIFICATION[0]);
-      expect(this.appState.shouldShowSignOutLinkInCurrentForm()).toBe(true);
-    });
-    it('returns true if param hideSignOutLinkInMFA is true but currentFormName is not part of FORMS_FOR_VERIFICATION', () => {
-      this.initAppState({ idx: { actions: { cancel: () => {} } } }, FORMS.DEVICE_CHALLENGE_POLL);
-      expect(this.appState.shouldShowSignOutLinkInCurrentForm(true)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description:

- When the configuration option `features.hideSignOutLinkInMFA` is provided views should **not contain** the "Back to sign in" text.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added e2e tests
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Reviewers:

- @mauriciocastillosilva-okta

### Issue:

- [OKTA-395411](https://oktainc.atlassian.net/browse/OKTA-395411)

