### PR TITLE
Okta 430932: missing password requirements

### DIFF
--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -33,3 +33,16 @@ h3 {
 .text-align-c {
   text-align: center;
 }
+
+.sr-only:not(:focus):not(:active) {
+  border: 0 none;
+  clip-path: inset(50%);
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/assets/sass/_base.scss
+++ b/assets/sass/_base.scss
@@ -33,16 +33,3 @@ h3 {
 .text-align-c {
   text-align: center;
 }
-
-.sr-only:not(:focus):not(:active) {
-  border: 0 none;
-  clip-path: inset(50%);
-  clip: rect(0, 0, 0, 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -842,5 +842,5 @@ const selfServiceRegistration = {
 };
 
 module.exports = {
-  mocks: selfServiceRegistration,
+  mocks: idx,
 };

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -835,6 +835,12 @@ const secondaryEmail = {
   ]
 };
 
+const selfServiceRegistration = {
+  '/api/v1/registration/form': [
+    'registration-form'
+  ]
+};
+
 module.exports = {
-  mocks: idx,
+  mocks: selfServiceRegistration,
 };

--- a/playground/mocks/spec-okta-api/api/v1/registration/form.js
+++ b/playground/mocks/spec-okta-api/api/v1/registration/form.js
@@ -1,0 +1,76 @@
+/* eslint-disable @okta/okta/no-unlocalized-text */
+const templateHelper = require('../../../../config/templateHelper');
+
+module.exports = [
+  templateHelper({
+    path: '/api/v1/registration/form',
+    method: 'GET',
+    template: JSON.stringify({
+      policyId: 'regyb5XILfdDeLzm10g3',
+      lastUpdate: 1634687026000,
+      profileSchema: {
+        properties: {
+          firstName: {
+            type: 'string',
+            title: 'First name',
+            minLength: 1,
+            maxLength: 50,
+            default: 'string'
+          },
+          lastName: {
+            type: 'string',
+            title: 'Last name',
+            minLength: 1,
+            maxLength: 50,
+            default: 'string'
+          },
+          password: {
+            type: 'string',
+            title: 'Password',
+            allOf: [
+              {
+                description: 'At least 8 character(s)',
+                minLength: 8
+              },
+              {
+                description: 'At least 1 number(s)',
+                format: '/[\\d]+/'
+              },
+              {
+                description: 'At least 1 lowercase letter(s)',
+                format: '/[a-z]+/'
+              },
+              {
+                description: 'At least 1 uppercase letter(s)',
+                format: '/[A-Z]+/'
+              },
+              {
+                description: 'Does not contain part of username',
+                format: '/^[#/userName]/'
+              }
+            ],
+            default: 'Password'
+          },
+          email: {
+            type: 'email',
+            title: 'Email',
+            format: 'email',
+            default: 'Email'
+          }
+        },
+        required: [
+          'email',
+          'password',
+          'firstName',
+          'lastName'
+        ],
+        fieldOrder: [
+          'email',
+          'password',
+          'firstName',
+          'lastName'
+        ]
+      }
+    })
+  }),
+];

--- a/src/util/RegistrationFormFactory.js
+++ b/src/util/RegistrationFormFactory.js
@@ -113,16 +113,35 @@ const checkSubSchemas = function(fieldName, model, subSchemas, showError) {
     } else {
       ele.children('p').addClass('default-schema');
     }
+
+    // clear aria role and live-region for re-validation
+    ele.children('p')
+      .removeAttr('role')
+      .removeAttr('aria-live');
+
+    // reset errors
     ele.removeClass('subschema-satisfied subschema-unsatisfied subschema-error');
+
+    // validate
     if (checkSubSchema(subSchema, value, model)) {
+      // passed
       ele.addClass('subschema-satisfied');
       ele.find('p span').removeClass('error error-16-small');
       ele.find('p span').addClass('confirm-16');
     } else {
+      // failed
       if (showError) {
         ele.find('p span').removeClass('confirm-16');
         ele.find('p span').addClass('error error-16-small');
         ele.addClass('subschema-error subschema-unsatisfied');
+
+        ele.find('p')
+          // set role="alert" so the password requirement is read by
+          // screen-readers
+          .attr('role', 'alert')
+          // set aria-live="polite" so it will "debounce" and wait to read the
+          // message between keystrokes
+          .attr('aria-live', 'polite');
       }
     }
   });

--- a/test/unit/spec/Registration_spec.js
+++ b/test/unit/spec/Registration_spec.js
@@ -443,8 +443,8 @@ Expect.describe('Registration', function() {
         expect(test.form.$('#subschemas-password').html()).toBe(
           '<div class="subschema-0 subschema-satisfied"><p class=""><span class="icon icon-16 confirm-16"></span>registration.passwordComplexity.minLength</p></div>' +
           '<div class="subschema-1 subschema-satisfied"><p class=""><span class="icon icon-16 confirm-16"></span>registration.passwordComplexity.minNumber</p></div>' + 
-          '<div class="subschema-2 subschema-error subschema-unsatisfied"><p class=""><span class="icon icon-16 error error-16-small"></span>registration.passwordComplexity.minLower</p></div>' + 
-          '<div class="subschema-3 subschema-error subschema-unsatisfied"><p class=""><span class="icon icon-16 error error-16-small"></span>registration.passwordComplexity.minUpper</p></div>' + 
+          '<div class="subschema-2 subschema-error subschema-unsatisfied"><p class="" role="alert" aria-live="polite"><span class="icon icon-16 error error-16-small"></span>registration.passwordComplexity.minLower</p></div>' + 
+          '<div class="subschema-3 subschema-error subschema-unsatisfied"><p class="" role="alert" aria-live="polite"><span class="icon icon-16 error error-16-small"></span>registration.passwordComplexity.minUpper</p></div>' + 
           '<div class="subschema-4 subschema-satisfied"><p class=""><span class="icon icon-16 confirm-16"></span>registration.passwordComplexity.excludeUsername</p></div>'
         );
       });

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -6,6 +6,7 @@ const nodemon = require('nodemon');
 
 const TARGET = path.resolve(__dirname, 'target');
 const PLAYGROUND = path.resolve(__dirname, 'playground');
+const HOST = '0.0.0.0';
 const DEV_SERVER_PORT = 3000;
 const MOCK_SERVER_PORT = 3030;
 const WIDGET_RC_JS = '.widgetrc.js';
@@ -52,6 +53,7 @@ module.exports = {
     ]
   },
   devServer: {
+    host: HOST,
     static: [
       PLAYGROUND,
       TARGET,
@@ -63,7 +65,9 @@ module.exports = {
     ],
     historyApiFallback: true,
     headers: {
-      'Content-Security-Policy': `script-src http://localhost:${DEV_SERVER_PORT}`
+      'Content-Security-Policy': [
+        `script-src http://${HOST}:${DEV_SERVER_PORT}`
+      ].join(';')
     },
     compress: true,
     port: DEV_SERVER_PORT,
@@ -78,7 +82,7 @@ module.exports = {
         '/oauth2/v1/authorize',
         '/auth/services/',
       ],
-      target: `http://localhost:${MOCK_SERVER_PORT}`
+      target: `http://${HOST}:${MOCK_SERVER_PORT}`
     }],
     onBeforeSetupMiddleware() {
       const script = path.resolve(

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -6,11 +6,13 @@ const nodemon = require('nodemon');
 
 const TARGET = path.resolve(__dirname, 'target');
 const PLAYGROUND = path.resolve(__dirname, 'playground');
-const HOST = '0.0.0.0';
 const DEV_SERVER_PORT = 3000;
 const MOCK_SERVER_PORT = 3030;
 const WIDGET_RC_JS = '.widgetrc.js';
 const WIDGET_RC = '.widgetrc';
+
+// run `OKTA_SIW_HOST=0.0.0.0 yarn start --watch` to override the host
+const HOST = process.env.OKTA_SIW_HOST || 'localhost';
 
 if (!fs.existsSync(WIDGET_RC_JS) && fs.existsSync(WIDGET_RC)) {
   console.error('============================================');
@@ -65,9 +67,7 @@ module.exports = {
     ],
     historyApiFallback: true,
     headers: {
-      'Content-Security-Policy': [
-        `script-src http://${HOST}:${DEV_SERVER_PORT}`
-      ].join(';')
+      'Content-Security-Policy': `script-src http://${HOST}:${DEV_SERVER_PORT}`
     },
     compress: true,
     port: DEV_SERVER_PORT,


### PR DESCRIPTION
## Description:

Need some feedback on this fix. AFAICT, there are 3 options to address the a11y issue outlined in <https://oktainc.atlassian.net/browse/OKTA-430932>. The satisfied/unsatisfied status of requirements should be audible for screen-reader users to fulfill (by adjusting their input).

* Option A: add `role="status"` or `role="alert"` to `<p>` tag
* Option B: add "sr-only" css class to prepended `<span>` with localized string indicating "unsatisfied" or similar.
* Option C: show password hints before input field (see https://incl.ca/show-hide-password-accessibility-and-password-hints-tutorial/)

Option A is best because it avoids the need for updated localizations and achieves the same effect as Option B but in a more semantic/standardized way, but I can't seem to produce the expected speech in NVDA on Windows.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-430932](https://oktainc.atlassian.net/browse/OKTA-430932)


