### PR TITLE
bug: show switch authenticator link only when needed

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -407,6 +407,19 @@ const ovTotpSuccess = {
   ],
 };
 
+// ov challenge (3 methods) and no other authenticator available
+const onlyOVAuthenticatorTOTPChallenge = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-okta-verify-select-method'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-verification-okta-verify-totp-onlyOV'
+  ],
+  '/idp/idx/challenge/answer': [
+    'success'
+  ],
+};
+
 // ov challenge m2 totp - error
 const ovTotpError = {
   '/idp/idx/introspect': [

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push.json
@@ -42,7 +42,7 @@
             "type": "object",
             "options": [
               {
-                "label": "",
+                "label": "Okta Verify",
                 "value": {
                   "form": {
                     "value": [
@@ -168,7 +168,7 @@
         "key": "okta_verify",
         "id": "aen1mz5J4cuNoaR3l0g4",
         "authenticatorId": "auttheidkwh282hv8g3",
-        "methods": [ 
+        "methods": [
           { "type": "signed_nonce" },
           { "type": "push" },
           { "type": "totp" }
@@ -180,7 +180,7 @@
         "key": "okta_verify",
         "id": "aen1mz5J4cuNoaR3l0g3",
         "authenticatorId": "auttheidkwh282hv8g3",
-        "methods": [ 
+        "methods": [
           { "type": "signed_nonce" },
           { "type": "push" },
           { "type": "totp" }

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp-onlyOV.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp-onlyOV.json
@@ -1,0 +1,202 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"challenge-authenticator",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"credentials",
+            "form":{
+              "value":[
+                {
+                 "name": "totp",
+                 "label": "Enter code from Okta Verify app",
+                 "visible": true,
+                 "required": true
+               }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "auttheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "mutable": true,
+                        "visible": false,
+                        "type": "string",
+                        "options": [
+                          {
+                            "value": "signed_nonce",
+                            "label": "Use Okta FastPass"
+                          },
+                          {
+                            "value": "push",
+                            "label": "Get a push notification"
+                          },
+                          {
+                            "value": "totp",
+                            "label": "Enter a code"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value": {
+      "type": "app",
+      "key": "okta_verify",
+      "id": "auttheidkwh282hv8g3",
+      "displayName": "",
+      "methods": [
+        { "type": "totp" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "key": "okta_verify",
+        "id": "auteq0lLiL9o1cYoN0g4",
+        "displayName": "",
+        "methods": [
+          {
+            "type": "signed_nonce"
+          },
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "",
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aen1mz5J4cuNoaR3l0g4",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
+        ]
+      },
+      {
+        "displayName": "",
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aen1mz5J4cuNoaR3l0g3",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "https://idx.okta1.com/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -18,7 +18,7 @@ import { AUTHENTICATOR_KEY } from '../RemediationConstants';
  * @param {AuthenticatorOption[]} options
  * @param {( AuthenticatorEnrollment[] || Authenticator[] )} authenticators
  */
-const createOVOptions = (options = []) => {
+export const createOVOptions = (options = []) => {
   // Split OV into individual entries for verification (one for each method).
   const ovItem = options.find((option) => option.relatesTo.key === AUTHENTICATOR_KEY.OV);
   const methodTypeObj = ovItem?.value?.form?.value?.find(v => v.name === 'methodType');

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -18,7 +18,7 @@ import { AUTHENTICATOR_KEY } from '../RemediationConstants';
  * @param {AuthenticatorOption[]} options
  * @param {( AuthenticatorEnrollment[] || Authenticator[] )} authenticators
  */
-function createOVOptions(options = []) {
+export function createOVOptions(options = []) {
   // Split OV into individual entries for verification (one for each method).
   const ovItem = options.find((option) => option.relatesTo.key === AUTHENTICATOR_KEY.OV);
   const methodTypeObj = ovItem?.value?.form?.value?.find(v => v.name === 'methodType');
@@ -109,7 +109,8 @@ function getAuthenticatorsVerifyUiSchema({ options }) {
 /**
   * Create ui schema for ION field that has type 'object'.
   */
-function createUiSchemaForObject(ionFormField, remediationForm, transformedResp, createUISchema, settings) {
+export default function createUiSchemaForObject(ionFormField, remediationForm, transformedResp,
+  createUISchema, settings) {
   const uiSchema = {};
 
   if (ionFormField.name === 'authenticator' &&
@@ -148,8 +149,3 @@ function createUiSchemaForObject(ionFormField, remediationForm, transformedResp,
 
   return uiSchema;
 }
-
-export {
-  createUiSchemaForObject as default,
-  createOVOptions
-};

--- a/src/v2/ion/ui-schema/ion-object-handler.js
+++ b/src/v2/ion/ui-schema/ion-object-handler.js
@@ -18,7 +18,7 @@ import { AUTHENTICATOR_KEY } from '../RemediationConstants';
  * @param {AuthenticatorOption[]} options
  * @param {( AuthenticatorEnrollment[] || Authenticator[] )} authenticators
  */
-export const createOVOptions = (options = []) => {
+function createOVOptions(options = []) {
   // Split OV into individual entries for verification (one for each method).
   const ovItem = options.find((option) => option.relatesTo.key === AUTHENTICATOR_KEY.OV);
   const methodTypeObj = ovItem?.value?.form?.value?.find(v => v.name === 'methodType');
@@ -63,9 +63,9 @@ export const createOVOptions = (options = []) => {
       ovItem.relatesTo.deviceKnown ? options.unshift(signedNonceOption) : options.push(signedNonceOption);
     }
   }
-};
+}
 
-const createAuthenticatorOptions = (options = []) => {
+function createAuthenticatorOptions(options = []) {
   createOVOptions(options);
   return options.map(option => {
     const value = option.value?.form?.value || [];
@@ -90,26 +90,26 @@ const createAuthenticatorOptions = (options = []) => {
       authenticatorKey: option.relatesTo?.key,
     };
   });
-};
+}
 
-const getAuthenticatorsEnrollUiSchema = ({ options }) => {
+function getAuthenticatorsEnrollUiSchema({ options }) {
   return {
     type: 'authenticatorEnrollSelect',
     options: createAuthenticatorOptions(options),
   };
-};
+}
 
-const getAuthenticatorsVerifyUiSchema = ({ options }) => {
+function getAuthenticatorsVerifyUiSchema({ options }) {
   return {
     type: 'authenticatorVerifySelect',
     options: createAuthenticatorOptions(options),
   };
-};
+}
 
 /**
   * Create ui schema for ION field that has type 'object'.
   */
-const createUiSchemaForObject = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
+function createUiSchemaForObject(ionFormField, remediationForm, transformedResp, createUISchema, settings) {
   const uiSchema = {};
 
   if (ionFormField.name === 'authenticator' &&
@@ -147,6 +147,9 @@ const createUiSchemaForObject = (ionFormField, remediationForm, transformedResp,
   }
 
   return uiSchema;
-};
+}
 
-export default createUiSchemaForObject;
+export {
+  createUiSchemaForObject as default,
+  createOVOptions
+};

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -17,6 +17,7 @@ import {
   FORMS_WITH_STATIC_BACK_LINK,
   FORMS_FOR_VERIFICATION,
 } from '../ion/RemediationConstants';
+import { createOVOptions } from '../ion/ui-schema/ion-object-handler';
 import { _ } from '../mixins/mixins';
 
 /**
@@ -75,6 +76,19 @@ export default Model.extend({
 
   hasRemediationObject(formName) {
     return this.get('idx').neededToProceed.find((remediation) => remediation.name === formName);
+  },
+
+  hasMoreThanOneAuthenticatorOption(formName) {
+    const form = this.hasRemediationObject(formName);
+    if (form) {
+      const authenticator = form.value.find((value) => value.name === 'authenticator');
+      let authenticatorOptions = authenticator && authenticator.options;
+      // OV is a special case, so process OV options
+      authenticatorOptions = [...authenticatorOptions]; //clone it since we are changing it for OV
+      createOVOptions(authenticatorOptions);
+      return authenticatorOptions.length > 1;
+    }
+    return false;
   },
 
   getActionByPath(actionPath) {

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -78,7 +78,7 @@ export default Model.extend({
     return this.get('idx').neededToProceed.find((remediation) => remediation.name === formName);
   },
 
-  hasMoreThanOneAuthenticatorOption(formName) {
+  getRemediationAuthenticationOptions(formName) {
     const form = this.hasRemediationObject(formName);
     if (!form) {
       return false;
@@ -88,7 +88,7 @@ export default Model.extend({
     // OV is a special case, so process OV options
     authenticatorOptions = [...authenticatorOptions]; //clone it since we are changing it for OV
     createOVOptions(authenticatorOptions);
-    return authenticatorOptions.length > 1;
+    return authenticatorOptions;
   },
 
   getActionByPath(actionPath) {

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -80,15 +80,15 @@ export default Model.extend({
 
   hasMoreThanOneAuthenticatorOption(formName) {
     const form = this.hasRemediationObject(formName);
-    if (form) {
-      const authenticator = form.value.find((value) => value.name === 'authenticator');
-      let authenticatorOptions = authenticator && authenticator.options;
-      // OV is a special case, so process OV options
-      authenticatorOptions = [...authenticatorOptions]; //clone it since we are changing it for OV
-      createOVOptions(authenticatorOptions);
-      return authenticatorOptions.length > 1;
+    if (!form) {
+      return false;
     }
-    return false;
+    const authenticator = form.value.find((value) => value.name === 'authenticator');
+    let authenticatorOptions = authenticator?.options || [];
+    // OV is a special case, so process OV options
+    authenticatorOptions = [...authenticatorOptions]; //clone it since we are changing it for OV
+    createOVOptions(authenticatorOptions);
+    return authenticatorOptions.length > 1;
   },
 
   getActionByPath(actionPath) {

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -81,7 +81,7 @@ export default Model.extend({
   getRemediationAuthenticationOptions(formName) {
     const form = this.hasRemediationObject(formName);
     if (!form) {
-      return false;
+      return [];
     }
     const authenticator = form.value.find((value) => value.name === 'authenticator');
     let authenticatorOptions = authenticator?.options || [];

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -4,7 +4,8 @@ import { ACTIONS, FORMS as RemediationForms } from '../../ion/RemediationConstan
 const { ENROLLED_PASSWORD_RECOVERY_LINK, ORG_PASSWORD_RECOVERY_LINK } = ACTIONS;
 
 const getSwitchAuthenticatorLink = (appState) => {
-  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE)) {
+  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE) &&
+    appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE)) {
     return [
       {
         'type': 'link',
@@ -15,7 +16,8 @@ const getSwitchAuthenticatorLink = (appState) => {
     ];
   }
 
-  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
+  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_ENROLL) &&
+    appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
     return [
       {
         'type': 'link',

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -4,8 +4,7 @@ import { ACTIONS, FORMS as RemediationForms } from '../../ion/RemediationConstan
 const { ENROLLED_PASSWORD_RECOVERY_LINK, ORG_PASSWORD_RECOVERY_LINK } = ACTIONS;
 
 const getSwitchAuthenticatorLink = (appState) => {
-  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE) &&
-    appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE)) {
+  if (appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE)) {
     return [
       {
         'type': 'link',
@@ -16,8 +15,7 @@ const getSwitchAuthenticatorLink = (appState) => {
     ];
   }
 
-  if (appState.hasRemediationObject(RemediationForms.SELECT_AUTHENTICATOR_ENROLL) &&
-    appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
+  if (appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
     return [
       {
         'type': 'link',

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -4,7 +4,7 @@ import { ACTIONS, FORMS as RemediationForms } from '../../ion/RemediationConstan
 const { ENROLLED_PASSWORD_RECOVERY_LINK, ORG_PASSWORD_RECOVERY_LINK } = ACTIONS;
 
 const getSwitchAuthenticatorLink = (appState) => {
-  if (appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE)) {
+  if (appState.getRemediationAuthenticationOptions(RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE).length > 1) {
     return [
       {
         'type': 'link',
@@ -15,7 +15,7 @@ const getSwitchAuthenticatorLink = (appState) => {
     ];
   }
 
-  if (appState.hasMoreThanOneAuthenticatorOption(RemediationForms.SELECT_AUTHENTICATOR_ENROLL)) {
+  if (appState.getRemediationAuthenticationOptions(RemediationForms.SELECT_AUTHENTICATOR_ENROLL).length > 1) {
     return [
       {
         'type': 'link',

--- a/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
@@ -53,11 +53,7 @@ test
   .requestHooks(mock)('renders an iframe for Duo', async t => {
     const challengeDuoPage = await setup(t);
 
-    const { log } = await t.getBrowserConsoleMessages();
-    await t.expect(log.length).eql(3);
-    await t.expect(log[0]).eql('===== playground widget ready event received =====');
-    await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-    await t.expect(JSON.parse(log[2])).eql({
+    await checkConsoleMessages({
       controller: 'mfa-verify-duo',
       formName: 'challenge-authenticator',
       authenticatorKey: 'duo',
@@ -68,6 +64,9 @@ test
     await t.expect(challengeDuoPage.getFormTitle()).eql('Verify with Duo Security');
     await t.expect(challengeDuoPage.hasDuoIframe()).eql(true);
 
+    // Verify links
+    await t.expect(await challengeDuoPage.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengeDuoPage.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
     await t.expect(await challengeDuoPage.signoutLinkExists()).ok();
     await t.expect(challengeDuoPage.getSignoutLinkText()).eql('Back to sign in');
   });

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -143,6 +143,11 @@ test
     await t.expect(pageTitle).contains('Verify with your email');
     await t.expect(challengeEmailPageObject.getFormSubtitle())
       .contains('Check your email for a verification message. Click the verification button in your email or enter the code below to continue.');
+
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await challengeEmailPageObject.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await challengeEmailPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeEmailPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
 test
@@ -259,7 +264,7 @@ test
       record => record.response.statusCode === 200 &&
       record.request.url.match(/poll/)
     )).eql(5);
-  }); 
+  });
 
 test
   .requestHooks(logger, validOTPmock)('resend after 30 seconds', async t => {

--- a/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
@@ -46,6 +46,12 @@ test.requestHooks(mockChallengeAuthenticatorOnPrem)('challenge on prem authentic
   await t.expect(saveBtnText).contains('Verify');
   await t.expect(pageTitle).contains('Verify with Atko Custom On-prem');
 
+  // Verify links
+  await t.expect(await challengeOnPremPage.switchAuthenticatorLinkExists()).ok();
+  await t.expect(challengeOnPremPage.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+  await t.expect(await challengeOnPremPage.signoutLinkExists()).ok();
+  await t.expect(challengeOnPremPage.getSignoutLinkText()).eql('Back to sign in');
+
   // verify passcode
   await challengeOnPremPage.verifyFactor('credentials.passcode', 'test');
   await challengeOnPremPage.clickNextButton();

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -183,6 +183,12 @@ test
     await t.expect(pageSubtitle).contains('+1 XXX-XXX-2342');
     await t.expect(primaryButtonText).contains('Receive a code via voice call');
     await t.expect(secondaryButtonText).contains('Receive an SMS instead');
+
+    // Verify links
+    await t.expect(await challengePhonePageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengePhonePageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+    await t.expect(await challengePhonePageObject.signoutLinkExists()).ok();
+    await t.expect(challengePhonePageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
 test

--- a/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
@@ -3,6 +3,7 @@ import xhrAuthenticatorRequiredRsa from '../../../playground/mocks/data/idp/idx/
 import xhrInvalidPasscode from '../../../playground/mocks/data/idp/idx/error-authenticator-verification-rsa';
 import xhrPasscodeChange from '../../../playground/mocks/data/idp/idx/error-authenticator-verification-passcode-change-rsa';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
+import { checkConsoleMessages } from '../framework/shared';
 import ChallengeRsaPageObject from '../framework/page-objects/ChallengeOnPremPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 
@@ -35,11 +36,7 @@ async function setup(t) {
 test.requestHooks(mockChallengeAuthenticatorRsa)('challenge RSA authenticator', async t => {
   const challengeRsaPage = await setup(t);
 
-  const { log } = await t.getBrowserConsoleMessages();
-  await t.expect(log.length).eql(3);
-  await t.expect(log[0]).eql('===== playground widget ready event received =====');
-  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-  await t.expect(JSON.parse(log[2])).eql({
+  await checkConsoleMessages({
     controller: 'mfa-verify-totp',
     formName: 'challenge-authenticator',
     authenticatorKey: 'rsa_token',
@@ -50,6 +47,12 @@ test.requestHooks(mockChallengeAuthenticatorRsa)('challenge RSA authenticator', 
   const saveBtnText = challengeRsaPage.getSaveButtonLabel();
   await t.expect(saveBtnText).contains('Verify');
   await t.expect(pageTitle).contains('Verify with RSA SecurID');
+
+  // Verify links
+  await t.expect(await challengeRsaPage.switchAuthenticatorLinkExists()).ok();
+  await t.expect(challengeRsaPage.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+  await t.expect(await challengeRsaPage.signoutLinkExists()).ok();
+  await t.expect(challengeRsaPage.getSignoutLinkText()).eql('Back to sign in');
 
   // verify passcode
   await challengeRsaPage.verifyFactor('credentials.passcode', 'test');

--- a/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
@@ -40,6 +40,10 @@ test.requestHooks(answerRequestLogger, authenticatorRequiredSecurityQuestionMock
   const challengeFactorPageObject = await setup(t);
 
   await t.expect(await challengeFactorPageObject.getAnswerLabel()).eql('Where did you go for your favorite vacation?');
+
+  // Verify links
+  await t.expect(await challengeFactorPageObject.switchAuthenticatorLinkExists()).ok();
+  await t.expect(challengeFactorPageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
   await t.expect(await challengeFactorPageObject.signoutLinkExists()).ok();
   await t.expect(challengeFactorPageObject.getSignoutLinkText()).eql('Back to sign in');
 

--- a/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
+++ b/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
@@ -60,6 +60,11 @@ test
     await t.expect(await challengeGoogleAuthenticatorPageObject.getOtpLabel())
       .contains('Enter code');
 
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await challengeGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await challengeGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeGoogleAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
+
     await challengeGoogleAuthenticatorPageObject.verifyFactor('credentials.passcode', '1234');
     await challengeGoogleAuthenticatorPageObject.clickNextButton();
     const successPage = new SuccessPageObject(t);

--- a/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyPush_spec.js
@@ -50,6 +50,12 @@ test
     await t.expect(a11ySpan.textContent).contains('Push notification sent');
     await t.expect(pushBtn.hasClass('link-button-disabled')).ok();
     await t.expect(pageTitle).contains('Get a push notification');
+
+    // Verify links
+    await t.expect(await challengeOktaVerifyPushPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengeOktaVerifyPushPageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+    await t.expect(await challengeOktaVerifyPushPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeOktaVerifyPushPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
 test

--- a/test/testcafe/spec/ChallengeOktaVerifyResendPushView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyResendPushView_spec.js
@@ -51,6 +51,12 @@ test
     const resendPushBtn = challengeOktaVerifyPushPageObject.getResendPushButton();
     await t.expect(resendPushBtn.value).contains('Resend push notification');
     await t.expect(resendPushBtn.hasClass('link-button-disabled')).notOk();
+
+    // Verify links
+    await t.expect(await challengeOktaVerifyPushPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengeOktaVerifyPushPageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+    await t.expect(await challengeOktaVerifyPushPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeOktaVerifyPushPageObject.getSignoutLinkText()).eql('Back to sign in');
   });
 
 test

--- a/test/testcafe/spec/ChallengeOktaVerifyTotp_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyTotp_spec.js
@@ -52,6 +52,12 @@ test
     await t.expect(await challengeOktaVerifyTOTPPageObject.getTotpLabel())
       .contains('Enter code from Okta Verify app');
 
+    // Verify links
+    await t.expect(await challengeOktaVerifyTOTPPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengeOktaVerifyTOTPPageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+    await t.expect(await challengeOktaVerifyTOTPPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeOktaVerifyTOTPPageObject.getSignoutLinkText()).eql('Back to sign in');
+
     await challengeOktaVerifyTOTPPageObject.verifyFactor('credentials.totp', '1234');
     await challengeOktaVerifyTOTPPageObject.clickNextButton();
     const successPage = new SuccessPageObject(t);

--- a/test/testcafe/spec/EnrollAuthenticatorDuo_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorDuo_spec.js
@@ -34,9 +34,8 @@ test('should render an iframe for duo', async t => {
   await t.expect(enrollDuoPage.getFormTitle()).eql('Set up Duo Security');
   await t.expect(enrollDuoPage.hasDuoIframe()).eql(true);
 
-  // Verify links
-  await t.expect(await enrollDuoPage.switchAuthenticatorLinkExists()).ok();
-  await t.expect(enrollDuoPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+  // Verify links (switch authenticator link not present since there are no other authenticators available)
+  await t.expect(await enrollDuoPage.switchAuthenticatorLinkExists()).notOk();
   await t.expect(await enrollDuoPage.signoutLinkExists()).ok();
 });
 

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -69,6 +69,11 @@ test
       .eql('Please check your email and enter the code below.');
     await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
 
+    // Verify links
+    await t.expect(await enrollEmailPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(enrollEmailPageObject.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+    await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
+
     await enrollEmailPageObject.enterCode('561234');
     await enrollEmailPageObject.form.clickSaveButton();
 

--- a/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorGoogleAuthenticator_spec.js
@@ -93,6 +93,11 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).notOk();
     await t.expect(enrollGoogleAuthenticatorPageObject.getBarcodeSubtitle()).eql('Scan barcode');
     await t.expect(enrollGoogleAuthenticatorPageObject.hasQRcode).ok();
+
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
+
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
@@ -116,6 +121,10 @@ test
     await t.expect(enrollGoogleAuthenticatorPageObject.getmanualSetupSubtitle()).eql('Can\'t scan barcode?');
     await t.expect(enrollGoogleAuthenticatorPageObject.getSharedSecret()).eql('ZR74DHZTG43NBULV');
     await enrollGoogleAuthenticatorPageObject.goToNextPage();
+
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollGoogleAuthenticatorPageObject.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await enrollGoogleAuthenticatorPageObject.signoutLinkExists()).ok();
 
     await t.expect(enrollGoogleAuthenticatorPageObject.isEnterCodeSubtitleVisible()).ok();
     await t.expect(await enrollGoogleAuthenticatorPageObject.getOtpLabel()).contains('Enter code');

--- a/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOktaVerify_spec.js
@@ -198,6 +198,12 @@ test.requestHooks(logger, enrollViaQRcodeMocks)('should be able to enroll via qr
   await t.expect(enrollOktaVerifyPage.hasEnrollViaSmsInstruction()).eql(false);
   await t.expect(enrollOktaVerifyPage.hasQRcode()).eql(true);
   await t.expect(enrollOktaVerifyPage.getQRInstruction()).eql(qrCodeInstruction);
+
+  // Verify links
+  await t.expect(await enrollOktaVerifyPage.switchAuthenticatorLinkExists()).ok();
+  await t.expect(enrollOktaVerifyPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+  await t.expect(await enrollOktaVerifyPage.signoutLinkExists()).ok();
+
   await t.wait(4000);
   await t.expect(logger.count(
     record => record.response.statusCode === 200 &&
@@ -220,6 +226,11 @@ test.requestHooks(mock)('should render switch channel view when Can\'t scan is c
     .eql('Text me a setup link');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Email me a setup link');
+
+  // Verify links
+  await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
+  await t.expect(switchChannelPageObject.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+  await t.expect(await switchChannelPageObject.signoutLinkExists()).ok();
 });
 
 test.requestHooks(resendEmailMocks)('should render switch channel view when "try different way" is clicked when in email flow', async t => {
@@ -233,6 +244,11 @@ test.requestHooks(resendEmailMocks)('should render switch channel view when "try
     .eql('Scan a QR code');
   await t.expect(switchChannelPageObject.getOptionLabel(1))
     .eql('Text me a setup link');
+
+  // Verify links
+  await t.expect(await switchChannelPageObject.switchAuthenticatorLinkExists()).ok();
+  await t.expect(switchChannelPageObject.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+  await t.expect(await switchChannelPageObject.signoutLinkExists()).ok();
 });
 
 test.requestHooks(resendSmsMocks)('should render switch channel view when "try different way" is clicked when in sms flow', async t => {

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -43,9 +43,9 @@ test
     await t.expect(enrollOnPremPage.userNameFieldExists()).eql(true);
     await t.expect(enrollOnPremPage.passcodeFieldExists()).eql(true);
 
-    // assert switch authenticator link shows up
-    await t.expect(await enrollOnPremPage.switchAuthenticatorLinkExists()).ok();
-    await t.expect(enrollOnPremPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollOnPremPage.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await enrollOnPremPage.signoutLinkExists()).ok();
 
     // fields are required
     await enrollOnPremPage.fillUserName('');

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -62,6 +62,8 @@ test
     await t.expect(pageSubtitle).contains('your phone');
     await t.expect(pageSubtitle).contains('Enter the code below to verify.');
 
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollPhonePageObject.switchAuthenticatorLinkExists()).notOk();
     await t.expect(await enrollPhonePageObject.signoutLinkExists()).ok();
   });
 
@@ -83,6 +85,9 @@ test
     await t.expect(pageSubtitle).contains('your phone');
     await t.expect(pageSubtitle).contains('Enter the code below to verify.');
 
+    // Verify links
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollPhonePageObject.switchAuthenticatorLinkExists()).notOk();
     await t.expect(await enrollPhonePageObject.signoutLinkExists()).ok();
   });
 

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -85,7 +85,6 @@ test
     await t.expect(pageSubtitle).contains('your phone');
     await t.expect(pageSubtitle).contains('Enter the code below to verify.');
 
-    // Verify links
     // Verify links (switch authenticator link not present since there are no other authenticators available)
     await t.expect(await enrollPhonePageObject.switchAuthenticatorLinkExists()).notOk();
     await t.expect(await enrollPhonePageObject.signoutLinkExists()).ok();

--- a/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorRsaView_spec.js
@@ -1,6 +1,7 @@
 import { RequestMock } from 'testcafe';
 import EnrollRsaPageObject from '../framework/page-objects/EnrollOnPremPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
+import { checkConsoleMessages } from '../framework/shared';
 import xhrAuthenticatorEnrollRsa from '../../../playground/mocks/data/idp/idx/authenticator-enroll-rsa';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import xhrPasscodeChange from '../../../playground/mocks/data/idp/idx/error-authenticator-enroll-passcode-change-rsa';
@@ -23,11 +24,7 @@ async function setup(t) {
   const enrollRsaPage = new EnrollRsaPageObject(t);
   await enrollRsaPage.navigateToPage();
 
-  const { log } = await t.getBrowserConsoleMessages();
-  await t.expect(log.length).eql(3);
-  await t.expect(log[0]).eql('===== playground widget ready event received =====');
-  await t.expect(log[1]).eql('===== playground widget afterRender event received =====');
-  await t.expect(JSON.parse(log[2])).eql({
+  await checkConsoleMessages({
     controller: 'enroll-rsa',
     formName: 'enroll-authenticator',
     authenticatorKey: 'rsa_token',
@@ -47,9 +44,9 @@ test
     await t.expect(enrollRsaPage.userNameFieldExists()).eql(true);
     await t.expect(enrollRsaPage.passcodeFieldExists()).eql(true);
 
-    // assert switch authenticator link shows up
-    await t.expect(await enrollRsaPage.switchAuthenticatorLinkExists()).ok();
-    await t.expect(enrollRsaPage.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollRsaPage.switchAuthenticatorLinkExists()).notOk();
+    await t.expect(await enrollRsaPage.signoutLinkExists()).ok();
 
     // fields are required
     await enrollRsaPage.fillUserName('');
@@ -58,6 +55,8 @@ test
     await t.expect(enrollRsaPage.getPasscodeError()).eql('This field cannot be left blank');
     await t.expect(enrollRsaPage.getUserNameError()).eql('This field cannot be left blank');
 
+    // Verify links (switch authenticator link not present since there are no other authenticators available)
+    await t.expect(await enrollRsaPage.switchAuthenticatorLinkExists()).notOk();
     await t.expect(await enrollRsaPage.signoutLinkExists()).ok();
   });
 

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -187,7 +187,7 @@ describe('v2/models/AppState', function() {
   });
 
   describe('hasRemediationObject', () => {
-    it('returns null if there form is not present', (done) => {
+    it('returns null if the form is not present', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
@@ -196,7 +196,7 @@ describe('v2/models/AppState', function() {
       });
     });
 
-    it('returns the remediation object if there form is present (select-authenticator-enroll)', (done) => {
+    it('returns the remediation object if the form is present (select-authenticator-enroll)', (done) => {
       const oktaVerifyEnrollResponse = JSON.parse(JSON.stringify(XHRAuthenticatorEnrollOktaVerify));
       MockUtil.mockIntrospect(done, oktaVerifyEnrollResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'enroll-authenticator');
@@ -205,7 +205,7 @@ describe('v2/models/AppState', function() {
       });
     });
 
-    it('returns the remediation object if there form is present (select-authenticator-authenticate)', (done) => {
+    it('returns the remediation object if the form is present (select-authenticator-authenticate)', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
@@ -215,7 +215,7 @@ describe('v2/models/AppState', function() {
     });
   });
 
-  describe('hasMoreThanOneAuthenticatorOption', () => {
+  describe('getRemediationAuthenticationOptions', () => {
     const getAuthenticatorOptionsObj = (response) => {
       const remediationObj = response.remediation.value.find(remediation => remediation.name  === 'select-authenticator-authenticate');
       return remediationObj.value.find(value => value.name === 'authenticator');
@@ -234,7 +234,7 @@ describe('v2/models/AppState', function() {
       methodTypes.options = methodTypes.options.filter(method => ovMethods.includes(method.value));
     };
 
-    it('returns false if there is only 1 authenticator', (done) => {
+    it('returns array size 1 if response has only 1 authenticator', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       const authenticatorOptionsObj = getAuthenticatorOptionsObj(oktaVerifyChallengResponse);
       // Replace options with only Password
@@ -243,12 +243,14 @@ describe('v2/models/AppState', function() {
 
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
-        expect(this.appState.hasMoreThanOneAuthenticatorOption('select-authenticator-authenticate')).toBe(false);
+        const options = this.appState.getRemediationAuthenticationOptions('select-authenticator-authenticate');
+        expect(options).toHaveLength(1);
+        expect(options[0].label).toBe('Okta Password');
         done();
       });
     });
 
-    it('returns true if there is more than 1 authenticator', (done) => {
+    it('returns array size 4 if response has Okta Verify (all methods) and password', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       const authenticatorOptionsObj = getAuthenticatorOptionsObj(oktaVerifyChallengResponse);
       // Okta Verify and Password are available
@@ -256,12 +258,17 @@ describe('v2/models/AppState', function() {
 
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
-        expect(this.appState.hasMoreThanOneAuthenticatorOption('select-authenticator-authenticate')).toBe(true);
+        const options = this.appState.getRemediationAuthenticationOptions('select-authenticator-authenticate');
+        expect(options).toHaveLength(4);
+        expect(options[0].label).toBe('Get a push notification');
+        expect(options[1].label).toBe('Enter a code');
+        expect(options[2].label).toBe('Okta Password');
+        expect(options[3].label).toBe('Use Okta FastPass');
         done();
       });
     });
 
-    it('returns true if only Okta Verify authenticator with 3 methods', (done) => {
+    it('returns array size 3 if response has Okta Verify with all methods', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       const authenticatorOptionsObj = getAuthenticatorOptionsObj(oktaVerifyChallengResponse);
       // Replace options with only Okta Verify with 3 methods available
@@ -272,12 +279,16 @@ describe('v2/models/AppState', function() {
 
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
-        expect(this.appState.hasMoreThanOneAuthenticatorOption('select-authenticator-authenticate')).toBe(true);
+        const options = this.appState.getRemediationAuthenticationOptions('select-authenticator-authenticate');
+        expect(options).toHaveLength(3);
+        expect(options[0].label).toBe('Get a push notification');
+        expect(options[1].label).toBe('Enter a code');
+        expect(options[2].label).toBe('Use Okta FastPass');
         done();
       });
     });
 
-    it('returns true if only Okta Verify authenticator with 2 methods', (done) => {
+    it('returns array size 2 if response has Okta Verify with 2 methods', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       const authenticatorOptionsObj = getAuthenticatorOptionsObj(oktaVerifyChallengResponse);
       // Replace options with only Okta Verify with 1 method available
@@ -289,12 +300,15 @@ describe('v2/models/AppState', function() {
 
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
-        expect(this.appState.hasMoreThanOneAuthenticatorOption('select-authenticator-authenticate')).toBe(true);
+        const options = this.appState.getRemediationAuthenticationOptions('select-authenticator-authenticate');
+        expect(options).toHaveLength(2);
+        expect(options[0].label).toBe('Get a push notification');
+        expect(options[1].label).toBe('Enter a code');
         done();
       });
     });
 
-    it('returns false if only Okta Verify authenticator with only 1 method (signed_nonce)', (done) => {
+    it('returns array size 1 if response has Okta Verify with only 1 method (signed_nonce)', (done) => {
       const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
       const authenticatorOptionsObj = getAuthenticatorOptionsObj(oktaVerifyChallengResponse);
       // Replace options with only Okta Verify with 1 method available
@@ -306,7 +320,9 @@ describe('v2/models/AppState', function() {
 
       MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
         this.initAppState({ idx: idxResp }, 'challenge-authenticator');
-        expect(this.appState.hasMoreThanOneAuthenticatorOption('select-authenticator-authenticate')).toBe(false);
+        const options = this.appState.getRemediationAuthenticationOptions('select-authenticator-authenticate');
+        expect(options).toHaveLength(1);
+        expect(options[0].label).toBe('Use Okta FastPass');
         done();
       });
     });

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -2,6 +2,8 @@ import AppState from 'v2/models/AppState';
 import MockUtil from '../../../helpers/v2/MockUtil';
 import XHRAuthenticatorChallengOktaVerify
   from '../../../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-push.json';
+import XHRAuthenticatorEnrollOktaVerify
+  from '../../../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-sms.json';
 import { FORMS_FOR_VERIFICATION, FORMS_WITHOUT_SIGNOUT } from 'v2/ion/RemediationConstants';
 
 describe('v2/models/AppState', function() {
@@ -182,6 +184,35 @@ describe('v2/models/AppState', function() {
       expect(this.appState.shouldReRenderView(transformedResponse)).toBe(false);
     });
 
+  });
+
+  describe('hasRemediationObject', () => {
+    it('returns null if there form is not present', (done) => {
+      const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
+      MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
+        this.initAppState({ idx: idxResp }, 'challenge-authenticator');
+        expect(this.appState.hasRemediationObject('other-form')).toBeUndefined();
+        done();
+      });
+    });
+
+    it('returns the remediation object if there form is present (select-authenticator-enroll)', (done) => {
+      const oktaVerifyEnrollResponse = JSON.parse(JSON.stringify(XHRAuthenticatorEnrollOktaVerify));
+      MockUtil.mockIntrospect(done, oktaVerifyEnrollResponse, idxResp => {
+        this.initAppState({ idx: idxResp }, 'enroll-authenticator');
+        expect(this.appState.hasRemediationObject('select-authenticator-enroll')).toBeDefined();
+        done();
+      });
+    });
+
+    it('returns the remediation object if there form is present (select-authenticator-authenticate)', (done) => {
+      const oktaVerifyChallengResponse = JSON.parse(JSON.stringify(XHRAuthenticatorChallengOktaVerify));
+      MockUtil.mockIntrospect(done, oktaVerifyChallengResponse, idxResp => {
+        this.initAppState({ idx: idxResp }, 'challenge-authenticator');
+        expect(this.appState.hasRemediationObject('select-authenticator-authenticate')).toBeDefined();
+        done();
+      });
+    });
   });
 
   describe('hasMoreThanOneAuthenticatorOption', () => {

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -5,7 +5,7 @@ import { getSwitchAuthenticatorLink } from 'v2/view-builder/utils/LinksUtil';
 describe('v2/utils/LinksUtil', function() {
   const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator) => {
     const appState = new AppState();
-    spyOn(appState, 'getRemediationAuthenticationOptions').and.callFake(formName => {
+    jest.spyOn(appState, 'getRemediationAuthenticationOptions').mockImplementation(formName => {
       if (formName === remediationFormName && hasMoreThanOneAuthenticator) {
         return [ { label: 'some authenticator '}, { label: 'another authenticator' } ];
       }

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -5,7 +5,12 @@ import { getSwitchAuthenticatorLink } from 'v2/view-builder/utils/LinksUtil';
 describe('v2/utils/LinksUtil', function() {
   const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator) => {
     const appState = new AppState();
-    jest.spyOn(appState, 'hasMoreThanOneAuthenticatorOption').mockReturnValue(hasMoreThanOneAuthenticator);
+    spyOn(appState, 'getRemediationAuthenticationOptions').and.callFake(formName => {
+      if (formName === remediationFormName && hasMoreThanOneAuthenticator) {
+        return [ { label: 'some authenticator '}, { label: 'another authenticator' } ];
+      }
+      return [];
+    });
     return appState;
   };
 

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -5,17 +5,11 @@ import { getSwitchAuthenticatorLink } from 'v2/view-builder/utils/LinksUtil';
 describe('v2/utils/LinksUtil', function() {
   const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator) => {
     const appState = new AppState();
-    spyOn(appState, 'hasRemediationObject').and.callFake(formName => formName === remediationFormName);
-    spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.returnValue(hasMoreThanOneAuthenticator);
+    jest.spyOn(appState, 'hasMoreThanOneAuthenticatorOption').mockReturnValue(hasMoreThanOneAuthenticator);
     return appState;
   };
 
   describe('getSwitchAuthenticatorLink', () => {
-    it('returns empty when remediation form is not present', function() {
-      const appState = mockAppState('other-form', true);
-      expect(getSwitchAuthenticatorLink(appState)).toHaveLength(0);
-    });
-
     describe('select-authenticator-authenticate', () => {
       it('returns a link when multiple authenticators available', function() {
         const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE, true);

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -1,0 +1,43 @@
+import AppState from 'v2/models/AppState';
+import { FORMS } from 'v2/ion/RemediationConstants';
+import { getSwitchAuthenticatorLink } from 'v2/view-builder/utils/LinksUtil';
+
+describe('v2/utils/LinksUtil', function() {
+  const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator) => {
+    const appState = new AppState();
+    spyOn(appState, 'hasRemediationObject').and.callFake(formName => formName === remediationFormName);
+    spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.returnValue(hasMoreThanOneAuthenticator);
+    return appState;
+  };
+
+  describe('getSwitchAuthenticatorLink', () => {
+    it('returns empty when remediation form is not present', function() {
+      const appState = mockAppState('other-form', true);
+      expect(getSwitchAuthenticatorLink(appState)).toHaveLength(0);
+    });
+
+    describe('select-authenticator-authenticate', () => {
+      it('returns a link when multiple authenticators available', function() {
+        const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE, true);
+        expect(getSwitchAuthenticatorLink(appState)).toHaveLength(1);
+      });
+
+      it('returns empty when just one authenticator available', function() {
+        const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE, false);
+        expect(getSwitchAuthenticatorLink(appState)).toHaveLength(0);
+      });
+    });
+
+    describe('select-authenticator-enroll', () => {
+      it('returns a link when multiple authenticators available', function() {
+        const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_ENROLL, true);
+        expect(getSwitchAuthenticatorLink(appState)).toHaveLength(1);
+      });
+
+      it('returns empty when just one authenticator available', function() {
+        const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_ENROLL, false);
+        expect(getSwitchAuthenticatorLink(appState)).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -24,6 +24,9 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
       spyOn(appState, 'hasRemediationObject').and.callFake(
         formName => formName === 'select-authenticator-authenticate'
       );
+      spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.callFake(
+        formName => formName === 'select-authenticator-authenticate'
+      );
       spyOn(appState, 'shouldShowSignOutLinkInCurrentForm').and.returnValue(false);
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       const currentViewState = {
@@ -66,7 +69,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
     expect(testContext.view.$('.idx-webauthn-verify-text').text()).toBe(
       'You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.'
     );
-    expect(testContext.view.$('.retry-webauthn').css('display')).not.toBe('none'); 
+    expect(testContext.view.$('.retry-webauthn').css('display')).not.toBe('none');
     expect(testContext.view.$('.retry-webauthn').text()).toBe('Verify');
     expect(testContext.view.$('.webauthn-not-supported').length).toBe(0);
   });

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -21,12 +21,12 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
         currentAuthenticatorEnrollment,
         authenticatorEnrollments,
       });
-      spyOn(appState, 'hasRemediationObject').and.callFake(
-        formName => formName === 'select-authenticator-authenticate'
-      );
-      spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.callFake(
-        formName => formName === 'select-authenticator-authenticate'
-      );
+      spyOn(appState, 'getRemediationAuthenticationOptions').and.callFake(formName => {
+        if (formName === 'select-authenticator-authenticate') {
+          return [ { label: 'some authenticator '} ];
+        }
+        return [];
+      });
       spyOn(appState, 'shouldShowSignOutLinkInCurrentForm').and.returnValue(false);
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       const currentViewState = {

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -28,6 +28,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         authenticatorEnrollments,
       });
       spyOn(appState, 'hasRemediationObject').and.callFake(formName => formName === 'select-authenticator-enroll');
+      spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.callFake(formName => formName === 'select-authenticator-enroll');
       spyOn(appState, 'shouldShowSignOutLinkInCurrentForm').and.returnValue(false);
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       testContext.view = new EnrollWebauthnView({

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -27,8 +27,12 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
         currentAuthenticator,
         authenticatorEnrollments,
       });
-      spyOn(appState, 'hasRemediationObject').and.callFake(formName => formName === 'select-authenticator-enroll');
-      spyOn(appState, 'hasMoreThanOneAuthenticatorOption').and.callFake(formName => formName === 'select-authenticator-enroll');
+      spyOn(appState, 'getRemediationAuthenticationOptions').and.callFake(formName => {
+        if (formName === 'select-authenticator-enroll') {
+          return [ { label: 'some authenticator '} ];
+        }
+        return [];
+      });
       spyOn(appState, 'shouldShowSignOutLinkInCurrentForm').and.returnValue(false);
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       testContext.view = new EnrollWebauthnView({


### PR DESCRIPTION
## Description:

- Show the link only if there are more authenticators to choose from. If there is only 1 authenticator, there is no point of showing it
- Context: API will now return the link all the time, so the logic to hide or show it is on the SIW

Resolves: OKTA-399497

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Added unit tests?
- [x] Added e2e tests
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

For more context, these are the links:
| Set up | Verify |
| --- | --- |
| <img width="421" alt="SIW-setup authenticator" src="https://user-images.githubusercontent.com/6979296/120678849-6458d000-c44d-11eb-8f64-e5bfdd36ae33.png"> | <img width="419" alt="SIW-verify authenticator" src="https://user-images.githubusercontent.com/6979296/120678836-60c54900-c44d-11eb-9749-ca938f93582f.png"> |


### Reviewers:


### Issue:

- [OKTA-399497](https://oktainc.atlassian.net/browse/OKTA-399497)


