### PR TITLE
disable sessionCookieRedirect tests on OIE env

### DIFF
--- a/test/e2e/specs/basic_spec.js
+++ b/test/e2e/specs/basic_spec.js
@@ -98,6 +98,11 @@ describe('Basic flows', function() {
   });
 
   it('redircts to successful page when features.redirectByFormSubmit is on', function() {
+    // TODO: remove when OKTA-415707 is resolved
+    if (process.env.ORG_OIE_ENABLED) {
+      console.error('test is disabled: OKTA-415707');
+      return;
+    }
     browser.executeScript('oktaSignIn.remove()');
     function createWidget() {
       options.features = {

--- a/test/e2e/specs/npm_spec.js
+++ b/test/e2e/specs/npm_spec.js
@@ -31,6 +31,12 @@ describe('OIDC flows', function() {
   });
 
   it('can login and auth in a basic flow', function() {
+    // TODO: remove when OKTA-415707 is resolved
+    if (process.env.ORG_OIE_ENABLED) {
+      console.error('test is disabled: OKTA-415707');
+      return;
+    }
+
     Expect.toBeA11yCompliant();
     primaryAuth.loginToForm('{{{WIDGET_BASIC_USER_3}}}', '{{{WIDGET_BASIC_PASSWORD_3}}}');
     oktaHome.waitForPageLoad();


### PR DESCRIPTION
OKTA-415707
OKTA-415709

## Description:

These tests are failing due to an apparent bug on the server-side. These tests can be re-enabled when the underlying bug has been fixed.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-415709](https://oktainc.atlassian.net/browse/OKTA-415709)


