### PR TITLE
fix: honour interaction handle from config - OKTA-435902

### DIFF
--- a/src/v2/client/transactionMeta.js
+++ b/src/v2/client/transactionMeta.js
@@ -38,8 +38,12 @@ export async function getTransactionMeta(settings) {
   const meta = await createTransactionMeta(settings);
 
   // If a codeChallenge was passed in config, use it
+  let interactionHandle = settings.get('interactionHandle');
   let codeChallenge = settings.get('codeChallenge');
   let codeChallengeMethod = settings.get('codeChallengeMethod');
+  if (interactionHandle) {
+    meta.interactionHandle = interactionHandle;
+  }
   if (codeChallenge) {
     meta.codeChallenge = codeChallenge;
   }
@@ -69,6 +73,12 @@ export function isTransactionMetaValid(settings, meta) {
     return authClient.options[key] !== meta[key];
   });
   if (mismatch) {
+    return false;
+  }
+
+  // if `interactionHandle` option was provided, validate it against the meta
+  const interactionHandle = settings.get('interactionHandle');
+  if (interactionHandle && meta.interactionHandle !== interactionHandle) {
     return false;
   }
 

--- a/test/unit/spec/v2/client/transactionMeta_spec.js
+++ b/test/unit/spec/v2/client/transactionMeta_spec.js
@@ -92,11 +92,13 @@ describe('v2/client/transactionMeta', () => {
         const res = await getTransactionMeta(testContext.settings);
         expect(res).toEqual(testContext.newMeta);
       });
-      it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
+      it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
+        testContext.settings.set('interactionHandle', testContext.interactionHandle);
         testContext.settings.set('codeChallenge', testContext.codeChallenge);
         testContext.settings.set('codeChallengeMethod', testContext.codeChallengeMethod);
         const res = await getTransactionMeta(testContext.settings);
         expect(res.foo).toBe('bar');
+        expect(res.interactionHandle).toBe(testContext.interactionHandle);
         expect(res.codeChallenge).toBe(testContext.codeChallenge);
         expect(res.codeChallengeMethod).toBe(testContext.codeChallengeMethod);
       });
@@ -114,17 +116,20 @@ describe('v2/client/transactionMeta', () => {
           const res = await getTransactionMeta(testContext.settings);
           expect(res).toEqual(testContext.transactionMeta);
         });
-        it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
-          const { codeChallenge, codeChallengeMethod } = testContext;
+        it('honors `interactionHandle`, `codeChallenge`, and `codeChallengeMethod` options', async () => {
+          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
+          testContext.settings.set('interactionHandle', interactionHandle);
           testContext.settings.set('codeChallenge', codeChallenge);
           testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
           Object.assign(testContext.transactionMeta, {
+            interactionHandle,
             codeChallenge,
             codeChallengeMethod 
           });
 
           const res = await getTransactionMeta(testContext.settings);
           expect(res).toEqual(testContext.transactionMeta);
+          expect(res.interactionHandle).toBe(interactionHandle);
           expect(res.codeChallenge).toBe(codeChallenge);
           expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
         });
@@ -145,13 +150,15 @@ describe('v2/client/transactionMeta', () => {
           expect(res).toEqual(testContext.newMeta);
         });
   
-        it('honors `codeChallenge`, and `codeChallengeMethod` options', async () => {
-          const { codeChallenge, codeChallengeMethod } = testContext;
+        it('honors `interactionHandle`, `codeChallenge` and `codeChallengeMethod` options', async () => {
+          const { interactionHandle, codeChallenge, codeChallengeMethod } = testContext;
+          testContext.settings.set('interactionHandle', interactionHandle);
           testContext.settings.set('codeChallenge', codeChallenge);
           testContext.settings.set('codeChallengeMethod', codeChallengeMethod);
   
           const res = await getTransactionMeta(testContext.settings);
           expect(res.foo).toBe('bar');
+          expect(res.interactionHandle).toBe(interactionHandle);
           expect(res.codeChallenge).toBe(codeChallenge);
           expect(res.codeChallengeMethod).toBe(codeChallengeMethod);
         });
@@ -196,6 +203,12 @@ describe('v2/client/transactionMeta', () => {
     it('returns false if `redirectUri` does not match', () => {
       testContext.transactionMeta.redirectUri = 'abc';
       testContext.authParams.redirectUri = 'def';
+      expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
+    });
+
+    it('returns false if `interactionHandle` does not match', () => {
+      testContext.transactionMeta.interactionHandle = 'abc';
+      testContext.settings.set('interactionHandle', 'def');
       expect(isTransactionMetaValid(testContext.settings, testContext.transactionMeta)).toBe(false);
     });
 


### PR DESCRIPTION
## Description:

Transaction meta should honour interactionHandle from config if provided


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-435902](https://oktainc.atlassian.net/browse/OKTA-435902)


