### PR TITLE
test: adds test for ov enroll poll in mobile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug with Jest",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v12.13.0/bin/node",
+      "args": [
+        "--runInBand",
+        "--no-cache",
+        "--config=jest.config.js",
+        "--testTimeout=3600000",
+        "${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "protocol": "inspector",
+      "request": "launch",
+      "name": "Debug with TestCafe",
+      "program": "${workspaceRoot}/node_modules/testcafe/bin/testcafe.js",
+      "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v12.13.0/bin/node",
+      "args": [
+          "chrome",
+          "${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}"
+    }
+  ]
+}

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -35,12 +35,14 @@ const Body = BaseForm.extend(Object.assign(
     noButtonBar: true,
     initialize() {
       BaseForm.prototype.initialize.apply(this, arguments);
+      this.listenTo(this.model, 'error', this.stopPolling);
+      this.startPolling();
+    },
+    postRender() {
       if ((BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) &
         this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode') {
         this.options.appState.trigger('switchForm', RemediationForms.SELECT_ENROLLMENT_CHANNEL);
       }
-      this.listenTo(this.model, 'error', this.stopPolling);
-      this.startPolling();
     },
     showMessages() {
       // override showMessages to display error message


### PR DESCRIPTION
## Description:

* Adds test for ov enroll poll in mobile  to make sure 'switchForm' removes the old UI and then renders the new form.
    
   
   RESOLVES: OKTA-419148

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-419148](https://oktainc.atlassian.net/browse/OKTA-419148)


