### PR TITLE
fix(v1): when location starts with data.userProfile in registration api error, render the error summary instead of generic error

### DIFF
--- a/src/RegistrationController.js
+++ b/src/RegistrationController.js
@@ -117,7 +117,7 @@ export default BaseLoginController.extend({
 
         if (responseJSON && responseJSON.errorCauses.length) {
           const { errorCode, errorCauses } = responseJSON;
-          const { errorSummary, reason } = errorCauses[0];
+          const { errorSummary, reason, location } = errorCauses[0];
 
           const isNotUniqueValue =
             errorCode === 'E0000001' &&
@@ -126,6 +126,8 @@ export default BaseLoginController.extend({
           if (isNotUniqueValue) {
             this.renderIsNotUniqueError(responseJSON);
           }
+
+          this.renderLegacyLocationErrorIfNeeded(location, errorSummary);
 
           Util.triggerAfterError(
             this,
@@ -146,6 +148,16 @@ export default BaseLoginController.extend({
     // without using backbone events because there was a race condition
     // between clearing and triggering errors
     this.$el.find('.okta-form-infobox-error p').text(errorSummary);
+  },
+
+  renderLegacyLocationErrorIfNeeded: function(location, errorSummary) {
+    // replace generic error message with errorSummary for v1 SIW
+    // this makes sure that with legacy location that starts with `data.userProfile`
+    // we still see the errorSummary in the error banner instead of only a generic error
+    // See example in https://developer.okta.com/docs/reference/registration-hook/#sample-json-payload-of-request
+    if (location && /^data\.userProfile.*/.test(location)) {
+      this.$el.find('.okta-form-infobox-error p').text(errorSummary);
+    }
   },
 
   createRegistrationModel: function(modelProperties) {

--- a/test/unit/helpers/xhr/ERROR_INVALID_EMAIL_DOMAIN.js
+++ b/test/unit/helpers/xhr/ERROR_INVALID_EMAIL_DOMAIN.js
@@ -1,0 +1,19 @@
+export default {
+  status: 400,
+  responseType: 'jrd+json',
+  response: {
+    errorCode: 'E0000135',
+    errorId: 'oae5MJyuqthRBuwY9u5A50SPw',
+    errorLink: 'E0000135',
+    errorSummary: 'Registration cannot be completed at this time',
+    errorCauses: [
+      {
+        domain: 'end-user',
+        errorSummary: 'You specified an invalid email domain',
+        location: 'data.userProfile.login',
+        locationType: 'body',
+        reason: 'INVALID_EMAIL_DOMAIN',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Description:
This is a fix for v1 self service registration inline hook. 

After https://github.com/okta/okta-ui/commit/03387a3452a4f2c65b8e769ca84b27b9a8ea3b68, the new expected behavior for showing error is: when received an api error, a generic error message is shown in error banner and each individual field error is shown down below that field.
<img width="1638" alt="Screen Shot 2021-07-23 at 3 50 56 PM" src="https://user-images.githubusercontent.com/49395917/127571637-7ba8fdaf-c5e4-441a-9ed9-e4228c87e809.png">

But in v1 inline hooks, the location property was in format that starts with `data.userProfile` according to our developer doc 
https://developer.okta.com/docs/reference/registration-hook/#sample-json-payload-of-request The commit above is a general enhancement and thus didn't cover well on this specific use case, and it's causing a regression where only a generic error message is shown in the error banner.
<img width="1658" alt="Screen Shot 2021-07-23 at 3 52 25 PM" src="https://user-images.githubusercontent.com/49395917/127571847-1eabbb2a-9bd0-4976-80dd-594438c6d923.png">

The proposed fix within this PR is: when we detect the location property starts with `data.userProfile`, we will replace the error banner with errorSummary returned in api response and the behavior is the same as before.
![Screen Shot 2021-07-29 at 3 03 01 PM](https://user-images.githubusercontent.com/49395917/127571939-8ac1143e-4da4-408a-9952-c338226365ed.png)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
https://okta.box.com/s/5rgkhl7pbcxnclb6spcezb04wat634m3

### Reviewers:
@sherizada-okta @pradeepdewda-okta 

### Issue:

- [OKTA-409142](https://oktainc.atlassian.net/browse/OKTA-409142)



