### PR TITLE
Allow SIW interstitial loading view to be configurable

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -957,6 +957,7 @@ oie.select.authenticators.verify.subtitle = Select from the following options
 
 ## Success Redirect
 oie.success.text.signingIn = Signing in
+oie.success.text.signingIn.with.ellipsis = Signing in...
 oie.success.text.signingIn.with.appName = Signing in to {0}
 oie.success.text.signingIn.with.appName.and.identifier = Signing in to {0} as {1}
 

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -769,6 +769,7 @@ oie.enroll.authenticator.button.text = 》Šéţ ûþ €홝한Ӝฐโ《
 oie.select.authenticators.verify.title = 》Ṽéŕîƒý îţ´š ýöû ŵîţĥ åñ åûţĥéñţîçåţöŕ 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.verify.subtitle = 》Šéļéçţ ƒŕöɱ ţĥé ƒöļļöŵîñĝ öþţîöñš Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.success.text.signingIn = 》Šîĝñîñĝ îñ ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.success.text.signingIn.with.ellipsis = 》Šîĝñîñĝ îñ··· ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.success.text.signingIn.with.appName = 》Šîĝñîñĝ îñ ţö ⾼ئ䀕ヸ€홝한Ӝฐโ {0}《
 oie.success.text.signingIn.with.appName.and.identifier = 》Šîĝñîñĝ îñ ţö 䀕ヸ€홝한Ӝฐโ {0} åš โ {1}《
 oie.go.back = 》Ĝö ƀåçķ ヸ€홝한Ӝฐโ《

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -133,7 +133,7 @@ const TERMINAL_FORMS = [
   FORMS.DEVICE_ENROLLMENT_TERMINAL,
 ];
 
-// Possible options for the SIW interistitial redirect view
+// Possible options for the SIW interstitial redirect view
 const INTERSTITIAL_REDIRECT_VIEW = {
   DEFAULT: 'DEFAULT',
   NONE: 'NONE'

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -133,6 +133,13 @@ const TERMINAL_FORMS = [
   FORMS.DEVICE_ENROLLMENT_TERMINAL,
 ];
 
+// Possible options for the SIW interistitial redirect view
+const INTERSTITIAL_REDIRECT_VIEW = {
+  DEFAULT: 'DEFAULT',
+  NONE: 'NONE'
+};
+
+
 export {
   ACTIONS,
   FORMS,
@@ -144,4 +151,5 @@ export {
   FORM_NAME_TO_OPERATION_MAP,
   HINTS,
   TERMINAL_FORMS,
+  INTERSTITIAL_REDIRECT_VIEW,
 };

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -8,6 +8,11 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
+    if (!this.showRedirectAnimation) {
+      titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
+      return titleString;
+    }
+
     if (_.isEmpty(app)) {
       return titleString;
     }
@@ -28,14 +33,16 @@ const Body = BaseForm.extend({
   noButtonBar: true,
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
-
+    this.showRedirectAnimation = this.settings.get('features.showRedirectAnimation');
     this.model.set('useRedirect', true);
     this.trigger('save', this.model);
   },
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    this.add('<div class="okta-waiting-spinner"></div>');
+    if (this.showRedirectAnimation) {
+      this.add('<div class="okta-waiting-spinner"></div>');
+    }
   }
 });
 

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -1,6 +1,12 @@
 import { _, loc } from 'okta';
 import { BaseForm, BaseView } from '../internals';
 
