### PR TITLE
Added IdP Discovery to OAuth2 Device Flow

### DIFF
--- a/assets/sass/v1/_all.scss
+++ b/assets/sass/v1/_all.scss
@@ -1,1 +1,2 @@
 @import "assets/sass/v1/device-code-terminal";
+@import "assets/sass/v1/idp-discovery";

--- a/assets/sass/v1/_idp-discovery.scss
+++ b/assets/sass/v1/_idp-discovery.scss
@@ -1,0 +1,7 @@
+.idp-discovery {
+  .force-idp-spinner {
+    height: 38px;
+    margin-top: 40px;
+    background: url('../img/ui/indicators/loader@1x.gif') no-repeat center;
+  }
+}

--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -34,6 +34,10 @@ export default PrimaryAuthController.extend({
     if(Util.isV1StateToken(requestContext)) {
       requestContext = stateToken;
     }
+    let forcedIdpEvaluation = options.appState.get('forcedIdpEvaluation');
+    if (forcedIdpEvaluation) {
+      requestContext = 'okta:forcedIdpEvaluation:' + stateToken;
+    }
 
     this.model = new IDPDiscoveryModel(
       {
@@ -88,6 +92,12 @@ export default PrimaryAuthController.extend({
         self.doPrimaryAuth();
       }
     });
+
+    this.add('<div class="force-idp-spinner" style="display: none"></div>');
+    if (this.options.appState.get('forcedIdpEvaluation')) {
+      this.model.triggerAutomatically();
+      return;
+    }
   },
 
   doPrimaryAuth : function() {

--- a/src/LoginRouter.js
+++ b/src/LoginRouter.js
@@ -163,7 +163,7 @@ export default BaseLoginRouter.extend({
       document.getElementById(Enums.WIDGET_CONTAINER_ID).focus();
       return;
     }
-    if (this.settings.get('features.idpDiscovery')) {
+    if (this.settings.get('features.idpDiscovery') || this.appState.get('forcedIdpEvaluation')) {
       this.idpDiscovery();
     } else {
       this.primaryAuth();

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -757,6 +757,15 @@ export default Model.extend({
         return res._embedded.deviceActivationStatus;
       },
     },
+    forcedIdpEvaluation: {
+      deps: ['lastAuthResponse'],
+      fn: function(res) {
+        if (!res._embedded) {
+          return null;
+        }
+        return res._embedded.forcedIdpEvaluation;
+      },
+    },
   },
 
   parse: function(options) {

--- a/src/models/IDPDiscovery.js
+++ b/src/models/IDPDiscovery.js
@@ -14,6 +14,8 @@ import PrimaryAuthModel from 'models/PrimaryAuth';
 import CookieUtil from 'util/CookieUtil';
 import Enums from 'util/Enums';
 import Util from 'util/Util';
+import {$} from 'okta';
+
 export default PrimaryAuthModel.extend({
   props: function() {
     const cookieUsername = CookieUtil.getCookieUsername();
@@ -29,7 +31,15 @@ export default PrimaryAuthModel.extend({
 
   local: {},
 
+  triggerAutomatically: function() {
+    this.saveInternal(true);
+  },
+
   save: function() {
+    this.saveInternal(false);
+  },
+
+  saveInternal: function(autoTriggered) {
     const username = this.settings.transformUsername(this.get('username'), Enums.IDP_DISCOVERY);
     const remember = this.get('remember');
     const lastUsername = this.get('lastUsername');
@@ -54,9 +64,10 @@ export default PrimaryAuthModel.extend({
       .webfinger(webfingerArgs)
       .then(res => {
         if (res && res.links && res.links[0]) {
-          if (res.links[0].properties['okta:idp:type'] === 'OKTA') {
+          if (res.links[0].properties['okta:idp:type'] === 'OKTA' && !autoTriggered) {
             this.trigger('goToPrimaryAuth');
-          } else if (res.links[0].href) {
+          } else if (res.links[0].properties['okta:idp:type'] !== 'OKTA' && res.links[0].href) {
+            this.showSpinner(autoTriggered);
             const redirectFn = res.links[0].href.includes('OKTA_INVALID_SESSION_REPOST%3Dtrue')
               ? Util.redirectWithFormGet.bind(Util)
               : this.settings.get('redirectUtilFn');
@@ -68,6 +79,7 @@ export default PrimaryAuthModel.extend({
         }
       })
       .catch(() => {
+        this.hideSpinner();
         this.trigger('error');
         // Specific event handled by the Header for the case where the security image is not
         // enabled and we want to show a spinner. (Triggered only here and handled only by Header).
@@ -78,4 +90,21 @@ export default PrimaryAuthModel.extend({
         this.appState.trigger('loading', false);
       });
   },
+
+  showSpinner: function(autoTriggered) {
+    if (autoTriggered) {
+      $('.idp-discovery-form').hide();
+      $('.force-idp-spinner').show();
+      $('.auth-footer').hide();
+    }
+  },
+
+  hideSpinner: function() {
+    $('.idp-discovery-form').show();
+    $('.force-idp-spinner').hide();
+    $('.auth-footer').show();
+  }
+
 });
+
+


### PR DESCRIPTION
## Description:
In order to perform IdP Discovery in OAuth2 Device Flow, we'll have to allow the widget in classic pipeline to evaluate the idp discovery as a remediation step rather than the first step of any flow. This required some modifications to the widget.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
- @nakuljoshi-okta @haishengwu-okta 

### Issue:

- [OKTA-434226](https://oktainc.atlassian.net/browse/OKTA-434226)


