### PR TITLE
fix: remove loading beacon after entering LOCKED_OUT state

### DIFF
--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1554,6 +1554,23 @@ Expect.describe('PrimaryAuth', function() {
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
+      it('hides beacon-loading animation when user lockout message is displayed(no security image and selfServiceUnlock is off)', function() {
+        return setup()
+          .then(function(test) {
+            Q.stopUnhandledRejectionTracking();
+            test.setNextResponse(resLockedOut);
+            test.form.setUsername('testuser');
+            test.form.setPassword('pass');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function(test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Your account is locked. Please contact your administrator.');
+            expect(test.beacon.isLoadingBeacon()).toBe(false);
+            expect(test.beacon.beacon().length).toBe(0);
+          });
+      });
       itp('does not show beacon-loading animation on CORS error (no security image)', function() {
         return setup()
           .then(function(test) {


### PR DESCRIPTION
## Description:

LOCKED_OUT response is not considered an error and does not fall into [`catch` block](https://github.com/okta/okta-signin-widget/blob/master/src/models/PrimaryAuth.js#L127) where spinner is cleared.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
After fix:

https://user-images.githubusercontent.com/71440851/125314518-ebe40980-e33e-11eb-96e1-4268992b3a83.mov


Before fix:


https://user-images.githubusercontent.com/71440851/125314593-028a6080-e33f-11eb-84e5-c749bd16372d.mov



### Reviewers:


### Issue:

- [OKTA-404101](https://oktainc.atlassian.net/browse/OKTA-404101)


