### PR TITLE
fix: qtip with jquery 3.6

### DIFF
--- a/playground/mocks/spec-okta-api/login/getimage/index.js
+++ b/playground/mocks/spec-okta-api/login/getimage/index.js
@@ -1,14 +1,38 @@
-const data = [
-  {
-    imageDescription: 'Security Image - Road',
-    pwdImg: 'https://tc1static.oktacdn.com/assets/img/security/road.jpg',
-    result: 'success',
-  }
-];
+const DEFAULT = {
+  imageDescription: 'Security Image - Road',
+  pwdImg: '/img/security/road.jpg',
+  result: 'success'
+};
+
+const UNKNOWN_USER = {
+  imageDescription: 'Security Image - Unknown',
+  pwdImg: '/img/security/unknown.png',
+  result: 'success'
+};
+
+const NEW_USER = {
+  imageDescription: 'Security Image - New User',
+  pwdImg: '/img/security/unknown-device.png',
+  result: 'success'
+};
 
 module.exports = {
   path: '/login/getimage',
   proxy: false,
   method: 'GET',
-  template: data[0],
+  template(params, query) {
+    let obj;
+    console.log('query', query);
+    switch (query.username) {
+    case 'unknown':
+      obj = UNKNOWN_USER;
+      break;
+    case 'new':
+      obj = NEW_USER;
+      break;
+    default:
+      obj = DEFAULT;
+    }
+    return obj;
+  }
 };

--- a/playground/mocks/spec-okta-api/login/getimage/index.js
+++ b/playground/mocks/spec-okta-api/login/getimage/index.js
@@ -22,7 +22,8 @@ module.exports = {
   method: 'GET',
   template(params, query) {
     let obj;
-    console.log('query', query);
+
+    // For playground users, show different images based on a username
     switch (query.username) {
     case 'unknown':
       obj = UNKNOWN_USER;

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -86,9 +86,10 @@ function antiPhishingMessage(image, host) {
     },
   });
 
+  // It is necessary to delay toggle to the next render cycle, since qtip internally defers some setup tasks.
   setTimeout(() => {
     image.qtip('toggle', image.is(':visible'));
-  }, 1);
+  }, 0);
 }
 
 function destroyAntiPhishingMessage(image) {

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -86,7 +86,9 @@ function antiPhishingMessage(image, host) {
     },
   });
 
