### PR TITLE
Update readme with build instructions on node version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1548,7 +1548,7 @@ signIn.on('pageRendered', function (data) {
 
 ## Building the Widget
 
-We use Yarn as our node package manager. To install Yarn, check out their [install documentation](https://yarnpkg.com/en/docs/install).
+We use Yarn as our node package manager. To install Yarn, check out their [install documentation](https://yarnpkg.com/en/docs/install). Please use the most recent LTS version of node to build the widget. 
 
 1. Clone this repo and navigate to the new `okta-signin-widget` folder.
 


### PR DESCRIPTION
This change makes sure that anyone that builds the SIW will need to use the latest LTS version of node is used when building. At the time of sending the PR that version is v14.3.7.

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


