### PR TITLE
feat: Error is shown on /activate screen when invalid user code is passed in the url

### DIFF
--- a/playground/mocks/data/api/v1/authn/error-device-code-activate.json
+++ b/playground/mocks/data/api/v1/authn/error-device-code-activate.json
@@ -1,0 +1,19 @@
+{
+  "status": "DEVICE_ACTIVATE",
+  "expiresAt": "2017-07-20T00:06:25.000Z",
+  "stateToken": "00-dummy-state-token",
+  "_embedded": {
+    "deviceActivationStatus": "INVALID_USER_CODE"
+  },
+  "_links": {
+    "next": {
+      "name": "deviceActivate",
+      "href": "http://localhost:3000/api/v1/authn/device/activate",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-device-code-activate.json
+++ b/playground/mocks/data/idp/idx/error-device-code-activate.json
@@ -1,0 +1,47 @@
+{
+  "stateHandle":"02itnqG312DoS3cU0z0LWs11l76yQ8ll4d95Oye61u",
+  "version":"1.0.0",
+  "expiresAt":"2020-04-13T20:30:53.000Z",
+  "step":"IDENTIFY",
+  "intent":"LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Invalid code. Try again.",
+        "i18n": {
+          "key": "api.authn.error.PASSCODE_INVALID",
+          "params": []
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"user-code",
+        "href":"http://localhost:3000/idp/idx/device/activate",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"userCode",
+            "label":"Activation Code"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02itnqG312DoS3cU0z0LWs11l76yQ8ll4d95Oye61u",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/DeviceActivateController.js
+++ b/src/DeviceActivateController.js
@@ -11,10 +11,20 @@
  */
 
 /* eslint max-len: [2, 160] */
-import { loc } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+import {loc, View} from 'okta';
 import FormController from 'util/FormController';
 import FormType from 'util/FormType';
 import TextBox from './views/shared/TextBox';
+
+const InvalidUserCodeErrorView = View.extend({
+  template: hbs`
+      <div class="okta-form-infobox-error infobox infobox-error" role="alert">
+          <span class="icon error-16"></span>
+           <p>{{i18n code="api.authn.error.PASSCODE_INVALID" bundle="login"}}</p>
+      </div>
+    `
+});
 
 export default FormController.extend({
   className: 'device-code-activate',
@@ -45,6 +55,10 @@ export default FormController.extend({
       return loc('device.code.activate.subtitle', 'login');
     },
     formChildren: function() {
+      if (this.options.appState.get('deviceActivationStatus') === 'INVALID_USER_CODE') {
+        this.add(InvalidUserCodeErrorView, '.o-form-error-container');
+      }
+
       return [
         FormType.Input({
           label: loc('device.code.activate.label', 'login'),

--- a/src/v2/view-builder/views/device/DeviceCodeActivateView.js
+++ b/src/v2/view-builder/views/device/DeviceCodeActivateView.js
@@ -1,5 +1,38 @@
-import { loc } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+import { loc, View } from 'okta';
 import { BaseForm, BaseView } from '../../internals';
+
+const InvalidUserCodeErrorView = View.extend({
+  template: hbs`
+      {{#each messages}}
+        {{#if isError}}
+          <div class="okta-form-infobox-error infobox infobox-error" role="alert">
+              <span class="icon error-16"></span>
+               <p>{{message}}</p>
+          </div>
+        {{else}}
+          <div class="ion-messages-container">
+              <p>{{message}}</p>
+          </div>
+        {{/if}}
+      {{/each}}
+    `,
+  getTemplateData: function() {
+    const messages = this.options.appState.get('messages') || {};
+    if (Array.isArray(messages.value)) {
+      return {
+        messages: messages.value
+          .map(m => {
+            return {
+              isError: m.class === 'ERROR',
+              message: m.message
+            };
+          })
+      };
+    }
+    return [];
+  },
+});
 
 const Body = BaseForm.extend({
 
@@ -24,7 +57,11 @@ const Body = BaseForm.extend({
     if (currentVal && currentVal.length === 4 && !['Backspace', 'Delete', '-'].includes(evt.key)) {
       evt.target.value = currentVal.concat('-');
     }
-  }
+  },
+
+  showMessages() {
+    this.add(InvalidUserCodeErrorView, '.o-form-error-container');
+  },
 });
 
 export default BaseView.extend({

--- a/src/v2/view-builder/views/device/DeviceCodeActivateView.js
+++ b/src/v2/view-builder/views/device/DeviceCodeActivateView.js
@@ -1,38 +1,5 @@
-import hbs from 'handlebars-inline-precompile';
-import { loc, View } from 'okta';
+import { createCallout, loc } from 'okta';
 import { BaseForm, BaseView } from '../../internals';
-
-const InvalidUserCodeErrorView = View.extend({
-  template: hbs`
-      {{#each messages}}
-        {{#if isError}}
-          <div class="okta-form-infobox-error infobox infobox-error" role="alert">
-              <span class="icon error-16"></span>
-               <p>{{message}}</p>
-          </div>
-        {{else}}
-          <div class="ion-messages-container">
-              <p>{{message}}</p>
-          </div>
-        {{/if}}
-      {{/each}}
-    `,
-  getTemplateData: function() {
-    const messages = this.options.appState.get('messages') || {};
-    if (Array.isArray(messages.value)) {
-      return {
-        messages: messages.value
-          .map(m => {
-            return {
-              isError: m.class === 'ERROR',
-              message: m.message
-            };
-          })
-      };
-    }
-    return [];
-  },
-});
 
 const Body = BaseForm.extend({
 
@@ -60,7 +27,23 @@ const Body = BaseForm.extend({
   },
 
   showMessages() {
-    this.add(InvalidUserCodeErrorView, '.o-form-error-container');
+    // override showMessages to display error message
+    const messagesObjs = this.options.appState.get('messages');
+    if (messagesObjs && Array.isArray(messagesObjs.value)) {
+      this.add('<div class="ion-messages-container"></div>', '.o-form-error-container');
+
+      messagesObjs.value.forEach(messagesObj => {
+        const msg = messagesObj.message;
+        if (messagesObj?.class === 'ERROR') {
+          this.add(createCallout({
+            content: msg,
+            type: 'error',
+          }), '.o-form-error-container');
+        } else {
+          this.add(`<p>${msg}</p>`, '.ion-messages-container');
+        }
+      });
+    }
   },
 });
 

--- a/test/testcafe/framework/page-objects-v1/DeviceCodeActivatePageObject.js
+++ b/test/testcafe/framework/page-objects-v1/DeviceCodeActivatePageObject.js
@@ -44,6 +44,10 @@ export default class DeviceCodeActivatePageObject extends BasePageObject {
     return this.form.getTextBoxValue(USER_CODE_FIELD);
   }
 
+  isUserNameFieldVisible() {
+    return this.form.findFormFieldInput('username').visible;
+  }
+
   fillUserNameField(value) {
     return this.form.setTextBoxValue('username', value);
   }

--- a/test/testcafe/framework/page-objects/DeviceCodeActivatePageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceCodeActivatePageObject.js
@@ -44,6 +44,10 @@ export default class DeviceCodeActivatePageObject extends BasePageObject {
     return this.form.getTextBoxValue(USER_CODE_FIELD);
   }
 
+  isIdentifierFieldVisible() {
+    return this.form.findFormFieldInput('identifier').visible;
+  }
+
   fillIdentifierField(value) {
     return this.form.setTextBoxValue('identifier', value);
   }

--- a/test/unit/helpers/xhr/DEVICE_CODE_ACTIVATE_invalidCode.js
+++ b/test/unit/helpers/xhr/DEVICE_CODE_ACTIVATE_invalidCode.js
@@ -1,0 +1,7 @@
+import xhrDeviceCodeActivateError from '../../../../playground/mocks/data/api/v1/authn/error-device-code-activate.json';
+
+export default {
+  'status': 200,
+  'responseType': 'json',
+  'response': xhrDeviceCodeActivateError,
+};

--- a/test/unit/spec/DeviceCodeActivate_spec.js
+++ b/test/unit/spec/DeviceCodeActivate_spec.js
@@ -5,6 +5,7 @@ import DeviceCodeActivateForm from 'helpers/dom/DeviceCodeActivateForm';
 import Util from 'helpers/mocks/Util';
 import Expect from 'helpers/util/Expect';
 import resDeviceCodeActivate from 'helpers/xhr/DEVICE_CODE_ACTIVATE';
+import resDeviceCodeActivateError from 'helpers/xhr/DEVICE_CODE_ACTIVATE_invalidCode';
 import resDeviceCodeActivated from 'helpers/xhr/DEVICE_CODE_TERMINAL_activated';
 import resDeviceCodeActivateInvalidCode from 'helpers/xhr/DEVICE_CODE_TERMINAL_invalidCode';
 import $sandbox from 'sandbox';
@@ -117,6 +118,17 @@ Expect.describe('DeviceCodeActivate', function() {
         .then(function(test) {
           test.form.setUserCodeAndTriggerKeyup('BADD');
           expect(test.form.userCodeField().val()).toBe('BADD-');
+        });
+    });
+    itp('url with invalid user code shows error', function() {
+      return setup(undefined, resDeviceCodeActivateError)
+        .then(function(test) {
+          Util.resetAjaxRequests();
+          return Expect.waitForFormError(test.form, test);
+        })
+        .then(function(test) {
+          expect(test.form.hasErrors()).toBe(true);
+          expect(test.form.errorMessage()).toBe('Invalid code. Try again.');
         });
     });
   });


### PR DESCRIPTION
## Description:
Today `/activate` endpoint bootstraps the state token and widget. Customers can enter the activation code on this page and go to authentication screen after that. If the code is invalid, currently widget displays inline error message. 

We are adding QR code functionality where the activation code can be part of the url e.g. `/activate?user_code=XYZ`. If this code is invalid, we want to bootstrap the form with error message already populated. 

- `Views` read error messages coming back in remediation response and show them in the device activate form. 
- Adding it on both v1 and v2 SIW. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
https://user-images.githubusercontent.com/79160458/127253412-00b06c0c-1ac3-4d1b-9b14-7ba1abb61b6e.mov

### Reviewers:


### Issue:

- [OKTA-415793](https://oktainc.atlassian.net/browse/OKTA-415793)