### PR TITLE
List "FastPass" Option To The Top Of Authenticator List

### DIFF
--- a/playground/mocks/data/idp/idx/authenticator-verification-data-ov-only-without-device-known.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-data-ov-only-without-device-known.json
@@ -34,16 +34,16 @@
                   "required": true,
                   "options": [
                     {
-                      "label": "FastPass",
-                      "value": "signed_nonce"
-                    },
-                    {
                       "label": "push notification",
                       "value": "push"
                     },
                     {
                       "label": "totp",
                       "value": "totp"
+                    },
+                    {
+                      "label": "FastPass",
+                      "value": "signed_nonce"
                     }
                   ]
                 }
@@ -89,16 +89,16 @@
                         "required": false,
                         "options": [
                           {
-                            "label": "Use Okta FastPass",
-                            "value": "signed_nonce"
-                          },
-                          {
                             "label": "Get a push notification",
                             "value": "push"
                           },
                           {
                             "label": "Enter a code",
                             "value": "totp"
+                          },
+                          {
+                            "label": "Use Okta FastPass",
+                            "value": "signed_nonce"
                           }
                         ]
                       }
@@ -148,13 +148,13 @@
       "displayName": "",
       "methods": [
         {
-          "type": "signed_nonce"
-        },
-        {
           "type": "push"
         },
         {
           "type": "totp"
+        },
+        {
+          "type": "signed_nonce"
         }
       ]
     }
@@ -169,13 +169,13 @@
         "displayName": "",
         "methods": [
           {
-            "type": "signed_nonce"
-          },
-          {
             "type": "push"
           },
           {
             "type": "totp"
+          },
+          {
+            "type": "signed_nonce"
           }
         ]
       }

--- a/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/ChallengeAuthenticatorDataOktaVerifyView.js
@@ -11,6 +11,9 @@ const Body = SelectAuthenticatorVerifyViewBody.extend({
     // Change the UI schema to not display radios here.
     const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
     const methodsSchema = uiSchemas.find(schema => schema.name === 'authenticator.methodType');
+
+    this._sortMethodOptionsIfDeviceKnown(methodsSchema.options);
+
     const methodOptions = methodsSchema.options.map((option) => {
       return Object.assign({}, option, getAuthenticatorDataForVerification({authenticatorKey: AUTHENTICATOR_KEY.OV}));
     });
@@ -22,6 +25,25 @@ const Body = SelectAuthenticatorVerifyViewBody.extend({
       }
     }];
   },
