### PR TITLE
feat: clear sessionStorage.stateHandle if URL changes

### DIFF
--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -179,6 +179,9 @@ export default Router.extend({
   },
 
   render: function(Controller, options = {}) {
+    if (sessionStorageHelper.getLastVisitedURL() !== window.location.href) {
+      sessionStorageHelper.removeStateHandle();
+    }
     // Since we have a wrapper view, render our wrapper and use its content
     // element as our new el.
     // Note: Render it here because we know dom is ready at this point

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -181,7 +181,7 @@ export default Router.extend({
   render: function(Controller, options = {}) {
     // If url changes then widget assumes that user's intention was to initiate a new login flow,
     // so clear stored token to use the latest token.
-    if (sessionStorageHelper.getLastVisitedURL() !== window.location.href) {
+    if (sessionStorageHelper.getLastInitiatedLoginUrl() !== window.location.href) {
       sessionStorageHelper.removeStateHandle();
     }
     // Since we have a wrapper view, render our wrapper and use its content

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -179,6 +179,8 @@ export default Router.extend({
   },
 
   render: function(Controller, options = {}) {
+    // If url changes then widget assumes that user's intention was to initiate a new login flow,
+    // so clear stored token to use the latest token.
     if (sessionStorageHelper.getLastVisitedURL() !== window.location.href) {
       sessionStorageHelper.removeStateHandle();
     }

--- a/src/v2/client/sessionStorageHelper.js
+++ b/src/v2/client/sessionStorageHelper.js
@@ -11,26 +11,26 @@
  */
 
 const STATE_HANDLE_SESSION_STORAGE_KEY = 'osw-oie-state-handle';
-const LAST_VISITED_URL_SESSION_STORAGE_KEY = 'osw-oie-last-visited-url';
+const LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY = 'osw-oie-last-initiated-login-url';
 
 const removeStateHandle = () => {
   sessionStorage.removeItem(STATE_HANDLE_SESSION_STORAGE_KEY);
-  sessionStorage.removeItem(LAST_VISITED_URL_SESSION_STORAGE_KEY);
+  sessionStorage.removeItem(LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY);
 };
 const setStateHandle = (token) => {
   sessionStorage.setItem(STATE_HANDLE_SESSION_STORAGE_KEY, token);
-  sessionStorage.setItem(LAST_VISITED_URL_SESSION_STORAGE_KEY, window.location.href);
+  sessionStorage.setItem(LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY, window.location.href);
 };
 const getStateHandle = () => {
   return sessionStorage.getItem(STATE_HANDLE_SESSION_STORAGE_KEY);
 };
-const getLastVisitedURL = () => {
-  return sessionStorage.getItem(LAST_VISITED_URL_SESSION_STORAGE_KEY);
+const getLastInitiatedLoginUrl = () => {
+  return sessionStorage.getItem(LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY);
 };
 
 export default {
   removeStateHandle,
   setStateHandle,
   getStateHandle,
-  getLastVisitedURL,
+  getLastInitiatedLoginUrl,
 };

--- a/src/v2/client/sessionStorageHelper.js
+++ b/src/v2/client/sessionStorageHelper.js
@@ -11,19 +11,26 @@
  */
 
 const STATE_HANDLE_SESSION_STORAGE_KEY = 'osw-oie-state-handle';
+const LAST_VISITED_URL_SESSION_STORAGE_KEY = 'osw-oie-last-visited-url';
 
 const removeStateHandle = () => {
   sessionStorage.removeItem(STATE_HANDLE_SESSION_STORAGE_KEY);
+  sessionStorage.removeItem(LAST_VISITED_URL_SESSION_STORAGE_KEY);
 };
 const setStateHandle = (token) => {
   sessionStorage.setItem(STATE_HANDLE_SESSION_STORAGE_KEY, token);
+  sessionStorage.setItem(LAST_VISITED_URL_SESSION_STORAGE_KEY, window.location.href);
 };
 const getStateHandle = () => {
   return sessionStorage.getItem(STATE_HANDLE_SESSION_STORAGE_KEY);
+};
+const getLastVisitedURL = () => {
+  return sessionStorage.getItem(LAST_VISITED_URL_SESSION_STORAGE_KEY);
 };
 
 export default {
   removeStateHandle,
   setStateHandle,
   getStateHandle,
+  getLastVisitedURL,
 };


### PR DESCRIPTION
## Description:
If a user has moved forward in the sign-in flow, then navigates to another app url in the **same tab**, SIW will clear the cached stateHandle and start the sign-in flow from the beginning. Fixes issue where SIW re-uses the last visited app's stateHandle for the current app.

Before change:
https://okta.box.com/s/xaqx1gihs3c6mwp7ue8n3gpat8rssrtg
After change:
https://okta.box.com/s/4xtyhjn6l51qedb61rzc91ipnbmzlt0i

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-397885](https://oktainc.atlassian.net/browse/OKTA-397885)


