### PR TITLE
Update login_sv.properties

### DIFF
--- a/packages/@okta/i18n/src/properties/login_sv.properties
+++ b/packages/@okta/i18n/src/properties/login_sv.properties
@@ -525,8 +525,8 @@ oktaverify.numberchallenge.explain = Det h\u00E4r extra steget bekr\u00E4ftar f\
 
 # Username & Password
 primaryauth.title = Logga in
-primaryauth.username.placeholder = L\u00F6senord
-primaryauth.username.tooltip = L\u00F6senord
+primaryauth.username.placeholder = Anv\u00E4ndarnamn
+primaryauth.username.tooltip = Anv\u00E4ndarnamn
 primaryauth.password.placeholder = L\u00F6senord
 primaryauth.password.tooltip = L\u00F6senord
 primaryauth.submit = Logga in


### PR DESCRIPTION
Username placeholder says "lösenord" meaning password, causing people to enter their password instead of username. Might be quite severe since it might put some passwords in the log files?

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


