### PR TITLE
Trigger afterError on LOCKED_OUT (v1)

### DIFF
--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint complexity: [2, 47], max-statements: [2, 56] */
+/* eslint complexity: [2, 47], max-statements: [2, 63] */
 
 import { _, loc } from 'okta';
 import hbs from 'handlebars-inline-precompile';
@@ -237,14 +237,21 @@ fn.handleResponseStatus = function(router, res) {
     if (router.settings.get('features.selfServiceUnlock')) {
       router.navigate('signin/unlock', { trigger: true });
     } else {
-      const err = {
+      const errorMessage = loc('error.auth.lockedOut', 'login');
+      const resError = {
         responseJSON: {
           errorCauses: [],
-          errorSummary: loc('error.auth.lockedOut', 'login'),
+          errorSummary: errorMessage,
+          errorCode: 'E0000069',
         },
       };
+      const err = {
+        name: 'AuthApiError',
+        message: errorMessage,
+        xhr: resError
+      };
       router.controller.model.appState.trigger('removeLoading');
-      router.controller.model.trigger('error', router.controller.model, err);
+      router.controller.model.trigger('error', router.controller.model, resError);
       Util.triggerAfterError(router.controller, err);
     }
     return;

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -233,19 +233,22 @@ fn.handleResponseStatus = function(router, res) {
   case 'PASSWORD_RESET':
     router.navigate('signin/password-reset', { trigger: true });
     return;
-  case 'LOCKED_OUT':
+  case 'LOCKED_OUT': {
     if (router.settings.get('features.selfServiceUnlock')) {
       router.navigate('signin/unlock', { trigger: true });
     } else {
-      router.controller.model.trigger('error', router.controller.model, {
+      const err = {
         responseJSON: {
           errorCauses: [],
           errorSummary: loc('error.auth.lockedOut', 'login'),
         },
-      });
+      };
       router.controller.model.appState.trigger('removeLoading');
+      router.controller.model.trigger('error', router.controller.model, err);
+      Util.triggerAfterError(router.controller, err);
     }
     return;
+  }
   case 'PROFILE_REQUIRED':
     router.navigate('signin/enroll-user', { trigger: true });
     return;

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -242,7 +242,7 @@ fn.handleResponseStatus = function(router, res) {
         responseJSON: {
           errorCauses: [],
           errorSummary: errorMessage,
-          errorCode: 'E0000069',
+          errorCode: 'E0000119',
         },
       };
       const err = {

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -2308,7 +2308,7 @@ Expect.describe('PrimaryAuth', function() {
                 responseJSON: {
                   errorCauses: [],
                   errorSummary: 'Your account is locked. Please contact your administrator.',
-                  errorCode: 'E0000069'
+                  errorCode: 'E0000119'
                 }
               }
             },

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -2286,6 +2286,35 @@ Expect.describe('PrimaryAuth', function() {
           expect(test.form.errorMessage()).toBe('Your account is locked. Please contact your administrator.');
         });
     });
+    itp('triggers afterError event if authClient returns with LOCKED_OUT response and selfServiceUnlock is off', function() {
+      return setup()
+        .then(function(test) {
+          test.form.setUsername('testuser');
+          test.form.setPassword('pass');
+          test.setNextResponse(resLockedOut);
+          test.form.submit();
+          return Expect.waitForSpyCall(test.afterErrorHandler, test);
+        })
+        .then(function(test) {
+          expect(test.afterErrorHandler).toHaveBeenCalledTimes(1);
+          expect(test.afterErrorHandler.calls.allArgs()[0]).toEqual([
+            {
+              controller: 'primary-auth',
+            },
+            {
+              name: 'AuthApiError',
+              message: 'Your account is locked. Please contact your administrator.',
+              xhr: {
+                responseJSON: {
+                  errorCauses: [],
+                  errorSummary: 'Your account is locked. Please contact your administrator.',
+                  errorCode: 'E0000069'
+                }
+              }
+            },
+          ]);
+        });
+    });
     itp('redirects to "unlock" if authClient returns with LOCKED_OUT response and selfServiceUnlock is on', function() {
       return setup({ 'features.selfServiceUnlock': true })
         .then(function(test) {


### PR DESCRIPTION
## Description:
Issue: https://github.com/okta/okta-signin-widget/issues/2057

For v1 when `LOCKED_OUT` status received, trigger `afterError` event.
Manually add `errorCode: E0000069` into error  to let user distinguish Locked Out error and customize own handler accordingly.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

<img width="566" alt="Screenshot 2021-07-27 at 02 21 54" src="https://user-images.githubusercontent.com/72614880/127071320-dcbfa47c-4d5d-4070-b80d-233d33cf5647.png">


### Reviewers:


### Issue:

- [OKTA-405208](https://oktainc.atlassian.net/browse/OKTA-405208)

