### PR TITLE
Update enroll profile update view set secondEmail to empty string by …

### DIFF
--- a/playground/mocks/data/idp/idx/enroll-profile-update-all-optional-params.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-update-all-optional-params.json
@@ -11,7 +11,7 @@
               "create-form"
            ],
            "name":"profile-update",
-           "href":"http://idx.okta1.com:1802/idp/idx/enroll/new",
+           "href":"http://localhost:3000/idp/idx/enroll/new",
            "method":"POST",
            "produces":"application/ion+json; okta-version=1.0.0",
            "value":[
@@ -37,7 +37,8 @@
                           "desc":"Use a second email to recover your account in case you become locked out. This email must be verified after set up.",
                           "required":false,
                           "minLength":1,
-                          "maxLength":100
+                          "maxLength":100,
+                          "descKey": "secondary.email.desc"
                        }
                     ]
                  }
@@ -96,7 +97,7 @@
         "create-form"
      ],
      "name":"cancel",
-     "href":"http://idx.okta1.com:1802/idp/idx/cancel",
+     "href":"http://localhost:3000/idp/idx/cancel",
      "method":"POST",
      "produces":"application/ion+json; okta-version=1.0.0",
      "value":[

--- a/playground/mocks/data/idp/idx/enroll-profile-update-params.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-update-params.json
@@ -37,7 +37,8 @@
                           "desc":"Use a second email to recover your account in case you become locked out. This email must be verified after set up.",
                           "required":false,
                           "minLength":1,
-                          "maxLength":100
+                          "maxLength":100,
+                          "descKey": "secondary.email.desc"
                        }
                     ]
                  }

--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -129,6 +129,19 @@ export default Model.extend({
   },
 
   /**
+   * Returns ui schema of the form field from current view state
+   * @param {string} fieldName
+   * @returns {}
+   */
+  getSchemaByName(fieldName) {
+    const currentViewState = this.getCurrentViewState();
+    if(currentViewState) {
+      const uiSchema = currentViewState.uiSchema;
+      return uiSchema.find(({ name }) => name === fieldName);
+    }
+  },
+
+  /**
    * Returns the displayName of the authenticator
    * @returns {string}
    */

--- a/src/v2/view-builder/views/EnrollProfileUpdateView.js
+++ b/src/v2/view-builder/views/EnrollProfileUpdateView.js
@@ -51,5 +51,16 @@ const Footer = BaseFooter.extend({
 
 export default BaseView.extend({
   Body,
-  Footer
+  Footer,
+
+  postRender() {
+    BaseView.prototype.postRender.apply(this, arguments);
+    /**
+     * As per requirement of this flow set secondEmail default to empty string, if exists in remediation
+     * ideally server should have passed default string in remediation
+     */
+    if (this.options.appState.getSchemaByName('userProfile.secondEmail')) {
+      this.model.set('userProfile.secondEmail', '');
+    }
+  }
 });

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -117,6 +117,20 @@ describe('v2/models/AppState', function() {
     });
   });
 
+  describe('getSchemaByName', () => {
+    it('returns ui schema for a given field', () => {
+      jest.spyOn(AppState.prototype, 'getCurrentViewState').mockReturnValue({uiSchema : [{name: 'some-field'}]});
+      this.initAppState({}, 'profile-update');
+      expect(this.appState.getSchemaByName('some-field')).toEqual({'name': 'some-field'});
+    });
+
+    it('returns undefined if given field does not exists', () => {
+      jest.spyOn(AppState.prototype, 'getCurrentViewState').mockReturnValue({uiSchema : [{name: 'some-field'}]});
+      this.initAppState({}, 'profile-update');
+      expect(this.appState.getSchemaByName('field')).toBeUndefined();
+    });
+  });
+
   describe('shouldReRenderView', () => {
     it('rerender view should be false if stateHandle are different', () => {
 


### PR DESCRIPTION
## Description:
Update enroll profile view to set secondEmail to empty string by default. So that when the widget form contains all optional fields and user do not enter anything and click `finish` button instead of `skip`, the request payload should contains secondEmail property as empty.

This allows backend to identify that user skipped setting up secondEmail and now default to empty.

1. add test
2. fix mocks



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2021-09-22 at 2 50 45 PM](https://user-images.githubusercontent.com/38230587/134441279-fc6b143e-87b5-4d76-b354-ea6e05b98530.png)


### Reviewers:


### Issue:

- [OKTA-430124](https://oktainc.atlassian.net/browse/OKTA-430124)


