### PR TITLE
feat: clear sessionStorage stateHandle when SSO extension fails

### DIFF
--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -33,6 +33,7 @@ import {
 } from './client';
 
 import transformIdxResponse from './ion/transformIdxResponse';
+import { FORMS } from './ion/RemediationConstants';
 
 export default Router.extend({
   Events: Backbone.Events,
@@ -104,6 +105,11 @@ export default Router.extend({
     //    -> introspect using options.stateHandle
     if (lastResponse) {
       sessionStorageHelper.setStateHandle(idxResponse?.context?.stateHandle);
+    }
+    // Ignore Device Probe calls that can occur on first page loads
+    // that mimic moving forward in remediation flow
+    if (this.appState.get('currentFormName') === FORMS.CANCEL_TRANSACTION) {
+      sessionStorageHelper.removeStateHandle();
     }
 
     // transform response

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -106,8 +106,9 @@ export default Router.extend({
     if (lastResponse) {
       sessionStorageHelper.setStateHandle(idxResponse?.context?.stateHandle);
     }
-    // Ignore Device Probe calls that can occur on first page loads
-    // that mimic moving forward in remediation flow
+    // Login flows that mimic step up (moving forward in login pipeline) via internal api calls,
+    // need to clear stored stateHandles.
+    // This way the flow can maintain the latest state handle. For eg. Device probe calls
     if (this.appState.get('currentFormName') === FORMS.CANCEL_TRANSACTION) {
       sessionStorageHelper.removeStateHandle();
     }

--- a/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifySSOExtensionView_spec.js
@@ -5,6 +5,7 @@ import identifyUserVerificationWithCredentialSSOExtension from '../../../playgro
 import identifyWithNoAppleCredentialSSOExtension from '../../../playground/mocks/data/idp/idx/identify-with-no-sso-extension';
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import { Constants } from '../framework/shared';
+import { getStateHandleFromSessionStorage } from '../framework/shared';
 
 const logger = RequestLogger(/introspect/);
 const verifyUrl = 'http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/ft2FCeXuk7ov8iehMivYavZFhPxZUpBvB0/verify';
@@ -74,4 +75,5 @@ test
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+    await t.expect(getStateHandleFromSessionStorage()).eql(null);
   });

--- a/test/testcafe/spec/DeviceSSOExtensionView_spec.js
+++ b/test/testcafe/spec/DeviceSSOExtensionView_spec.js
@@ -8,6 +8,7 @@ import identifyUserVerificationWithCredentialSSOExtension from '../../../playgro
 import identify from '../../../playground/mocks/data/idp/idx/identify';
 import error from '../../../playground/mocks/data/idp/idx/error-email-verify';
 import { Constants } from '../framework/shared';
+import { getStateHandleFromSessionStorage } from '../framework/shared';
 
 const logger = RequestLogger(/introspect/);
 const verifyUrl = 'http://localhost:3000/idp/idx/authenticators/sso_extension/transactions/123/verify?\
@@ -134,6 +135,7 @@ test
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+    await t.expect(getStateHandleFromSessionStorage()).eql(null);
   });
 
 test


### PR DESCRIPTION
## Description:
If you navigate to an app to sign-in that calls apple_sso_extension verify, then navigate to a different app in the same tab, the app context in the last introspect call should match the current app being visited, and the cached stateHandle should match this app context.

Before change:
https://okta.box.com/s/0uoxet3yhdv4h3u6ga1bwz8d5hqhxejp
After change:
https://okta.box.com/s/i73jrmrxwzc1v8o9dm9yrsl7oqu765ka

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-397885](https://oktainc.atlassian.net/browse/OKTA-397885)


