### PR TITLE
fix: error when enrolling OV in mobile on OIE

### DIFF
--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -35,10 +35,6 @@ const Body = BaseForm.extend(Object.assign(
     noButtonBar: true,
     initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
-      if ((BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) &
-        this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode') {
-        this.options.appState.trigger('switchForm', RemediationForms.SELECT_ENROLLMENT_CHANNEL);
-      }
       this.listenTo(this.model, 'error', this.stopPolling);
       this.startPolling();
     },
@@ -70,6 +66,16 @@ const Body = BaseForm.extend(Object.assign(
         });
 
       }
+    },
+    postRender() {
+      // Using setTimeout of 0 because, the view is added in postRender of formController and not the initialize,
+      // and hence by the time swithForm is called, current view is not rendered and availabe on controller $el.
+      setTimeout(() => {
+        if ((BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) &
+          this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode') {
+          this.options.appState.trigger('switchForm', RemediationForms.SELECT_ENROLLMENT_CHANNEL);
+        }
+      }, 0);
     },
     getUISchema() {
       const schema = [];

--- a/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
@@ -4,6 +4,7 @@ import Settings from 'models/Settings';
 import $sandbox from 'sandbox';
 import BrowserFeatures from 'util/BrowserFeatures';
 import xhrAuthenticatorEnrollOktaVerifyQr from '../../../../../../playground/mocks/data/idp/idx/authenticator-enroll-ov-qr';
+import Expect from 'helpers/util/Expect';
 
 describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
   let testContext;
@@ -36,30 +37,39 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
     $sandbox.empty();
   });
 
-  it('triggers switchForm on appState when on ios device to select channel', function() {
+  it('triggers switchForm on appState when on ios device to select channel', function(done) {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => true);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => false);
     testContext.init();
-    expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
-    expect(BrowserFeatures.isIOS).toHaveBeenCalled();
-    expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
+    Expect.waitForSpyCall(BrowserFeatures.isAndroid).then(() => {
+      expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
+      expect(BrowserFeatures.isIOS).toHaveBeenCalled();
+      expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
+      done();
+    });
   });
 
-  it('triggers switchForm on appState when on android device to select channel', function() {
+  it('triggers switchForm on appState when on android device to select channel', function(done) {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => false);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => true);
     testContext.init();
-    expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
-    expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
+    Expect.waitForSpyCall(BrowserFeatures.isAndroid).then(() => {
+      expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
+      expect(testContext.view.options.appState.trigger).toHaveBeenCalledWith('switchForm', 'select-enrollment-channel');
+      done();
+    });
   });
 
-  it('renders QR code view when on desktop', function() {
+  it('renders QR code view when on desktop', function(done) {
     spyOn(BrowserFeatures, 'isIOS').and.callFake(() => false);
     spyOn(BrowserFeatures, 'isAndroid').and.callFake(() => false);
     testContext.init();
-    expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
-    expect(BrowserFeatures.isIOS).toHaveBeenCalled();
-    expect(testContext.view.options.appState.trigger).not.toHaveBeenCalled();
-    expect(testContext.view.$('.qrcode').length).toBe(1);
+    Expect.waitForSpyCall(BrowserFeatures.isAndroid).then(() => {
+      expect(BrowserFeatures.isAndroid).toHaveBeenCalled();
+      expect(BrowserFeatures.isIOS).toHaveBeenCalled();
+      expect(testContext.view.options.appState.trigger).not.toHaveBeenCalled();
+      expect(testContext.view.$('.qrcode').length).toBe(1);
+      done();
+    });
   });
 });


### PR DESCRIPTION
* in OIE during OV enrollment on mobile, we call switchForm to load the
'select-enrollment-channel' the issue was that switchForm was called even before the render of
initial form 'enroll-poll' thus both views were displayed.

* Moving to postRender also doesnt help since forms are added in postRender of FormController.
The add logic in baseView takes an extra eventloop to render the Form hence adding a timeout ot 0.

RESOLVES: OKTA-418833

**before**
![image](https://user-images.githubusercontent.com/17267130/128787006-abf591b1-c3d8-45fd-a7b8-6269715522e0.png)


**after**
<img width="583" alt="Screen Shot 2021-08-09 at 4 30 04 PM" src="https://user-images.githubusercontent.com/17267130/128786869-fee8ea7c-225d-4a3f-a903-39485c2c86c1.png">




## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-418833](https://oktainc.atlassian.net/browse/OKTA-418833)


