### PR TITLE
hide spinner on invalid login attempt

### DIFF
--- a/src/models/PrimaryAuth.js
+++ b/src/models/PrimaryAuth.js
@@ -110,7 +110,7 @@ export default BaseLoginModel.extend({
       } else {
         primaryAuthPromise = this.doTransaction(function(transaction) {
           return this.doPrimaryAuth(authClient, signInArgs, transaction.authenticate);
-        });
+        }, true);
       }
     } else {
       //normal username/password flow without stateToken

--- a/test/unit/spec/PrimaryAuth_spec.js
+++ b/test/unit/spec/PrimaryAuth_spec.js
@@ -1625,6 +1625,23 @@ Expect.describe('PrimaryAuth', function() {
             expect(test.beacon.beacon().length).toBe(0);
           });
       });
+      itp('hide beacon spinner when security image is disabled during invalid login attempt', function() {
+        return setup()
+          .then(function(test) {
+            Q.stopUnhandledRejectionTracking();
+            test.setNextResponse(resUnauthorized);
+            test.form.setUsername('testuser');
+            test.form.setPassword('pass');
+            test.form.submit();
+            return Expect.waitForFormError(test.form, test);
+          })
+          .then(function(test) {
+            expect(test.form.hasErrors()).toBe(true);
+            expect(test.form.errorMessage()).toBe('Unable to sign in');
+            expect(test.beacon.isLoadingBeacon()).toBe(false);
+            expect(test.beacon.beacon().length).toBe(0);
+          });
+      });
       itp('does not show beacon-loading animation on CORS error (no security image)', function() {
         return setup()
           .then(function(test) {


### PR DESCRIPTION
## Description:
hide spinner on invalid login attempt


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Before - on preview
![Screen Shot 2021-12-01 at 11 05 31 AM](https://user-images.githubusercontent.com/38230587/144297632-724622fa-aee0-4e83-bcea-89693211dfac.png)
After - playground
![Screen Shot 2021-12-01 at 11 06 13 AM](https://user-images.githubusercontent.com/38230587/144297636-2bedb335-b642-4753-9535-b7e1739f85b2.png)


### Reviewers:


### Issue:

- [OKTA-416595](https://oktainc.atlassian.net/browse/OKTA-416595)


