### PR TITLE
Load Captcha lib based on SIW language

### DIFF
--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -24,7 +24,7 @@ const RECAPTCHAV2_URL =
   `https://www.google.com/recaptcha/api.js?onload=${OktaSignInWidgetOnCaptchaLoadedCallback}&render=explicit`;
 
 const getCaptchaUrl = (baseURL, locale) => {
-  return `${baseURL}&hl=${locale || 'en'}`;
+  return `${baseURL}&hl=${locale || navigator.language}`;
 };
 
 export default View.extend({

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -23,6 +23,10 @@ const HCAPTCHA_URL =
 const RECAPTCHAV2_URL = 
   `https://www.google.com/recaptcha/api.js?onload=${OktaSignInWidgetOnCaptchaLoadedCallback}&render=explicit`;
 
+const getCaptchaUrl = (baseURL, locale) => {
+  return `${baseURL}&hl=${locale || 'en'}`;
+};
+
 export default View.extend({
   className: 'captcha-view',
 
@@ -131,10 +135,11 @@ export default View.extend({
     // the 'data-callback' attribute which the Captcha library uses to invoke the callback.
     window[OktaSignInWidgetOnCaptchaSolvedCallback] = onCaptchaSolved;
 
+    const locale = this.options.settings.get('language');
     if (this.captchaConfig.type === 'HCAPTCHA') {
-      this._loadCaptchaLib(HCAPTCHA_URL);
+      this._loadCaptchaLib(getCaptchaUrl(HCAPTCHA_URL, locale));
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
-      this._loadCaptchaLib(RECAPTCHAV2_URL);
+      this._loadCaptchaLib(getCaptchaUrl(RECAPTCHAV2_URL, locale));
     }
   },
   

--- a/src/v2/view-builder/views/captcha/CaptchaView.js
+++ b/src/v2/view-builder/views/captcha/CaptchaView.js
@@ -23,10 +23,6 @@ const HCAPTCHA_URL =
 const RECAPTCHAV2_URL = 
   `https://www.google.com/recaptcha/api.js?onload=${OktaSignInWidgetOnCaptchaLoadedCallback}&render=explicit`;
 
-const getCaptchaUrl = (baseURL, locale) => {
-  return `${baseURL}&hl=${locale || navigator.language}`;
-};
-
 export default View.extend({
   className: 'captcha-view',
 
@@ -135,11 +131,11 @@ export default View.extend({
     // the 'data-callback' attribute which the Captcha library uses to invoke the callback.
     window[OktaSignInWidgetOnCaptchaSolvedCallback] = onCaptchaSolved;
 
-    const locale = this.options.settings.get('language');
+    
     if (this.captchaConfig.type === 'HCAPTCHA') {
-      this._loadCaptchaLib(getCaptchaUrl(HCAPTCHA_URL, locale));
+      this._loadCaptchaLib(this._getCaptchaUrl(HCAPTCHA_URL));
     } else if (this.captchaConfig.type === 'RECAPTCHA_V2') {
-      this._loadCaptchaLib(getCaptchaUrl(RECAPTCHAV2_URL, locale));
+      this._loadCaptchaLib(this._getCaptchaUrl(RECAPTCHAV2_URL));
     }
   },
   
@@ -177,5 +173,10 @@ export default View.extend({
   _getCaptchaOject() {
     const captchaObject = this.captchaConfig.type === 'HCAPTCHA' ? window.hcaptcha : window.grecaptcha;
     return captchaObject;
+  },
+
+  _getCaptchaUrl(baseURL) {
+    const locale = this.options.settings.get('language');
+    return `${baseURL}&hl=${locale || navigator.language}`;
   }
 });

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -63,6 +63,9 @@ describe('v2/view-builder/views/CaptchaView', function() {
   });
 
   it('Captcha gets loaded properly', function() {
+    // Mock browser locale
+    jest.spyOn(navigator, 'language', 'get').mockReturnValue('en');
+
     const spy = jest.spyOn(CaptchaView.prototype, '_loadCaptchaLib');
     testContext.init();
     expect(spy).toHaveBeenCalledWith('https://www.google.com/recaptcha/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=en');

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -8,13 +8,14 @@ import { WIDGET_FOOTER_CLASS } from 'v2/view-builder/utils/Constants';
 
 describe('v2/view-builder/views/CaptchaView', function() {
   let testContext;
+  let language = undefined;
   beforeEach(function() { 
     testContext = {};
     testContext.init = (captcha = enrollProfileWithReCaptcha.captcha.value) => {
       const appState = new AppState({
         captcha
       });
-      const settings = new Settings({ baseUrl: 'http://localhost:3000' });
+      const settings = new Settings({ baseUrl: 'http://localhost:3000', language });
       testContext.view = new CaptchaView({
         appState,
         settings,
@@ -64,10 +65,18 @@ describe('v2/view-builder/views/CaptchaView', function() {
   it('Captcha gets loaded properly', function() {
     const spy = jest.spyOn(CaptchaView.prototype, '_loadCaptchaLib');
     testContext.init();
-    expect(spy).toHaveBeenCalledWith('https://www.google.com/recaptcha/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit');
+    expect(spy).toHaveBeenCalledWith('https://www.google.com/recaptcha/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=en');
     
     testContext.init(enrollProfileWithHCaptcha.captcha.value);
-    expect(spy).toHaveBeenCalledWith('https://hcaptcha.com/1/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit');
+    expect(spy).toHaveBeenCalledWith('https://hcaptcha.com/1/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=en');
+
+    // Switch the language for SIW and ensure Captcha gets loaded with correct locale
+    language = 'fr';
+    testContext.init();
+    expect(spy).toHaveBeenCalledWith('https://www.google.com/recaptcha/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=fr');
+    
+    testContext.init(enrollProfileWithHCaptcha.captcha.value);
+    expect(spy).toHaveBeenCalledWith('https://hcaptcha.com/1/api.js?onload=OktaSignInWidgetOnCaptchaLoaded&render=explicit&hl=fr');
   });
 
   it('Captcha gets removed properly', function() {


### PR DESCRIPTION
## Description:

- Previously the Captcha lib relied on the browser's locale to set its language, but the SIW language could differ from the browser locale. So now we drive the Captcha language based on the SIW language exclusively.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/77295104/123118276-7c9a8a00-d410-11eb-8b6f-a9b39233231a.mov

### Reviewers:


### Issue:

- [OKTA-406089](https://oktainc.atlassian.net/browse/OKTA-406089)


