### PR TITLE
SIW OIE English leak: 'Enter a code' when setting up Google Authenticator

### DIFF
--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -105,7 +105,7 @@ const I18N_OVERRIDE_MAPPINGS = {
   'enroll-authenticator.security_question.credentials.answer': 'mfa.challenge.answer.placeholder',
   'enroll-authenticator.security_question.credentials.question': 'oie.security.question.createQuestion.label',
   'enroll-authenticator.security_question.credentials.questionKey': 'oie.security.question.questionKey.label',
-  'enroll-authenticator.google_otp.credentials.passcode': 'oie.google_authenticator.otp.title',
+  'enroll-authenticator.google_otp.credentials.passcode': 'oie.google_authenticator.otp.enterCodeText',
   'enroll-authenticator.onprem_mfa.credentials.clientData': 'enroll.onprem.username.placeholder',
   'enroll-authenticator.onprem_mfa.credentials.passcode': 'enroll.onprem.passcode.placeholder',
   'enroll-authenticator.rsa_token.credentials.clientData': 'enroll.onprem.username.placeholder',

--- a/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollGoogleAuthenticatorPageObject.js
@@ -46,6 +46,10 @@ export default class EnrollGoogleAuthenticatorPageObject extends BasePageObject 
     await this.form.clickElement('.google-authenticator-verify');
   }
 
+  getOtpLabel() {
+    return this.form.getFormFieldLabel(CODE_FIELD_NAME);
+  }
+
   enterCode(value) {
     return this.form.setTextBoxValue(CODE_FIELD_NAME, value);
   }

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -59,6 +59,7 @@ test
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
     await enrollGoogleAuthenticatorPageObject.enterCode('123456');
     await enrollGoogleAuthenticatorPageObject.submit();
 
@@ -77,6 +78,7 @@ test
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
     await enrollGoogleAuthenticatorPageObject.enterCode('123456');
     await enrollGoogleAuthenticatorPageObject.submit();
 
@@ -94,6 +96,7 @@ test
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
     await enrollGoogleAuthenticatorPageObject.enterCode('123456');
     await enrollGoogleAuthenticatorPageObject.submit();
 
@@ -115,6 +118,7 @@ test
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');
     await enrollGoogleAuthenticatorPageObject.enterCode('123456');
     await enrollGoogleAuthenticatorPageObject.submit();
 

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -35,7 +35,7 @@ describe('v2/ion/i18nTransformer', function() {
       'mfa.challenge.enterCode.placeholder': 'enter code',
       'mfa.challenge.password.placeholder': 'password',
       'oie.okta_verify.totp.enterCodeText': 'enter totp code',
-      'oie.google_authenticator.otp.enterCodeText': 'enter passcode',
+      'oie.google_authenticator.otp.enterCodeText': 'enter code',
       'oie.enroll.okta_verify.channel.email.label': 'email',
       'oie.password.newPasswordLabel': 'new password',
 
@@ -912,7 +912,7 @@ describe('v2/ion/i18nTransformer', function() {
           name: 'challenge-authenticator',
           uiSchema: [
             {
-              label: 'unit test - enter passcode',
+              label: 'unit test - enter code',
               'label-top': true,
               name: 'credentials.passcode',
               type: 'text',
@@ -1750,7 +1750,7 @@ describe('v2/ion/i18nTransformer', function() {
                 [
                   {
                     'name': 'credentials.passcode',
-                    'label': 'unit test - enter passcode',
+                    'label': 'unit test - enter code',
                     'required': true,
                     'visible': true,
                   }


### PR DESCRIPTION
## Description:
- English leak: 'Enter a code' when setting up Google Authenticator



## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

#### Before
<img width="404" alt="Screen Shot 2021-05-26 at 11 35 07 AM" src="https://user-images.githubusercontent.com/19613909/120384326-dceb4f80-c2da-11eb-8453-241baee3ca20.png">

#### After
<img width="408" alt="Screen Shot 2021-05-27 at 4 50 58 PM" src="https://user-images.githubusercontent.com/19613909/120384255-c513cb80-c2da-11eb-9e7f-f2ce8db627ae.png">


### Reviewers:
- @nikhilvenkatraman-okta 

### Issue:
- [OKTA-399298](https://oktainc.atlassian.net/browse/OKTA-399298)


