### PR TITLE
Don't show widget until loaded

### DIFF
--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint max-params: [2, 16], max-statements: [2, 18] */
+/* eslint max-params: [2, 16], max-statements: [2, 20] */
 // BaseLoginRouter contains the more complicated router logic - rendering/
 // transition, etc. Most router changes should happen in LoginRouter (which is
 // responsible for adding new routes)

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -201,14 +201,6 @@ export default Router.extend({
       this.el = this.header.render().getContentEl();
     }
 
-    setTimeout(() => {
-      const hasRendered = this.controller && this.controller.constructor === Controller && this.controller.rendered();
-      if (!this.header.isLoadingBeacon() && !hasRendered) {
-        this.show();
-        this.header.setLoadingBeacon(true);
-      }
-    }, 1000);
-
     // If we need to load a language (or apply custom i18n overrides), do
     // this now and re-run render after it's finished.
     if (!Bundles.isLoaded(this.appState.get('languageCode'))) {
@@ -242,8 +234,6 @@ export default Router.extend({
     return this.controller
       .fetchInitialData()
       .then(() => {
-        this.header.removeLoadingBeacon();
-
         // Beacon transition occurs in parallel to page swap
         if (!beaconIsAvailable(Beacon, this.settings)) {
           Beacon = null;

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -113,7 +113,15 @@ export default Router.extend({
       settings: this.settings,
     });
 
+    // Hide until unitial render
     this.hide();
+    // Show if loading state was set to true before initial render
+    // (eg. because of long load of language)
+    this.listenTo(this.appState, 'loading', function(isLoading) {
+      if (isLoading) {
+        this.show();
+      }
+    });
 
     this.listenTo(this.appState, 'change:transactionError', function(appState, err) {
       RouterUtil.routeAfterAuthStatusChangeError(this, err);

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -193,6 +193,14 @@ export default Router.extend({
       this.el = this.header.render().getContentEl();
     }
 
+    setTimeout(() => {
+      const hasRendered = this.controller && this.controller.constructor === Controller && this.controller.rendered();
+      if (!this.header.isLoadingBeacon() && !hasRendered) {
+        this.show();
+        this.header.setLoadingBeacon(true);
+      }
+    }, 1000);
+
     // If we need to load a language (or apply custom i18n overrides), do
     // this now and re-run render after it's finished.
     if (!Bundles.isLoaded(this.appState.get('languageCode'))) {
@@ -226,6 +234,8 @@ export default Router.extend({
     return this.controller
       .fetchInitialData()
       .then(() => {
+        this.header.removeLoadingBeacon();
+
         // Beacon transition occurs in parallel to page swap
         if (!beaconIsAvailable(Beacon, this.settings)) {
           Beacon = null;

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -113,6 +113,8 @@ export default Router.extend({
       settings: this.settings,
     });
 
+    this.hide();
+
     this.listenTo(this.appState, 'change:transactionError', function(appState, err) {
       RouterUtil.routeAfterAuthStatusChangeError(this, err);
     });
@@ -233,6 +235,7 @@ export default Router.extend({
         this.controller.render();
 
         if (!oldController) {
+          this.show();
           this.el.append(this.controller.el);
           this.controller.postRenderAnimation();
           return;

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -115,13 +115,6 @@ export default Router.extend({
 
     // Hide until unitial render
     this.hide();
-    // Show if loading state was set to true before initial render
-    // (eg. because of long load of language)
-    this.listenTo(this.appState, 'loading', function(isLoading) {
-      if (isLoading) {
-        this.show();
-      }
-    });
 
     this.listenTo(this.appState, 'change:transactionError', function(appState, err) {
       RouterUtil.routeAfterAuthStatusChangeError(this, err);

--- a/src/util/BaseLoginRouter.js
+++ b/src/util/BaseLoginRouter.js
@@ -240,10 +240,12 @@ export default Router.extend({
         }
         this.header.setBeacon(Beacon, controllerOptions);
 
+        // Show before initial render
+        this.show();
+
         this.controller.render();
 
         if (!oldController) {
-          this.show();
           this.el.append(this.controller.el);
           this.controller.postRenderAnimation();
           return;

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -219,14 +219,6 @@ export default Router.extend({
       this.el = this.header.render().getContentEl();
     }
 
-    setTimeout(() => {
-      const hasRendered = this.controller && this.controller.constructor === Controller && this.controller.rendered();
-      if (!this.header.isLoadingBeacon() && !hasRendered) {
-        this.show();
-        this.header.setLoadingBeacon(true);
-      }
-    }, 1000);
-
     // If we need to load a language (or apply custom i18n overrides), do
     // this now and re-run render after it's finished.
     if (!Bundles.isLoaded(this.settings.get('languageCode'))) {
@@ -256,8 +248,6 @@ export default Router.extend({
 
       ColorsUtil.addStyle(colors);
     }
-
-    this.header.removeLoadingBeacon();
 
     // render Controller
     this.unload();

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -79,6 +79,8 @@ export default Router.extend({
       settings: this.settings,
     });
 
+    this.hide();
+
     configIdxJsClient(this.appState);
     this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);
     this.listenTo(this.appState, 'remediationError', this.handleIdxResponseFailure);
@@ -252,6 +254,8 @@ export default Router.extend({
     this.listenTo(this.controller, 'all', this.trigger);
 
     this.controller.render();
+
+    this.show();
   },
 
   /**

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -81,13 +81,6 @@ export default Router.extend({
 
     // Hide until unitial render
     this.hide();
-    // Show if loading state was set to true before initial render
-    // (eg. because of long load of language)
-    this.listenTo(this.appState, 'loading', function(isLoading) {
-      if (isLoading) {
-        this.show();
-      }
-    });
 
     configIdxJsClient(this.appState);
     this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -205,7 +205,7 @@ export default Router.extend({
     // }
   },
 
-  /* eslint max-statements: [2, 21] */
+  /* eslint max-statements: [2, 22] */
   render: async function(Controller, options = {}) {
     // If url changes then widget assumes that user's intention was to initiate a new login flow,
     // so clear stored token to use the latest token.

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -79,7 +79,15 @@ export default Router.extend({
       settings: this.settings,
     });
 
+    // Hide until unitial render
     this.hide();
+    // Show if loading state was set to true before initial render
+    // (eg. because of long load of language)
+    this.listenTo(this.appState, 'loading', function(isLoading) {
+      if (isLoading) {
+        this.show();
+      }
+    });
 
     configIdxJsClient(this.appState);
     this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -211,6 +211,14 @@ export default Router.extend({
       this.el = this.header.render().getContentEl();
     }
 
+    setTimeout(() => {
+      const hasRendered = this.controller && this.controller.constructor === Controller && this.controller.rendered();
+      if (!this.header.isLoadingBeacon() && !hasRendered) {
+        this.show();
+        this.header.setLoadingBeacon(true);
+      }
+    }, 1000);
+
     // If we need to load a language (or apply custom i18n overrides), do
     // this now and re-run render after it's finished.
     if (!Bundles.isLoaded(this.settings.get('languageCode'))) {
@@ -240,6 +248,8 @@ export default Router.extend({
 
       ColorsUtil.addStyle(colors);
     }
+
+    this.header.removeLoadingBeacon();
 
     // render Controller
     this.unload();

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -249,6 +249,9 @@ export default Router.extend({
       ColorsUtil.addStyle(colors);
     }
 
+    // Show before initial render
+    this.show();
+
     // render Controller
     this.unload();
     const controllerOptions = _.extend({
@@ -262,8 +265,6 @@ export default Router.extend({
     this.listenTo(this.controller, 'all', this.trigger);
 
     this.controller.render();
-
-    this.show();
   },
 
   /**

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -102,7 +102,7 @@ export default View.extend({
     const container = this.$(selector);
     const transition = typeOfTransition(this.currentBeacon, NextBeacon, options);
     const self = this;
-
+    
     switch (transition) {
     case 'none':
       this.$el.addClass(NO_BEACON_CLS);
@@ -179,6 +179,9 @@ export default View.extend({
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.
   removeLoadingBeacon: function() {
+    if (!isLoadingBeacon(this.currentBeacon)) {
+      return;
+    }
     const self = this;
     const container = this.$('[data-type="beacon-container"]');
 
@@ -188,6 +191,10 @@ export default View.extend({
         container.removeClass(LOADING_BEACON_CLS);
       })
       .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+  },
+
+  isLoadingBeacon: function() {
+    return isLoadingBeacon(this.currentBeacon);
   },
 
   getTemplateData: function() {

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -102,7 +102,7 @@ export default View.extend({
     const container = this.$(selector);
     const transition = typeOfTransition(this.currentBeacon, NextBeacon, options);
     const self = this;
-    
+
     switch (transition) {
     case 'none':
       this.$el.addClass(NO_BEACON_CLS);
@@ -179,9 +179,6 @@ export default View.extend({
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.
   removeLoadingBeacon: function() {
-    if (!isLoadingBeacon(this.currentBeacon)) {
-      return;
-    }
     const self = this;
     const container = this.$('[data-type="beacon-container"]');
 
@@ -191,10 +188,6 @@ export default View.extend({
         container.removeClass(LOADING_BEACON_CLS);
       })
       .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
-  },
-
-  isLoadingBeacon: function() {
-    return isLoadingBeacon(this.currentBeacon);
   },
 
   getTemplateData: function() {

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -2,6 +2,8 @@
 import { _, $, Backbone, Router, internal } from 'okta';
 import createAuthClient from 'widget/createAuthClient';
 import LoginRouter from 'LoginRouter';
+import PrimaryAuthController from 'PrimaryAuthController';
+import SecurityBeacon from 'views/shared/SecurityBeacon';
 import config from 'config/config.json';
 import EnrollCallForm from 'helpers/dom/EnrollCallForm';
 import IDPDiscoveryForm from 'helpers/dom/IDPDiscoveryForm';
@@ -2243,5 +2245,22 @@ Expect.describe('LoginRouter', function() {
         });
       });
     });
+  });
+
+  itp('should not be visible until initial render', async function() {
+    const test = await setup();
+
+    // Should not be visible on init
+    Expect.isNotVisible(test.router.header.$el);
+
+    // Should not be visible until initial data has been loaded
+    spyOn(PrimaryAuthController.prototype, 'fetchInitialData').and.callFake(function() {
+      Expect.isNotVisible(test.router.header.$el);
+      return Promise.resolve();
+    });
+
+    // Should be visible after render
+    await test.router.render(PrimaryAuthController, { Beacon: SecurityBeacon });
+    Expect.isVisible(test.router.header.$el);
   });
 });

--- a/test/unit/spec/LoginRouter_spec.js
+++ b/test/unit/spec/LoginRouter_spec.js
@@ -2262,5 +2262,6 @@ Expect.describe('LoginRouter', function() {
     // Should be visible after render
     await test.router.render(PrimaryAuthController, { Beacon: SecurityBeacon });
     Expect.isVisible(test.router.header.$el);
+    expect(test.afterRenderHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/spec/v2/WidgetRouter_spec.js
+++ b/test/unit/spec/v2/WidgetRouter_spec.js
@@ -1,0 +1,51 @@
+import { _ } from 'okta';
+import WidgetRouter from 'v2/WidgetRouter';
+import FormController from 'v2/controllers/FormController';
+import $sandbox from 'sandbox';
+import createAuthClient from 'widget/createAuthClient';
+
+describe('v2/WidgetRouter', function() {
+  let testContext;
+
+  function setup(settings = {}) {
+    const baseUrl = 'https://foo.com';
+    const authParams = { issuer: baseUrl, headers: {} };
+    Object.keys(settings).forEach(key => {
+      const parts = key.split('.');
+      if (parts[0] === 'authParams') {
+        authParams[parts[1]] = settings[key];
+      }
+    });
+    const authClient = createAuthClient(authParams);
+
+    const router = new WidgetRouter(
+      _.extend(
+        {
+          el: $sandbox,
+          baseUrl: baseUrl,
+          authClient: authClient,
+        },
+        settings
+      )
+    );
+
+    testContext = {
+      router,
+    };
+  }
+
+  beforeEach(function() {
+    testContext = {};
+  });
+
+  afterEach(function() {
+    $sandbox.empty();
+  });
+
+  it('should not be visible until initial render', async function() {
+    setup();
+    expect(testContext.router.header.$el.css('display')).toBe('none');
+    await testContext.router.render(FormController);
+    expect(testContext.router.header.$el.css('display')).toBe('block');
+  });
+});

--- a/test/unit/spec/v2/WidgetRouter_spec.js
+++ b/test/unit/spec/v2/WidgetRouter_spec.js
@@ -12,7 +12,7 @@ describe('v2/WidgetRouter', function() {
   function setup(
     settings = {}, 
     remediations = XHRIdentifyWithPassword.remediation.value,
-    formName = "identify"
+    formName = 'identify'
   ) {
     const baseUrl = 'https://foo.com';
     const authParams = { issuer: baseUrl, headers: {} };
@@ -35,7 +35,7 @@ describe('v2/WidgetRouter', function() {
         settings
       )
     );
-    
+
     router.appState.set('remediations', remediations);
     router.appState.set('currentFormName', formName);
     router.appState.set('idx', {neededToProceed: []});


### PR DESCRIPTION
## Description:

Don't show widget in initial state (blank line w/ or w/o logo) until is ready and rendered. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

Before:

https://user-images.githubusercontent.com/72614880/133684081-3249a56f-33ac-4fec-9bb4-27a87e27417e.mov

After:

https://user-images.githubusercontent.com/72614880/133683195-c48492fe-a81d-40e8-8051-a910eaf0edb9.mov


### Reviewers:

@aarongranick-okta 

### Issue:

- [OKTA-416911](https://oktainc.atlassian.net/browse/OKTA-416911)

### Additional notes


1) To test changes locally uncomment this:
https://github.com/okta/okta-signin-widget/blob/8d9bbd5ff0e257e1391b3047750e02ee9b180c7c/playground/mocks/config/templateHelper.js#L41

2) An additional enhancement to show loading spinner for slow internet connection (not in scope of this task, could be in future) was partially implemented for loading of i18n file:
https://github.com/okta/okta-signin-widget/blob/8d9bbd5ff0e257e1391b3047750e02ee9b180c7c/src/util/LanguageUtil.js#L9-L12
Note that the loading spinner will not be shown after this PR (because whole widget will be hidden until all needed data has been loaded - well-known, instrospect, interact, language file).

<!---
### Enhancement

With loading beacon (last commit `Show loading spinner after 1s`):


https://user-images.githubusercontent.com/72614880/133693666-3d164cac-70c9-4d88-8165-7255b02cce74.mov


https://user-images.githubusercontent.com/72614880/133693679-dbea565a-f04c-4ddb-9a12-8b3bce454aeb.mov

-->