### PR TITLE
Increasing poll timeout to 5min

### DIFF
--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -1,5 +1,6 @@
 export const SHOW_RESEND_TIMEOUT = 30000;
 export const WARNING_TIMEOUT = 30000;
+export const CHALLENGE_TIMEOUT = 300000;
 export const MS_PER_SEC = 1000;
 export const UNIVERSAL_LINK_POST_DELAY = 500;
 export const CANCEL_POLLING_ACTION = 'authenticatorChallenge-cancel';

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -3,7 +3,7 @@ import { BaseForm, BaseFormWithPolling, BaseFooter, BaseView } from '../../inter
 import Logger from '../../../../util/Logger';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import Enums from '../../../../util/Enums';
-import { CANCEL_POLLING_ACTION } from '../../utils/Constants';
+import { CANCEL_POLLING_ACTION, CHALLENGE_TIMEOUT } from '../../utils/Constants';
 import Link from '../../components/Link';
 import { doChallenge } from '../../utils/ChallengeViewUtil';
 import OktaVerifyAuthenticatorHeader from '../../components/OktaVerifyAuthenticatorHeader';
@@ -90,7 +90,7 @@ const Body = BaseFormWithPolling.extend(
           url: getAuthenticatorUrl('challenge'),
           method: 'POST',
           data: JSON.stringify({ challengeRequest }),
-          timeout: 3000 // authenticator should respond within 3000ms for challenge request
+          timeout: CHALLENGE_TIMEOUT // authenticator should respond within 5 min (300000ms) for challenge request
         });
       };
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,6 +1,7 @@
 import { $ } from 'okta';
 import { BaseForm } from '../../internals';
 import Logger from '../../../../util/Logger';
+import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import polling from '../shared/polling';
 import {doChallenge} from '../../utils/ChallengeViewUtil';
@@ -82,7 +83,7 @@ const Body = BaseForm.extend(Object.assign(
           url: getAuthenticatorUrl('challenge'),
           method: 'POST',
           data: JSON.stringify({ challengeRequest }),
-          timeout: 3000 // authenticator should respond within 3000ms for challenge request
+          timeout: CHALLENGE_TIMEOUT // authenticator should respond within 5 min (300000ms) for challenge request
         });
       };
 


### PR DESCRIPTION
## Description:

When user tries to access an app that requires device context, device probing kicks in and SIW makes a /challenge call on the port that OV is running on. Then OV initiates inline enrollment since there is no account. User waits for some time and clicks cancel on the inline enrollment prompt in OV
Now, on step 2 the http connection timeout from SIW to OV is 3s.
So, OV has no way to respond back to SIW that user cancelled the inline enrollment (if it happens after 3s).

This PR increases the timeout to 5min

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Reviewers:

@santoshmale-okta , @johannesstockmann-okta , @diptishiralkar-okta , @arunthotta-okta , @saurinpandya-okta 

### Issue:

- [OKTA-406443](https://oktainc.atlassian.net/browse/OKTA-406443)


