### PR TITLE
chore: fix sass build warning

### DIFF
--- a/assets/sass/common/enduser/_helpers.scss
+++ b/assets/sass/common/enduser/_helpers.scss
@@ -1,6 +1,8 @@
 // Generated from okta-core sha: 900f683
 // Note: Do not modify this file directly.
 
+@use "sass:math";
+
 // ======= Mixins =======
 
 @mixin dropdown-env($bg-color: $white) {
@@ -87,7 +89,7 @@
 // ======= Functions =======
 
 @function compute-color-brightness($color) {
-  @return ((red($color) * 299) + (green($color) * 587) + (blue($color) * 114)) / 1000;
+  @return ((red($color) * 299) + (green($color) * 587) + math.div((blue($color) * 114)), 1000);
 }
 
 // ======= Classes (Classes should rarely be added) =======

--- a/assets/sass/common/enduser/_responsive-variables.scss
+++ b/assets/sass/common/enduser/_responsive-variables.scss
@@ -1,6 +1,8 @@
 // Generated from okta-core sha: 900f683
 // Note: Do not modify this file directly.
 
+@use "sass:math";
+
 // Break Points
 $x-large: 1209px;
 $large: 1024px;
@@ -22,11 +24,11 @@ $medium-max-org-logo-width: 90px;
 $x-small-max-org-logo-width: 55px;
 
 // Tab Size
-$x-large-tab-width: floor($x-large-container-width / $num-tabs);
-$large-tab-width: floor($large-container-width / $num-tabs);
-$medium-tab-width: floor($medium-container-width / $num-tabs);
-$small-tab-width: floor($small-container-width / $num-tabs);
-$x-small-tab-width: floor($x-small-container-width / $num-tabs);
+$x-large-tab-width: floor(math.div($x-large-container-width, $num-tabs));
+$large-tab-width: floor(math.div($large-container-width, $num-tabs));
+$medium-tab-width: floor(math.div($medium-container-width, $num-tabs));
+$small-tab-width: floor(math.div($small-container-width, $num-tabs));
+$x-small-tab-width: floor(math.div($x-small-container-width, $num-tabs));
 
 // App Button Size
 $large-app-wrapper-spacing: 28px;

--- a/assets/sass/common/shared/helpers/_variables.scss
+++ b/assets/sass/common/shared/helpers/_variables.scss
@@ -1,6 +1,8 @@
 // Generated from okta-core sha: 900f683
 // Note: Do not modify this file directly.
 
+@use "sass:math";
+
 // Okta colors
 $primary-color: #007dc1;
 $primary-border-color: #005380;
@@ -33,7 +35,7 @@ $text-color-placeholder: #a1a1a1;
 $paragraph-line-height: 18px;
 $component-heading-color: #919191;
 $form-heading-color: $secondary-color-text;
-$paragraph-margin: $paragraph-line-height / 2;
+$paragraph-margin: math.div($paragraph-line-height, 2);
 
 // Buttons
 $btn-bg-color-primary: $secondary-color;


### PR DESCRIPTION
## Description:

Fix sass build deprecation warning
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($paragraph-line-height, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

╷
36 │ $paragraph-margin: $paragraph-line-height / 2;
│                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
╵
target/sass/common/shared/helpers/_variables.scss 36:20  @import
target/sass/common/shared/helpers/_all.scss 4:9          @import
target/sass/okta-sign-in.scss 3:9                        root stylesheet
```

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-444096](https://oktainc.atlassian.net/browse/OKTA-444096)


