### PR TITLE
Wraps logo in `h1` to provide semantic heading info to screenreaders

### DIFF
--- a/playground/mocks/spec-okta-api/app/userHome.js
+++ b/playground/mocks/spec-okta-api/app/userHome.js
@@ -7,7 +7,7 @@ const apis = [
     method: 'GET',
     template(params, query) {
       return `
-        <h1>Mock User Dashboard</h1>
+        <h1 id="mock-user-dashboard-title">Mock User Dashboard</h1>
         <h2>Query parameters</h2>
         <pre id="preview-query">${JSON.stringify(query, null, 2)}</pre>
         <a href="/">Back to Login</a>`;

--- a/src/views/shared/Header.js
+++ b/src/views/shared/Header.js
@@ -76,7 +76,7 @@ export default View.extend({
     '\
       <div class="okta-sign-in-header auth-header">\
         {{#if logo}}\
-        <img src="{{logo}}" class="auth-org-logo" alt="{{logoText}} logo" aria-label="{{logoText}} logo">\
+        <h1><img src="{{logo}}" class="auth-org-logo" alt="{{logoText}} logo" aria-label="{{logoText}} logo"></h1>\
         {{/if}}\
         <div data-type="beacon-container" class="beacon-container"></div>\
       </div>\

--- a/test/e2e/specs/dev_spec.js
+++ b/test/e2e/specs/dev_spec.js
@@ -41,7 +41,9 @@ describe('Dev Mode flows', function() {
   afterEach(function() {
     // Logout of Okta session
     browser.get('{{{WIDGET_TEST_SERVER}}}/login/signout');
+
     const el = element(by.css('#okta-sign-in'));
+    browser.wait(protractor.ExpectedConditions.presenceOf(el), 2000);
     expect(el.isDisplayed()).toBe(true);
   });
 

--- a/test/e2e/specs/dev_spec.js
+++ b/test/e2e/specs/dev_spec.js
@@ -43,7 +43,7 @@ describe('Dev Mode flows', function() {
     browser.get('{{{WIDGET_TEST_SERVER}}}/login/signout');
 
     const el = element(by.css('#okta-sign-in'));
-    browser.wait(protractor.ExpectedConditions.presenceOf(el), 2000);
+    browser.wait(protractor.ExpectedConditions.visibilityOf(el), 5000);
     expect(el.isDisplayed()).toBe(true);
   });
 

--- a/test/testcafe/framework/page-objects/SuccessPageObject.js
+++ b/test/testcafe/framework/page-objects/SuccessPageObject.js
@@ -6,7 +6,7 @@ export default class SuccessPageObject extends BasePageObject {
     super(t);
   }
   async getPageUrl() {
-    await this.t.expect(Selector('h1').innerText).eql('Mock User Dashboard');
+    await this.t.expect(Selector('#mock-user-dashboard-title').innerText).eql('Mock User Dashboard');
 
     const pageUrl = await ClientFunction(() => window.location.href)();
     return pageUrl;


### PR DESCRIPTION
## Description:

* Adds `h1` wrapper around the logo `img` tag (if logoImg is set)
* `h1` provides a top level heading for the entire page (various views contain `h2` and `h3`) to complete heading hierarchy

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![Screen Shot 2021-10-06 at 3 06 48 PM](https://user-images.githubusercontent.com/72248639/136267350-aeea95a1-35c6-4610-a0a5-13552feecbe7.png)


### Reviewers:


### Issue:

- [OKTA-430954](https://oktainc.atlassian.net/browse/OKTA-430954)


