### PR TITLE
Authenticator Name Does Not Appear Clearly When They Are Required

### DIFF
--- a/assets/sass/modules/_enroll.scss
+++ b/assets/sass/modules/_enroll.scss
@@ -39,13 +39,13 @@ $enroll-content-spacing: 15px;
   align-items: center;
 
   .enroll-factor-description {
+    width: 100%;
     overflow: hidden;
   }
 
   .enroll-factor-label {
     display: flex;
     justify-content: space-between;
-    min-width: 250px;
   }
 
   .enroll-factor-button {


### PR DESCRIPTION
## Description:
- When the width of the SIW is smaller than a specific value, the `min-width: 250px` property will cause authenticator icons not to be displayed correctly due to overflow. 
- As a result, we set the `width: 100%` property to let the component adjust well with the width of the SIW instead. 
- The QA has verified the fix in the demo cell. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

## Screenshot/Video:
- https://okta.box.com/s/z87c897ux3hcmow726my3f2lizceqmv9

## Reviewers:
- @mauriciocastillosilva-okta 
- @magizh-okta 

## Issue:

- [OKTA-413405](https://oktainc.atlassian.net/browse/OKTA-413405)


