### PR TITLE
Only show 4s spinner for identifier view, not assurance view.

### DIFF
--- a/assets/sass/v2/_device-challenge.scss
+++ b/assets/sass/v2/_device-challenge.scss
@@ -49,6 +49,13 @@
     }
     .app-link-content {
       margin-bottom: 15px;
+
+      .spinner {
+        margin-bottom: 30px;
+      }
+    }
+    .hide.button.link-button {
+      display: none;
     }
   }
 }

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -395,6 +395,18 @@ const androidAuthnLoopbackFailfast = {
   ],
 };
 
+const identifierAndroidAppLink = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-loopback-challenge-not-received',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'identify-with-app-link',
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'identify-with-app-link',
+  ]
+};
+
 // user verification: Windows/Android authenticator with loopback server
 const userVerificationLoopback = {
   '/idp/idx/introspect': [
@@ -418,6 +430,22 @@ const userVerificationCustomUri = {
   ],
   '/idp/idx/authenticators/okta-verify/launch': [
     'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+  ]
+};
+
+// user verification: Android authenticator with app link
+const userVerificationAppLink = {
+  '/idp/idx/introspect': [
+    'identify-with-device-probing-loopback-challenge-not-received',
+  ],
+  '/idp/idx/identify': [
+    'authenticator-verification-okta-verify-signed-nonce-app-link',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'authenticator-verification-okta-verify-signed-nonce-app-link',
+  ],
+  '/idp/idx/authenticators/okta-verify/launch': [
+    'authenticator-verification-okta-verify-signed-nonce-app-link',
   ]
 };
 

--- a/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-app-link.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-app-link.json
@@ -1,0 +1,245 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "name": "challenge-poll",
+        "href": "http://localhost:3000/idp/idx/authenticators/poll",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Okta Verify",
+                "relatesTo": "$.authenticatorEnrollments.value[0]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttheidkwh282hv8g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "signed_nonce",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              },
+              {
+                "label": "Okta Password",
+                "relatesTo": "$.authenticatorEnrollments.value[1]",
+                "form": {
+                  "value": [
+                    {
+                      "name": "id",
+                      "value": "auttmbseAWnMPtLe20g3",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    },
+                    {
+                      "name": "methodType",
+                      "value": "password",
+                      "required": true,
+                      "mutable": false,
+                      "visible": false
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "displayName":"Okta Verify",
+      "type": "app",
+      "key": "okta_verify",
+      "id": "aen1mz5J4cuNoaR3l0g4",
+      "methods":[
+        {
+          "type":"signed_nonce"
+        }
+      ],
+      "cancel": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "cancel-polling",
+        "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvMTgzcDRKUU9VcmsydkwwZzQiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..YpDq57xO4bBSv3jl.w3VVhTW7O6chSQkfps9eG7Vsd-VH7-Y8j_pPhiZCxQCVzVNVzj-D8iWRMsxYySZ6uike3nVj7hSFaAq_-BGMktseWOqy3gMvl6I7HLunOf8T2qHHzcnHl_N4nKs8pyyqIXyfEICpfV36U7FkIY-QZQ18oEofPb6TmXFNbstI33cW8S_Wg0SOCdVe24Jm4G71JN6G59zPFJA_2M3IDUsl4w57hO9ZbJRJ3DrRIgyQkUuS38YSUdWw7d0mh4sQIVomTG12u8fs86mWcEeyJnGEv_53h32NTN2cJXGcZq7TvOX1lLxAtY8GwCfUzW2IoFX8ERCGkhnYu_0NCEH9Jjl-1BcApLKA2hrjzlB7ogTQAtlUwBzo9TS-N-ygG6_uGssbgWQEywVXwTgnazqFq1vSZr2W17f-8yhaNp568jHPbFlDCl_GWC6nP2KHx5t4OznTji6-s1REigaPTG5V7ovxx2_JJaeyiQa6Vg6mJWfXCh9tu8zxkln9xL5R8jjVfozYyfKI_A3uhxb825q2nMbNA7yavkQxOBK1MFGrzhe1WyiPgrTxFt0DcO83OwbF8R34L00bH4I1OUK6-vUwV9Q0c6N3JzBJlFVGPsZxhUrVgGq7u1CNj-xrLH5Vqzo_TVDgEqSPeAsj_0Fy1ZiaFuM1Y2B8S4WAWLLO2RGQZLbsIm7TS15hPd13pC5e7X1HXzrxRQLuCjnzz7qHnEfnltPzcjJ_xxNF61mZoz_Xnx9Illks9CL7ty8h1M-4FxzkzoIrZm1G2KOL1b3SGK5OxUlmNJbcLfyqC7G93c33qDPPqtdi2Ev9WdB3R2kWBW6g6Qczilyo4uNa3gmQgwUDjnGhJROzX61EkYa2Ozg0SJmW4ru7ao0jBSNsrBfAjR4CIXFsLhPsO65G1UzfhB4wLE7ObtwvMoUegp2X6DgAmjhB4-NeChsxcPbJTX9A5vdkKY0NpQBcbKyeB1TkkVt-RbYL-e1J6Il7KrffTpRzGFQeQBEM9yLo2z7zUqK6yTr4-FAencdarp8NAgeQ6SAlXiFyBD5VEK3cVX8ILnxr3CSotwbZ6h9ie-tiRInBSQ_7zU3wp3NfEfumOmTVS7Sjvi2qo1F_Gbcq-CXbngof4nKUIvxablSThMdsixfS4nMECS2InGgIOjkwn6fSbG9czkj9liIMxDCiLU4VaT3pOx-QmjRR-_ntQhWAanUIkCh_DVhJAtVrsN64B54CF9xOP9UUrPATTx3dxdHEOgWVB5SwZPs7vbxyQ8YfRXluT-FUJXRNh4-N5uzc5cM2Tzc8uEzMsnIRyCadT8QUDqsJHeZ_mkvIjavCzy1E4Mo1q99Vv4ovpkagoa1-cb1Sn-iH-unoIYa-nHf5n5aqFFyIwHvsi9PTAUCQRg3Nwd8RvFtgembFJMmRxUrfSyQjyX6IVCntEQq0hK2Mq6kaMOzkT-pdZo6u-xotrsCkQnBqqdOIY74Fyr22e5r31FUFZGBgeH9ztiOmDz_NIHGVb6tMmar-jUXoMIK8rfn0G537HeV9dLbjOGnBNodYGdHJ2r5uMQdQv1kuNAecw-uuVEu7k8z398_yMQGtM4WccuvNxWyTX5g5kzv8suyd5Eor9aKJAiKjJaflwNIb8AldOID4eS4a8y7lf9o2bpV-xGxGGya2cUGa3Q8jOHlok4Vw4wBlkAU6QWGJ_WVqavG4733uFzEKKfxJpfMd98Y88gSu.UI6b0mlQalzOjwlF8nqGWA",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      "contextualData": {
+        "challenge": {
+          "type": "object",
+          "value": {
+            "challengeMethod": "APP_LINK",
+            "href": "http://localhost:3000/auth/okta-verify",
+            "cancel": {
+                "rel": ["create-form"],
+                "name": "cancel-polling-transaction",
+                "href": "http://localhost:3000/idp/idx/authenticators/poll/cancel",
+                "method": "POST",
+                "accepts": "application/ion+json;okta-version=1",
+                "produces": "application/ion+json;okta-version=1",
+                "value": [{
+                    "name": "stateHandle",
+                    "value": "02vQULJDA20fnlkloDn2swWJkaxVTPQ10lyJH6I5c",
+                    "required": true,
+                    "visible": false
+                }]
+            }
+          }
+        }
+      }
+    }
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+      {
+        "type":"app",
+        "key": "okta_verify",
+        "id":"autmho3zRhIfiSzOy0g4",
+        "displayName":"Okta Verify",
+        "methods":[
+          {
+            "type":"signed_nonce"
+          }
+        ]
+      },
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"autmhm5s2gQhWbPfu0g4",
+        "displayName":"Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      {
+        "profile":{
+          "deviceName":"ANDROID-9AD225Q"
+        },
+        "type":"app",
+        "key": "okta_verify",
+        "id":"pfdtxkyRQrmwfWdIE0g4",
+        "displayName":"Okta Verify",
+        "methods":[
+          {
+            "type":"signed_nonce"
+          }
+        ]
+      },
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"lae3obwhjXZOu3dfz0g4",
+        "displayName":"Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Native client",
+      "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -9,10 +9,11 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-import { loc, View, createButton } from 'okta';
+import { loc, View, createButton, _ } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import Enums from '../../../util/Enums';
 import Util from '../../../util/Util';
+import { FASTPASS_FALLBACK_SPINNER_TIMEOUT, IDENTIFIER_FLOW } from '../utils/Constants';
 
 export function appendLoginHint(deviceChallengeUrl, loginHint) {
   if (deviceChallengeUrl && loginHint) {
@@ -22,9 +23,10 @@ export function appendLoginHint(deviceChallengeUrl, loginHint) {
   return deviceChallengeUrl;
 }
 
-export function doChallenge(view) {
+export function doChallenge(view, fromView) {
   const deviceChallenge = view.getDeviceChallengePayload();
   const loginHint = view.options?.settings?.get('identifier');
+  const HIDE_CLASS = 'hide';
   switch (deviceChallenge.challengeMethod) {
   case Enums.LOOPBACK_CHALLENGE:
     view.title = loc('deviceTrust.sso.redirectText', 'login');
@@ -98,17 +100,43 @@ export function doChallenge(view) {
     view.add(View.extend({
       className: 'app-link-content',
       template: hbs`
-            {{i18n code="appLink.content" bundle="login"}}
-          `
+        <div class="spinner {{hideClass}}"></div>
+        <div class="appLinkContent {{hideClass}}">{{i18n code="appLink.content" bundle="login"}}</div>
+      `,
+      getTemplateData() {
+        return { hideClass: HIDE_CLASS };
+      },
+      postRender() {
+        if (fromView === IDENTIFIER_FLOW) {
+          this.$('.spinner').removeClass(HIDE_CLASS);
+          setTimeout(_.bind(()=> {
+            const data = { label: loc('goback', 'login') };
+            this.options.appState.trigger('updateFooterLink', data);
+            this.$('.spinner').addClass(HIDE_CLASS);
+            this.$('.appLinkContent').removeClass(HIDE_CLASS);
+          }, this), FASTPASS_FALLBACK_SPINNER_TIMEOUT);
+        } else {
+          this.$('.appLinkContent').removeClass(HIDE_CLASS);
+        }
+      },
     }));
     view.add(createButton({
-      className: 'al-button button button-wide button-primary',
+      className: `${HIDE_CLASS} al-button button button-wide button-primary`,
       title: loc('oktaVerify.open.button', 'login'),
       click: () => {
         // only window.location.href can open app link in Android
         // other methods won't do, ex, AJAX get or form get (Util.redirectWithFormGet)
         let deviceChallengeUrl = appendLoginHint(deviceChallenge.href, loginHint);
         Util.redirect(deviceChallengeUrl, window, true);
+      },
+      postRender() {
+        if (fromView === IDENTIFIER_FLOW) {
+          setTimeout(_.bind(()=> {
+            this.$el.removeClass(HIDE_CLASS);
+          }, this), FASTPASS_FALLBACK_SPINNER_TIMEOUT);
+        } else {
+          this.$el.removeClass(HIDE_CLASS);
+        }
       }
     }));
     break;

--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -5,3 +5,5 @@ export const MS_PER_SEC = 1000;
 export const UNIVERSAL_LINK_POST_DELAY = 500;
 export const CANCEL_POLLING_ACTION = 'authenticatorChallenge-cancel';
 export const WIDGET_FOOTER_CLASS = 'siw-main-footer';
+export const FASTPASS_FALLBACK_SPINNER_TIMEOUT = 4000;
+export const IDENTIFIER_FLOW = 'IDENTIFIER';

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -3,7 +3,7 @@ import { BaseFormWithPolling, BaseFooter, BaseView } from '../../internals';
 import Logger from '../../../../util/Logger';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import Enums from '../../../../util/Enums';
-import { CANCEL_POLLING_ACTION, CHALLENGE_TIMEOUT } from '../../utils/Constants';
+import { CANCEL_POLLING_ACTION, CHALLENGE_TIMEOUT, IDENTIFIER_FLOW } from '../../utils/Constants';
 import Link from '../../components/Link';
 import { doChallenge } from '../../utils/ChallengeViewUtil';
 import OktaVerifyAuthenticatorHeader from '../../components/OktaVerifyAuthenticatorHeader';
@@ -33,7 +33,7 @@ const Body = BaseFormWithPolling.extend(
     initialize() {
       BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.onPollingFail);
-      doChallenge(this);
+      doChallenge(this, IDENTIFIER_FLOW);
       this.startPolling();
     },
 
@@ -162,7 +162,7 @@ const Body = BaseFormWithPolling.extend(
 const Footer = BaseFooter.extend({
   initialize() {
     this.listenTo(this.options.appState, 'updateFooterLink', this.handleUpdateFooterLink);
-    if (this.isFallbackApproach()) {
+    if (this.isFallbackApproach() && !this.isFallbackDelayed()) {
       BaseFooter.prototype.initialize.apply(this, arguments);
     } else {
       this.backLink = this.add(Link, {
@@ -177,7 +177,7 @@ const Footer = BaseFooter.extend({
 
   handleUpdateFooterLink(data) {
     // only update link for loopback
-    if (!this.isFallbackApproach()) {
+    if (!this.isFallbackApproach() || this.isFallbackDelayed()) {
       this.backLink && this.backLink.remove();
       this.backLink = this.add(Link, {
         options: getSignOutLink(this.options.settings, data)[0]
@@ -191,6 +191,12 @@ const Footer = BaseFooter.extend({
       Enums.UNIVERSAL_LINK_CHALLENGE,
       Enums.APP_LINK_CHALLENGE
     ].includes(this.options.currentViewState.relatesTo.value.challengeMethod);
+  },
+
+  isFallbackDelayed() {
+    // only delay showing the reopen Okta Verify button for the app link approach for now
+    // until we have more data shows other approaches have the slow cold start problem of the Okta Verify app as well
+    return this.options.currentViewState.relatesTo.value.challengeMethod === Enums.APP_LINK_CHALLENGE;
   },
 });
 

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -3,7 +3,7 @@ import { BaseFormWithPolling } from '../../internals';
 import Logger from '../../../../util/Logger';
 import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
-import {doChallenge} from '../../utils/ChallengeViewUtil';
+import { doChallenge } from '../../utils/ChallengeViewUtil';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -62,6 +62,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.body.find('[data-se="o-form-fieldset-container"] .button-primary').innerText;
   }
 
+  waitForPrimaryButtonAfterSpinner() {
+    return Selector('[data-se="o-form-fieldset-container"] .button-primary', { timeout: 4500 });
+  }
+
   async clickUniversalLink() {
     await this.t.click(Selector('.ul-button'));
   }

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -1,4 +1,4 @@
-import { RequestLogger, RequestMock, Selector } from 'testcafe';
+import { RequestLogger, RequestMock, ClientFunction, Selector } from 'testcafe';
 import DeviceChallengePollPageObject from '../framework/page-objects/DeviceChallengePollPageObject';
 import SelectAuthenticatorPageObject from '../framework/page-objects/SelectAuthenticatorPageObject';
 import BasePageObject from '../framework/page-objects/BasePageObject';
@@ -8,6 +8,9 @@ import identifyWithUserVerificationLoopback from '../../../playground/mocks/data
 import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri';
 import identifyWithSSOExtensionFallback from '../../../playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback';
 import identifyWithUserVerificationLaunchUniversalLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link';
+import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received';
+import assureWithLaunchAppLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-app-link';
+import { renderWidget } from '../framework/shared';
 
 const BEACON_CLASS = 'mfa-okta-verify';
 
@@ -93,6 +96,20 @@ const universalLinkMock = RequestMock()
   .onRequestTo(mockHttpCustomUri)
   .respond('<html><h1>open universal link</h1></html>');
 
+const customAppLink = 'http://localhost:3000/auth/okta-verify'; // can't use loopback server port as they are occupied
+const username = 'john.smith@okta.com';
+const loginHintAppLink = customAppLink+'&login_hint='+encodeURIComponent(username);
+const LoginHintAppLinkMock = RequestMock()
+  .onRequestTo(/idp\/idx\/introspect/)
+  .respond(loopbackChallengeNotReceived)
+  .onRequestTo(/idp\/idx\/identify/)
+  .respond(assureWithLaunchAppLink)
+  .onRequestTo(/idp\/idx\/authenticators\/okta-verify\/launch/)
+  .respond(assureWithLaunchAppLink)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(assureWithLaunchAppLink)
+  .onRequestTo(loginHintAppLink)
+  .respond('<html><h1>open app link with login_hint</h1></html>');
 fixture('Device Challenge Polling View for user verification and MFA with the Loopback Server, Custom URI and Universal Link approaches');
 
 async function setup(t) {
@@ -207,4 +224,29 @@ test
     deviceChallengeFalllbackPage.clickOktaVerifyButton();
     await t.expect(Selector('h1').innerText).eql('open universal link');
     await t.expect(await (new BasePageObject()).getPageUrl()).contains(mockHttpCustomUri);
+  });
+
+const getPageUrl = ClientFunction(() => window.location.href);
+test
+  .requestHooks(LoginHintAppLinkMock)('expect login_hint in AppLink when engFastpassMultipleAccounts is on', async t => {
+    const identityPage = await setupLoopbackFallback(t);
+    await renderWidget({
+      features: { engFastpassMultipleAccounts: true },
+    });
+
+    await identityPage.fillIdentifierField(username);
+    identityPage.clickOktaVerifyButton();
+    const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
+
+    const content = deviceChallengePollPageObject.getContent();
+    await t.expect(content)
+      .contains('If Okta Verify did not open automatically, tap the button below to reopen Okta Verify.');
+    await t.expect(deviceChallengePollPageObject.getFooterSwitchAuthenticatorLink().innerText).eql('Verify with something else');
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
+
+    deviceChallengePollPageObject.clickAppLink();
+    // verify login_hint has been appended to the app link url
+    await t.expect(getPageUrl()).contains('login_hint='+encodeURIComponent(username));
+    await t.expect(Selector('h1').innerText).eql('open app link with login_hint');
   });

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -429,10 +429,17 @@ test
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
+
+    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
+
+    await t.expect(deviceChallengePollPageObject.waitForPrimaryButtonAfterSpinner().innerText).eql('Open Okta Verify');
+
     await t.expect(deviceChallengePollPageObject.getContent())
       .contains('If Okta Verify did not open automatically, tap the button below to reopen Okta Verify.');
     await t.expect(deviceChallengePollPageObject.getPrimiaryButtonText()).eql('Open Okta Verify');
     await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().exists).eql(false);
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
     deviceChallengePollPageObject.clickAppLink();
     await t.expect(getPageUrl()).contains(customAppLink);
     await t.expect(Selector('h1').innerText).eql('open app link');
@@ -608,6 +615,14 @@ test
     identityPage.clickOktaVerifyButton();
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Sign in with Okta FastPass');
+
+    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('block');
+    await t.expect(deviceChallengePollPageObject.getFooterCancelPollingLink().innerText).eql('Cancel and take me to sign in');
+
+
+    await t.expect(deviceChallengePollPageObject.waitForPrimaryButtonAfterSpinner().innerText).eql('Open Okta Verify');
+    await t.expect(deviceChallengePollPageObject.getFooterSignOutLink().innerText).eql('Back to sign in');
+    await t.expect(deviceChallengePollPageObject.getSpinner().getStyleProperty('display')).eql('none');
 
     deviceChallengePollPageObject.clickAppLink();
     // verify login_hint has been appended to the app link url

--- a/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/ChallengeViewUtil_spec.js
@@ -156,10 +156,11 @@ describe('v2/utils/ChallengeViewUtil', function() {
     expect(testView.add).toHaveBeenCalledTimes(2);
     expect(expectedAddArgs[0].className).toBe('app-link-content');
     expect(expectedAddArgs[0].template.call()).toBe(hbs`
-            {{{i18n code="appLink.content" bundle="login"}}}
-          `.call());
+      <div class="spinner "></div>
+      <div class="appLinkContent ">If Okta Verify did not open automatically, tap the button below to reopen Okta Verify.</div>
+    `.call());
     let expectedCreateButton = createButton({
-      className: 'al-button button button-wide button-primary',
+      className: 'hide al-button button button-wide button-primary',
       title: loc('oktaVerify.reopen.button', 'login'),
       click: () => {
         // only window.location.href can open universal link in iOS/MacOS


### PR DESCRIPTION
## Description:

This is the same change from https://github.com/okta/okta-signin-widget/pull/2284. Just rebased off the `master` branch instead of `5.13`. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-432811](https://oktainc.atlassian.net/browse/OKTA-432811)


