### PR TITLE
fix: Remove leftover word from the English version

### DIFF
--- a/packages/@okta/i18n/src/properties/login_fr.properties
+++ b/packages/@okta/i18n/src/properties/login_fr.properties
@@ -480,7 +480,7 @@ recoveryChallenge.call.title = Saisissez le code de validation re\u00E7u par app
 
 # Factors Dropdown
 mfa.factors.dropdown.title = S\u00E9lectionnez un facteur d'authentification
-mfa.factors.dropdown.sr.text = S\u00E9lectionner le facteur d\u2019authentification Factor \u2013 Facteur {0} s\u00E9lectionn\u00E9
+mfa.factors.dropdown.sr.text = S\u00E9lectionner le facteur d\u2019authentification \u2013 Facteur {0} s\u00E9lectionn\u00E9
 mfa.duoSecurity.push = Push \u2014 {0}
 mfa.duoSecurity.sms = SMS \u2014 {0}
 mfa.duoSecurity.call = Appel \u2014 {0}


### PR DESCRIPTION
## Description:

Removed a leftover word from the English version in the French translation file.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/25467653/125959629-e6a6a4df-a1d2-4ff1-8f95-342a6e77c104.png)




