### PR TITLE
Fix res.session is not defined in success callback when STATE_TOKEN_ALL_FLOWS is enabled

### DIFF
--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -320,6 +320,9 @@ function handleSuccessResponseStatus(router, res) {
       successData.next = function() {
         redirectFn(nextUrl);
       };
+    } else {
+      // Add the type for now until the API returns it.
+      successData.type = Enums.SESSION_SSO;
     }
 
     if (res.sessionToken) {

--- a/test/unit/helpers/xhr/SUCCESS_with_STAF.js
+++ b/test/unit/helpers/xhr/SUCCESS_with_STAF.js
@@ -1,0 +1,31 @@
+export default {
+  status: 200,
+  responseType: 'json',
+  response: {
+    expiresAt: '2015-08-05T14:10:54.000Z',
+    status: 'SUCCESS',
+    sessionToken: 'THE_SESSION_TOKEN',
+    stateToken: 'THE_STATE_TOKEN',
+    _embedded: {
+      user: {
+        id: '00ui0jgywTAHxYGMM0g3',
+        profile: {
+          login: 'administrator1@clouditude.net',
+          firstName: 'Add-Min',
+          lastName: "O'Cloudy Tud",
+          locale: 'en_US',
+          timeZone: 'America\/Los_Angeles',
+        },
+      },
+    },
+    _links: {
+      next: {
+        href: 'http://foo.okta.com/login/token/redirect?stateToken=aStateToken',
+        name: 'original',
+        hints: {
+          allow: ['GET'],
+        },
+      },
+    },
+  },
+};

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -22,6 +22,7 @@ import resRecovery from 'helpers/xhr/RECOVERY';
 import resSuccess from 'helpers/xhr/SUCCESS';
 import resSuccessNext from 'helpers/xhr/SUCCESS_next';
 import resSuccessOriginal from 'helpers/xhr/SUCCESS_original';
+import resSuccessWithSTAF from 'helpers/xhr/SUCCESS_with_STAF';
 import resSuccessStepUp from 'helpers/xhr/SUCCESS_session_step_up';
 import resUnauthenticated from 'helpers/xhr/UNAUTHENTICATED';
 import labelsCountryJa from 'helpers/xhr/labels_country_ja';
@@ -613,6 +614,50 @@ Expect.describe('LoginRouter', function() {
         .then(function() {
           expect(WidgetUtil.redirectWithFormGet).toHaveBeenCalledWith(
             'http://foo.okta.com/next/redirect?stateToken=aStateToken'
+          );
+        });
+    }
+  );
+  itp(
+    'for success with session token and next link, success callback data contains a next function and session object that implements setCookieAndRedirect function (when STATE_TOKEN_ALL_FLOWS is enabled)',
+    function() {
+      const spied = {};
+      spied.successFn = function(resp) {
+        if (resp.status === 'SUCCESS') {
+          if (resp.session) {
+            resp.session.setCookieAndRedirect('http://baz.com/foo');
+          }
+          if (resp.next) {
+            resp.next();
+          }
+        }
+      };
+      const successSpy = spyOn(spied, 'successFn').and.callThrough();
+      spyOn(SharedUtil, 'redirect');
+      const opt = {
+        stateToken: 'aStateToken',
+        globalSuccessFn: successSpy,
+      };
+
+      return setup(opt, resSuccessWithSTAF)
+        .then(function(test) {
+          test.setNextResponse(resSuccessWithSTAF);
+          test.router.refreshAuthState('dummy-token');
+          return Expect.waitForSpyCall(successSpy);
+        })
+        .then(function() {
+          const res = successSpy.calls.mostRecent().args[0];
+          expect(res.status).toBe('SUCCESS');
+          expect(res.session.token).toBe('THE_SESSION_TOKEN');
+          expect(_.isFunction(res.session.setCookieAndRedirect)).toBe(true);
+          expect(_.isFunction(res.next)).toBe(true);
+
+          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+            'https://foo.com/login/sessionCookieRedirect?checkAccountSetupComplete=true' +
+              '&token=THE_SESSION_TOKEN&redirectUrl=http%3A%2F%2Fbaz.com%2Ffoo'
+          );
+          expect(SharedUtil.redirect).toHaveBeenCalledWith(
+            'http://foo.okta.com/login/token/redirect?stateToken=aStateToken'
           );
         });
     }

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -1,4 +1,4 @@
-/* eslint max-params: [2, 34], max-statements: 0, max-len: [2, 180], camelcase:0 */
+/* eslint max-params: [2, 34], max-statements: 0, max-len: [2, 210], camelcase:0 */
 import { _, $, Backbone, Router, internal } from 'okta';
 import createAuthClient from 'widget/createAuthClient';
 import LoginRouter from 'LoginRouter';


### PR DESCRIPTION
## Description:

With ff `STATE_TOKEN_ALL_FLOWS`  enabled in the org, while the `/authn` call DOES return a `sessionToken`, a session object is not created and `res.session.setCookieAndRedirect` throws the following error in renderEl: `Uncaught TypeError: Cannot read property 'setCookieAndRedirect' of undefined.`

Reason: response contains `_links.next` AND `sessionToken`.  Current code only processes link and ignores sessionToken

Last PR that edited affected code: https://github.com/okta/okta-signin-widget/pull/619

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

GH Issue: https://github.com/okta/okta-signin-widget/issue/901

- [OKTA-260472](https://oktainc.atlassian.net/browse/OKTA-260472)
- [OKTA-357746](https://oktainc.atlassian.net/browse/OKTA-357746) (related, has issue description and repro steps)
- [OKTA-256599](https://oktainc.atlassian.net/browse/OKTA-256599) (related)
