### PR TITLE
Updated releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 <link href="https://global.oktacdn.com/okta-signin-widget/5.9.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
-The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](/releases).
+The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](../../releases).
 
 The standard JS asset served from our CDN includes polyfills via [`core-js`](https://github.com/zloirock/core-js) and [`regenerator-runtime`](https://github.com/facebook/regenerator/blob/master/packages/regenerator-runtime/runtime.js) to ensure compatibility with older browsers.
 


### PR DESCRIPTION
Current releases link (/releases) brings you to https://github.com/okta/okta-signin-widget/blob/master/releases which gives a 404 error page.

So suggested updating the link to (../../releases) as it will take you to the correct releases page. 

Note - Github doco on releases here - https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/linking-to-releases

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


