### PR TITLE
Support idpDisplay config for OIE flow

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -74,13 +74,30 @@ const Body = BaseForm.extend({
         });
       }
 
-      this.add(signInWithIdps, {
-        selector: '.o-form-button-bar',
-        options: {
-          idpButtons,
-          addSeparateLine: true,
-        }
-      });
+      // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
+      // above or below the form
+      const idpDisplay = this.options.settings.get('idpDisplay');
+      if (idpDisplay.toUpperCase() === 'PRIMARY') {
+        // Render idp buttons above the form
+        this.add(signInWithIdps, {
+          prepend: true,
+          selector: '.o-form-fieldset-container',
+          options: {
+            idpButtons,
+            addSeparateLine: true,
+            addSeparateLineAtBottom: true
+          }
+        });
+      } else {
+        // Render idp buttons below the form
+        this.add(signInWithIdps, {
+          selector: '.o-form-button-bar',
+          options: {
+            idpButtons,
+            addSeparateLine: true,
+          }
+        });
+      }
     }
 
     const customButtons = createCustomButtons(this.options.settings);

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -60,33 +60,12 @@ const Body = BaseForm.extend({
       this.add(signInWithDeviceOption, '.o-form-fieldset-container', false, true, { isRequired: false });
     }
 
-    // add external idps buttons
+    // add forgot password link and external idps buttons if needed
     const idpButtons = createIdpButtons(this.options.appState.get('remediations'));
     if (Array.isArray(idpButtons) && idpButtons.length) {
-
       // Add the forgot password link before the buttons for multiple IDPs
-      const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
-      if (forgotPasswordLink.length) {
-        this.add('<div class="links-primary"></div>', { selector: '.o-form-button-bar' });
-        this.add(Link, {
-          selector: '.links-primary',
-          options: forgotPasswordLink[0],
-        });
-      }
-
-      // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
-      // above or below the login fields
-      const idpDisplay = this.options.settings.get('idpDisplay');
-      const isPrimaryIdpDisplay = idpDisplay && idpDisplay.toUpperCase() === 'PRIMARY';
-
-      this.add(signInWithIdps, {
-        prepend: isPrimaryIdpDisplay,
-        selector: isPrimaryIdpDisplay ? '.o-form-fieldset-container' : '.o-form-button-bar',
-        options: {
-          idpButtons,
-          isPrimaryIdpDisplay
-        }
-      });
+      this._addForgotPasswordView();
+      this._addIdpView(idpButtons);
     }
 
     const customButtons = createCustomButtons(this.options.settings);
@@ -154,6 +133,33 @@ const Body = BaseForm.extend({
     });
 
     return newSchemas;
+  },
+
+  _addForgotPasswordView() {
+    const forgotPasswordLink = getForgotPasswordLink(this.options.appState, this.options.settings);
+    if (forgotPasswordLink.length) {
+      this.add('<div class="links-primary"></div>', { selector: '.o-form-button-bar' });
+      this.add(Link, {
+        selector: '.links-primary',
+        options: forgotPasswordLink[0],
+      });
+    }
+  },
+
+  _addIdpView(idpButtons) {
+    // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
+    // above or below the login fields
+    const idpDisplay = this.options.settings.get('idpDisplay');
+    const isPrimaryIdpDisplay = idpDisplay && idpDisplay.toUpperCase() === 'PRIMARY';
+
+    this.add(signInWithIdps, {
+      prepend: isPrimaryIdpDisplay,
+      selector: isPrimaryIdpDisplay ? '.o-form-fieldset-container' : '.o-form-button-bar',
+      options: {
+        idpButtons,
+        isPrimaryIdpDisplay
+      }
+    });
   },
 });
 

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -77,27 +77,17 @@ const Body = BaseForm.extend({
       // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
       // above or below the form
       const idpDisplay = this.options.settings.get('idpDisplay');
-      if (idpDisplay.toUpperCase() === 'PRIMARY') {
-        // Render idp buttons above the form
-        this.add(signInWithIdps, {
-          prepend: true,
-          selector: '.o-form-fieldset-container',
-          options: {
-            idpButtons,
-            addSeparateLine: true,
-            addSeparateLineAtBottom: true
-          }
-        });
-      } else {
-        // Render idp buttons below the form
-        this.add(signInWithIdps, {
-          selector: '.o-form-button-bar',
-          options: {
-            idpButtons,
-            addSeparateLine: true,
-          }
-        });
-      }
+      const isPrimaryDisplay = idpDisplay.toUpperCase() === 'PRIMARY';
+
+      this.add(signInWithIdps, {
+        prepend: isPrimaryDisplay,
+        selector: isPrimaryDisplay ? '.o-form-fieldset-container' : '.o-form-button-bar',
+        options: {
+          idpButtons,
+          addSeparateLine: true,
+          addSeparateLineAtBottom: isPrimaryDisplay
+        }
+      });
     }
 
     const customButtons = createCustomButtons(this.options.settings);

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -75,17 +75,16 @@ const Body = BaseForm.extend({
       }
 
       // We check the 'idpDisplay' option config to determine whether to render the idp buttons 
-      // above or below the form
+      // above or below the login fields
       const idpDisplay = this.options.settings.get('idpDisplay');
-      const isPrimaryDisplay = idpDisplay.toUpperCase() === 'PRIMARY';
+      const isPrimaryIdpDisplay = idpDisplay && idpDisplay.toUpperCase() === 'PRIMARY';
 
       this.add(signInWithIdps, {
-        prepend: isPrimaryDisplay,
-        selector: isPrimaryDisplay ? '.o-form-fieldset-container' : '.o-form-button-bar',
+        prepend: isPrimaryIdpDisplay,
+        selector: isPrimaryIdpDisplay ? '.o-form-fieldset-container' : '.o-form-button-bar',
         options: {
           idpButtons,
-          addSeparateLine: true,
-          addSeparateLineAtBottom: isPrimaryDisplay
+          isPrimaryIdpDisplay
         }
       });
     }

--- a/src/v2/view-builder/views/signin/SignInWithIdps.js
+++ b/src/v2/view-builder/views/signin/SignInWithIdps.js
@@ -4,10 +4,13 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   className: 'sign-in-with-idp',
   template: hbs`
-    {{#if addSeparateLine}}
+    {{#if addSeparateLineAtTop}}
     <div class="separation-line"><span>{{i18n code="socialauth.divider.text" bundle="login"}}</span></div>
     {{/if}}
     <div class="okta-idps-container"></div>
+    {{#if addSeparateLineAtBottom}}
+    <div class="separation-line"><span>{{i18n code="socialauth.divider.text" bundle="login"}}</span></div>
+    {{/if}}    
     `,
   initialize() {
     this.options.idpButtons.forEach((idpButton) => {
@@ -19,7 +22,8 @@ export default View.extend({
     const jsonData = View.prototype.getTemplateData.apply(this, arguments);
 
     return Object.assign(jsonData, {
-      addSeparateLine: this.options.addSeparateLine,
+      addSeparateLineAtTop: this.options.addSeparateLine && !this.options.addSeparateLineAtBottom,
+      addSeparateLineAtBottom: this.options.addSeparateLine && this.options.addSeparateLineAtBottom,
     });
   }
 });

--- a/src/v2/view-builder/views/signin/SignInWithIdps.js
+++ b/src/v2/view-builder/views/signin/SignInWithIdps.js
@@ -4,11 +4,11 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   className: 'sign-in-with-idp',
   template: hbs`
-    {{#if addSeparateLineAtTop}}
+    {{#if isSecondaryIdpDisplay}}
     <div class="separation-line"><span>{{i18n code="socialauth.divider.text" bundle="login"}}</span></div>
     {{/if}}
     <div class="okta-idps-container"></div>
-    {{#if addSeparateLineAtBottom}}
+    {{#if isPrimaryIdpDisplay}}
     <div class="separation-line"><span>{{i18n code="socialauth.divider.text" bundle="login"}}</span></div>
     {{/if}}    
     `,
@@ -20,10 +20,11 @@ export default View.extend({
 
   getTemplateData() {
     const jsonData = View.prototype.getTemplateData.apply(this, arguments);
+    const addDivider = this.options.idpButtons.length > 0;
 
     return Object.assign(jsonData, {
-      addSeparateLineAtTop: this.options.addSeparateLine && !this.options.addSeparateLineAtBottom,
-      addSeparateLineAtBottom: this.options.addSeparateLine && this.options.addSeparateLineAtBottom,
+      isPrimaryIdpDisplay: addDivider && this.options.isPrimaryIdpDisplay,
+      isSecondaryIdpDisplay: addDivider && !this.options.isPrimaryIdpDisplay
     });
   }
 });

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -9,12 +9,17 @@ import XHRIdentifyWithThirdPartyIdps
 
 describe('v2/view-builder/views/IdentifierView', function() {
   let testContext;
+  let idpDisplay = 'SECONDARY';
+
   beforeEach(function() { 
     testContext = {};
     testContext.init = (remediations = XHRIdentifyWithThirdPartyIdps.remediation.value) => {
       const appState = new AppState();
       appState.set('remediations', remediations);
-      const settings = new Settings({ baseUrl: 'http://localhost:3000' });
+      const settings = new Settings({ 
+        baseUrl: 'http://localhost:3000',
+        idpDisplay
+      });
       testContext.view = new IdentifierView({
         appState,
         settings,
@@ -48,5 +53,24 @@ describe('v2/view-builder/views/IdentifierView', function() {
     // The forgot password link should be in the siw-main-footer
     expect(testContext.view.$el.find('.siw-main-footer .js-forgot-password').length).toEqual(1);
     expect(testContext.view.$el.find('.links-primary .js-forgot-password').length).toEqual(0);
+  });
+
+  it('view renders IDP buttons correctly with idpDisplay property', function() {
+    jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
+    idpDisplay = 'PRIMARY';
+    testContext.init();
+
+    // The idp buttons should be rendered above the main form.
+    expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(1);
+    expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(0);
+
+    idpDisplay = 'SECONDARY';
+    testContext.init();
+
+    // The idp buttons should be rendered below the main form.
+    expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(1);
+    expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
   });
 });

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -79,4 +79,15 @@ describe('v2/view-builder/views/IdentifierView', function() {
     expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(1);
     expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
   });
+
+  it('view renders no IDP buttons with no IDPs in the remediation', function() {
+    jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
+    testContext.init(XHRIdentifyWithPassword.remediation.value);
+    
+    // No IDP buttons should be rendered.
+    expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
+    expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(0);
+  });
 });

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -9,7 +9,7 @@ import XHRIdentifyWithThirdPartyIdps
 
 describe('v2/view-builder/views/IdentifierView', function() {
   let testContext;
-  let idpDisplay = 'SECONDARY';
+  let idpDisplay = undefined;
 
   beforeEach(function() { 
     testContext = {};
@@ -59,17 +59,23 @@ describe('v2/view-builder/views/IdentifierView', function() {
     jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
+    testContext.init();
+
+    // The idp buttons should be rendered below the main login fields when no idpDisplay defined.
+    expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(1);
+    expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
+
     idpDisplay = 'PRIMARY';
     testContext.init();
 
-    // The idp buttons should be rendered above the main form.
+    // The idp buttons should be rendered above the main login fields when idpDisplay is PRIMARY.
     expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(1);
     expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(0);
 
     idpDisplay = 'SECONDARY';
     testContext.init();
 
-    // The idp buttons should be rendered below the main form.
+    // The idp buttons should be rendered below the main login fields when idpDisplay is SECONDARY.
     expect(testContext.view.$el.find('.o-form-button-bar .sign-in-with-idp').length).toEqual(1);
     expect(testContext.view.$el.find('.o-form-fieldset-container .sign-in-with-idp').length).toEqual(0);
   });


### PR DESCRIPTION
## Description:

- Currently we don't support the idpDisplay config for OIE. For parity with v1, we add support for this. If idpDisplay is PRIMARY, the idp buttons are rendered above the main form, otherwise they're rendered below the main form if SECONDARY.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/77295104/121367849-a203a000-c908-11eb-8d91-400a53ac5059.mov

### Reviewers:

### Issue:

- [OKTA-398647](https://oktainc.atlassian.net/browse/OKTA-398647)


