### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ var signIn = new OktaSignIn(
 
 // When the authorization flow is complete there will be a redirect to Okta.
 // Okta's servers will process the information and then redirect back to your application's `redirectUri`
-// If succesful, an authorization code will exist in the URL as the "code" query parameter
+// If successful, an authorization code will exist in the URL as the "code" query parameter
 // If unsuccesful, there will be an "error" query parameter in the URL
 signIn.showSignInAndRedirect({
   // Assumes there is an empty element on the page with an id of 'osw-container'
@@ -819,7 +819,7 @@ var config = {
     logo: 'https://acme.com/img/logo.png'
     ```
 
-- **logoText:** Text for `alt` attribute of the logo image, logo text will only show up when logo image is not avaiable
+- **logoText:** Text for `alt` attribute of the logo image, logo text will only show up when logo image is not available
 
     ```javascript
     // Text to describe the logo
@@ -1775,7 +1775,7 @@ To generate pseudo-loc, run the following command:
 # Navigate into the pseudo-loc package
 [okta-signin-widget]$ cd packages/@okta/pseudo-loc/
 
-# Install all required dependencies and generate login_ok_PL.propertiies
+# Install all required dependencies and generate login_ok_PL.properties
 # NOTE: This requires VPN access
 [pseudo-loc]$ yarn install
 [pseudo-loc]$ yarn pseudo-loc

--- a/docs/interaction_code_flow.md
+++ b/docs/interaction_code_flow.md
@@ -132,7 +132,7 @@ There are many different ways the Okta Sign-In Widget can be customized.
 
 #### logoText
 
-  Text for `alt` attribute of the logo image, logo text will only show up when logo image is not avaiable
+  Text for `alt` attribute of the logo image, logo text will only show up when logo image is not available
 
 ```javascript
 // Text to describe the logo

--- a/playground/main.js
+++ b/playground/main.js
@@ -71,14 +71,14 @@ const renderPlaygroundWidget = (options = {}) => {
 
   signIn.on('ready', () => {
     // handle `ready` event.
-    // use `console.log` in particular so that those logs can be retrived
+    // use `console.log` in particular so that those logs can be retrieved
     // in testcafe for assertion
     console.log('===== playground widget ready event received =====');
   });
 
   signIn.on('afterRender', (context) => {
     // handle `afterRender` event.
-    // use `console.log` in particular so that those logs can be retrived
+    // use `console.log` in particular so that those logs can be retrieved
     // in testcafe for assertion
     console.log('===== playground widget afterRender event received =====');
     console.log(JSON.stringify(context));
@@ -106,7 +106,7 @@ const renderPlaygroundWidget = (options = {}) => {
 
   signIn.on('afterError', (context, error) => {
     // handle `afterError` event.
-    // use `console.log` in particular so that those logs can be retrived
+    // use `console.log` in particular so that those logs can be retrieved
     // in testcafe for assertion
     console.log('===== playground widget afterError event received =====');
     console.log(JSON.stringify(context));

--- a/src/IDPDiscoveryController.js
+++ b/src/IDPDiscoveryController.js
@@ -30,7 +30,7 @@ export default PrimaryAuthController.extend({
     const lastAuthResponse = options.appState.get('lastAuthResponse');
     const stateToken = lastAuthResponse && lastAuthResponse?.stateToken;
 
-    //Update requestContext wiht last stateToken, if the context was stateToken and not a fromUri
+    //Update requestContext with last stateToken, if the context was stateToken and not a fromUri
     if(Util.isV1StateToken(requestContext)) {
       requestContext = stateToken;
     }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -107,7 +107,7 @@ Util.toLower = function(strings) {
 };
 
 // A languageCode can be composed of multiple parts, i.e:
-// {{langage}}-{{region}}-{{dialect}}
+// {{language}}-{{region}}-{{dialect}}
 //
 // In these cases, it's necessary to generate a list of other possible
 // combinations that we might support (in preferred order).

--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -90,7 +90,7 @@ export default Router.extend({
 
   async handleUpdateAppState(idxResponse) {
     // Only update the cookie when the user has successfully authenticated themselves 
-    // to avoid incorrect/uneccessary updates.
+    // to avoid incorrect/unnecessary updates.
     if (this.hasAuthenticationSucceeded(idxResponse) 
       && this.settings.get('features.rememberMyUsernameOnOIE')) {
       this.updateIdentifierCookie(idxResponse);

--- a/src/views/shared/SecurityBeacon.js
+++ b/src/views/shared/SecurityBeacon.js
@@ -118,7 +118,7 @@ async function updateSecurityImage($el, appState, animate) {
 
   // Animate loading the security beacon
   if (!hasBorder) {
-    // This occurrs when appState username is blank
+    // This occurs when appState username is blank
     // we do not yet know if the user is recognized
     image.fadeOut(duration, function() {
       setBackgroundImage(image, appState);
@@ -127,7 +127,7 @@ async function updateSecurityImage($el, appState, animate) {
     });
   } else {
     // Animate loading the security beacon with a loading bar for the border
-    // This occurrs when the username has been checked against Okta.
+    // This occurs when the username has been checked against Okta.
     border.removeClass('auth-beacon-border');
     await Animations.radialProgressBar({
       $el: radialProgressBar,

--- a/test/testcafe/spec/EnrollAuthenticatorWebAuthn_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorWebAuthn_spec.js
@@ -25,7 +25,7 @@ async function setup(t) {
   return enrollWebauthnPage;
 }
 
-// This is the only test we can perfrom in testcafe as webauthn api is not available in the version of chrome/chromeheadless
+// This is the only test we can perform in testcafe as webauthn api is not available in the version of chrome/chromeheadless
 // that testcafe loads.
 test('should have webauthn not supported error if browser doesnt support', async t => {
   const enrollWebauthnPage = await setup(t);

--- a/test/unit/spec/MfaVerify_spec.js
+++ b/test/unit/spec/MfaVerify_spec.js
@@ -707,7 +707,7 @@ Expect.describe('MFA Verify', function() {
     // 3: Set for verifyFactor poll finish
     test.setNextResponse([resChallengePush, firstPollResponse || resChallengePush, finalResponse]);
 
-    // View contains 2 forms when push and totp are avaiable
+    // View contains 2 forms when push and totp are available
     // For polling we are only interested in the push form.
     if (test.form.length > 0) {
       test.form = test.form[0];
@@ -3686,7 +3686,7 @@ Expect.describe('MFA Verify', function() {
             .then(function(form) {
               form.setAnswer('');
               // clicks are throttled with 100ms.
-              // _.thrrottle cannot be mocked by jasmine.clock.tick
+              // _.throttle cannot be mocked by jasmine.clock.tick
               // hence using real timeout of 100ms.
               setTimeout(() => {
                 form.inlineTOTPVerify().click();


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/interaction_code_flow.md
- playground/main.js
- src/IDPDiscoveryController.js
- src/util/Util.js
- src/v2/BaseLoginRouter.js
- src/views/shared/SecurityBeacon.js
- test/testcafe/spec/EnrollAuthenticatorWebAuthn_spec.js
- test/unit/spec/MfaVerify_spec.js

Fixes:
- Should read `retrieved` rather than `retrived`.
- Should read `available` rather than `avaiable`.
- Should read `occurs` rather than `occurrs`.
- Should read `with` rather than `wiht`.
- Should read `unnecessary` rather than `uneccessary`.
- Should read `throttle` rather than `thrrottle`.
- Should read `successful` rather than `succesful`.
- Should read `properties` rather than `propertiies`.
- Should read `perform` rather than `perfrom`.
- Should read `language` rather than `langage`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md