### PR TITLE
chore: Rename authenticators to security methods

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -753,7 +753,7 @@ oie.password.challenge.title = Verify with your password
 oie.password.enroll.title = Set up password
 oie.password.passwordLabel = Enter password
 oie.password.confirmPasswordLabel = Re-enter password
-oie.password.reset.verification = Verify with one of the following authenticators to reset your password.
+oie.password.reset.verification = Verify with one of the following security methods to reset your password.
 idx.password.expiring.message = When your password expires you will be locked out of your Okta account.
 oie.password.incorrect.message = Password is incorrect
 oie.selfservice.reset.password.not.allowed = Reset password is not allowed at this time. Please contact support for assistance.
@@ -920,9 +920,9 @@ oie.symantecVip.challenge.description = Enter the generated security code from t
 oie.symantecVip.verify.passcode.label = Enter security code
 
 ## Select authenticator enrollment
-oie.select.authenticators.enroll.title = Set up authenticators
-oie.select.authenticators.enroll.subtitle = Authenticators help protect your account by ensuring only you have access.
-oie.select.authenticators.enroll.subtitle.custom = Authenticators help protect your {0} account by ensuring only you have access.
+oie.select.authenticators.enroll.title = Set up security methods
+oie.select.authenticators.enroll.subtitle = Security methods help protect your account by ensuring only you have access.
+oie.select.authenticators.enroll.subtitle.custom = Security methods help protect your {0} account by ensuring only you have access.
 
 oie.setup.required = Set up required
 oie.setup.optional = Set up optional
@@ -931,7 +931,7 @@ oie.verify.authenticator.button.text = Select
 oie.enroll.authenticator.button.text = Set up
 
 ## Select authenticator verification
-oie.select.authenticators.verify.title = Verify it\'s you with an authenticator
+oie.select.authenticators.verify.title = Verify it\'s you with a security method
 oie.select.authenticators.verify.subtitle = Select from the following options
 
 ## Success Redirect
@@ -1073,9 +1073,9 @@ consent.scopes.okta.templates.manage.desc=Allows the app to manage all custom te
 consent.scopes.okta.templates.read.desc=Allows the app to read all custom templates in your Okta organization.
 consent.scopes.okta.factors.manage.desc=Allows the app to manage all admin operations for org factors (e.g. activate, deactivate, read).
 consent.scopes.okta.factors.read.desc=Allows the app to read org factors information.
-consent.scopes.okta.authenticators.manage.desc=Allows the app to manage all authenticators (e.g. enrollments, reset).
-consent.scopes.okta.authenticators.read.desc=Allows the app to read org authenticators information.
-consent.scopes.okta.authenticators.manage.self.desc=Allows the app to manage users own authenticators (e.g. enrollments, reset).
+consent.scopes.okta.authenticators.manage.desc=Allows the app to manage all security methods (e.g. enrollments, reset).
+consent.scopes.okta.authenticators.read.desc=Allows the app to read org security method information.
+consent.scopes.okta.authenticators.manage.self.desc=Allows the app to manage users own security methods (e.g. enrollments, reset).
 consent.scopes.idSnapshot.read.desc=Allows the app to read your identity snapshot attestation.
 consent.scopes.idSnapshot.manage.desc=Allows the app to create and manage your identity snapshot attestation.
 logo.for.the.app.alt.text = Logo for the app

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -9,7 +9,7 @@ import xhrChallengeTotpOktaVerifyOnly
   from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp-onlyOV';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 
-const FORM_TITLE = 'Verify it\'s you with an authenticator';
+const FORM_TITLE = 'Verify it\'s you with a security method';
 const FORM_SUBTITLE = 'Select from the following options';
 const ENTER_CODE_TEXT = 'Enter a code';
 const FAST_PASS_TEXT = 'Use Okta Verify on this device';

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -156,7 +156,7 @@ test
     await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
     await deviceChallengePollPageObject.clickSwitchAuthenticatorButton();
     const secondSelectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
