### PR TITLE
chore: make Okta Verify MFA challenge UI extends from BaseFormWithPolling

### DIFF
--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -1,5 +1,5 @@
 import { $, loc } from 'okta';
-import { BaseForm, BaseFormWithPolling, BaseFooter, BaseView } from '../../internals';
+import { BaseFormWithPolling, BaseFooter, BaseView } from '../../internals';
 import Logger from '../../../../util/Logger';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import Enums from '../../../../util/Enums';
@@ -47,7 +47,7 @@ const Body = BaseFormWithPolling.extend(
     },
 
     remove() {
-      BaseForm.prototype.remove.apply(this, arguments);
+      BaseFormWithPolling.prototype.remove.apply(this, arguments);
       this.stopProbing();
       this.stopPolling();
     },

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,9 +1,8 @@
 import { $ } from 'okta';
-import { BaseForm } from '../../internals';
+import { BaseFormWithPolling } from '../../internals';
 import Logger from '../../../../util/Logger';
 import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
-import polling from '../shared/polling';
 import {doChallenge} from '../../utils/ChallengeViewUtil';
 
 const request = (opts) => {
@@ -14,7 +13,7 @@ const request = (opts) => {
   return $.ajax(ajaxOptions);
 };
 
-const Body = BaseForm.extend(Object.assign(
+const Body = BaseFormWithPolling.extend(Object.assign(
   {
     noButtonBar: true,
 
@@ -28,7 +27,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     initialize() {
-      BaseForm.prototype.initialize.apply(this, arguments);
+      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.onPollingFail);
       doChallenge(this);
       this.startPolling();
@@ -40,7 +39,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     remove() {
-      BaseForm.prototype.remove.apply(this, arguments);
+      BaseFormWithPolling.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
 
@@ -125,8 +124,6 @@ const Body = BaseForm.extend(Object.assign(
       `).last();
     },
   },
-
-  polling,
 ));
 
 export default Body;


### PR DESCRIPTION
## Description:
Make the Okta Verify MFA challenge view extends from the BaseFormWithPolling so that it gets access to the polling functions. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@magizh-okta

### Issue:

- [OKTA-422561](https://oktainc.atlassian.net/browse/OKTA-422561)


