### PR TITLE
fix: Generate fingerprint for IdP discovery flows

### DIFF
--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -16,6 +16,7 @@ import PrimaryAuthModel from 'models/PrimaryAuth';
 import BaseLoginController from 'util/BaseLoginController';
 import IDPDiscoveryForm from 'views/idp-discovery/IDPDiscoveryForm';
 import CustomButtons from 'views/primary-auth/CustomButtons';
+import DeviceFingerprint from 'util/DeviceFingerprint';
 
 export default PrimaryAuthController.extend({
   className: 'idp-discovery',
@@ -60,25 +61,46 @@ export default PrimaryAuthController.extend({
 
     this.listenTo(this.model, 'goToPrimaryAuth', function() {
       this.settings.set('username', this.model.get('username'));
-      if (this.settings.get('features.passwordlessAuth')) {
-        const primaryAuthModel = new PrimaryAuthModel(
-          {
-            username: this.model.get('username'),
-            multiOptionalFactorEnroll: this.options.settings.get('features.multiOptionalFactorEnroll'),
-            settings: this.options.settings,
-            appState: this.options.appState,
-          },
-          { parse: true }
-        );
-
-        // Events to set the transaction attributes on the app state.
-        this.addModelListeners(primaryAuthModel);
-        // Make the primary auth request
-        primaryAuthModel.save();
+      const self = this;
+      if (this.settings.get('features.deviceFingerprinting')) {
+        DeviceFingerprint.generateDeviceFingerprint(this.settings.get('baseUrl'), this.$el)
+          .then(function(fingerprint) {
+            self.options.appState.set('deviceFingerprint', fingerprint);
+            self.options.appState.set('username', self.model.get('username'));
+          })
+          .catch(function() {
+          // Keep going even if device fingerprint fails
+            self.options.appState.set('username', self.model.get('username'));
+          })
+          .finally(function() {
+            self.doPrimaryAuth();
+          });
       } else {
-        this.options.appState.set('disableUsername', true);
-        this.options.appState.trigger('navigate', 'signin');
+        self.doPrimaryAuth();
       }
     });
   },
+
+  doPrimaryAuth : function() {
+    if (this.settings.get('features.passwordlessAuth')) {
+      const primaryAuthModel = new PrimaryAuthModel(
+        {
+          username: this.model.get('username'),
+          multiOptionalFactorEnroll: this.options.settings.get('features.multiOptionalFactorEnroll'),
+          settings: this.options.settings,
+          appState: this.options.appState,
+        },
+        { parse: true }
+      );
+
+      // Events to set the transaction attributes on the app state.
+      this.addModelListeners(primaryAuthModel);
+      // Make the primary auth request
+      primaryAuthModel.save();
+    } else {
+      this.options.appState.set('disableUsername', true);
+      this.options.appState.trigger('navigate', 'signin');
+    }
+  },
+
 });


### PR DESCRIPTION
## Description:
When an org has an IDP set up with active IDP rules , the SIW goes through the IDP Discovery flow
When the `authn` call was made, we did not generate a device fingerprint here due to which new device Sign in email notifications were not being sent

When passwordless is ENABLED
![image](https://user-images.githubusercontent.com/12519317/123484714-ac3ac500-d5bd-11eb-951f-904030b0eaa4.png)



When passwordless is disabled
![image](https://user-images.githubusercontent.com/12519317/123484682-9cbb7c00-d5bd-11eb-8175-095a14c0d848.png)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Attached above

### Reviewers:
@mauriciocastillosilva-okta 

### Issue:

- [OKTA-402247](https://oktainc.atlassian.net/browse/OKTA-402247)