-  image.qtip('toggle', image.is(':visible'));
+  setTimeout(() => {
+    image.qtip('toggle', image.is(':visible'));
+  }, 1);
 }
 
 function destroyAntiPhishingMessage(image) {

--- a/test/unit/helpers/util/Expect.js
+++ b/test/unit/helpers/util/Expect.js
@@ -211,6 +211,13 @@ fn.waitForWindowListener = function(eventName, resolveValue) {
   return fn.wait(condition, resolveValue);
 };
 
+fn.waitForSecurityImageTooltip = function(expectToBeVisible, resolveValue) {
+  return fn.wait(() => {
+    const $el = $('.okta-security-image-tooltip:visible');
+    const isVisible = $el.isInViewport();
+    return isVisible === expectToBeVisible;
+  }, resolveValue);
+};
 
 fn.wait = function(condition, resolveValue, timeout) {
   function check(success, fail, triesLeft) {

--- a/test/unit/helpers/util/jquery.okta.js
+++ b/test/unit/helpers/util/jquery.okta.js
@@ -3,3 +3,17 @@ import { $ } from 'okta';
 $.fn.trimmedText = function() {
   return $.trim(this.text());
 };
+
+$.fn.isInViewport = function() {
+  if (!this.length) {
+    return false;
+  }
+
+  var elementTop = $(this).offset().top;
+  var elementBottom = elementTop + $(this).outerHeight();
+
+  var viewportTop = $(window).scrollTop();
+  var viewportBottom = viewportTop + $(window).height();
+
+  return elementBottom > viewportTop && elementTop < viewportBottom;
+};

--- a/test/unit/helpers/xhr/security_image_new_user.js
+++ b/test/unit/helpers/xhr/security_image_new_user.js
@@ -1,0 +1,9 @@
+export default {
+  status: 200,
+  responseType: 'json',
+  response: {
+    result: 'success',
+    pwdImg: '/img/security/unknown-device.png',
+    imageDescription: '',
+  },
+};

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -23,6 +23,7 @@ import resUnauthenticated from 'helpers/xhr/UNAUTHENTICATED';
 import resUnauthorized from 'helpers/xhr/UNAUTHORIZED_ERROR';
 import resSecurityImage from 'helpers/xhr/security_image';
 import resSecurityImageFail from 'helpers/xhr/security_image_fail';
+import resSecurityImageNewUser from 'helpers/xhr/security_image_new_user';
 import PrimaryAuth from 'models/PrimaryAuth';
 import Q from 'q';
 import $sandbox from 'sandbox';
@@ -1702,27 +1703,54 @@ Expect.describe('PrimaryAuth', function() {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
         });
     });
-    itp('show anti-phishing message if security image become visible', function() {
+    
+    itp('show anti-phishing message when security image is new user', function() {
       return setup({ features: { securityImage: true } })
         .then(function(test) {
           spyOn($.qtip.prototype, 'toggle').and.callThrough();
-          test.setNextResponse(resSecurityImageFail);
+          test.setNextResponse(resSecurityImageNewUser);
           test.form.setUsername('testuser');
-          return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
+          return Expect.waitForSecurityImageTooltip(true, test);
         })
         .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().hide();
           $(window).trigger('resize');
-          return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
+          return Expect.waitForSecurityImageTooltip(false, test);
         })
         .then(function(test) {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
           $.qtip.prototype.toggle.calls.reset();
           test.form.securityBeaconContainer().show();
           $(window).trigger('resize');
-          return Expect.waitForSpyCall($.qtip.prototype.toggle, test);
+          return Expect.waitForSecurityImageTooltip(true, test);
+        })
+        .then(function() {
+          expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
+        });
+    });
+    itp('show anti-phishing message if security image become visible', function() {
+      return setup({ features: { securityImage: true } })
+        .then(function(test) {
+          spyOn($.qtip.prototype, 'toggle').and.callThrough();
+          test.setNextResponse(resSecurityImageFail);
+          test.form.setUsername('testuser');
+          return Expect.waitForSecurityImageTooltip(true, test);
+        })
+        .then(function(test) {
+          expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));
+          $.qtip.prototype.toggle.calls.reset();
+          test.form.securityBeaconContainer().hide();
+          $(window).trigger('resize');
+          return Expect.waitForSecurityImageTooltip(false, test);
+        })
+        .then(function(test) {
+          expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: false }));
+          $.qtip.prototype.toggle.calls.reset();
+          test.form.securityBeaconContainer().show();
+          $(window).trigger('resize');
+          return Expect.waitForSecurityImageTooltip(true, test);
         })
         .then(function() {
           expect($.qtip.prototype.toggle.calls.argsFor(0)).toEqual(jasmine.objectContaining({ 0: true }));

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -70,7 +70,7 @@ module.exports = {
         '/oauth2/',
         '/api/v1/',
         '/idp/idx/',
-        '/login/getimage/',
+        '/login/getimage',
         '/sso/idps/',
         '/app/UserHome',
         '/oauth2/v1/authorize',


### PR DESCRIPTION
## Description:

Fixes an issue with the qtip jquery plugin related to the jquery 3.6 upgrade.
Deferred tasks which ran synchronously on jquery 1.12 are now running async.
Adding a setTimeout with 0ms defers toggle to the next render cycle and fixes the issue.

Added test expectations to fill the test gap for this issue - the tooltip is verified to be visible in the viewport.

Also fixes `/getimage` in playground and adds switch logic so that various states with the security image can be easily simulated

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-409364](https://oktainc.atlassian.net/browse/OKTA-409364)


