### PR TITLE
test: fix e2e okta home selectors

### DIFF
--- a/test/e2e-wdio/page-objects/okta-home.page.js
+++ b/test/e2e-wdio/page-objects/okta-home.page.js
@@ -1,6 +1,6 @@
 class OktaHomePage {
-  get mainContent() { return $('.main-content'); }
-  get username() { return $('[data-se=user-menu] .option-selected-text'); }
+  get mainContent() { return $('#main-content'); }
+  get username() { return $('[data-se=dropdown-menu-button-header]'); }
 
   async waitForPageLoad() {
     await browser.waitUntil(async () => {

--- a/test/e2e/page-objects/OktaHomePage.js
+++ b/test/e2e/page-objects/OktaHomePage.js
@@ -16,8 +16,8 @@ const EC = protractor.ExpectedConditions;
 class OktaHomePage {
 
   constructor() {
-    this.mainContentEl = $('.main-content');
-    this.usernameEl = $('[data-se=user-menu] .option-selected-text');
+    this.mainContentEl = $('#main-content');
+    this.usernameEl = $('[data-se=dropdown-menu-button-header]');
   }
 
   waitForPageLoad() {


### PR DESCRIPTION
OKTA-443328
<<<Jenkins Check-In of Tested SHA: 99206c955b582a9c6ad9d13da09f3aa5d8047804 for eng_productivity_ci_bot_okta@okta.com>>>
Artifact: okta-signin-widget
Files changed count: 2
PR Link: "https://github.com/okta/okta-signin-widget/pull/2286"

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


