### PR TITLE
Updating Resend Views to use a global timer

### DIFF
--- a/src/v2/client/sessionStorageHelper.js
+++ b/src/v2/client/sessionStorageHelper.js
@@ -12,6 +12,7 @@
 
 const STATE_HANDLE_SESSION_STORAGE_KEY = 'osw-oie-state-handle';
 const LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY = 'osw-oie-last-initiated-login-url';
+const RESEND_TIMESTAMP_SESSION_STORAGE_KEY = 'osw-oie-resend-timestamp';
 
 const removeStateHandle = () => {
   sessionStorage.removeItem(STATE_HANDLE_SESSION_STORAGE_KEY);
@@ -27,10 +28,23 @@ const getStateHandle = () => {
 const getLastInitiatedLoginUrl = () => {
   return sessionStorage.getItem(LAST_INITIATED_LOGIN_URL_SESSION_STORAGE_KEY);
 };
+const removeResendTimestamp = () => {
+  sessionStorage.removeItem(RESEND_TIMESTAMP_SESSION_STORAGE_KEY);
+};
+const setResendTimestamp = (token) => {
+  sessionStorage.setItem(RESEND_TIMESTAMP_SESSION_STORAGE_KEY, token);
+};
+const getResendTimestamp = () => {
+  return sessionStorage.getItem(RESEND_TIMESTAMP_SESSION_STORAGE_KEY);
+};
+
 
 export default {
   removeStateHandle,
   setStateHandle,
   getStateHandle,
   getLastInitiatedLoginUrl,
+  removeResendTimestamp,
+  setResendTimestamp,
+  getResendTimestamp
 };

--- a/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/BaseAuthenticatorEmailView.js
@@ -1,11 +1,11 @@
-import { loc, View, createCallout, _ } from 'okta';
+import { loc, createCallout } from 'okta';
 import { BaseForm } from '../../internals';
 import email from '../shared/email';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
-import { SHOW_RESEND_TIMEOUT } from '../../utils/Constants';
+import BaseResendView from '../shared/BaseResendView';
 import BaseFormWithPolling from '../../internals/BaseFormWithPolling';
 
-const ResendView = View.extend(
+const ResendView = BaseResendView.extend(
   {
     className: 'hide resend-email-view',
     events: {
@@ -26,23 +26,8 @@ const ResendView = View.extend(
       if (!this.$el.hasClass('hide')) {
         this.$el.addClass('hide');
       }
-      this.showCalloutWithDelay();
+      this.showCalloutAfterTimeout();
     },
-
-    postRender() {
-      this.showCalloutWithDelay();
-    },
-
-    showCalloutWithDelay() {
-      this.showMeTimeout = _.delay(() => {
-        this.$el.removeClass('hide');
-      }, SHOW_RESEND_TIMEOUT);
-    },
-
-    remove() {
-      View.prototype.remove.apply(this, arguments);
-      clearTimeout(this.showMeTimeout);
-    }
   },
 );
 

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -4,7 +4,7 @@ import BrowserFeatures from '../../../../util/BrowserFeatures';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import polling from '../shared/polling';
 import { FORMS as RemediationForms } from '../../../ion/RemediationConstants';
-import ResendView from './ResendView';
+import OVResendView from './OVResendView';
 import SwitchEnrollChannelLinkView from './SwitchEnrollChannelLinkView';
 import EnrollChannelPollDescriptionView from './EnrollChannelPollDescriptionView';
 
@@ -89,7 +89,7 @@ const Body = BaseForm.extend(Object.assign(
       });
       if (['email', 'sms'].includes(selectedChannel)) {
         schema.push({
-          View: ResendView,
+          View: OVResendView,
           selector: '.o-form-error-container',
         });
       }

--- a/src/v2/view-builder/views/ov/OVResendView.js
+++ b/src/v2/view-builder/views/ov/OVResendView.js
@@ -1,8 +1,8 @@
-import { View, createCallout, _ } from 'okta';
+import { createCallout } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import { SHOW_RESEND_TIMEOUT } from '../../utils/Constants';
+import BaseResendView from '../shared/BaseResendView';
 
-export default View.extend({
+export default BaseResendView.extend({
   //only show after certain threshold of polling
   className: 'hide resend-ov-link-view',
   events: {
@@ -23,21 +23,6 @@ export default View.extend({
     this.options.appState.trigger('invokeAction', 'currentAuthenticator-resend');
     //hide warning, but reinitiate to show warning again after some threshold of polling
     this.$el.addClass('hide');
-    this.showCalloutWithDelay();
+    this.showCalloutAfterTimeout();
   },
-
-  postRender() {
-    this.showCalloutWithDelay();
-  },
-
-  showCalloutWithDelay() {
-    this.showMeTimeout = _.delay(() => {
-      this.$el.removeClass('hide');
-    }, SHOW_RESEND_TIMEOUT);
-  },
-
-  remove() {
-    View.prototype.remove.apply(this, arguments);
-    clearTimeout(this.showMeTimeout);
-  }
 });

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -1,9 +1,9 @@
-import { loc, View, createCallout } from 'okta';
+import { loc, createCallout } from 'okta';
 import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
-import { SHOW_RESEND_TIMEOUT } from '../../utils/Constants';
+import BaseResendView from '../shared/BaseResendView';
 
-const ResendView = View.extend(
+const ResendView = BaseResendView.extend(
   {
     // To be shown after a timeout
     className: 'phone-authenticator-challenge__resend-warning hide',
@@ -35,21 +35,6 @@ const ResendView = View.extend(
       }
       this.showCalloutAfterTimeout();
     },
-
-    postRender() {
-      this.showCalloutAfterTimeout();
-    },
-
-    showCalloutAfterTimeout() {
-      this.showCalloutTimer = setTimeout(() => {
-        this.el.classList.remove('hide');
-      }, SHOW_RESEND_TIMEOUT);
-    },
-
-    remove() {
-      View.prototype.remove.apply(this, arguments);
-      clearTimeout(this.showCalloutTimer);
-    }
   },
 );
 

--- a/src/v2/view-builder/views/shared/BaseResendView.js
+++ b/src/v2/view-builder/views/shared/BaseResendView.js
@@ -1,0 +1,35 @@
+import { View } from 'okta';
+import { SHOW_RESEND_TIMEOUT } from '../../utils/Constants';
+import sessionStorageHelper from '../../../client/sessionStorageHelper';
+
+export default View.extend({
+
+  postRender() {
+    this.showCalloutAfterTimeout();
+  },
+
+  showCalloutAfterTimeout() {
+    const timeStamp = sessionStorageHelper.getResendTimestamp();
+    if (!timeStamp) {
+      sessionStorageHelper.setResendTimestamp(Date.now());
+    }
+
+    // We keep track of a 'global' timestamp in sessionStorage because if the SIW does a re-render,
+    // we don't want to force the user to wait another 30s again to see the resend link. With this
+    // the user will wait AT MOST 30s until they see the resend link.
+    const start = sessionStorageHelper.getResendTimestamp();
+    this.showMeTimeout = setInterval(() => {
+      const now = Date.now();
+      if (now - start >= SHOW_RESEND_TIMEOUT) {
+        this.$el.removeClass('hide');
+        clearInterval(this.showMeTimeout);
+        sessionStorageHelper.removeResendTimestamp();
+      }
+    }, 250);
+  },
+
+  remove() {
+    View.prototype.remove.apply(this, arguments);
+    clearTimeout(this.showMeTimeout);
+  },
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -349,6 +349,21 @@ test
   });
 
 test
+  .requestHooks(logger, validOTPmock)('resend after at most 30 seconds even after re-render', async t => {
+    const challengeEmailPageObject = await setup(t);
+    await challengeEmailPageObject.clickEnterCodeLink();
+
+    await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).ok();
+    await t.wait(15000);
+    challengeEmailPageObject.navigateToPage();
+    await challengeEmailPageObject.clickEnterCodeLink();
+    await t.wait(15500);
+    await t.expect(challengeEmailPageObject.resendEmailView().hasClass('hide')).notOk();
+    const resendEmailView = challengeEmailPageObject.resendEmailView();
+    await t.expect(resendEmailView.innerText).eql('Haven\'t received an email? Send again');
+  });
+
+test
   .requestHooks(magicLinkReturnTabMock)('challenge email factor with magic link', async t => {
     await setup(t);
     const terminalPageObject = new TerminalPageObject(t);

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -496,6 +496,20 @@ test
   });
 
 test
+  .requestHooks(logger, smsPrimaryMock)('Callout appears after 30 seconds at most even after re-render', async t => {
+    const challengePhonePageObject = await setup(t);
+    await challengePhonePageObject.clickNextButton();
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();
+    await t.wait(15000);
+    challengePhonePageObject.navigateToPage();
+    await challengePhonePageObject.clickNextButton();
+    await t.wait(15500);
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).notOk();
+    const resendEmailView = challengePhonePageObject.resendEmailView();
+    await t.expect(resendEmailView.innerText).eql('Haven\'t received an SMS? Send again');
+  });
+
+test
   .requestHooks(logger, ratelimitReachedMock)('Voice ratelimit error followed by primary button click will send correct request body', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickSecondaryLink();

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -145,3 +145,14 @@ test
     await t.expect(lastRequestMethod).eql('post');
     await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
   });
+
+test
+  .requestHooks(logger, validOTPmock)('resend after 30 seconds at most even after re-render', async t => {
+    const enrollEmailPageObject = await setup(t);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.wait(15000);
+    enrollEmailPageObject.navigateToPage();
+    await t.wait(15500);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
+    await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+  });

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -167,3 +167,17 @@ test
     const resendEmailView = challengePhonePageObject.resendEmailView();
     await t.expect(resendEmailView.innerText).eql('Haven\'t received a call? Call again');
   });
+
+test
+  .requestHooks(smsMock)('Callout appears after 30 seconds at most even after re-render', async t => {
+    const challengePhonePageObject = await setup(t);
+    await challengePhonePageObject.clickNextButton();
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();
+    await t.wait(15000);
+    challengePhonePageObject.navigateToPage();
+    await challengePhonePageObject.clickNextButton();
+    await t.wait(15500);
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).notOk();
+    const resendEmailView = challengePhonePageObject.resendEmailView();
+    await t.expect(resendEmailView.innerText).eql('Haven\'t received an SMS? Send again');
+  });


### PR DESCRIPTION
## Description:
- Updating Resend Views to use a global timer so that even if a SIW re-render occurs, at most the user will wait for 30s until they see the resend link.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/77295104/131181926-a509415a-6809-4559-af7c-e71495c9e8d5.mov

### Reviewers:

### Issue:

- [OKTA-412691](https://oktainc.atlassian.net/browse/OKTA-412691)



