### PR TITLE
Prevent back link in FastPass loopback view from showing multiple times.

### DIFF
--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -165,23 +165,23 @@ const Footer = BaseFooter.extend({
     if (this.isFallbackApproach()) {
       BaseFooter.prototype.initialize.apply(this, arguments);
     } else {
-      this.add(Link, {
+      this.backLink = this.add(Link, {
         options: {
           name: 'cancel-authenticator-challenge',
           label: loc('loopback.polling.cancel.link', 'login'),
           actionPath: CANCEL_POLLING_ACTION,
         }
-      });
+      }).last();
     }
   },
 
   handleUpdateFooterLink(data) {
     // only update link for loopback
     if (!this.isFallbackApproach()) {
-      this.$el.find('.js-cancel-authenticator-challenge').remove();
-      this.add(Link, {
+      this.backLink && this.backLink.remove();
+      this.backLink = this.add(Link, {
         options: getSignOutLink(this.options.settings, data)[0]
-      });
+      }).last();
     } 
   },
 


### PR DESCRIPTION
## Description:

In loopback polling, when an error is responded, the back link is updated. In a rare case, loopback pollings respond with errors consecutively. To prevent a new back link to be added each time, remove the old back link first. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

![back-link-before](https://user-images.githubusercontent.com/5066836/132543830-7c520763-2d7b-4bb0-855d-9d5208972cea.gif)

![back-link-after](https://user-images.githubusercontent.com/5066836/132543824-d688ffce-1359-4f46-80df-be5ab5f796ca.gif)

### Reviewers:
@yannongli-okta 

### Issue:

- [OKTA-422726](https://oktainc.atlassian.net/browse/OKTA-422726)


