### PR TITLE
(v2) remove config option: interactionHandle

### DIFF
--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -34,7 +34,6 @@ export default Model.extend({
     baseUrl: ['string', true],
     recoveryToken: ['string', false, undefined],
     stateToken: ['string', false, undefined],
-    interactionHandle: ['string', false, undefined],
     username: ['string', false],
     signOutLink: ['string', false],
     relayState: ['string', false],
@@ -242,9 +241,9 @@ export default Model.extend({
       },
     },
     mode: {
-      deps: ['useInteractionCodeFlow', 'interactionHandle', 'codeChallenge'],
-      fn: function(useInteractionCodeFlow, interactionHandle, codeChallenge) {
-        if (interactionHandle || (useInteractionCodeFlow && codeChallenge)) {
+      deps: ['useInteractionCodeFlow', 'codeChallenge'],
+      fn: function(useInteractionCodeFlow, codeChallenge) {
+        if (useInteractionCodeFlow && codeChallenge) {
           return 'remediation';
         }
         return 'relying-party';

--- a/src/v2/client/startLoginFlow.js
+++ b/src/v2/client/startLoginFlow.js
@@ -33,9 +33,8 @@ export async function startLoginFlow(settings) {
     sessionStorageHelper.removeStateHandle();
   }
 
-  // Use or acquire interactionHandle
-  const useInteractionHandle = settings.get('useInteractionCodeFlow') || settings.get('interactionHandle');
-  if (useInteractionHandle) {
+  // Use interaction code flow, if enabled
+  if (settings.get('useInteractionCodeFlow')) {
     return interact(settings);
   }
 

--- a/src/v2/client/transactionMeta.js
+++ b/src/v2/client/transactionMeta.js
@@ -35,15 +35,11 @@ export async function getTransactionMeta(settings) {
   }
 
   // New transaction
+  const meta = await createTransactionMeta(settings);
 
-  let interactionHandle = settings.get('interactionHandle');
+  // If a codeChallenge was passed in config, use it
   let codeChallenge = settings.get('codeChallenge');
   let codeChallengeMethod = settings.get('codeChallengeMethod');
-
-  const meta = await createTransactionMeta(settings);
-  if (interactionHandle) {
-    meta.interactionHandle = interactionHandle;
-  }
   if (codeChallenge) {
     meta.codeChallenge = codeChallenge;
   }
@@ -73,12 +69,6 @@ export function isTransactionMetaValid(settings, meta) {
     return authClient.options[key] !== meta[key];
   });
   if (mismatch) {
-    return false;
-  }
-
-  // if `interactionHandle` option was provided, validate it against the meta
-  const interactionHandle = settings.get('interactionHandle');
-  if (interactionHandle && meta.interactionHandle !== interactionHandle) {
     return false;
   }
 

--- a/src/widget/OktaSignIn.js
+++ b/src/widget/OktaSignIn.js
@@ -125,8 +125,7 @@ var OktaSignIn = (function() {
     var authClient = options.authClient ? options.authClient : createAuthClient(authParams);
 
     // validate authClient configuration against widget options
-    const useInteractionHandle = options.useInteractionCodeFlow || options.interactionHandle;
-    if (useInteractionHandle && authClient.isPKCE() === false) {
+    if (options.useInteractionCodeFlow  && authClient.isPKCE() === false) {
       throw new Errors.ConfigError(
         'The "useInteractionCodeFlow" option requires PKCE to be enabled on the authClient.'
       );
@@ -134,8 +133,8 @@ var OktaSignIn = (function() {
 
     var Router;
     if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) 
-        // Self hosted widget can use `useInteractionCodeFlow` or `interactionHandle` option to use V2Router
-        || useInteractionHandle
+        // Self hosted widget can use `useInteractionCodeFlow` to use V2Router
+        || options.useInteractionCodeFlow 
         || options.proxyIdxResponse) {
       Router = V2Router;
     } else {

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -70,16 +70,6 @@ describe('v2/client/startLoginFlow', () => {
     expect(mocked.introspect.introspect).not.toHaveBeenCalled();
   });
 
-  it('shall run interation flow when pass a "interactionHandle"', async () => {
-    testContext.settings.set('interactionHandle', 'abc interaction handle 123');
-    const result = await startLoginFlow(testContext.settings);
-    expect(result).toEqual('fake interact response');
-
-    expect(mocked.interact.interact).toHaveBeenCalledWith(testContext.settings);
-    expect(mocked.interact.interact).toHaveBeenCalledTimes(1);
-    expect(mocked.introspect.introspect).not.toHaveBeenCalled();
-  });
-
   it('shall introspect on "settings.stateToken"', async () => {
     const result = await startLoginFlow(testContext.settings);
     expect(result).toEqual('first introspect response');

--- a/test/unit/spec/v2/client/transactionMeta_spec.js
+++ b/test/unit/spec/v2/client/transactionMeta_spec.js
@@ -92,13 +92,11 @@ describe('v2/client/transactionMeta', () => {
         const res = await getTransactionMeta(testContext.settings);
         expect(res).toEqual(testContext.newMeta);
       });
-      it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
-        testContext.settings.set('interactionHandle', testContext.interactionHandle);
+      it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
         testContext.settings.set('codeChallenge', testContext.codeChallenge);
         testContext.settings.set('codeChallengeMethod', testContext.codeChallengeMethod);
         const res = await getTransactionMeta(testContext.settings);
         expect(res.foo).toBe('bar');
-        expect(res.interactionHandle).toBe(testContext.interactionHandle);
         expect(res.codeChallenge).toBe(testContext.codeChallenge);
         expect(res.codeChallengeMethod).toBe(testContext.codeChallengeMethod);
       });
@@ -116,20 +114,17 @@ describe('v2/client/transactionMeta', () => {
           const res = await getTransactionMeta(testContext.settings);
           expect(res).toEqual(testContext.transactionMeta);
         });
-        it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
-          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
-          testContext.settings.set('interactionHandle', interactionHandle);
+        it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
+          const { codeChallenge, codeChallengeMethod } = testContext;
           testContext.settings.set('codeChallenge', codeChallenge);
           testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
           Object.assign(testContext.transactionMeta, {
-            interactionHandle,
             codeChallenge,
             codeChallengeMethod 
           });
 
           const res = await getTransactionMeta(testContext.settings);
           expect(res).toEqual(testContext.transactionMeta);
-          expect(res.interactionHandle).toBe(interactionHandle);
           expect(res.codeChallenge).toBe(codeChallenge);
           expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
         });
@@ -150,15 +145,13 @@ describe('v2/client/transactionMeta', () => {
           expect(res).toEqual(testContext.newMeta);
         });
   
-        it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
-          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
-          testContext.settings.set('interactionHandle', interactionHandle);
+        it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
+          const { codeChallenge, codeChallengeMethod } = testContext;
           testContext.settings.set('codeChallenge', codeChallenge);
           testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
   
           const res = await getTransactionMeta(testContext.settings);
           expect(res.foo).toBe('bar');
-          expect(res.interactionHandle).toBe(interactionHandle);
           expect(res.codeChallenge).toBe(codeChallenge);
           expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
         });
@@ -206,12 +199,6 @@ describe('v2/client/transactionMeta', () => {
       expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
     });
 
-    it('returns false if `interactionHandle` does not match', () => {
-      testContext.transactionMeta.interactionHandle = 'abc';
-      testContext.settings.set('interactionHandle', 'def');
-      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
-    });
-
     it('returns false if `codeChallenge` does not match', () => {
       testContext.transactionMeta.codeChallenge = 'abc';
       testContext.settings.set('codeChallenge', 'def');
@@ -232,13 +219,11 @@ describe('v2/client/transactionMeta', () => {
       expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(true);
     });
 
-    it('returns true if clientId and redirectId from authParams and interactionHandle, codeChallenge, codeChallengeMethod from settings match', () => {
+    it('returns true if clientId and redirectId from authParams and codeChallenge, codeChallengeMethod from settings match', () => {
       testContext.transactionMeta.clientId = 'abc';
       testContext.authParams.clientId = 'abc';
       testContext.transactionMeta.redirectUri = 'abc';
       testContext.authParams.redirectUri = 'abc';
-      testContext.transactionMeta.interactionHandle = 'abc';
-      testContext.settings.set('interactionHandle', 'abc');
       testContext.transactionMeta.codeChallenge = 'abc';
       testContext.settings.set('codeChallenge', 'abc');
       testContext.transactionMeta.codeChallengeMethod = 'abc';


### PR DESCRIPTION
## Description:
interaction handle should always be acquired client-side. Server can "own" the transaction (and put widget into "remediation" mode) by passing `codeChallenge` option.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