+
+  // If the `deviceKnown` attribute is true, we should put the signed_nonce method to the top of authenticator list.
+  // This is in sync with v2/ion/ui-schema/ion-object-handler.js - createOVOptions
+  _sortMethodOptionsIfDeviceKnown(methodOptions) {
+    // Check if the `deviceKnown` attribute is true
+    const deviceKnown = this.options?.currentViewState?.relatesTo?.value?.deviceKnown;
+
+    if (deviceKnown) {
+      const signedNonceIndex = methodOptions.findIndex((e) => e.value === 'signed_nonce');
+
+      if (signedNonceIndex > 0) {
+        const signedNonceModel = methodOptions[signedNonceIndex];
+
+        // Put the 'signed_nonce' option to the top of the list
+        methodOptions.splice(signedNonceIndex, 1);
+        methodOptions.unshift(signedNonceModel);
+      }
+    }
+  }
 });
 
 export default BaseAuthenticatorView.extend({

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -2,10 +2,19 @@ import { RequestMock, RequestLogger } from 'testcafe';
 import { renderWidget } from '../framework/shared';
 import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import ChallengeOktaVerifyTotpPageObject from '../framework/page-objects/ChallengeOktaVerifyTotpPageObject';
-import xhrSelectMethodOktaVerify from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-select-method';
-import xhrChallengeTotpOktaVerifyOnly from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp-onlyOV';
-import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
+import xhrOktaVerifyOnlyMethodsWithoutDeviceKnown
+  from '../../../playground/mocks/data/idp/idx/authenticator-verification-data-ov-only-without-device-known';
+import xhrChallengeTotpOktaVerifyOnly
+  from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp-onlyOV';
+import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
+
+const FORM_TITLE = 'Verify it\'s you with an authenticator';
+const FORM_SUBTITLE = 'Select from the following options';
+const ENTER_CODE_TEXT = 'Enter a code';
+const FAST_PASS_TEXT = 'Use Okta Verify on this device';
+const PUSH_NOTIFICATION_TEXT = 'Get a push notification';
+const SIGN_OUT_TEXT = 'Back to sign in';
 
 const requestLogger = RequestLogger(/challenge/,
   {
@@ -16,99 +25,86 @@ const requestLogger = RequestLogger(/challenge/,
 
 const mockChallengeOVSelectMethod = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(xhrSelectMethodOktaVerify)
+  .respond(xhrOktaVerifyOnlyMethodsWithoutDeviceKnown)
   .onRequestTo('http://localhost:3000/idp/idx/challenge')
   .respond(xhrSuccess);
 
 const mockChallengeOVTotpMethod = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(xhrSelectMethodOktaVerify)
+  .respond(xhrOktaVerifyOnlyMethodsWithoutDeviceKnown)
   .onRequestTo('http://localhost:3000/idp/idx/challenge')
   .respond(xhrChallengeTotpOktaVerifyOnly)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(xhrSuccess);
 
+const xhrOktaVerifyOnlyMethodsWithDeviceKnown = JSON.parse(JSON.stringify((xhrOktaVerifyOnlyMethodsWithoutDeviceKnown)));
+xhrOktaVerifyOnlyMethodsWithDeviceKnown.currentAuthenticator.value.deviceKnown = true;
+
+const mockChallengeOVOnlyMethodsWithDeviceKnown = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrOktaVerifyOnlyMethodsWithDeviceKnown);
+
 fixture('Select Method screen for Okta verify');
+
+async function verifyFactorByIndex(t, selectAuthenticatorPage, index, expectedLabel) {
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(index)).eql(expectedLabel);
+  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(index)).eql(false);
+  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(index)).contains('mfa-okta-verify');
+  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(index)).eql('Select');
+}
+
+async function verifySelectAuthenticator(t, selectAuthenticatorPage, expectedResponse) {
+  const successPage = new SuccessPageObject(t);
+  const pageUrl = await successPage.getPageUrl();
+  const requestLog = requestLogger.requests[0].request;
+
+  await t.expect(pageUrl).eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+  await t.expect(requestLog.url).eql('http://localhost:3000/idp/idx/challenge');
+  await t.expect(requestLog.method).eql('post');
+  await t.expect(JSON.parse(requestLog.body)).eql(expectedResponse);
+}
 
 async function setup(t) {
   const selectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
   await selectAuthenticatorPageObject.navigateToPage();
+
+  await t.expect(selectAuthenticatorPageObject.getFormTitle()).eql(FORM_TITLE);
+  await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql(FORM_SUBTITLE);
+  await t.expect(selectAuthenticatorPageObject.getFactorsCount()).eql(3);
+
   return selectAuthenticatorPageObject;
 }
 
-test.requestHooks(mockChallengeOVSelectMethod)('should load select method list with okta verify options', async t => {
+test.requestHooks(mockChallengeOVSelectMethod)('preserve the order of authenticator list when the `deviceKnown` attribute is either null or false', async t => {
   const selectAuthenticatorPage = await setup(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
-  //await t.expect(selectAuthenticatorPage.getFactorsCount()).eql(3);
-  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(0)).eql('Use Okta Verify on this device');
-  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(0)).eql(false);
-  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
-  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(0)).eql('Select');
 
-  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(1)).eql('Get a push notification');
-  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(1)).eql(false);
-  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
-  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(1)).eql('Select');
-
-  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(2)).eql('Enter a code');
-  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(2)).eql(false);
-  await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-verify');
-  await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(2)).eql('Select');
+  await verifyFactorByIndex(t, selectAuthenticatorPage, 0, PUSH_NOTIFICATION_TEXT);
+  await verifyFactorByIndex(t, selectAuthenticatorPage, 1, ENTER_CODE_TEXT);
+  await verifyFactorByIndex(t, selectAuthenticatorPage, 2, FAST_PASS_TEXT);
 
   // signout link at enroll page
   await t.expect(await selectAuthenticatorPage.signoutLinkExists()).ok();
-  await t.expect(selectAuthenticatorPage.getSignoutLinkText()).eql('Back to sign in');
+  await t.expect(selectAuthenticatorPage.getSignoutLinkText()).eql(SIGN_OUT_TEXT);
 });
 
 test.requestHooks(mockChallengeOVSelectMethod)('should load select method list with okta verify and no sign-out link', async t => {
   const selectAuthenticatorPage = await setup(t);
   await renderWidget({
-    features: { hideSignOutLinkInMFA: true },
+    features: {
+      hideSignOutLinkInMFA: true
+    },
   });
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
 
   // signout link is not visible
   await t.expect(await selectAuthenticatorPage.signoutLinkExists()).notOk();
 });
 
