### PR TITLE
fix: webauthn verification on OIE

### DIFF
--- a/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
+++ b/src/v2/view-builder/views/webauthn/ChallengeWebauthnView.js
@@ -1,4 +1,4 @@
-import { loc, createButton, createCallout } from 'okta';
+import { _, loc, createButton, createCallout } from 'okta';
 import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import CryptoUtil from '../../../../util/CryptoUtil';
@@ -75,11 +75,11 @@ const Body = BaseForm.extend({
         });
       }
     });
-    const options = {
+    const challengeData = authenticatorData.contextualData.challengeData;
+    const options = _.extend({}, challengeData, {
       allowCredentials,
-      userVerification: authenticatorData.contextualData.challengeData.userVerification,
-      challenge: CryptoUtil.strToBin(authenticatorData.contextualData.challengeData.challenge),
-    };
+      challenge: CryptoUtil.strToBin(challengeData.challenge),
+    });
     navigator.credentials.get({
       publicKey: options,
       signal: this.webauthnAbortController.signal

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -174,6 +174,9 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
               ),
             },
           ],
+          extensions: {
+            appid: 'https://localhost:3000',
+          },
           userVerification: 'required',
           challenge: CryptoUtil.strToBin(
             ChallengeWebauthnResponse.currentAuthenticator.value.contextualData.challengeData.challenge


### PR DESCRIPTION
* Part of challenge data, specifically the extension was not passed to
credentials.get.  This caused issue with verifying u2f keys that were originally enrolled
when u2f factor was enabled in v1 and later on migrated to webauthn and finallly webauthn on OIE.

RESOLVES: OKTA-422158


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