+// Possible options for the SIW interistitial redirect view
+const REDIRECT_VIEW = {
+  DEFAULT: 'DEFAULT',
+  NONE: 'NONE'
+};
+
 const Body = BaseForm.extend({
   title() {
     let titleString = loc('oie.success.text.signingIn', 'login');
@@ -8,7 +14,10 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
-    if (!this.redirectView || this.redirectView === 'NONE') {
+    // If the option is not set, we treat that as being the case where we don't render the spinner.
+    // This is to account for the customer hosted scenario, because by default okta-core will pass in
+    // the correct value as set by the option in the Admin UI (which by default is "DEFAULT").
+    if (!this.redirectView || this.redirectView === REDIRECT_VIEW.NONE) {
       titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
       return titleString;
     }
@@ -40,7 +49,7 @@ const Body = BaseForm.extend({
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.redirectView === 'DEFAULT') {
+    if (this.redirectView === REDIRECT_VIEW.DEFAULT) {
       this.add('<div class="okta-waiting-spinner"></div>');
     }
   }

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -8,7 +8,7 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
-    if (!this.showRedirectAnimation) {
+    if (!this.showRedirectView) {
       titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
       return titleString;
     }
@@ -33,14 +33,14 @@ const Body = BaseForm.extend({
   noButtonBar: true,
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
-    this.showRedirectAnimation = this.settings.get('features.showRedirectAnimation');
+    this.showRedirectView = this.settings.get('features.showRedirectView');
     this.model.set('useRedirect', true);
     this.trigger('save', this.model);
   },
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.showRedirectAnimation) {
+    if (this.showRedirectView) {
       this.add('<div class="okta-waiting-spinner"></div>');
     }
   }

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -33,7 +33,7 @@ const Body = BaseForm.extend({
   noButtonBar: true,
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
-    this.redirectView = this.settings.get('features.interstitialBeforeLoginRedirect');
+    this.redirectView = this.settings.get('interstitialBeforeLoginRedirect');
     this.model.set('useRedirect', true);
     this.trigger('save', this.model);
   },

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -1,11 +1,6 @@
 import { _, loc } from 'okta';
 import { BaseForm, BaseView } from '../internals';
-
-// Possible options for the SIW interistitial redirect view
-const REDIRECT_VIEW = {
-  DEFAULT: 'DEFAULT',
-  NONE: 'NONE'
-};
+import { INTERSTITIAL_REDIRECT_VIEW } from '../../ion/RemediationConstants';
 
 const Body = BaseForm.extend({
   title() {
@@ -17,7 +12,7 @@ const Body = BaseForm.extend({
     // If the option is not set, we treat that as being the case where we don't render the spinner.
     // This is to account for the customer hosted scenario, because by default okta-core will pass in
     // the correct value as set by the option in the Admin UI (which by default is "DEFAULT").
-    if (!this.redirectView || this.redirectView === REDIRECT_VIEW.NONE) {
+    if (!this.redirectView || this.redirectView === INTERSTITIAL_REDIRECT_VIEW.NONE) {
       titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
       return titleString;
     }
@@ -49,7 +44,7 @@ const Body = BaseForm.extend({
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.redirectView === REDIRECT_VIEW.DEFAULT) {
+    if (this.redirectView === INTERSTITIAL_REDIRECT_VIEW.DEFAULT) {
       this.add('<div class="okta-waiting-spinner"></div>');
     }
   }

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -8,7 +8,7 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
-    if (!this.redirectView || this.redirectView === 'Simplified') {
+    if (!this.redirectView || this.redirectView === 'NONE') {
       titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
       return titleString;
     }
@@ -33,14 +33,14 @@ const Body = BaseForm.extend({
   noButtonBar: true,
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
-    this.redirectView = this.settings.get('features.showRedirectView');
+    this.redirectView = this.settings.get('features.interstitialBeforeLoginRedirect');
     this.model.set('useRedirect', true);
     this.trigger('save', this.model);
   },
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.redirectView === 'Default') {
+    if (this.redirectView === 'DEFAULT') {
       this.add('<div class="okta-waiting-spinner"></div>');
     }
   }

--- a/src/v2/view-builder/views/AutoRedirectView.js
+++ b/src/v2/view-builder/views/AutoRedirectView.js
@@ -8,7 +8,7 @@ const Body = BaseForm.extend({
     const app = this.options.appState.get('app');
     const user = this.options.appState.get('user');
 
-    if (!this.showRedirectView) {
+    if (!this.redirectView || this.redirectView === 'Simplified') {
       titleString = loc('oie.success.text.signingIn.with.ellipsis', 'login');
       return titleString;
     }
@@ -33,14 +33,14 @@ const Body = BaseForm.extend({
   noButtonBar: true,
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
-    this.showRedirectView = this.settings.get('features.showRedirectView');
+    this.redirectView = this.settings.get('features.showRedirectView');
     this.model.set('useRedirect', true);
     this.trigger('save', this.model);
   },
 
   render() {
     BaseForm.prototype.render.apply(this, arguments);
-    if (this.showRedirectView) {
+    if (this.redirectView === 'Default') {
       this.add('<div class="okta-waiting-spinner"></div>');
     }
   }

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -38,7 +38,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   it('view renders correctly according to showRedirectView', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectView': false
+      'features.showRedirectView': 'Simplified'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +46,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectView': true
+      'features.showRedirectView': 'Default'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -38,7 +38,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   it('view renders correctly according to interstitialBeforeLoginRedirect', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.interstitialBeforeLoginRedirect': 'NONE'
+      'interstitialBeforeLoginRedirect': 'NONE'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +46,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.interstitialBeforeLoginRedirect': 'DEFAULT'
+      'interstitialBeforeLoginRedirect': 'DEFAULT'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -1,0 +1,54 @@
+import { Model } from 'okta';
+import AutoRedirectView from 'v2/view-builder/views/AutoRedirectView';
+import AppState from 'v2/models/AppState';
+import Settings from 'models/Settings';
+import SuccessWithAppUser
+  from '../../../../../../playground/mocks/data/idp/idx/success-with-app-user.json';
+
+describe('v2/view-builder/views/AutoRedirectView', function() {
+  let testContext;
+  let settings = new Settings({ 
+    baseUrl: 'http://localhost:3000'
+  });  
+  beforeEach(function() { 
+    testContext = {};
+    testContext.init = (user = SuccessWithAppUser.user.value, app = SuccessWithAppUser.app.value) => {
+      const appState = new AppState();
+      appState.set('user', user);
+      appState.set('app', app);
+
+      testContext.view = new AutoRedirectView({
+        appState,
+        settings,
+        currentViewState: {},
+        model: new Model(),
+      });
+      testContext.view.render();
+    };
+  });
+  afterEach(function() {
+    jest.resetAllMocks();
+  });
+
+  it('view renders corectly - default case', function() {
+    testContext.init();
+    expect(testContext.view.el).toMatchSnapshot();
+  });
+
+  it('view renders correctly according to showRedirectAnimation', function() {
+    settings = new Settings({ 
+      baseUrl: 'http://localhost:3000',
+      'features.showRedirectAnimation': false
+    });    
+    testContext.init();
+    expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
+    
+
+    settings = new Settings({ 
+      baseUrl: 'http://localhost:3000',
+      'features.showRedirectAnimation': true
+    });    
+    testContext.init();
+    expect(testContext.view.el).toMatchSnapshot('should have spinner');
+  });
+});

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -35,10 +35,10 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
     expect(testContext.view.el).toMatchSnapshot();
   });
 
-  it('view renders correctly according to showRedirectAnimation', function() {
+  it('view renders correctly according to showRedirectView', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectAnimation': false
+      'features.showRedirectView': false
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +46,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectAnimation': true
+      'features.showRedirectView': true
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -35,10 +35,10 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
     expect(testContext.view.el).toMatchSnapshot();
   });
 
-  it('view renders correctly according to showRedirectView', function() {
+  it('view renders correctly according to interstitialBeforeLoginRedirect', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectView': 'Simplified'
+      'features.interstitialBeforeLoginRedirect': 'Simplified'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +46,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.showRedirectView': 'Default'
+      'features.interstitialBeforeLoginRedirect': 'Default'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -38,7 +38,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   it('view renders correctly according to interstitialBeforeLoginRedirect', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.interstitialBeforeLoginRedirect': 'Simplified'
+      'features.interstitialBeforeLoginRedirect': 'NONE'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +46,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'features.interstitialBeforeLoginRedirect': 'Default'
+      'features.interstitialBeforeLoginRedirect': 'DEFAULT'
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -4,6 +4,8 @@ import AppState from 'v2/models/AppState';
 import Settings from 'models/Settings';
 import SuccessWithAppUser
   from '../../../../../../playground/mocks/data/idp/idx/success-with-app-user.json';
+import { INTERSTITIAL_REDIRECT_VIEW } from 'v2/ion/RemediationConstants';
+
 
 describe('v2/view-builder/views/AutoRedirectView', function() {
   let testContext;
@@ -38,7 +40,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   it('view renders correctly according to interstitialBeforeLoginRedirect', function() {
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'interstitialBeforeLoginRedirect': 'NONE'
+      'interstitialBeforeLoginRedirect': INTERSTITIAL_REDIRECT_VIEW.NONE
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should NOT render spinner');
@@ -46,7 +48,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
 
     settings = new Settings({ 
       baseUrl: 'http://localhost:3000',
-      'interstitialBeforeLoginRedirect': 'DEFAULT'
+      'interstitialBeforeLoginRedirect': INTERSTITIAL_REDIRECT_VIEW.DEFAULT
     });    
     testContext.init();
     expect(testContext.view.el).toMatchSnapshot('should have spinner');

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`v2/view-builder/views/AutoRedirectView view renders corectly - default case 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form1"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          Signing in...
+        </h2>
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        />
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectAnimation: should NOT render spinner 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form2"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          Signing in...
+        </h2>
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        />
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;
+
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectAnimation: should have spinner 1`] = `
+<div
+  class="siw-main-view "
+>
+  <div
+    class="siw-main-header"
+  >
+    <div />
+  </div>
+  <div
+    class="siw-main-body"
+  >
+    <form
+      action="/"
+      class="ion-form o-form o-form-edit-mode"
+      data-se="o-form"
+      id="form3"
+      method="POST"
+      slot="content"
+    >
+      <div
+        class="o-form-content o-form-theme clearfix"
+        data-se="o-form-content"
+      >
+        <h2
+          class="okta-form-title o-form-head"
+          data-se="o-form-head"
+        >
+          Signing in to Okta Administration as admin@idx.com
+        </h2>
+        <div
+          class="o-form-error-container"
+          data-se="o-form-error-container"
+        />
+        <div
+          class="o-form-fieldset-container"
+          data-se="o-form-fieldset-container"
+        >
+          <div
+            class="okta-waiting-spinner"
+          />
+        </div>
+      </div>
+    </form>
+  </div>
+  <div
+    class="siw-main-footer"
+  >
+    <div
+      class="auth-footer"
+    />
+  </div>
+</div>
+`;

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -51,7 +51,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders corectly - default 
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectAnimation: should NOT render spinner 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectView: should NOT render spinner 1`] = `
 <div
   class="siw-main-view "
 >
@@ -102,7 +102,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectAnimation: should have spinner 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectView: should have spinner 1`] = `
 <div
   class="siw-main-view "
 >

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -51,7 +51,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders corectly - default 
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectView: should NOT render spinner 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to interstitialBeforeLoginRedirect: should NOT render spinner 1`] = `
 <div
   class="siw-main-view "
 >
@@ -102,7 +102,7 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
 </div>
 `;
 
-exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to showRedirectView: should have spinner 1`] = `
+exports[`v2/view-builder/views/AutoRedirectView view renders correctly according to interstitialBeforeLoginRedirect: should have spinner 1`] = `
 <div
   class="siw-main-view "
 >


### PR DESCRIPTION
## Description:

- The SIW now display two interstitial loading views based on configuration. 
    Default - which renders the loading view as it is today with the spinner and dynamic Sign in message
    Simple - which simply renders "Signing in..." with no spinner
- okta-core by default will pass in Default
- This is related to this okta-ui PR: https://github.com/okta/okta-ui/pull/4066

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Demo:
https://user-images.githubusercontent.com/77295104/125137008-d7eb9e00-e0d9-11eb-9185-56ad78d2c345.mov

Default:
<img width="430" alt="Default Loading" src="https://user-images.githubusercontent.com/77295104/125137038-e46ff680-e0d9-11eb-9515-bda1bf34a49b.png">

Simple:
<img width="422" alt="Simple Loading" src="https://user-images.githubusercontent.com/77295104/125137051-e934aa80-e0d9-11eb-8385-d11ef8236a53.png">


### Reviewers:


### Issue:

- [OKTA-399274](https://oktainc.atlassian.net/browse/OKTA-399274)


