### PR TITLE
bump version to 5.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description:

Since we promoted a minor version from the `5.10` branch, master was not auto-bumped

### Issue:

- [OKTA-430085](https://oktainc.atlassian.net/browse/OKTA-430085)


