### PR TITLE
Pass username as login_hint to OV

### DIFF
--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -14,9 +14,17 @@ import hbs from 'handlebars-inline-precompile';
 import Enums from '../../../util/Enums';
 import Util from '../../../util/Util';
 
+export function appendLoginHint(deviceChallengeUrl, loginHint) {
+  if (deviceChallengeUrl && loginHint) {
+    deviceChallengeUrl += '&login_hint=' + loginHint;
+  }
+
+  return deviceChallengeUrl;
+}
 
 export function doChallenge(view) {
   const deviceChallenge = view.getDeviceChallengePayload();
+  const loginHint = view.options?.settings?.get('identifier');
   switch (deviceChallenge.challengeMethod) {
   case Enums.LOOPBACK_CHALLENGE:
     view.title = loc('deviceTrust.sso.redirectText', 'login');
@@ -62,7 +70,7 @@ export function doChallenge(view) {
         };
       },
     }));
-    view.customURI = deviceChallenge.href;
+    view.customURI = appendLoginHint(deviceChallenge.href, loginHint);
     view.doCustomURI();
     break;
   case Enums.UNIVERSAL_LINK_CHALLENGE:
@@ -80,7 +88,8 @@ export function doChallenge(view) {
       click: () => {
         // only window.location.href can open universal link in iOS/MacOS
         // other methods won't do, ex, AJAX get or form get (Util.redirectWithFormGet)
-        Util.redirect(deviceChallenge.href);
+        let deviceChallengeUrl = appendLoginHint(deviceChallenge.href, loginHint);
+        Util.redirect(deviceChallengeUrl);
       }
     }));
     break;
@@ -98,7 +107,8 @@ export function doChallenge(view) {
       click: () => {
         // only window.location.href can open app link in Android
         // other methods won't do, ex, AJAX get or form get (Util.redirectWithFormGet)
-        Util.redirect(deviceChallenge.href, window, true);
+        let deviceChallengeUrl = appendLoginHint(deviceChallenge.href, loginHint);
+        Util.redirect(deviceChallengeUrl, window, true);
       }
     }));
     break;

--- a/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
+++ b/src/v2/view-builder/views/signin/SignInWithDeviceOption.js
@@ -4,6 +4,7 @@ import Util from '../../../../util/Util';
 import Enums from '../../../../util/Enums';
 import { UNIVERSAL_LINK_POST_DELAY } from '../../utils/Constants';
 import { FORMS } from '../../../ion/RemediationConstants';
+import { appendLoginHint } from '../../utils/ChallengeViewUtil';
 
 export default View.extend({
   className: 'sign-in-with-device-option',
@@ -31,16 +32,22 @@ export default View.extend({
       icon: 'okta-verify-authenticator',
       title: loc('oktaVerify.button', 'login'),
       click() {
+        if (this.settings.get('features.engFastpassMultipleAccounts') && this.model.get('identifier')) {
+          this.options.settings.set('identifier', encodeURIComponent(this.model.get('identifier')));
+        }
+
         const isUVapproach = deviceChallenge?.challengeMethod === Enums.UNIVERSAL_LINK_CHALLENGE;
         if (isUVapproach) {
           // launch the Okta Verify app
-          Util.redirect(deviceChallenge.href);
+          let deviceChallengeUrl = appendLoginHint(deviceChallenge.href, this.options?.settings?.get('identifier'));
+          Util.redirect(deviceChallengeUrl);
         }
 
         const isAppLinkapproach = deviceChallenge?.challengeMethod === Enums.APP_LINK_CHALLENGE;
         if (isAppLinkapproach) {
           // launch the Okta Verify app
-          Util.redirect(deviceChallenge.href, window, true);
+          let deviceChallengeUrl = appendLoginHint(deviceChallenge.href, this.options?.settings?.get('identifier'));
+          Util.redirect(deviceChallengeUrl, window, true);
         }
 
         // OKTA-350084

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -18,6 +18,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-head"]').innerText;
   }
 
+  getIframeAttributes() {
+    return Selector('#custom-uri-container').attributes;
+  }
+
   getContent() {
     return this.getTextContent('[data-se="o-form-fieldset-container"]');
   }


### PR DESCRIPTION
## Description:
Pass the username entered in the SIW to Okta Verify as a URL parameter in CustomURI/UniversalLink/AppLink bindings
The username is used by OV as login_hint to pick up the right account if there are multiple accounts for same org
The change is behind ENG_FASTPASS_MULTIPLE_ACCOUNTS FF

1. Capture the username that user entered on the SIW (local model in localDeviceChallengePollView) into a persistent model
2. Append the username as login_hint to the Universal Link/App Link URL
3. In the next view (SignInWithDeviceOption), retrieve the username from the persistent model, and append it to the CustomURL/Universal Link/App Link URL
4.  Add test cases to validate the loginHint will be correctly appended.

-   expect login_hint in CustomURI when engFastpassMultipleAccounts is on
-   expect login_hint not in CustomURI when engFastpassMultipleAccounts is off
-   expect login_hint in UniversalLink with engFastpassMultipleAccounts on
-   expect login_hint not in UniversalLink engFastpassMultipleAccounts off
-   expect login_hint in AppLink when engFastpassMultipleAccounts is on
-   expect login_hint not in AppLink when engFastpassMultipleAccounts is off

5. We will not pass the login_hint to OV in the factor selection page. After identify transaction, the userId and loginHint will be put into the device challenge token directly. We will have a separate JARA to take care of this use case.
6. Test:
- MacOS: Chrome, Firefox
- Window VM: Chrome, Firefox, Edge
- iPhone X: Chrome, Safari

Bacon: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=yutong-OKTA-424820&page=1&pageSize=6


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-424820](https://oktainc.atlassian.net/browse/OKTA-424820)


