### PR TITLE
chore: upgrade okta-idx-js to replace jsonpath module with a lightweight one - OKTA-396841

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,9 @@
     "@babel/plugin-transform-runtime": "^7.10.3",
     "@babel/preset-env": "^7.10.3",
     "@babel/runtime-corejs3": "^7.10.3",
+    "@okta/eslint-plugin-okta": "0.4.0",
     "@okta/okta-auth-js": "4.8.0",
-    "@okta/okta-idx-js": "0.14.0",
+    "@okta/okta-idx-js": "0.18.0",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "autoprefixer": "^9.6.1",
     "axe-core": "^3.3.1",
@@ -87,9 +88,9 @@
     "dyson": "^2.0.5",
     "eslint": "^7.23.0",
     "eslint-plugin-jasmine": "^4.1.0",
+    "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-local-rules": "^0.1.1",
     "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-json": "^2.1.2",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.3",
     "grunt": "^1.0.3",
@@ -143,8 +144,7 @@
     "webdriver-manager": "^12.1.8",
     "webpack": "^3.5.4",
     "webpack-bundle-analyzer": "^3.0.2",
-    "webpack-dev-server": "2.11.3",
-    "@okta/eslint-plugin-okta": "0.4.0"
+    "webpack-dev-server": "2.11.3"
   },
   "dependencies": {
     "@babel/polyfill": "^7.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2403,14 +2403,15 @@
     webcrypto-shim "^0.1.5"
     xhr2 "0.1.3"
 
-"@okta/okta-idx-js@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.14.0.tgz#0c5f3bfe3ae3bce526407c86a08e69c873d7d428"
-  integrity sha512-RijnD13ryu3BdsMMjc5TCML63f11nppfRzyWSvydQe9CsRVZi5+TkRuLI/eeDVrCSSZVXxX96nPpNwNQRqbsZg==
+"@okta/okta-idx-js@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-idx-js/-/okta-idx-js-0.18.0.tgz#a419c915a68bcb925da33fe57a651826f681c57a"
+  integrity sha512-r6MZ7SMY/KwKVxDv0CuBR5QS5Iy6NsZCEC/zHqNpgXCd0GcKJPqrAt/xDWkp9oUccZrXI4PauU6zHnFSHLJEag==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"
-    jsonpath "^1.0.2"
+    core-js "^3.15.1"
+    jsonpath-plus "^5.1.0"
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -4719,6 +4720,11 @@ core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
 
+core-js@^3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.1.tgz#6c08ab88abdf56545045ccf5fd81f47f407e7f1a"
+  integrity sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==
+
 core-js@^3.6.5:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
@@ -5876,7 +5882,7 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
-escodegen@^1.14.1, escodegen@^1.8.1:
+escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -6007,11 +6013,6 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
-
-esprima@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
-  integrity sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=
 
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
@@ -9065,14 +9066,10 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpath@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.1.0.tgz#ff3e9e4746eae77c11bc09d542e7219333c28055"
-  integrity sha512-CZHwa1sZOf42qkIyK7evwToFXeTB4iplbl6Z9CVwU0wmBQPffL6gtYJXCoeciJoZENMuzaidPjhp2iOLRei4wQ==
-  dependencies:
-    esprima "1.2.2"
-    static-eval "2.0.2"
-    underscore "1.7.0"
+jsonpath-plus@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz#2fc4b2e461950626c98525425a3a3518b85af6c3"
+  integrity sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -13497,13 +13494,6 @@ state-toggle@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.2.tgz#75e93a61944116b4959d665c8db2d243631d6ddc"
 
-static-eval@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
-  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
-  dependencies:
-    escodegen "^1.8.1"
-
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -14677,11 +14667,6 @@ underscore@1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha1-DBxr0t9UtrafIxQGbWW2zeb8+dE=
-
-underscore@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 underscore@>=1.7.0:
   version "1.9.1"


### PR DESCRIPTION
## Description:

Upgrade okta-idx-js to 0.18.0, which replaced jsonpath (200+k) with a smaller module to parse json path. 
Reference: https://github.com/okta/okta-idx-js/pull/67

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

**Before:**
<img width="1356" alt="Screen Shot 2021-06-28 at 5 44 38 PM" src="https://user-images.githubusercontent.com/4027992/123708077-cd5b1a00-d838-11eb-9693-bad99b0bd619.png">

**After:** 
<img width="1321" alt="Screen Shot 2021-06-28 at 5 36 18 PM" src="https://user-images.githubusercontent.com/4027992/123708096-d815af00-d838-11eb-9732-e9da355a7a91.png">



### Reviewers:


### Issue:

- [OKTA-396841](https://oktainc.atlassian.net/browse/OKTA-396841)


