### PR TITLE
feat: hooks

### DIFF
--- a/.widgetrc.sample.js
+++ b/.widgetrc.sample.js
@@ -1,3 +1,16 @@
+function createDummyHook(name, waitTimeMs) {
+  // Hook functions receive no parameters. They may return a promise but the value is not used.
+  return function() {
+    console.log('hook started: ' + name);
+    return new Promise(resolve => {
+      setTimeout(() => {
+        console.log('hook finished: ' + name);
+        resolve();
+      }, waitTimeMs);
+    });
+  };
+}
+
 module.exports = {
   baseUrl: 'http://localhost:3000',
   logo: '/img/logo_widgico.png',
@@ -14,5 +27,18 @@ module.exports = {
   // Host the assets (i.e. json files) locally
   assets: {
     baseUrl: '/'
+  },
+  // Hooks block processing and run custom logic before or after a form is rendered
+  hooks: {
+    'identify': {
+      after: [
+        // createDummyHook('after-identify', 0)
+      ]
+    },
+    'success-redirect': {
+      before: [
+        // createDummyHook('before-success-redirect',  1000)
+      ]
+    }
   }
 };

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
   - [on](#on)
   - [off](#off)
   - [authClient](#authclient)
+  - [before](#before)
+  - [after](#after)
 - [Configuration](#configuration)
   - [OIDC Applications](#oidc-applications)
   - [Basic config options](#basic-config-options)
@@ -87,6 +89,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
   - [Smart Card IdP](#smart-card-idp)
   - [Bootstrapping from a recovery token](#bootstrapping-from-a-recovery-token)
   - [Feature flags](#feature-flags)
+  - [Hooks](#hooks)
 - [Events](#events)
   - [ready](#ready)
   - [afterError](#aftererror)
@@ -627,6 +630,50 @@ var config = {
 
 var signIn = new OktaSignIn(config);
 // signIn.authClient.options.clientId === '{yourClientId}'
+```
+
+### before
+
+> **Note**: This function is only supported when using the Okta Identity Engine
+
+Adds an asynchronous hook function which will execute before a view is rendered.
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authParams: {
+    issuer: 'https://{yourOktaDomain}/oauth2/default',
+    clientId: '{yourClientId}'  
+  },
+  useInteractionCodeFlow: true
+};
+var signIn = new OktaSignIn(config);
+signIn.before('success-redirect', async () => {
+  // custom logic can go here. when the function resolves, execution will continue.
+});
+
+```
+
+### after
+
+> **Note**: This function is only supported when using the Okta Identity Engine
+
+Adds an asynchronous hook function which will execute after a view is rendered.
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authParams: {
+    issuer: 'https://{yourOktaDomain}/oauth2/default',
+    clientId: '{yourClientId}'  
+  },
+  useInteractionCodeFlow: true
+};
+var signIn = new OktaSignIn(config);
+signIn.after('identify', async () => {
+  // custom logic can go here. when the function resolves, execution will continue.
+});
+
 ```
 
 ## Configuration
@@ -1464,6 +1511,44 @@ features: {
 - **features.showPasswordToggleOnSignInPage** - End users can now toggle visibility of their password on the Okta Sign-In page, allowing end users to check their password before they click Sign In. This helps prevent account lock outs caused by end users exceeding your org's permitted number of failed sign-in attempts. Note that passwords are visible for 30 seconds and then hidden automatically. Defaults to `false`.
 
 - **features.scrollOnError** - By default, errors will be scrolled into view. Set to `false` to disable this behavior.
+
+### Hooks
+
+> **Note**: Hooks are only supported when using the Okta Identity Engine
+
+Asynchronous callbacks can be invoked before or after a specific view is rendered. Hook callbacks block processing to run custom logic. Nomal execution will resume after the Promise returned from the callback function resolves.
+
+```javascript
+// Hooks can be added via config
+const config = {
+  hooks: {
+    'identify': {
+      after: [
+        async function afterIdentify() {
+          // custom logic goes here
+        }
+      ]
+    },
+    'success-redirect': {
+      before: [
+        async function afterIdentify() {
+          // custom logic goes here
+        }
+      ]
+    }
+  }
+};
+
+// Hooks can also be added at runtime
+signIn.before('success-redirect', async () => {
+  // custom logic goes here
+});
+
+signIn.after('identify', async () => {
+  // custom logic goes here
+});
+
+```
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 [Custom Authorization Server]: https://developer.okta.com/docs/guides/customize-authz-server/overview/
 [Authorization Server]: https://developer.okta.com/docs/concepts/auth-servers/#which-authorization-server-should-you-use
 [Social Login]: https://developer.okta.com/docs/concepts/social-login/
+[Identity Engine]: https://developer.okta.com/docs/guides/oie-intro/
 <!-- end links -->
 
 <!-- omit in toc -->
@@ -40,6 +41,7 @@ The widget is used on Okta's default signin page to start an Okta SSO session an
 See the [Usage Guide](#usage-guide) for more information on how to get started using the Sign-in Widget.
 
 <!-- TOC is generated using Markdown All in One -->
+- [Okta Identity Engine](#okta-identity-engine)
 - [Related SDKs](#related-sdks)
   - [Javascript](#javascript)
   - [Java](#java)
@@ -101,6 +103,10 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
   - [Utilizing Pseudo-loc](#utilizing-pseudo-loc)
 - [Browser support](#browser-support)
 - [Contributing](#contributing)
+
+## Okta Identity Engine
+
+The Okta [Identity Engine][] (OIE) is a platform service that allows enterprises to build more flexible access experiences that are tailored to their organizational needs. The Okta Sign-in Widget supports OIE in all [usage](#usage-guide) scenarios.
 
 ## Related SDKs
 
@@ -174,6 +180,8 @@ For a completely seamless experience, which also allows for the highest level of
 Using an embedded widget, client-side web and native apps can avoid the round-trip redirect of the [hosted flow][]. An embedded widget is able to perform the [OIDC][] flow and return [OAuth][] tokens directly within the application. See [showSignInToGetTokens](#showsignintogettokens).
 
 Server-side web applications using the [authorization code flow][] will complete the [OIDC][] flow and receive [OAuth][] tokens on the server, so they **must use a redirect flow**. These apps should use [showSignInAndRedirect](#showsigninandredirect).
+
+Organizations using the Okta [Identity Engine][] should follow the [interaction code flow](#interaction-code-flow).
 
 You can embed the Sign-In Widget in your app either by including a script from the Okta CDN or by bundling the npm module [@okta/okta-signin-widget](https://www.npmjs.com/package/@okta/okta-signin-widget) with your app.
 
@@ -387,7 +395,7 @@ signIn.renderEl({
 
 ### Interaction Code Flow
 
-Support for the interaction code grant is available for organizations with the Identity Engine feature enabled. Please visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details.
+Support for the interaction code grant is available for organizations with the [Identity Engine](#okta-identity-engine) feature enabled. Please visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details.
 
 Documentation for configuring the Okta Sign-in Widget for the interaction code grant is [available here]('./docs/interaction_code_flow.md').
 
@@ -634,9 +642,9 @@ var signIn = new OktaSignIn(config);
 
 ### before
 
-> **Note**: This function is only supported when using the Okta Identity Engine
+> **Note**: This function is only supported when using the [Okta Identity Engine](#okta-identity-engine)
 
-Adds an asynchronous hook function which will execute before a view is rendered.
+Adds an asynchronous [hook](#hooks) function which will execute before a view is rendered.
 
 ```javascript
 var config = {
@@ -656,9 +664,9 @@ signIn.before('success-redirect', async () => {
 
 ### after
 
-> **Note**: This function is only supported when using the Okta Identity Engine
+> **Note**: This function is only supported when using the [Okta Identity Engine](#okta-identity-engine)
 
-Adds an asynchronous hook function which will execute after a view is rendered.
+Adds an asynchronous [hook](#hooks) function which will execute after a view is rendered.
 
 ```javascript
 var config = {
@@ -1514,9 +1522,9 @@ features: {
 
 ### Hooks
 
-> **Note**: Hooks are only supported when using the Okta Identity Engine
+> **Note**: Hooks are only supported when using the [Okta Identity Engine](#okta-identity-engine)
 
-Asynchronous callbacks can be invoked before or after a specific view is rendered. Hook callbacks block processing to run custom logic. Nomal execution will resume after the Promise returned from the callback function resolves.
+Asynchronous callbacks can be invoked before or after a specific view is rendered. Hooks can be used to add custom logic such as tracking, logging, or additional user input. Normal execution is blocked while the hooks is executing and will resume after the Promise returned from the hook function resolves. Hooks can be added via config, as shown below, or at runtime using the [before](#before) or [after](#after) methods. The full list of views can be found in [RemediationConstants.js](https://github.com/okta/okta-signin-widget/blob/master/src/v2/ion/RemediationConstants.js#L19).
 
 ```javascript
 // Hooks can be added via config

--- a/docs/interaction_code_flow.md
+++ b/docs/interaction_code_flow.md
@@ -4,6 +4,9 @@
 
 - [Setup](#setup)
 - [Getting started](#getting-started)
+- [API Reference](#api-reference)
+  - [before](#before)
+  - [after](#after)
 - [Configuration options](#configuration-options)
   - [Brand](#brand)
     - [logo](#logo)
@@ -28,12 +31,13 @@
       - [helpLinks.unlock](#helplinksunlock)
       - [helpLinks.custom](#helplinkscustom)
   - [Hooks](#hooks)
+  - [Username and password](#username-and-password)
     - [transformUsername](#transformusername)
-    - [Registration hooks](#registration-hooks)
-      - [parseSchema](#parseschema)
-      - [preSubmit](#presubmit)
-      - [postSubmit](#postsubmit)
-    - [Handling registration hook errors](#handling-registration-hook-errors)
+  - [Registration](#registration)
+    - [parseSchema](#parseschema)
+    - [preSubmit](#presubmit)
+    - [postSubmit](#postsubmit)
+    - [Handling registration callback errors](#handling-registration-callback-errors)
       - [Use the default error](#use-the-default-error)
       - [Display a form error](#display-a-form-error)
       - [Display a form field error](#display-a-form-field-error)
@@ -53,14 +57,59 @@ To begin using the Interaction code flow in the Okta Sign-In Widget follow this 
 
 ## Getting started
 
-The only configuration required to initialize the Okta Sign-In Widget is the `baseUrl`.
+Interaction code flow extends OIDC flow with PKCE. You should provide the OIDC configuration for your app, including `redirectUri` and `clientId` as shown below. Additionally, the `useInteractionCodeFlow` option should be set to `true`.
 
 ```javascript
-const signIn = new OktaSignIn(
+var signIn = new OktaSignIn(
   {
     baseUrl: 'https://{yourOktaDomain}',
+    clientId: '{{clientId of your OIDC app}}',
+    redirectUri: '{{redirectUri configured in OIDC app}}',
+    useInteractionCodeFlow: true
   }
 );
+```
+
+## API Reference
+
+### before
+
+Adds an asynchronous [hook](#hooks) function which will execute before a view is rendered.
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authParams: {
+    issuer: 'https://{yourOktaDomain}/oauth2/default',
+    clientId: '{yourClientId}'  
+  },
+  useInteractionCodeFlow: true
+};
+var signIn = new OktaSignIn(config);
+signIn.before('success-redirect', async () => {
+  // custom logic can go here. when the function resolves, execution will continue.
+});
+
+```
+
+### after
+
+Adds an asynchronous [hook](#hooks) function which will execute after a view is rendered.
+
+```javascript
+var config = {
+  baseUrl: 'https://{yourOktaDomain}',
+  authParams: {
+    issuer: 'https://{yourOktaDomain}/oauth2/default',
+    clientId: '{yourClientId}'  
+  },
+  useInteractionCodeFlow: true
+};
+var signIn = new OktaSignIn(config);
+signIn.after('identify', async () => {
+  // custom logic can go here. when the function resolves, execution will continue.
+});
+
 ```
 
 ## Configuration options
@@ -171,7 +220,7 @@ Set the default countryCode of the widget. If no `defaultCountryCode` is provide
 
 #### i18n
 
-Override the text in the widget. The full list of properties can be found in the [login.properties](packages/@okta/i18n/src/properties/login.properties) and [country.properties](packages/@okta/i18n/src/properties/country.properties) files.
+Override the text in the widget. The full list of properties can be found in the [login.properties](../packages/@okta/i18n/src/properties/login.properties) and [country.properties](../packages/@okta/i18n/src/properties/country.properties) files.
 
   ```javascript
   // The i18n object maps language codes to a hash of property keys ->
@@ -309,7 +358,7 @@ Array of custom link objects `{text, href, target}` that will be added to the *"
 
 ### Hooks
 
-Asynchronous callbacks can be invoked before or after a specific view is rendered. Hook callbacks block processing to run custom logic. Nomal execution will resume after the Promise returned from the callback function resolves.
+Asynchronous callbacks can be invoked before or after a specific view is rendered. Hooks can be used to add custom logic such as tracking, logging, or additional user input. Normal execution is blocked while the hooks is executing and will resume after the Promise returned from the hook function resolves. Hooks can be added via config, as shown below, or at runtime using the [before](#before) or [after](#after) methods. The full list of views can be found in [RemediationConstants.js](https://github.com/okta/okta-signin-widget/blob/master/src/v2/ion/RemediationConstants.js#L19).
 
 ```javascript
 // Hooks can be set in config
@@ -341,6 +390,8 @@ signIn.after('identify', async () => {
 
 ```
 
+### Username and password
+
 #### transformUsername
 
 Transforms the username before sending requests with the username to Okta. This is useful when you have an internal mapping between what the user enters and their Okta username.
@@ -361,9 +412,9 @@ Transforms the username before sending requests with the username to Okta. This 
   }
   ```
 
-#### Registration hooks
+### Registration
 
-Hook into registration events.
+Callback functions can be provided which will be called at specific moments in the registration process.
 
 ```javascript
   registration: {
@@ -382,7 +433,7 @@ Hook into registration events.
   },
 ```
 
-##### parseSchema
+#### parseSchema
 
 Callback used to change the JSON schema that comes back from the Okta API.
 
@@ -404,7 +455,7 @@ Callback used to change the JSON schema that comes back from the Okta API.
   }
   ```
 
-##### preSubmit
+#### preSubmit
 
 Callback used primarily to modify the request parameters sent to the Okta API.
 
@@ -420,7 +471,7 @@ Callback used primarily to modify the request parameters sent to the Okta API.
     }
   ```
 
-##### postSubmit
+#### postSubmit
 
 Callback used to primarily get control and to modify the behavior post submission to registration API.
 
@@ -432,7 +483,7 @@ Callback used to primarily get control and to modify the behavior post submissio
   }
 ```
 
-#### Handling registration hook errors
+#### Handling registration callback errors
 
 - **onFailure and ErrorObject:** The onFailure callback accepts an error object that can be used to show a form level vs field level error on the registration form.
 

--- a/docs/interaction_code_flow.md
+++ b/docs/interaction_code_flow.md
@@ -45,6 +45,7 @@
   - [Feature flags](#feature-flags)
     - [features.showPasswordToggleOnSignInPage](#featuresshowpasswordtoggleonsigninpage)
     - [features.hideSignOutLinkInMFA](#featureshidesignoutlinkinmfa)
+    - [features.rememberMe](#featuresrememberme)
 
 ## Setup
 
@@ -307,6 +308,38 @@ Custom link href for the "Unlock Account" link. For this link to display, `featu
 Array of custom link objects `{text, href, target}` that will be added to the *"Need help signing in?"* section. The `target` of the link is optional.
 
 ### Hooks
+
+Asynchronous callbacks can be invoked before or after a specific view is rendered. Hook callbacks block processing to run custom logic. Nomal execution will resume after the Promise returned from the callback function resolves.
+
+```javascript
+// Hooks can be set in config
+hooks: {
+  'identify': {
+    after: [
+      async function afterIdentify() {
+        // custom logic goes here
+      }
+    ]
+  },
+  'success-redirect': {
+    before: [
+      async function afterIdentify() {
+        // custom logic goes here
+      }
+    ]
+  }
+}
+
+// Hooks can also be added at runtime
+signIn.before('success-redirect', async () => {
+  // custom logic goes here
+});
+
+signIn.after('identify', async () => {
+  // custom logic goes here
+});
+
+```
 
 #### transformUsername
 

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -211,6 +211,10 @@ export default Model.extend({
     this.unset('lastFailedChallengeFactorData');
   },
 
+  getUser: function() {
+    return this.get('user');
+  },
+
   derived: {
     isSuccessResponse: {
       deps: ['lastAuthResponse'],

--- a/src/models/Hooks.js
+++ b/src/models/Hooks.js
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) 2015-2016, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Model } from 'okta';
+import { mergeHook } from 'util/Hooks';
+
+export default Model.extend({
+
+  mergeHook: function(formName, hookToMerge) {
+    const hooks = this.get('hooks') || {};
+    mergeHook(hooks, formName, hookToMerge);
+    this.set('hooks', hooks);
+  },
+
+  getHook: function(formName) {
+    const hooks = this.get('hooks') || {};
+    return hooks[formName]; // may be undefined
+  }
+  
+});

--- a/src/models/Settings.js
+++ b/src/models/Settings.js
@@ -52,6 +52,7 @@ export default Model.extend({
     globalSuccessFn: 'function',
     globalErrorFn: 'function',
     processCreds: 'function',
+    hooks: 'object',
 
     // IMAGES
     logo: 'string',
@@ -529,4 +530,5 @@ export default Model.extend({
   isDsTheme: function() {
     return false;
   },
+
 });

--- a/src/util/Hooks.js
+++ b/src/util/Hooks.js
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+export async function executeHookFunctions(functions) {
+  for (let i = 0; i < functions.length; i++) {
+    await functions[i]();
+  }
+}
+
+export async function executeHooksBefore(hook) {
+  if (!hook || !hook.before || !hook.before.length) {
+    return;
+  }
+  await executeHookFunctions(hook.before);
+}
+
+export async function executeHooksAfter(hook) {
+  if (!hook || !hook.after || !hook.after.length) {
+    return;
+  }
+  await executeHookFunctions(hook.after);
+}
+
+export function mergeHook(hooks, formName, hookToMerge) {
+  const existingHook = hooks[formName] = hooks[formName] || { before: [], after: [] };
+  if (hookToMerge.before) {
+    existingHook.before = existingHook.before.concat(hookToMerge.before);
+  }
+  if (hookToMerge.after) {
+    existingHook.after = existingHook.after.concat(hookToMerge.after);
+  }
+}

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -51,7 +51,7 @@ export default Router.extend({
       };
     }
 
-    this.settings = new Settings(_.omit(options, 'el', 'authClient'), { parse: true });
+    this.settings = new Settings(_.omit(options, 'el', 'authClient', 'hooks'), { parse: true });
     this.settings.setAuthClient(options.authClient);
 
     if (!options.el) {
@@ -66,6 +66,7 @@ export default Router.extend({
       // and then the open tooltip will lose focus and close.
     });
 
+    this.hooks = options.hooks;
     this.appState = new AppState();
 
     const wrapper = new AuthContainer({ appState: this.appState });
@@ -84,7 +85,7 @@ export default Router.extend({
     this.listenTo(this.appState, 'restartLoginFlow', this.restartLoginFlow);
   },
 
-  handleUpdateAppState(idxResponse) {
+  async handleUpdateAppState(idxResponse) {
     // Only update the cookie when the user has successfully authenticated themselves 
     // to avoid incorrect/uneccessary updates.
     if (this.hasAuthenticationSucceeded(idxResponse) 
@@ -125,7 +126,7 @@ export default Router.extend({
     // transform response
     const ionResponse = transformIdxResponse(this.settings, idxResponse, lastResponse);
 
-    this.appState.setIonResponse(ionResponse);
+    await this.appState.setIonResponse(ionResponse, this.hooks);
   },
 
   handleIdxResponseFailure(error = {}) {

--- a/src/widget/createRouter.js
+++ b/src/widget/createRouter.js
@@ -1,12 +1,13 @@
 import { $ } from 'okta';
 import Enums from 'util/Enums';
 
-export default function createRouter(Router, widgetOptions, renderOptions, authClient, successFn, errorFn) {
+export default function createRouter(Router, widgetOptions, renderOptions, authClient, successFn, errorFn, hooks) {
   let router;
   let routerOptions;
   const promise = new Promise((resolve, reject) => {
     routerOptions = $.extend(true, {}, widgetOptions, renderOptions, {
       authClient,
+      hooks,
       globalSuccessFn: (res) => {
         successFn && successFn(res); // call success function if provided
         if (res && res.status === Enums.SUCCESS) {

--- a/test/e2e/conf.js
+++ b/test/e2e/conf.js
@@ -84,7 +84,7 @@ if (process.env.TRAVIS  || process.env.CHROME_HEADLESS) {
 // WIDGET_BASIC_USER
 // WIDGET_BASIC_PASSWORD
 else {
-  const webdriverManagerConfig = require('webdriver-manager/selenium/update-config.json');
+  const webdriverManagerConfig = require('protractor/node_modules/webdriver-manager/selenium/update-config.json');
 
   config.directConnect = true;
   config.chromeDriver = webdriverManagerConfig.chrome.last;

--- a/test/testcafe/spec/SessionStorage_spec.js
+++ b/test/testcafe/spec/SessionStorage_spec.js
@@ -330,7 +330,7 @@ test.requestHooks(identifyChallengeMock)('shall back to sign-in and authenticate
   await challengeEmailPageObject.clickEnterCodeLink();
   await challengeEmailPageObject.verifyFactor('credentials.passcode', '1234');
   await challengeEmailPageObject.clickNextButton();
-  
+
   // Check success
   await checkConsoleMessages([
     'ready',
@@ -345,11 +345,6 @@ test.requestHooks(identifyChallengeMock)('shall back to sign-in and authenticate
       formName: 'challenge-authenticator',
       authenticatorKey: 'okta_email',
       methodType: 'email'
-    },
-    'afterRender',
-    {
-      controller: 'primary-auth',
-      formName: 'identify'
     },
     'afterRender',
     {

--- a/test/unit/spec/Hooks_spec.js
+++ b/test/unit/spec/Hooks_spec.js
@@ -1,0 +1,206 @@
+import Hooks from 'models/Hooks';
+import { mergeHook, executeHookFunctions, executeHooksBefore, executeHooksAfter } from 'util/Hooks';
+
+describe('Hooks', () => {
+  let testContext;
+  
+  beforeEach(() => {
+    testContext = {};
+  });
+
+  function createDummyHook(callback, failWithError) {
+    // Hook functions receive no parameters. They may return a promise but the value is not used.
+    return jest.fn().mockImplementation(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          callback();
+          failWithError ? reject(failWithError) : resolve();
+        }, 1);
+      });
+    });
+  }
+
+  function flushPromises() {
+    return new Promise(res => process.nextTick(res));
+  }
+
+  describe('Hooks model', () => {
+    beforeEach(() => {
+      const hooks = new Hooks();
+      testContext = {
+        hooks
+      };
+    });
+
+    describe('mergeHook', () => {
+      it('will set "hooks" data', () => {
+        expect(testContext.hooks.get('hooks')).toBeUndefined();
+        const mockHook = { before: [jest.fn()], after: [jest.fn()] };
+        testContext.hooks.mergeHook('some-form', mockHook);
+        expect(testContext.hooks.get('hooks')).toEqual({
+          'some-form': mockHook
+        });
+      });
+    });
+  
+    describe('getHook', () => {
+      it('returrns undefined by default', () => {
+        expect(testContext.hooks.get('hooks')).toBeUndefined();
+        expect(testContext.hooks.getHook('some-form')).toBeUndefined();
+      });
+      it('returrns undefined if a hook has not been set for a given formName', () => {
+        const mockHook = { before: [jest.fn()], after: [jest.fn()] };
+        testContext.hooks.set('hooks', {
+          'some-form': mockHook
+        });
+        expect(testContext.hooks.getHook('another-form')).toBeUndefined();
+      });
+      it('returns a value if it exists', () => {
+        const mockHook = { before: [jest.fn()], after: [jest.fn()] };
+        testContext.hooks.set('hooks', {
+          'some-form': mockHook
+        });
+        expect(testContext.hooks.getHook('some-form')).toEqual(mockHook);
+      });
+    });
+  });
+
+  describe('Hooks util', () => {
+    beforeEach(() => {
+      const hooks = {};
+      const beforeFn = jest.fn();
+      const afterFn = jest.fn();
+      const mockHook = { before: [beforeFn], after: [afterFn] };
+      testContext = {
+        hooks,
+        beforeFn,
+        afterFn,
+        mockHook
+      };
+      jest.useRealTimers();
+    });
+    describe('mergeHook', () => {
+      it('adds the hook if it does not already exist', () => {
+        const { hooks, mockHook, beforeFn, afterFn } = testContext;
+        mergeHook(hooks, 'some-form', mockHook);
+        expect(hooks['some-form']).toEqual(mockHook);
+        expect(hooks['some-form'].before[0]).toBe(beforeFn);
+        expect(hooks['some-form'].after[0]).toBe(afterFn);
+      });
+      it('concats before and after arrays for an existing hook', () => {
+        const { hooks, mockHook, beforeFn, afterFn } = testContext;
+        const existingBefore = jest.fn();
+        const existingAfter = jest.fn();
+        hooks['some-form'] = {
+          before: [existingBefore],
+          after: [existingAfter]
+        };
+        mergeHook(hooks, 'some-form', mockHook);
+        expect(hooks['some-form'].before[0]).toBe(existingBefore);
+        expect(hooks['some-form'].after[0]).toBe(existingAfter);
+        expect(hooks['some-form'].before[1]).toBe(beforeFn);
+        expect(hooks['some-form'].after[1]).toBe(afterFn);
+      });
+    });
+
+    describe('executeHookFunctions', () => {
+      it('executes functions in order', async () => {
+        jest.useFakeTimers();
+        const callback1 = jest.fn();
+        const fn1 = createDummyHook(callback1);
+        const callback2 = jest.fn();
+        const fn2 = createDummyHook(callback2);
+        executeHookFunctions([fn1, fn2]);
+        expect(fn1).toHaveBeenCalled();
+        expect(callback1).not.toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback1).toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        await flushPromises();
+        expect(fn2).toHaveBeenCalled();
+        expect(callback2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback2).toHaveBeenCalled();
+      });
+      it('does not catch exceptions thrown from async functions', async () => {
+        const error = new Error('mock error');
+        const callback1 = jest.fn();
+        const fn1 = createDummyHook(callback1, error);
+        const callback2 = jest.fn();
+        const fn2 = createDummyHook(callback2);
+        let errorThrown = false;
+        try {
+          await executeHookFunctions([fn1, fn2]);
+        } catch (e) {
+          expect(e).toBe(error);
+          errorThrown = true;
+        }
+        expect(errorThrown).toBe(true);
+        expect(fn1).toHaveBeenCalled();
+        expect(callback1).toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('executeHooksBefore', () => {
+      it('does not throw if no hook was passed', () => {
+        expect(executeHooksBefore).not.toThrow();
+      });
+      it('does not throw if a hook with no before section was passed', () => {
+        expect(executeHooksBefore.bind(null, {})).not.toThrow();
+      });
+      it('executes before functions in order', async () => {
+        jest.useFakeTimers();
+        const callback1 = jest.fn();
+        const fn1 = createDummyHook(callback1);
+        const callback2 = jest.fn();
+        const fn2 = createDummyHook(callback2);
+        const hook = { before: [fn1, fn2] };
+        executeHooksBefore(hook);
+        expect(fn1).toHaveBeenCalled();
+        expect(callback1).not.toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback1).toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        await flushPromises();
+        expect(fn2).toHaveBeenCalled();
+        expect(callback2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback2).toHaveBeenCalled();
+      });
+    });
+
+    describe('executeHooksAfter', () => {
+      it('does not throw if no hook was passed', () => {
+        expect(executeHooksAfter).not.toThrow();
+      });
+      it('does not throw if a hook with no before section was passed', () => {
+        expect(executeHooksAfter.bind(null, {})).not.toThrow();
+      });
+      it('executes afterr functions in order', async () => {
+        jest.useFakeTimers();
+        const callback1 = jest.fn();
+        const fn1 = createDummyHook(callback1);
+        const callback2 = jest.fn();
+        const fn2 = createDummyHook(callback2);
+        const hook = { after: [fn1, fn2] };
+        executeHooksAfter(hook);
+        expect(fn1).toHaveBeenCalled();
+        expect(callback1).not.toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback1).toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+        await flushPromises();
+        expect(fn2).toHaveBeenCalled();
+        expect(callback2).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(callback2).toHaveBeenCalled();
+      });
+    });
+
+  });
+
+});

--- a/test/unit/spec/Hooks_spec.js
+++ b/test/unit/spec/Hooks_spec.js
@@ -44,11 +44,11 @@ describe('Hooks', () => {
     });
   
     describe('getHook', () => {
-      it('returrns undefined by default', () => {
+      it('returns undefined by default', () => {
         expect(testContext.hooks.get('hooks')).toBeUndefined();
         expect(testContext.hooks.getHook('some-form')).toBeUndefined();
       });
-      it('returrns undefined if a hook has not been set for a given formName', () => {
+      it('returns undefined if a hook has not been set for a given formName', () => {
         const mockHook = { before: [jest.fn()], after: [jest.fn()] };
         testContext.hooks.set('hooks', {
           'some-form': mockHook
@@ -179,7 +179,7 @@ describe('Hooks', () => {
       it('does not throw if a hook with no before section was passed', () => {
         expect(executeHooksAfter.bind(null, {})).not.toThrow();
       });
-      it('executes afterr functions in order', async () => {
+      it('executes after functions in order', async () => {
         jest.useFakeTimers();
         const callback1 = jest.fn();
         const fn1 = createDummyHook(callback1);
@@ -200,7 +200,5 @@ describe('Hooks', () => {
         expect(callback2).toHaveBeenCalled();
       });
     });
-
   });
-
 });

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -9,6 +9,10 @@ import $sandbox from 'sandbox';
 import Logger from 'util/Logger';
 import Widget from 'widget/OktaSignIn';
 import V1Router from 'LoginRouter';
+import V1AppState from 'models/AppState';
+import V2AppState from 'v2/models/AppState';
+import Hooks from 'models/Hooks';
+
 const url = 'https://foo.com';
 const itp = Expect.itp;
 
@@ -65,6 +69,15 @@ Expect.describe('OktaSignIn initialization', function() {
     });
     it('has a remove method', function() {
       expect(signIn.remove).toBeDefined();
+    });
+    it('has a before method', function() {
+      expect(signIn.before).toBeDefined();
+    });
+    it('has an after method', function() {
+      expect(signIn.after).toBeDefined();
+    });
+    it('has a getUser method', function() {
+      expect(signIn.getUser).toBeDefined();
     });
   });
 
@@ -572,4 +585,67 @@ describe('OktaSignIn object API', function() {
     });
   });
 
+  describe('getUser', () => {
+
+    describe('before render', () => {
+      beforeEach(() => {
+        createWidget();
+      });
+      it('returns undefined', () => {
+        expect(signIn.getUser()).toBeUndefined();
+      });
+    });
+
+    describe('after render', () => {
+      beforeEach(() => {
+        createWidget();
+        signIn.renderEl({ el: $sandbox });
+      });
+      it('returns result from appState', () => {
+        const mockUser = { fake: true };
+        jest.spyOn(V1AppState.prototype, 'getUser').mockReturnValue(mockUser);
+        expect(signIn.getUser()).toBe(mockUser);
+
+      });
+    });
+
+    describe('after render v2', () => {
+      beforeEach(() => {
+        createWidget({ stateToken: 'fakeV2Token' });
+        signIn.renderEl({ el: $sandbox });
+      });
+      it('returns result from appState', () => {
+        const mockUser = { fake: true };
+        jest.spyOn(V2AppState.prototype, 'getUser').mockReturnValue(mockUser);
+        expect(signIn.getUser()).toBe(mockUser);
+
+      });
+    });
+  });
+
+  describe('Hooks API', () => {
+    beforeEach(() => {
+      jest.spyOn(Hooks.prototype, 'mergeHook');
+      createWidget();
+    });
+    describe('before()', () => {
+      it('calls mergeHook', () => {
+        const fn = jest.fn();
+        signIn.before('some-form', fn);
+        expect(Hooks.prototype.mergeHook).toHaveBeenCalledWith('some-form', {
+          before: [fn]
+        });
+      });
+    });
+
+    describe('after()', () => {
+      it('calls mergeHook', () => {
+        const fn = jest.fn();
+        signIn.after('some-form', fn);
+        expect(Hooks.prototype.mergeHook).toHaveBeenCalledWith('some-form', {
+          after: [fn]
+        });
+      });
+    });
+  });
 });

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -341,4 +341,12 @@ describe('v2/models/AppState', function() {
       });
     });
   });
+
+  describe('getUser', () => {
+    it('returns the "user" object', () => {
+      const user = { identifier: 'nobody@nowhere', firstName: 'fake', lastName: 'also-fake' };
+      this.initAppState({ user });
+      expect(this.appState.getUser()).toBe(user);
+    });
+  });
 });

--- a/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
@@ -67,11 +67,11 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
   });
 
   it('switches to select enroll method form when on mobile', function(done) {
-    MockUtil.mockIntrospect(done, xhrAuthenticatorEnrollOktaVerifyQr, idxResp => {
+    MockUtil.mockIntrospect(done, xhrAuthenticatorEnrollOktaVerifyQr, async (idxResp) => {
       const appState = new AppState();
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       const ionResponse = transformIdxResponse(settings, idxResp);
-      appState.setIonResponse(ionResponse);
+      await appState.setIonResponse(ionResponse);
       testContext.view = new FormController({
         el: $sandbox,
         appState,


### PR DESCRIPTION
## Description:

async functions can block processing and execute custom logic before or after form render (in OIE).

Hooks functions can be defined and passed via widget config, or at runtime using new methods `before()` and `after()`

New method `getUser` is added to facilitate needed logic for OKTA-422364

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-425549](https://oktainc.atlassian.net/browse/OKTA-425549)


