### PR TITLE
fix: open app store links in new tab/window

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -399,7 +399,7 @@ enroll.yubikey.subtitle = Insert your YubiKey into a USB port and tap it to gene
 # Enroll TOTP
 enroll.totp.title = Setup {0}
 enroll.totp.selectDevice = Select your device type
-enroll.totp.downloadApp = Download <a href="{0}" target="_blank" rel=“noreferer noopener” class="inline-link">{1} from the {2}</a> onto your mobile device.
+enroll.totp.downloadApp = Download <a href="{0}" target="_blank" rel="noreferer noopener"= class="inline-link">{1} from the {2}</a> onto your mobile device.
 
 # Enroll HOTP
 enroll.hotp.restricted = Contact your administrator to continue enrollment.

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -399,7 +399,7 @@ enroll.yubikey.subtitle = Insert your YubiKey into a USB port and tap it to gene
 # Enroll TOTP
 enroll.totp.title = Setup {0}
 enroll.totp.selectDevice = Select your device type
-enroll.totp.downloadApp = Download <a href="{0}" target="_blank" rel="noreferer noopener"= class="inline-link">{1} from the {2}</a> onto your mobile device.
+enroll.totp.downloadApp = Download <a href="{0}" class="inline-link">{1} from the {2}</a> onto your mobile device.
 
 # Enroll HOTP
 enroll.hotp.restricted = Contact your administrator to continue enrollment.

--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -399,7 +399,7 @@ enroll.yubikey.subtitle = Insert your YubiKey into a USB port and tap it to gene
 # Enroll TOTP
 enroll.totp.title = Setup {0}
 enroll.totp.selectDevice = Select your device type
-enroll.totp.downloadApp = Download <a href="{0}" class="inline-link">{1} from the {2}</a> onto your mobile device.
+enroll.totp.downloadApp = Download <a href="{0}" target="_blank" rel=“noreferer noopener” class="inline-link">{1} from the {2}</a> onto your mobile device.
 
 # Enroll HOTP
 enroll.hotp.restricted = Contact your administrator to continue enrollment.

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -35,9 +35,8 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
     this.listenTo(this.model, 'change:__deviceType__', this.render);
   },
   postRender: function() {
-    // TODO remove after translations are in place. OKTA-417836
     const link  = this.$el.find('.instructions a');
-    if (window.self !== window.top && link.length) {
+    if (link.length) {
       link[0].setAttribute('target', '_blank');
       link[0].setAttribute('rel', 'noreferer noopener');
     }

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -34,6 +34,16 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
   initialize: function() {
     this.listenTo(this.model, 'change:__deviceType__', this.render);
   },
+  postRender() {
+    try {
+      const link  = this.$el.find('a');
+      if (window.self !== window.top && link.length) {
+        link[0].setAttribute('target', '_blank');
+      }
+    } catch (e) {
+      // do nothing
+    }
+  },
   getTemplateData: function() {
     let appStoreLink;
     let appIcon;

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -34,6 +34,14 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
   initialize: function() {
     this.listenTo(this.model, 'change:__deviceType__', this.render);
   },
+  postRender: function() {
+    // TODO remove after translations are in place. OKTA-417836
+    const link  = this.$el.find('.instructions a');
+    if (window.self !== window.top && link.length) {
+      link[0].setAttribute('target', '_blank');
+      link[0].setAttribute('rel', 'noreferer noopener');
+    }
+  },
   getTemplateData: function() {
     let appStoreLink;
     let appIcon;

--- a/src/EnrollTotpController.js
+++ b/src/EnrollTotpController.js
@@ -34,16 +34,6 @@ const EnrollTotpControllerAppDownloadInstructionsView = View.extend({
   initialize: function() {
     this.listenTo(this.model, 'change:__deviceType__', this.render);
   },
-  postRender() {
-    try {
-      const link  = this.$el.find('a');
-      if (window.self !== window.top && link.length) {
-        link[0].setAttribute('target', '_blank');
-      }
-    } catch (e) {
-      // do nothing
-    }
-  },
   getTemplateData: function() {
     let appStoreLink;
     let appIcon;

--- a/test/unit/helpers/dom/EnrollTotpDeviceTypeForm.js
+++ b/test/unit/helpers/dom/EnrollTotpDeviceTypeForm.js
@@ -22,6 +22,10 @@ export default Form.extend({
     return this.appDownloadInstructions().find('a').text().trim();
   },
 
+  appDownloadInstructionsLink: function() {
+    return this.appDownloadInstructions().find('a');
+  },
+
   selectDeviceType: function(val) {
     const options = this.deviceTypeOptions();
 

--- a/test/unit/spec/EnrollTotpController_spec.js
+++ b/test/unit/spec/EnrollTotpController_spec.js
@@ -190,6 +190,16 @@ Expect.describe('EnrollTotp', function() {
         expect(test.form.appDownloadInstructionsLinkText()).toEqual('Google Authenticator from the Google Play Store');
       });
     });
+    itp('has link right target and rel attributes for app/play store links', function() {
+      return setupOktaTotpFn().then(function(test) {
+        test.form.selectDeviceType('APPLE');
+        expect(test.form.appDownloadInstructionsLink()[0].getAttribute('target')).toEqual('_blank');
+        expect(test.form.appDownloadInstructionsLink()[0].getAttribute('rel')).toEqual('noreferer noopener');
+        test.form.selectDeviceType('ANDROID');
+        expect(test.form.appDownloadInstructionsLink()[0].getAttribute('target')).toEqual('_blank');
+        expect(test.form.appDownloadInstructionsLink()[0].getAttribute('rel')).toEqual('noreferer noopener');
+      });
+    });
     itp('has a next button not displayed until device type is selected', function() {
       return setupOktaTotpFn().then(function(test) {
         Expect.isNotVisible(test.form.submitButton());


### PR DESCRIPTION
* For cases where siw is embedded in iframe, opening app store links in iframe throws error "('X-Frame-Options' set to 'sameorigin'.)"
* Also when user is going through the enroll flow in SIW, by opening the link in the same page user looses state hence opening in new tab. 

RESOLVES: OKTA-411448


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-411448](https://oktainc.atlassian.net/browse/OKTA-411448)


