### PR TITLE
Support username config in OIE for SIW

### DIFF
--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -23,8 +23,13 @@ const Body = BaseForm.extend({
   initialize() {
     BaseForm.prototype.initialize.apply(this, arguments);
 
-    if (this.getUISchema().find(schema => schema.name === 'credentials.passcode')) {
+    const uiSchema = this.getUISchema();
+    if (uiSchema.find(schema => schema.name === 'credentials.passcode')) {
       this.save = loc('oie.primaryauth.submit', 'login');
+    }
+
+    if(this._shouldAddUsername(uiSchema)) {
+      this.model.set('identifier', this.settings.get('username'));
     }
   },
 
@@ -161,6 +166,12 @@ const Body = BaseForm.extend({
       }
     });
   },
+
+  _shouldAddUsername(uiSchema) {
+    // We pre-populate the identifier/username field only if we're in an identifier
+    // form and if the option is passed in.
+    return (uiSchema.find(schema => schema.name === 'identifier') && this.settings.get('username'));
+  },  
 });
 
 export default BaseView.extend({

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -8,6 +8,11 @@ import xhrAuthenticatorVerifySelect from '../../../playground/mocks/data/idp/idx
 import xhrAuthenticatorOVTotp from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-totp';
 import config from '../../../src/config/config.json';
 
+
+const baseIdentifyMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentify);
+
 const identifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify)
@@ -300,4 +305,15 @@ test.requestHooks(identifyRequestLogger, identifyMockWithFingerprintError)('shou
   await identityPage.waitForErrorBox();
   await t.expect(identityPage.getSaveButtonLabel()).eql('Next');
   await t.expect(identityPage.getGlobalErrors()).contains('You do not have permission to perform the requested action');
+});
+
+test.requestHooks(identifyRequestLogger, baseIdentifyMock)('should pre-populate identifier field with username config', async t => {
+  const identityPage = await setup(t);
+  await rerenderWidget({
+    username: 'myTestUsername@okta.com'
+  });
+
+  // Ensure identifier field is pre-filled
+  const identifier = identityPage.getIdentifierValue();
+  await t.expect(identifier).eql('myTestUsername@okta.com');
 });


### PR DESCRIPTION
## Description:

- Support for the config.username in OIE for the SIW
- When the config is passed in, we should pre-fill the identifier field with that value (https://oktainc.atlassian.net/browse/OKTA-417463 for more details)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/77295104/129060610-90f1c944-638c-4ed1-839a-233de4af1c99.mov

### Reviewers:


### Issue:

- [OKTA-417463](https://oktainc.atlassian.net/browse/OKTA-417463)


