### PR TITLE
Update to have only one poll call OKTA-423330

### DIFF
--- a/src/v2/models/AppState.js
+++ b/src/v2/models/AppState.js
@@ -179,11 +179,8 @@ export default Model.extend({
     const identicalResponse = _.isEqual(
       _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'refresh', 'stateHandle']),
       _.nestedOmit(previousRawState, ['expiresAt', 'refresh', 'stateHandle']));
-    const isSameRefreshInterval = _.isEqual(
-      _.nestedOmit(transformedResponse.idx.rawIdxState, ['expiresAt', 'stateHandle']),
-      _.nestedOmit(previousRawState, ['expiresAt', 'stateHandle']));
 
-    if (identicalResponse && !isSameRefreshInterval) {
+    if (identicalResponse) {
       this.set('dynamicRefreshInterval', this.getRefreshInterval(transformedResponse));
     }
 

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -39,7 +39,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       this.startPolling();
     },
     postRender() {
-      BaseForm.prototype.postRender.apply(this, arguments);
+      BaseFormWithPolling.prototype.postRender.apply(this, arguments);
 
       if ((BrowserFeatures.isAndroid() || BrowserFeatures.isIOS()) &
         this.options.appState.get('currentAuthenticator').contextualData.selectedChannel === 'qrcode') {

--- a/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
+++ b/src/v2/view-builder/views/ov/EnrollPollOktaVerifyView.js
@@ -1,5 +1,5 @@
 import { loc } from 'okta';
-import { BaseForm } from '../../internals';
+import { BaseFormWithPolling } from '../../internals';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import polling from '../shared/polling';
@@ -14,7 +14,7 @@ const OV_FORCE_FIPS_COMPLIANCE_UPGRAGE_KEY_NON_IOS =
   'oie.authenticator.app.non_fips_compliant_enrollment_app_update_required';
 const OV_QR_ENROLL_ENABLE_BIOMETRICS_KEY = 'oie.authenticator.app.method.push.enroll.enable.biometrics';
 
-const Body = BaseForm.extend(Object.assign(
+const Body = BaseFormWithPolling.extend(Object.assign(
   {
     title() {
       const selectedChannel = this.options.appState.get('currentAuthenticator').contextualData.selectedChannel;
@@ -34,7 +34,7 @@ const Body = BaseForm.extend(Object.assign(
     className: 'oie-enroll-ov-poll',
     noButtonBar: true,
     initialize() {
-      BaseForm.prototype.initialize.apply(this, arguments);
+      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       this.listenTo(this.model, 'error', this.stopPolling);
       this.startPolling();
     },
@@ -57,7 +57,7 @@ const Body = BaseForm.extend(Object.assign(
         // add a title for OV enable biometrics message during enrollment
         calloutOptions.title = loc('oie.authenticator.app.method.push.enroll.enable.biometrics.title', 'login');
       }
-      BaseForm.prototype.showMessages.call(this, calloutOptions);
+      BaseFormWithPolling.prototype.showMessages.call(this, calloutOptions);
     },
     getUISchema() {
       const schema = [];
@@ -82,7 +82,7 @@ const Body = BaseForm.extend(Object.assign(
       return schema;
     },
     remove() {
-      BaseForm.prototype.remove.apply(this, arguments);
+      BaseFormWithPolling.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
   },

--- a/src/v2/view-builder/views/ov/NumberChallengePushView.js
+++ b/src/v2/view-builder/views/ov/NumberChallengePushView.js
@@ -1,10 +1,10 @@
 import { loc } from 'okta';
-import { BaseForm } from '../../internals';
+import { BaseFormWithPolling } from '../../internals';
 import polling from '../shared/polling';
 import ResendNumberChallengeView from './ResendNumberChallengeView';
 import NumberChallengePhoneView from './NumberChallengePhoneView';
 
-const Body = BaseForm.extend(Object.assign(
+const Body = BaseFormWithPolling.extend(Object.assign(
   {
     noButtonBar: true,
 
@@ -25,12 +25,12 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     initialize() {
-      BaseForm.prototype.initialize.apply(this, arguments);
+      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       this.add(NumberChallengePhoneView);
     },
 
     triggerAfterError() {
-      BaseForm.prototype.triggerAfterError.apply(this, arguments);
+      BaseFormWithPolling.prototype.triggerAfterError.apply(this, arguments);
       this.stopPolling();
       this.$el.find('.o-form-fieldset-container').empty();
     },
@@ -55,7 +55,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     remove() {
-      BaseForm.prototype.remove.apply(this, arguments);
+      BaseFormWithPolling.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
   },

--- a/src/v2/view-builder/views/ov/NumberChallengePushView.js
+++ b/src/v2/view-builder/views/ov/NumberChallengePushView.js
@@ -36,7 +36,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     },
 
     postRender() {
-      BaseForm.prototype.postRender.apply(this, arguments);
+      BaseFormWithPolling.prototype.postRender.apply(this, arguments);
       this.startPoll();
     },
 

--- a/src/v2/view-builder/views/shared/ChallengePushView.js
+++ b/src/v2/view-builder/views/shared/ChallengePushView.js
@@ -61,7 +61,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     },
 
     postRender() {
-      BaseForm.prototype.postRender.apply(this, arguments);
+      BaseFormWithPolling.prototype.postRender.apply(this, arguments);
 
       const className = this.isOV() ?
         'okta-verify-push-challenge' : ' custom-app-push-challenge';

--- a/src/v2/view-builder/views/shared/ChallengePushView.js
+++ b/src/v2/view-builder/views/shared/ChallengePushView.js
@@ -1,7 +1,7 @@
 // Common view for OV push and custom push.
 import { loc, createButton, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import { BaseForm } from '../../internals';
+import { BaseFormWithPolling } from '../../internals';
 import polling from '../shared/polling';
 import { WARNING_TIMEOUT } from '../../utils/Constants';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
@@ -14,7 +14,7 @@ const warningTemplate = View.extend({
     <p>{{warning}}</p>
   `
 });
-const Body = BaseForm.extend(Object.assign(
+const Body = BaseFormWithPolling.extend(Object.assign(
   {
     noButtonBar: true,
 
@@ -24,7 +24,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     initialize() {
-      BaseForm.prototype.initialize.apply(this, arguments);
+      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
       // 'hasSavingState' would be true when the auth key is custom_app.
       // Setting it to false when auth key is okta_verify with autochallenge schema
       // So that 'o-form-saving' css class is not added while polling and checkbox remains enabled.
@@ -50,9 +50,9 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     render() {
-      BaseForm.prototype.render.apply(this, arguments);
+      BaseFormWithPolling.prototype.render.apply(this, arguments);
       // Move checkbox below the button
-      // Checkbox is rendered by BaseForm using remediation response and 
+      // Checkbox is rendered by BaseForm using remediation response and
       // hence by default always gets added above buttons.
       if (this.isOVWithAutoChallenge()) {
         const checkbox = this.$el.find('[data-se="o-form-fieldset-autoChallenge"]');
@@ -96,7 +96,7 @@ const Body = BaseForm.extend(Object.assign(
     },
 
     remove() {
-      BaseForm.prototype.remove.apply(this, arguments);
+      BaseFormWithPolling.prototype.remove.apply(this, arguments);
       this.stopPolling();
     },
 

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -27,7 +27,7 @@ export default {
         const authenticatorPollAction = `${responseKey}-poll`;
         const pollInterval = this.dynamicPollingInterval || authenticator?.poll?.refresh;
         if (_.isNumber(pollInterval)) {
-          this.polling = setInterval(()=>{
+          this.polling = setTimeout(()=>{
             this.options.appState.trigger('invokeAction', authenticatorPollAction);
           }, pollInterval);
         }
@@ -41,7 +41,7 @@ export default {
   _startRemediationPolling() {
     const pollInterval = this.dynamicPollingInterval || this.fixedPollingInterval;
     if (_.isNumber(pollInterval)) {
-      this.polling = setInterval(() => {
+      this.polling = setTimeout(() => {
         this.options.appState.trigger('saveForm', this.model);
       }, pollInterval);
     }

--- a/src/v2/view-builder/views/shared/polling.js
+++ b/src/v2/view-builder/views/shared/polling.js
@@ -49,7 +49,7 @@ export default {
 
   stopPolling() {
     if (this.polling) {
-      clearInterval(this.polling);
+      clearTimeout(this.polling);
       this.polling = null;
     }
   }

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -28,6 +28,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return this.getTextContent('[data-se="o-form-fieldset-container"]');
   }
 
+  getAppLinkContent() {
+    return this.getTextContent('.appLinkContent');
+  }
+
   getFooterLink() {
     return this.footer.find('[data-se="sign-in-options"]');
   }

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -14,12 +14,6 @@ import userIsNotAssignedError from '../../../playground/mocks/data/idp/idx/error
 
 const BEACON_CLASS = 'mfa-okta-verify';
 
-const wait = async (timeout) => {
-  await new Promise((resolve) => setTimeout( () => {
-    resolve();
-  }, timeout));
-};
-
 let failureCount = 0, pollingError = false;
 const loopbackSuccessLogger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
 const loopbackSuccessMock = RequestMock()
@@ -71,6 +65,7 @@ const loopbackPollTimeoutMock = RequestMock()
   .respond(identifyWithDeviceProbingLoopback)
   .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
   .respond((req, res) => {
+    console.log('Here => ' + new Date().getSeconds());
     return new Promise((resolve) => setTimeout(function() {
       res.statusCode = '200';
       res.setBody(identifyWithDeviceProbingLoopback);
@@ -409,7 +404,7 @@ test
   .requestHooks(loopbackPollMockLogger, loopbackPollFailedMock)('next poll should not start if previous is failed', async t => {
     loopbackPollMockLogger.clear();
     await setup(t);
-    await wait(10_000);
+    await t.wait(10_000);
 
     await t.expect(loopbackPollMockLogger.count(
       record => record.request.url.match(/\/idp\/idx\/authenticators\/poll/)
@@ -424,7 +419,7 @@ test
     // Updating /poll response to take 5 sec to response.
     // Then counting the number of calls that should be done in time interval. Default Timeout for /poll is 2 sec.
     // Expecting to get only 2 calls(first at 2nd sec, second at 9th(5 sec response + 2 sec timeout) second).
-    await wait(10_000);
+    await t.wait(10_000);
 
     await t.expect(loopbackPollMockLogger.count(
       record => record.request.url.match(/\/idp\/idx\/authenticators\/poll/)

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -14,6 +14,12 @@ import userIsNotAssignedError from '../../../playground/mocks/data/idp/idx/error
 
 const BEACON_CLASS = 'mfa-okta-verify';
 
+const wait = async (timeout) => {
+  await new Promise((resolve) => setTimeout( () => {
+    resolve();
+  }, timeout));
+};
+
 let failureCount = 0, pollingError = false;
 const loopbackSuccessLogger = RequestLogger(/introspect|probe|challenge/, { logRequestBody: true, stringifyRequestBody: true });
 const loopbackSuccessMock = RequestMock()
@@ -59,7 +65,7 @@ const loopbackSuccessMock = RequestMock()
     'access-control-allow-methods': 'POST, OPTIONS'
   });
 
-const loopbackPollTimeoutMockLogger = RequestLogger(/poll/, { logRequestBody: true, stringifyRequestBody: true });
+const loopbackPollMockLogger = RequestLogger(/poll/, { logRequestBody: true, stringifyRequestBody: true });
 const loopbackPollTimeoutMock = RequestMock()
   .onRequestTo(/\/idp\/idx\/introspect/)
   .respond(identifyWithDeviceProbingLoopback)
@@ -72,7 +78,46 @@ const loopbackPollTimeoutMock = RequestMock()
     }, Constants.TESTCAFE_DEFAULT_AJAX_WAIT + 2_000));
   })
   .onRequestTo(/2000\/probe/)
-  .respond(null, 500, {
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6511\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6511\/challenge/)
+  .respond((req, res) => {
+    res.statusCode = req.method !== 'POST' ? 204 : 403;
+    res.headers = {
+      'access-control-allow-origin': '*',
+      'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
+      'access-control-allow-methods': 'POST, GET, OPTIONS'
+    };
+  })
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'Origin, X-Requested-With, Content-Type, Accept, X-Okta-Xsrftoken',
+    'access-control-allow-methods': 'POST, OPTIONS'
+  });
+
+const loopbackPollFailedMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
+  .respond(identifyWithDeviceProbingLoopback)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond((req, res) => {
+    res.statusCode = '400';
+    res.setBody(userIsNotAssignedError);
+  })
+  .onRequestTo(/2000\/probe/)
+  .respond(null, 200, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   })
@@ -361,18 +406,27 @@ test
   });
 
 test
-  .requestHooks(loopbackPollTimeoutMockLogger, loopbackPollTimeoutMock)('new poll does not starts until last one is ended', async t => {
+  .requestHooks(loopbackPollMockLogger, loopbackPollFailedMock)('next poll should not start if previous is failed', async t => {
+    loopbackPollMockLogger.clear();
+    await setup(t);
+    await wait(10_000);
+
+    await t.expect(loopbackPollMockLogger.count(
+      record => record.request.url.match(/\/idp\/idx\/authenticators\/poll/)
+    )).eql(1);
+  });
+
+test
+  .requestHooks(loopbackPollMockLogger, loopbackPollTimeoutMock)('new poll does not starts until last one is ended', async t => {
+    loopbackPollMockLogger.clear();
     await setup(t);
     // This test verify if new /poll calls are made only if the previous one was finished instead of polling with fixed interval.
     // Updating /poll response to take 5 sec to response.
     // Then counting the number of calls that should be done in time interval. Default Timeout for /poll is 2 sec.
     // Expecting to get only 2 calls(first at 2nd sec, second at 9th(5 sec response + 2 sec timeout) second).
-    const tetsTimeout = 10_000;
-    await new Promise((resolve) => setTimeout( () => {
-      resolve();
-    }, tetsTimeout));
+    await wait(10_000);
 
-    await t.expect(loopbackPollTimeoutMockLogger.count(
+    await t.expect(loopbackPollMockLogger.count(
       record => record.request.url.match(/\/idp\/idx\/authenticators\/poll/)
     )).eql(2);
   });

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -146,36 +146,6 @@ describe('v2/models/AppState', function() {
   describe('shouldReRenderView', () => {
     it('rerender view should be false if stateHandle are different', () => {
 
-      const transformedResponse = {
-        'idx': {
-          'rawIdxState':{
-            'version':'1.0.0',
-            'stateHandle':'12345',
-            'intent':'LOGIN',
-            'remediation':{
-              'type':'array',
-              'value':[
-                {
-                  'rel':[
-                    'create-form'
-                  ],
-                  'name':'device-challenge-poll',
-                  'relatesTo':[
-                    'authenticatorChallenge'
-                  ],
-                  'refresh':2000,
-                  'value':[
-                    {
-                      'name':'stateHandle',
-                      'required':true,
-                      'value':'12345'
-                    }
-                  ]
-                }
-              ]
-            }
-          }}};
-
       const idxObj = {
         'idx': {
           'rawIdxState':{
@@ -204,7 +174,14 @@ describe('v2/models/AppState', function() {
                 }
               ]
             }
-          }}};
+          }}, 
+        'remediations': [{
+          'name': 'create-form',
+          'refresh': 2000,
+        }]};
+
+      const transformedResponse = JSON.parse(JSON.stringify(idxObj));
+      transformedResponse.idx.rawIdxState.stateHandle = '1234';
 
       this.initAppState(idxObj, 'create-form');
       expect(this.appState.shouldReRenderView(transformedResponse)).toBe(false);

--- a/test/unit/spec/v2/view-builder/views/shared/polling_spec.js
+++ b/test/unit/spec/v2/view-builder/views/shared/polling_spec.js
@@ -1,0 +1,77 @@
+import polling from '../../../../../../../src/v2/view-builder/views/shared/polling';
+import AppState from '../../../../../../../src/v2/models/AppState';
+
+describe('v2/view-builder/views/polling', function() {
+  let testContext;
+
+  const init = () => {
+    testContext = {};
+    testContext.pollingTestObj = {};
+    Object.assign(testContext.pollingTestObj, polling);
+
+    testContext.pollingTestObj.options = {};
+    testContext.pollingTestObj.options.appState = new AppState();
+    testContext.appState = testContext.pollingTestObj.options.appState;
+    testContext.pollingTestObj.model = {};
+  };
+
+  const wait = async (timeout) => {
+    await new Promise((resolve) => setTimeout( () => {
+      resolve();
+    }, timeout));
+  };
+
+  beforeEach(() => {
+    init();
+  });
+
+  it('_startRemediationPolling makes only one poll call with timeout', async () => {
+    testContext.pollingTestObj.fixedPollingInterval = 100;
+    spyOn(testContext.appState, 'trigger');
+
+    testContext.pollingTestObj._startRemediationPolling();
+    await wait(1_000);
+
+    expect(testContext.appState.trigger).toHaveBeenCalledTimes(1);
+    expect(testContext.appState.trigger).toHaveBeenCalledWith('saveForm', testContext.pollingTestObj.model);
+  });
+
+  it('stopPolling should prevent _startRemediationPolling from making poll call', async () => {
+    testContext.pollingTestObj.fixedPollingInterval = 500;
+    spyOn(testContext.appState, 'trigger');
+
+    testContext.pollingTestObj._startRemediationPolling();
+    testContext.pollingTestObj.stopPolling();
+    await wait(1_000);
+
+    expect(testContext.appState.trigger).not.toHaveBeenCalled();
+  });
+
+
+  it('_startAuthenticatorPolling makes only one poll call with timeout', async () => {
+    testContext.pollingTestObj.dynamicPollingInterval = 100;
+    const respKey = 'currentAuthenticator';
+    spyOn(testContext.appState, 'has').and.callFake(responseKey => responseKey === respKey);
+    spyOn(testContext.appState, 'trigger');
+
+    testContext.pollingTestObj._startAuthenticatorPolling();
+    await wait(1_000);
+
+    expect(testContext.appState.trigger).toHaveBeenCalledTimes(1);
+    expect(testContext.appState.trigger).toHaveBeenCalledWith('invokeAction', `${respKey}-poll`);
+  });
+
+  it('stopPolling should prevent _startAuthenticatorPolling from making poll call', async () => {
+    testContext.pollingTestObj.dynamicPollingInterval = 500;
+    const respKey = 'currentAuthenticator';
+    spyOn(testContext.appState, 'has').and.callFake(responseKey => responseKey === respKey);
+    spyOn(testContext.appState, 'trigger');
+
+    testContext.pollingTestObj._startAuthenticatorPolling();
+    testContext.pollingTestObj.stopPolling();
+    await wait(1_000);
+
+    expect(testContext.appState.trigger).not.toHaveBeenCalled();
+  });
+
+});


### PR DESCRIPTION
## Description:
- update remediation poll from setInterval to setTimeout
- update v2 AppState to trigger 'change:dynamicRefreshInterval' even if interval is not changed
- update NumberChallengePushView, ChallengePushView, EnrollPollOktaVerifyView to be extended from BaseFormWithPolling
- add test case for new polling logic in DeviceChallengePollView
- Update AppState unit test

SIW bacon [link](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&sha=9e9b47c9674c7a1b53f842d491aea0c6ca5889e6&page=1&pageSize=6)
Core bacon [link](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&sha=ff56129adf983bf2ab45c9454b8b7c18377c61ab&page=1&pageSize=6)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
- [before fix](https://okta.box.com/s/k8j42wa5anibalj0b5b83v1cw3ebc3my)
- [after fix](https://okta.box.com/s/e7vjbk955zr5h1f39xnd3k3t7wbobliu)

### Reviewers:
@haishengwu-okta 
@pradeepdewda-okta 
@YangChen-okta 

### Issue:

- [OKTA-423330](https://oktainc.atlassian.net/browse/OKTA-423330)