### PR TITLE
fix: update i18n key/message identify-unknown-user.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,7 +102,6 @@ module.exports = {
             'playground/**/error-with-failure-redirect.json', //OKTA-390647
             'playground/**/error-internal-server-error.json', //OKTA-389430
             'playground/**/error-user-is-not-assigned.json', //OKTA-389249
-            'playground/**/identify-unknown-user.json', //OKTA-386386
           ],
           'rules': {
             'local-rules/no-missing-api-keys': 0

--- a/playground/mocks/data/idp/idx/identify-unknown-user.json
+++ b/playground/mocks/data/idp/idx/identify-unknown-user.json
@@ -52,12 +52,11 @@
     "type": "array",
     "value": [
       {
-        "message": "There is no account with the email test@rain.com.",
+        "message": "Authentication failed",
         "i18n": {
-          "key": "idx.unknown.user",
-          "params": []
+          "key": "errors.E0000004"
         },
-        "class": "INFO"
+        "class": "ERROR"
       }
     ]
   },

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -14,7 +14,6 @@ const ignoredMocks = [
   'success-with-interaction-code.json',
   'identify-with-third-party-idps.json',
   'identify-with-apple-redirect-sso-extension.json', // flaky on bacon
-  'identify-unknown-user.json',
   'error-user-is-not-assigned.json',
   'error-internal-server-error.json',
   'error-forgot-password.json',

--- a/test/testcafe/spec/IdentifyUnknownUser_spec.js
+++ b/test/testcafe/spec/IdentifyUnknownUser_spec.js
@@ -13,7 +13,7 @@ const mock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(registeredUser);
 
-fixture('Identify but Unknown User')
+fixture('Identify Unknown User')
   .requestHooks(mock);
 
 async function setup(t) {
@@ -33,7 +33,7 @@ test('should show messages callout for unknown user', async t => {
   await identityPage.fillIdentifierField('unknown');
   await identityPage.clickNextButton();
   await t.expect(identityPage.getUnknownUserCalloutContent())
-    .eql('There is no account with the email test@rain.com.');
+    .eql('Unable to sign in');
 });
 
 test('should remove messages callout for unknown user once successful', async t => {

--- a/test/unit/spec/v2/ion/responseTransformer_spec.js
+++ b/test/unit/spec/v2/ion/responseTransformer_spec.js
@@ -206,12 +206,11 @@ describe('v2/ion/responseTransformer', function() {
         messages: {
           value: [
             {
-              message: 'There is no account with the email test@rain.com.',
+              message: 'Authentication failed',
               i18n: {
-                key: 'idx.unknown.user',
-                params: [],
+                key: 'errors.E0000004',
               },
-              class: 'INFO',
+              class: 'ERROR',
             },
           ],
         },


### PR DESCRIPTION
## Description:
On playground it shows as an info/warning but in production it will be an error:
<img width="430" alt="Screenshot 2021-06-07 at 10 21 58 AM" src="https://user-images.githubusercontent.com/71431120/121063291-fb3dc900-c77a-11eb-969c-86b8a9815a26.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-386386](https://oktainc.atlassian.net/browse/OKTA-386386)


