### PR TITLE
Fix swedish translation for login placeholder

### DIFF
--- a/packages/@okta/i18n/src/properties/login_sv.properties
+++ b/packages/@okta/i18n/src/properties/login_sv.properties
@@ -525,8 +525,8 @@ oktaverify.numberchallenge.explain = Det h\u00E4r extra steget bekr\u00E4ftar f\
 
 # Username & Password
 primaryauth.title = Logga in
-primaryauth.username.placeholder = L\u00F6senord
-primaryauth.username.tooltip = L\u00F6senord
+primaryauth.username.placeholder = Anv\u00E4ndarnamn
+primaryauth.username.tooltip = Anv\u00E4ndarnamn
 primaryauth.password.placeholder = L\u00F6senord
 primaryauth.password.tooltip = L\u00F6senord
 primaryauth.submit = Logga in


### PR DESCRIPTION
Fixes incorrect translation for `primaryauth.username` in Swedish
The username is listed as `Lösenord` (which is `Password`) but should be `Användarnamn`.


Copied from https://github.com/okta/okta-signin-widget/pull/2169
Internal ref: [OKTA-418716](https://oktainc.atlassian.net/browse/OKTA-418716)
Resolves https://github.com/okta/okta-signin-widget/issues/2156