-    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with an authenticator');
+    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with a security method');
   });
 
 test

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -177,7 +177,7 @@ test.requestHooks(identifyThenSelectAuthenticatorMock)('navigate to other screen
 
   const selectAuthenticatorPage = new SelectFactorPageObject();
 
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   const { log } = await t.getBrowserConsoleMessages();
 
@@ -267,7 +267,7 @@ test.requestHooks(identifyRequestLogger, identifyMockWithFingerprint)('should co
 
   // Validate future requests do NOT contain the request header
   const selectAuthenticatorPage = new SelectFactorPageObject(t);
-  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectAuthenticatorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await selectAuthenticatorPage.selectFactorByIndex(0);
 
   await t.expect(identifyRequestLogger.count(() => true)).eql(2);

--- a/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForEnroll_spec.js
@@ -52,9 +52,9 @@ async function setup(t) {
 
 test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authenticator list', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Set up authenticators');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
   await t.expect(selectFactorPage.getFormSubtitle()).eql(
-    'Authenticators help protect your account by ensuring only you have access.');
+    'Security methods help protect your account by ensuring only you have access.');
   await t.expect(selectFactorPage.getFactorsCount()).eql(12);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Password');
@@ -139,7 +139,7 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should load select authentic
 
 test.requestHooks(mockEnrollAuthenticatorPassword)('should navigate to password enrollment page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Set up authenticators');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
 
   selectFactorPage.selectFactorByIndex(0);
   const enrollPasswordPage = new FactorEnrollPasswordPageObject(t);
@@ -149,14 +149,14 @@ test.requestHooks(mockEnrollAuthenticatorPassword)('should navigate to password 
 
 test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Set up authenticators');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
 
   selectFactorPage.selectFactorByIndex(0);
   const enrollPasswordPage = new FactorEnrollPasswordPageObject(t);
   await t.expect(enrollPasswordPage.passwordFieldExists()).eql(true);
   await t.expect(enrollPasswordPage.confirmPasswordFieldExists()).eql(true);
   await enrollPasswordPage.clickSwitchAuthenticatorButton();
-  await t.expect(selectFactorPage.getFormTitle()).eql('Set up authenticators');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
   // re-select password
   selectFactorPage.selectFactorByIndex(0);
   await t.expect(enrollPasswordPage.passwordFieldExists()).eql(true);
@@ -179,7 +179,7 @@ test.requestHooks(requestLogger, mockEnrollAuthenticatorPassword)('select passwo
 
 test.requestHooks(mockOptionalAuthenticatorEnrollment)('should skip optional enrollment and go to success', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Set up authenticators');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Set up security methods');
 
   selectFactorPage.skipOptionalEnrollment();
   const successPage = new SuccessPageObject(t);

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -116,7 +116,7 @@ async function setup(t) {
 
 test.requestHooks(mockChallengePassword)('should load select authenticator list', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(14);
 
@@ -217,7 +217,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list 
   await renderWidget({
     features: { hideSignOutLinkInMFA: true },
   });
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   // signout link is not visible
   await t.expect(await selectFactorPage.signoutLinkExists()).notOk();
 });
@@ -236,7 +236,7 @@ test.requestHooks(mockAuthenticatorListNoNumber)('should not display phone numbe
 test.requestHooks(mockSelectAuthenticatorForRecovery)('should load select authenticator list for recovery password', async t => {
   const selectFactorPage = await setup(t);
   await t.expect(selectFactorPage.getFormTitle()).eql('Reset your password');
-  await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following authenticators to reset your password.');
+  await t.expect(selectFactorPage.getFormSubtitle()).eql('Verify with one of the following security methods to reset your password.');
   await t.expect(selectFactorPage.getFactorsCount()).eql(2);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Security Key or Biometric Authenticator');
@@ -254,7 +254,7 @@ test.requestHooks(mockSelectAuthenticatorForRecovery)('should load select authen
 
 test.requestHooks(mockChallengePassword)('should navigate to password challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -263,13 +263,13 @@ test.requestHooks(mockChallengePassword)('should navigate to password challenge 
 
 test.requestHooks(requestLogger, mockChallengePassword)('select password challenge page and hit switch authenticator and re-select password', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with your password');
   await challengeFactorPage.clickSwitchAuthenticatorButton();
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   // re-select password
   selectFactorPage.selectFactorByIndex(0);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Verify with your password');
@@ -292,7 +292,7 @@ test.requestHooks(requestLogger, mockChallengePassword)('select password challen
 
 test.requestHooks(mockChallengeWebauthn)('should navigate to webauthn challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(1);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -301,7 +301,7 @@ test.requestHooks(mockChallengeWebauthn)('should navigate to webauthn challenge 
 
 test.requestHooks(mockChallengeEmail)('should navigate to email challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(2);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -311,7 +311,7 @@ test.requestHooks(mockChallengeEmail)('should navigate to email challenge page',
 test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when device is unknown and backend returns
   signed_nonce since there is an enrollmnent with the same os user is loging in from`, async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(4);
 
@@ -346,7 +346,7 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
 
 test.requestHooks(mockSelectAuthenticatorKnownDevice)('should load signed_nonce at top when device is known', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(4);
 
@@ -381,11 +381,11 @@ test.requestHooks(mockSelectAuthenticatorKnownDevice)('should load signed_nonce 
 
 test.requestHooks(mockSelectAuthenticatorNoSignedNonce)('should not display signed_nonce when signed_nonce method is not in OV remediation', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(3);
 
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   await t.expect(selectFactorPage.getFormSubtitle()).eql('Select from the following options');
   await t.expect(selectFactorPage.getFactorsCount()).eql(3);
 
@@ -414,7 +414,7 @@ test.requestHooks(mockSelectAuthenticatorNoSignedNonce)('should not display sign
 
 test.requestHooks(requestLogger, mockChallengeOVTotp)('should navigate to okta verify totp page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(1);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -439,7 +439,7 @@ test.requestHooks(requestLogger, mockChallengeOVTotp)('should navigate to okta v
 
 test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta verify push page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(0);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -464,7 +464,7 @@ test.requestHooks(requestLogger, mockChallengeOVPush)('should navigate to okta v
 
 test.requestHooks(requestLogger, mockChallengeOVFastPass)('should navigate to okta verify fast pass page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
   selectFactorPage.selectFactorByIndex(3);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getPageTitle()).eql('Verifying your identity');
@@ -488,7 +488,7 @@ test.requestHooks(requestLogger, mockChallengeOVFastPass)('should navigate to ok
 
 test.requestHooks(mockChallengeOnPremMFA)('should navigate to on prem mfa challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(7);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -497,7 +497,7 @@ test.requestHooks(mockChallengeOnPremMFA)('should navigate to on prem mfa challe
 
 test.requestHooks(mockChallengeRsa)('should navigate to RSA challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(8);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -506,7 +506,7 @@ test.requestHooks(mockChallengeRsa)('should navigate to RSA challenge page', asy
 
 test.requestHooks(mockChallengeDuo)('should navigate to Duo challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(8);
   const challengeFactorPage = new ChallengeFactorPageObject(t);
@@ -515,7 +515,7 @@ test.requestHooks(mockChallengeDuo)('should navigate to Duo challenge page', asy
 
 test.requestHooks(mockChallengeCustomOTP)('should navigate to Custom OTP challenge page', async t => {
   const selectFactorPage = await setup(t);
-  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with an authenticator');
+  await t.expect(selectFactorPage.getFormTitle()).eql('Verify it\'s you with a security method');
 
   selectFactorPage.selectFactorByIndex(9);
   const challengeFactorPage = new ChallengeFactorPageObject(t);

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -149,7 +149,7 @@ test.requestHooks(mockEnrollAuthenticator)('should show custom brandName title o
     'brandName': 'Spaghetti Inc',
   });
   await t.expect(selectAuthenticatorPageObject.getFormSubtitle()).eql(
-    'Authenticators help protect your Spaghetti Inc account by ensuring only you have access.');
+    'Security methods help protect your Spaghetti Inc account by ensuring only you have access.');
 });
 
 test.requestHooks(mockAuthenticatorResetPassword)('should show custom brandName title on reset password page', async t => {


### PR DESCRIPTION
## Description:

Renames instances where more than one authenticator is used to "security methods".

### Issue:

- [OKTA-405261](https://oktainc.atlassian.net/browse/OKTA-405261)