-test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when fastpass is selected', async t => {
-  const selectAuthenticatorPage = await setup(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
-  selectAuthenticatorPage.selectFactorByIndex(0);
-  const successPage = new SuccessPageObject(t);
-  const pageUrl = await successPage.getPageUrl();
-  await t.expect(pageUrl)
-    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
-  const req2 = requestLogger.requests[0].request;
-  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
-  await t.expect(req2.method).eql('post');
-  await t.expect(JSON.parse(req2.body)).eql({
-    'authenticator':
-    {
-      'id': 'aut13qrZReYpIib7R0g4',
-      'methodType': 'signed_nonce'
-    },
-    'stateHandle': '02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3'
-  });
-});
-
 test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when push is selected', async t => {
   const selectAuthenticatorPage = await setup(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
-  selectAuthenticatorPage.selectFactorByIndex(1);
-  const successPage = new SuccessPageObject(t);
-  const pageUrl = await successPage.getPageUrl();
-  await t.expect(pageUrl)
-    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
-  const req2 = requestLogger.requests[0].request;
-  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
-  await t.expect(req2.method).eql('post');
-  await t.expect(JSON.parse(req2.body)).eql({
-    'authenticator':
-    {
+
+  await selectAuthenticatorPage.selectFactorByIndex(0);
+  await verifySelectAuthenticator(t, selectAuthenticatorPage, {
+    'authenticator': {
       'id': 'aut13qrZReYpIib7R0g4',
       'methodType': 'push'
     },
@@ -118,19 +114,10 @@ test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right
 
 test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when totp is selected', async t => {
   const selectAuthenticatorPage = await setup(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
-  selectAuthenticatorPage.selectFactorByIndex(2);
-  const successPage = new SuccessPageObject(t);
-  const pageUrl = await successPage.getPageUrl();
-  await t.expect(pageUrl)
-    .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
-  const req2 = requestLogger.requests[0].request;
-  await t.expect(req2.url).eql('http://localhost:3000/idp/idx/challenge');
-  await t.expect(req2.method).eql('post');
-  await t.expect(JSON.parse(req2.body)).eql({
-    'authenticator':
-    {
+
+  await selectAuthenticatorPage.selectFactorByIndex(1);
+  await verifySelectAuthenticator(t, selectAuthenticatorPage, {
+    'authenticator': {
       'id': 'aut13qrZReYpIib7R0g4',
       'methodType': 'totp'
     },
@@ -138,18 +125,37 @@ test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right
   });
 });
 
+test.requestHooks(requestLogger, mockChallengeOVSelectMethod)('should send right methodType when fastpass is selected', async t => {
+  const selectAuthenticatorPage = await setup(t);
+
+  await selectAuthenticatorPage.selectFactorByIndex(2);
+  await verifySelectAuthenticator(t, selectAuthenticatorPage, {
+    'authenticator': {
+      'id': 'aut13qrZReYpIib7R0g4',
+      'methodType': 'signed_nonce'
+    },
+    'stateHandle': '02ciZ1YTWakSanNu8GNNTnTXzhL5hoLzTlR0JewfG3'
+  });
+});
+
+test.requestHooks(mockChallengeOVOnlyMethodsWithDeviceKnown)('FastPass option is rendered 1st in the list when deviceKnown=true', async t => {
+  const selectAuthenticatorPage = await setup(t);
+
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(0)).eql(FAST_PASS_TEXT);
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(1)).eql(PUSH_NOTIFICATION_TEXT);
+  await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(2)).eql(ENTER_CODE_TEXT);
+});
+
 test.requestHooks(requestLogger, mockChallengeOVTotpMethod)('should show switch authenticator link only when needed', async t => {
   const selectAuthenticatorPage = await setup(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
-  await t.expect(selectAuthenticatorPage.getFormSubtitle()).eql('Select from the following options');
 
   // This view (only OV authenticator, but with 3 methods) is custom
   // The response contains the same select-authenticator-authenticate form as other views
-  // So we need to be sure we don't display a switch authenticator link in this page specificallym
+  // So we need to be sure we don't display a switch authenticator link in this page specifically
   // since this page itself is a select authenticator page
   await t.expect(await selectAuthenticatorPage.switchAuthenticatorLinkExists()).notOk();
 
-  selectAuthenticatorPage.selectFactorByIndex(2);
+  await selectAuthenticatorPage.selectFactorByIndex(2);
   const challengeOktaVerifyTOTPPageObject = new ChallengeOktaVerifyTotpPageObject(t);
   const saveBtnText = challengeOktaVerifyTOTPPageObject.getSaveButtonLabel();
   await t.expect(saveBtnText).contains('Verify');


### PR DESCRIPTION
## Description:
- Pretend that the `deviceKnown` attribute is added to the `currentAuthenticator` object.
- If the `deviceKnown` value is `true`, display the `FastPass` option to the top of the authenticator list.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
- https://okta.box.com/s/43nctdxzra2dfs3tccgxnbyzt3npfktt

### Reviewers:
- @gowthamidommety-okta 
- @mauriciocastillosilva-okta 
- @SamSanjabi-okta 
- @ManuMalhotra-okta 

### Issue:

- [OKTA-398032](https://oktainc.atlassian.net/browse/OKTA-398032)


