### PR TITLE
fix baseForm to avoid clearing form-error-container

### DIFF
--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -69,9 +69,11 @@ export default Form.extend({
   },
 
   postRender() {
-    // widget would use info container to display interactive messages that would not be cleared once displayed
-    // but can be replaced by view classes. For eg resend-warning callout should not be cleared upon form submission
-    // if there is any error. Rerender would clear info container.
+    /**
+     * Widget would use infoContainer to display interactive messages that should be persisted during
+     * invalid form submissions. For eg resend-warning callout should not be cleared upon invalid form submit.
+     * Rerender would clear infoContainer or views classes can clear it explicitly.
+     */
     const infoContainer= '<div class=\'o-form-info-container\'></div>';
     this.$el.find('.o-form-error-container').before(infoContainer);
   },

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -68,6 +68,14 @@ export default Form.extend({
     }
   },
 
+  postRender() {
+    // widget would use info container to display interactive messages that would not be cleared once displayed
+    // but can be replaced by view classes. For eg resend-warning callout should not be cleared upon form submission
+    // if there is any error. Rerender would clear info container.
+    const infoContainer= '<div class=\'o-form-info-container\'></div>';
+    this.$el.find('.o-form-error-container').before(infoContainer);
+  },
+
   cancelForm() {
     this.options.appState.trigger('invokeAction', 'cancel');
   },

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorPhoneView.js
@@ -74,7 +74,7 @@ const Body = BaseForm.extend(Object.assign(
     postRender() {
       BaseForm.prototype.postRender.apply(this, arguments);
       this.add(ResendView, {
-        selector: '.o-form-error-container',
+        selector: '.o-form-info-container',
         prepend: true,
       });
     },

--- a/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
+++ b/src/v2/view-builder/views/phone/EnrollAuthenticatorPhoneView.js
@@ -24,7 +24,7 @@ const Body = ChallengeAuthenticatorPhoneView.prototype.Body.extend(
     postRender() {
       BaseForm.prototype.postRender.apply(this, arguments);
       this.add(EnrollResendView, {
-        selector: '.o-form-error-container',
+        selector: '.o-form-info-container',
         prepend: true,
       });
     },

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -469,11 +469,14 @@ test
     await challengePhonePageObject.waitForErrorBox();
     await t.expect(challengePhonePageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengePhonePageObject.getInvalidOTPError()).contains('We found some errors.');
+    await t.wait(30500);
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).notOk();
+    const resendEmailView = challengePhonePageObject.resendEmailView();
+    await t.expect(resendEmailView.innerText).eql('Haven\'t received an SMS? Send again');
   });
 
 test
-  .requestHooks(logger, smsPrimaryMock)(`Callout appears after 30 seconds in sms mode
-  - enter code screen`, async t => {
+  .requestHooks(logger, smsPrimaryMock)('Callout appears after 30 seconds in sms mode enter code screen', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
     await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();
@@ -484,8 +487,7 @@ test
   });
 
 test
-  .requestHooks(voicePrimaryMock)(`Callout appears after 30 seconds in voice mode
-  - enter code screen`, async t => {
+  .requestHooks(voicePrimaryMock)('Callout appears after 30 seconds in voice mode enter code screen', async t => {
     const challengePhonePageObject = await setup(t);
     await challengePhonePageObject.clickNextButton();
     await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).ok();

--- a/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorPhoneView_spec.js
@@ -144,6 +144,10 @@ test
     await challengePhonePageObject.waitForErrorBox();
     await t.expect(challengePhonePageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengePhonePageObject.getInvalidOTPError()).contains('We found some errors.');
+    await t.wait(30500);
+    await t.expect(challengePhonePageObject.resendEmailView().hasClass('hide')).notOk();
+    const resendEmailView = challengePhonePageObject.resendEmailView();
+    await t.expect(resendEmailView.innerText).eql('Haven\'t received an SMS? Send again');
   });
 
 test

--- a/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
+++ b/test/unit/spec/v2/view-builder/views/__snapshots__/AutoRedirectView_spec.js.snap
@@ -31,6 +31,9 @@ exports[`v2/view-builder/views/AutoRedirectView view renders corectly - default 
           Signing in...
         </h2>
         <div
+          class="o-form-info-container"
+        />
+        <div
           class="o-form-error-container"
           data-se="o-form-error-container"
         />
@@ -82,6 +85,9 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
           Signing in...
         </h2>
         <div
+          class="o-form-info-container"
+        />
+        <div
           class="o-form-error-container"
           data-se="o-form-error-container"
         />
@@ -132,6 +138,9 @@ exports[`v2/view-builder/views/AutoRedirectView view renders correctly according
         >
           Signing in to Okta Administration as admin@idx.com
         </h2>
+        <div
+          class="o-form-info-container"
+        />
         <div
           class="o-form-error-container"
           data-se="o-form-error-container"


### PR DESCRIPTION
## Description:
1. form-error-container can have hidden warning callouts, on submit if baseForm clears them then warning will never show up until user refreshes the page
2. For sms code flow, if user enter invalid code then warning callout should show up so that user can ask to resend code.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/38230587/134408404-8ee1ab13-36f7-46e7-8e27-51a94763ba7c.mov



### Reviewers:


### Issue:

- [OKTA-419156](https://oktainc.atlassian.net/browse/OKTA-419156)


