### PR TITLE
fix: Respect message type in introspect.

### DIFF
--- a/assets/sass/v2/_forms.scss
+++ b/assets/sass/v2/_forms.scss
@@ -1,5 +1,6 @@
 .siw-main-view {
-  .infobox-warning {
+  .infobox-warning,
+  .infobox-error {
     display: block;
     margin-bottom: 15px;
   }

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -250,6 +250,18 @@ const emailVerificationMocks = {
 
 
 // ===== IDX
+const fastpassUnassignedApp = {
+  '/idp/idx/introspect': [
+    'error-400-user-not-assigned',
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'error-400-user-not-assigned-2',
+  ],
+  '/idp/idx/identify': [
+    'error-400-user-not-assigned-3',
+  ],
+};
+
 // device probe: Windows authenticator with loopback server
 const windowAuthnLoopback = {
   '/idp/idx/introspect': [

--- a/playground/mocks/data/idp/idx/error-400-user-not-assigned-2.json
+++ b/playground/mocks/data/idp/idx/error-400-user-not-assigned-2.json
@@ -1,0 +1,119 @@
+{
+  "version":"1.0.0",
+  "stateHandle":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+  "expiresAt":"2022-08-26T00:16:52.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"identify",
+        "href":"http://localhost:3000/idp/idx/identify",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"identifier",
+            "label":"Username"
+          },
+          {
+            "name":"rememberMe",
+            "type":"boolean",
+            "label":"Remember this device"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"launch-authenticator",
+        "relatesTo":[
+          "authenticatorChallenge"
+        ],
+        "href":"http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"unlock-account",
+        "href":"http://localhost:3000/idp/idx/unlock-account",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages":{
+    "type":"array",
+    "value":[
+      {
+        "message":"User is not assigned to this application.",
+        "i18n":{
+          "key":"idx.error.user.not.assigned.to.app"
+        },
+        "class":"ERROR"
+      }
+    ]
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "produces":"application/ion+json; okta-version=1.0.0",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+        "visible":false,
+        "mutable":false
+      }
+    ],
+    "accepts":"application/json; okta-version=1.0.0"
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"okta_oktaprise_1",
+      "label":"oktaprise",
+      "id":"0oa14q13b78mZ5dVy1d8"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-400-user-not-assigned-3.json
+++ b/playground/mocks/data/idp/idx/error-400-user-not-assigned-3.json
@@ -1,0 +1,119 @@
+{
+  "version":"1.0.0",
+  "stateHandle":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+  "expiresAt":"2022-08-26T00:16:55.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"identify",
+        "href":"http://localhost:3000/idp/idx/identify",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"identifier",
+            "label":"Username"
+          },
+          {
+            "name":"rememberMe",
+            "type":"boolean",
+            "label":"Remember this device"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"launch-authenticator",
+        "relatesTo":[
+          "authenticatorChallenge"
+        ],
+        "href":"http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"unlock-account",
+        "href":"http://localhost:3000/idp/idx/unlock-account",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages":{
+    "type":"array",
+    "value":[
+      {
+        "message":"User is not assigned to this application.",
+        "i18n":{
+          "key":"idx.error.user.not.assigned.to.app"
+        },
+        "class":"ERROR"
+      }
+    ]
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "produces":"application/ion+json; okta-version=1.0.0",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+        "visible":false,
+        "mutable":false
+      }
+    ],
+    "accepts":"application/json; okta-version=1.0.0"
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"okta_oktaprise_1",
+      "label":"oktaprise",
+      "id":"0oa14q13b78mZ5dVy1d8"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/error-400-user-not-assigned.json
+++ b/playground/mocks/data/idp/idx/error-400-user-not-assigned.json
@@ -1,0 +1,119 @@
+{
+  "version":"1.0.0",
+  "stateHandle":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+  "expiresAt":"2022-08-26T00:16:50.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"identify",
+        "href":"http://localhost:3000/idp/idx/identify",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"identifier",
+            "label":"Username"
+          },
+          {
+            "name":"rememberMe",
+            "type":"boolean",
+            "label":"Remember this device"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"launch-authenticator",
+        "relatesTo":[
+          "authenticatorChallenge"
+        ],
+        "href":"http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"unlock-account",
+        "href":"http://localhost:3000/idp/idx/unlock-account",
+        "method":"POST",
+        "produces":"application/ion+json; okta-version=1.0.0",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages":{
+    "type":"array",
+    "value":[
+      {
+        "message":"User is not assigned to this application.",
+        "i18n":{
+          "key":"idx.error.user.not.assigned.to.app"
+        },
+        "class":"ERROR"
+      }
+    ]
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "produces":"application/ion+json; okta-version=1.0.0",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"02DjWW-aa8tJ1lIspi9pjD44c6N7pXC__J3WWjp_FK",
+        "visible":false,
+        "mutable":false
+      }
+    ],
+    "accepts":"application/json; okta-version=1.0.0"
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"okta_oktaprise_1",
+      "label":"oktaprise",
+      "id":"0oa14q13b78mZ5dVy1d8"
+    }
+  }
+}

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -45,7 +45,9 @@ export default Form.extend({
   },
 
   handleClearFormError() {
-    if (this.$('.o-form-error-container').hasClass('o-form-has-errors')) {
+    const formErrorContainer = this.$('.o-form-error-container');
+    formErrorContainer.empty();
+    if (formErrorContainer.hasClass('o-form-has-errors')) {
       this.clearErrors();
     }
   },

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -91,20 +91,15 @@ const Body = BaseForm.extend({
   },
 
   showMessages() {
-    /**
-     * Renders a warning callout for unknown user flow
-     * Note: Anytime we get back `messages` object along with identify view
-     * we would render it as a warning callout
-     * */
     const messagesObj = this.options.appState.get('messages');
     if (messagesObj?.value.length
         && this.options.appState.get('currentFormName') === 'identify') {
-      const content = messagesObj.value[0].message;
+      const displayMessageObj = messagesObj.value[0];
       const messageCallout = createCallout({
-        content: content,
-        type: 'warning',
+        content: displayMessageObj.message,
+        type: (displayMessageObj.class || '').toLowerCase(),
       });
-      this.add(messageCallout, '.o-form-error-container');
+      this.introspectMessage = this.add(messageCallout, '.o-form-error-container').last();
     }
   },
   /**

--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -1,7 +1,7 @@
 import { Selector } from 'testcafe';
 import BasePageObject from './BasePageObject';
 
-const CALLOUT_SELECTOR = '.infobox-warning > div';
+const CALLOUT_SELECTOR = '[data-se="callout"]';
 const ENROLL_SELECTOR = 'a[data-se="enroll"]';
 const NEEDHELP_SELECTOR = 'a[data-se="help"]';
 const FORGOT_PASSWORD_SELECTOR = 'a[data-se="forgot-password"]';
@@ -116,6 +116,10 @@ export default class IdentityPageObject extends BasePageObject {
 
   hasCallout() {
     return !this.form.getCallout(CALLOUT_SELECTOR);
+  }
+
+  hasUnknownUserErrorCallout() {
+    return this.form.getCallout(CALLOUT_SELECTOR).hasClass('infobox-error');
   }
 
   getUnknownUserCalloutContent() {


### PR DESCRIPTION
## Description:

In the identifier view, when a warning message is displayed, when the next error message is shown, the warning message is not removed. The fix includes:
- remove all the errors and warnings on clear form error
- have identifier view respect the message type in idx response when showing the callout


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Before:
![warning-error-before](https://user-images.githubusercontent.com/5066836/132754852-2c87eb86-dcdc-4d1f-8ed1-0c0ad6bab3cc.gif)

After:
![warning-error-after](https://user-images.githubusercontent.com/5066836/132754863-f6caedf8-f914-4015-bb76-96c76635d9e8.gif)


### Reviewers:
@pradeepdewda-okta 

### Issue:

- [OKTA-422719](https://oktainc.atlassian.net/browse/OKTA-422719)


