### PR TITLE
remove "required" attribute on enroll password form

### DIFF
--- a/src/views/primary-auth/PrimaryAuthForm.js
+++ b/src/views/primary-auth/PrimaryAuthForm.js
@@ -143,9 +143,6 @@ export default Form.extend({
             'aria-invalid': 'false',
             'aria-required': 'true',
           })
-          .prop({
-            required: true,
-          })
           .focusout(clearAriaInvalid)
           .change(clearAriaInvalid);
       },
@@ -189,9 +186,6 @@ export default Form.extend({
           .attr({
             'aria-invalid': 'false',
             'aria-required': 'true',
-          })
-          .prop({
-            required: true
           })
           .focusout(clearAriaInvalid)
           .change(clearAriaInvalid);

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -508,7 +508,7 @@ Expect.describe('PrimaryAuth', function() {
         expect(username.length).toBe(1);
         expect(username.attr('type')).toEqual('text');
         expect(username.attr('id')).toEqual('okta-signin-username');
-        expect(username.prop('required')).toEqual(true);
+        expect(username.prop('required')).toEqual(false);
       });
     });
     itp('has a password field', function() {
@@ -518,7 +518,7 @@ Expect.describe('PrimaryAuth', function() {
         expect(password.length).toBe(1);
         expect(password.attr('type')).toEqual('password');
         expect(password.attr('id')).toEqual('okta-signin-password');
-        expect(password.prop('required')).toEqual(true);
+        expect(password.prop('required')).toEqual(false);
       });
     });
     itp('has a sign in button', function() {


### PR DESCRIPTION
## Description:

* HTML5 "required" attribute causes NVDA and JAWS screen readers to
announce "invalid entry" even if "aria-invalid" is set to false
* removing "required" attribute will affect form validation behavior

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-430928](https://oktainc.atlassian.net/browse/OKTA-430928)


