### PR TITLE
Fixing device flow

### DIFF
--- a/playground/mocks/data/api/v1/authn/unauthenticated-using-device-flow.json
+++ b/playground/mocks/data/api/v1/authn/unauthenticated-using-device-flow.json
@@ -2,7 +2,7 @@
   "stateToken": "aStateToken",
   "status": "UNAUTHENTICATED",
   "_embedded": {
-    "forceIdpDiscovery": true
+    "usingDeviceFlow": true
   },
   "_links": {
     "next": {

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -761,10 +761,10 @@ export default Model.extend({
         return res._embedded.deviceActivationStatus;
       },
     },
-    forceIdpDiscovery: {
+    usingDeviceFlow: {
       deps: ['lastAuthResponse'],
       fn: function(res) {
-        return !!(res._embedded && res._embedded.forceIdpDiscovery);
+        return !!(res._embedded && res._embedded.usingDeviceFlow);
       },
     },
   },

--- a/src/util/RouterUtil.js
+++ b/src/util/RouterUtil.js
@@ -268,7 +268,8 @@ fn.handleResponseStatus = function(router, res) {
       router.navigate(factorURL, { trigger: true });
       return;
     }
-    if (router.appState.get('forceIdpDiscovery')) {
+    // Or we're in device flow and we need to force idp discovery check
+    if (router.appState.get('usingDeviceFlow')) {
       router.navigate('signin/idp-discovery-check', { trigger: true });
       return;
     }

--- a/src/views/primary-auth/CustomButtons.js
+++ b/src/views/primary-auth/CustomButtons.js
@@ -79,9 +79,17 @@ export default View.extend({
           OAuth2Util.getTokens(this.settings, { idp: options.id }, this.options.currentController);
         } else {
           const baseUrl = this.settings.get('baseUrl');
-          const params = $.param({
-            fromURI: this.settings.get('relayState'),
-          });
+          let params;
+          const lastAuthResponse = this.options.appState.get('lastAuthResponse');
+          if (this.options.appState.get('usingDeviceFlow')) {
+            params = $.param({
+              stateToken: lastAuthResponse?.stateToken,
+            });
+          } else {
+            params = $.param({
+              fromURI: this.settings.get('relayState'),
+            });
+          }
           const targetUri = `${baseUrl}/sso/idps/${options.id}?${params}`;
           SharedUtil.redirect(targetUri);
         }


### PR DESCRIPTION
## Description:

- Allows for the social buttons to work with device flow by associating the current flow with the state token instead of the fromUri.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
- @nakuljoshi-okta @haishengwu-okta 

### Issue:

- [OKTA-443544](https://oktainc.atlassian.net/browse/OKTA-443544)


