### PR TITLE
QR code in OAuth device flow is missing user confirmation step

### DIFF
--- a/playground/mocks/data/api/v1/authn/device-code-activate-userCode.json
+++ b/playground/mocks/data/api/v1/authn/device-code-activate-userCode.json
@@ -1,0 +1,19 @@
+{
+  "status": "DEVICE_ACTIVATE",
+  "expiresAt": "2017-07-20T00:06:25.000Z",
+  "stateToken": "00-dummy-state-token",
+  "_embedded": {
+    "userCode": "ABCDXYWZ"
+  },
+  "_links": {
+    "next": {
+      "name": "deviceActivate",
+      "href": "http://localhost:3000/api/v1/authn/device/activate",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/device-code-activate-userCode.json
+++ b/playground/mocks/data/idp/idx/device-code-activate-userCode.json
@@ -1,0 +1,35 @@
+{
+  "stateHandle":"02itnqG312DoS3cU0z0LWs11l76yQ8ll4d95Oye61u",
+  "version":"1.0.0",
+  "expiresAt":"2020-04-13T20:30:53.000Z",
+  "step":"IDENTIFY",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"user-code",
+        "href":"http://localhost:3000/idp/idx/device/activate",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value":[
+          {
+            "name":"userCode",
+            "label":"Activation Code",
+            "value": "ABCDXYWZ"
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02itnqG312DoS3cU0z0LWs11l76yQ8ll4d95Oye61u",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/DeviceActivateController.js
+++ b/src/DeviceActivateController.js
@@ -31,10 +31,8 @@ export default FormController.extend({
   Model: function() {
     return {
       props: {
-        stateToken: 'string',
-      },
-      local: {
         userCode: ['string', true, this.options?.appState?.get('userCode')],
+        stateToken: 'string',
       },
       save: function() {
         const self = this;

--- a/src/DeviceActivateController.js
+++ b/src/DeviceActivateController.js
@@ -28,19 +28,23 @@ const InvalidUserCodeErrorView = View.extend({
 
 export default FormController.extend({
   className: 'device-code-activate',
-  Model: {
-    props: {
-      userCode: ['string', true],
-      stateToken: 'string',
-    },
-    save: function() {
-      const self = this;
-      return this.doTransaction(function(transaction) {
-        return transaction.deviceActivate({
-          userCode: self.get('userCode')
+  Model: function() {
+    return {
+      props: {
+        stateToken: 'string',
+      },
+      local: {
+        userCode: ['string', true, this.options?.appState?.get('userCode')],
+      },
+      save: function() {
+        const self = this;
+        return this.doTransaction(function(transaction) {
+          return transaction.deviceActivate({
+            userCode: self.get('userCode')
+          });
         });
-      });
-    },
+      }
+    };
   },
   Form: {
     noCancelButton: true,

--- a/src/models/AppState.js
+++ b/src/models/AppState.js
@@ -767,6 +767,12 @@ export default Model.extend({
         return !!(res._embedded && res._embedded.usingDeviceFlow);
       },
     },
+    userCode: {
+      deps: ['lastAuthResponse'],
+      fn: function(res) {
+        return res?._embedded?.userCode;
+      },
+    },
   },
 
   parse: function(options) {

--- a/test/testcafe/spec/DeviceCodeActivate_spec.js
+++ b/test/testcafe/spec/DeviceCodeActivate_spec.js
@@ -2,6 +2,7 @@ import { RequestMock, RequestLogger } from 'testcafe';
 import DeviceCodeActivatePageObject from '../framework/page-objects/DeviceCodeActivatePageObject';
 import deviceCodeActivateResponse from '../../../playground/mocks/data/idp/idx/device-code-activate.json';
 import deviceCodeActivateErrorResponse from '../../../playground/mocks/data/idp/idx/error-device-code-activate.json';
+import deviceCodeActivateWithUserCodeResponse from '../../../playground/mocks/data/idp/idx/device-code-activate-userCode.json';
 import idxActivateResponse from '../../../playground/mocks/data/idp/idx/identify-with-password.json';
 import idxActivateErrorResponse from '../../../playground/mocks/data/idp/idx/error-invalid-device-code.json';
 import idxDeviceActivatedTerminalResponse from '../../../playground/mocks/data/idp/idx/terminal-device-activated.json';
@@ -45,6 +46,14 @@ const deviceCodeInvalidUserCodeMock = RequestMock()
   .respond(idxActivateResponse)
   .onRequestTo('http://localhost:3000/idp/idx/identify')
   .respond(idxDeviceActivatedTerminalResponse);
+
+const deviceCodeSuccessWithUserCodeMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(deviceCodeActivateWithUserCodeResponse)
+  .onRequestTo('http://localhost:3000/idp/idx/device/activate')
+  .respond(idxActivateResponse)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(idxDeviceActivatedTerminalResponse);  
 
 const identifyRequestLogger = RequestLogger(
   /idx/,
@@ -190,4 +199,57 @@ test.requestHooks(identifyRequestLogger, deviceCodeSuccessMock)('should be able 
   await deviceCodeActivatePageObject.setActivateCodeTextBoxValue('ABCDE');
   // expect hyphen after 4th character
   await t.expect(deviceCodeActivatePageObject.getActivateCodeTextBoxValue()).eql('ABCD-E');
+});
+
+test.requestHooks(identifyRequestLogger, deviceCodeSuccessWithUserCodeMock)('should be able to complete device code activation flow with user code prefilled', async t => {
+  identifyRequestLogger.clear();
+  const deviceCodeActivatePageObject = await setup(t);
+
+  await t.expect(deviceCodeActivatePageObject.getPageTitle()).eql('Activate your device');
+  await t.expect(deviceCodeActivatePageObject.getPageSubtitle()).eql('Follow the instructions on your device to get an activation code');
+  await t.expect(await deviceCodeActivatePageObject.getActivationCodeTextBoxLabel()).eql('Activation Code');
+  await t.expect(deviceCodeActivatePageObject.isActivateCodeTextBoxVisible()).eql(true);
+
+  // check if user code is prefilled in the input
+  await t.expect(deviceCodeActivatePageObject.getActivateCodeTextBoxValue()).eql('ABCDXYWZ');
+
+  // submit user code
+  await deviceCodeActivatePageObject.clickNextButton();
+
+  await t.expect(identifyRequestLogger.count(() => true)).eql(2);
+  const req = identifyRequestLogger.requests[1].request;
+  const reqBody = JSON.parse(req.body);
+  await t.expect(reqBody).eql({
+    userCode: 'ABCDXYWZ',
+    stateHandle: '02itnqG312DoS3cU0z0LWs11l76yQ8ll4d95Oye61u',
+  });
+  await t.expect(req.method).eql('post');
+  await t.expect(req.url).eql('http://localhost:3000/idp/idx/device/activate');
+
+  identifyRequestLogger.clear();
+
+  // identify with password
+  await deviceCodeActivatePageObject.fillIdentifierField('Test Identifier');
+  await deviceCodeActivatePageObject.fillPasswordField('random password 123');
+  await deviceCodeActivatePageObject.clickNextButton();
+
+  await t.expect(identifyRequestLogger.count(() => true)).eql(1);
+  const reqIdentify = identifyRequestLogger.requests[0].request;
+  const reqBodyIdentify = JSON.parse(reqIdentify.body);
+  await t.expect(reqBodyIdentify).eql({
+    identifier: 'Test Identifier',
+    credentials: {
+      passcode: 'random password 123',
+    },
+    stateHandle: 'eyJ6aXAiOiJERUYiLCJhbGlhcyI6ImVuY3J5cHRpb25rZXkiLCJ2ZXIiOiIxIiwib2lkIjoiMDBvczI0VHZiWHlqOVFLSm4wZzMiLCJlbmMiOiJBMjU2R0NNIiwiYWxnIjoiZGlyIn0..4z7WWUdd0LzIJLxz.GmOyeMJ5XtS7kZipFanQxaMd2rblpEeaWv8U5IfaJv5F2V1otwft4q1tVo3yqbedhBjN-nO5qk6qR-0Op34lmecwwmHeRyzYbhrFiLZaR88nhCFMblP8Bo5d3Opl5gkX02e0FQL-Osorxvml0XYbuO7GdTH5EkIv0Q7h0Dq7L__h_uFLies8AkJZWIDQh25RlqcEjToHCvVW31A_NJJ1Vf5c8GFuyb9LsJ9kUpZikpK6C72GPrU_LGrIW8VBT4l24dDEre4J8XvTNO7fdVDiq-H7BEeIjaY06q1zqlVLWwqOHoKpGNQ0NMhBIXB0ZZC57Me9pFI5GLIUwRDUIm1vw3t_mHJDVIcCJe9kmt29tTccZ8Zo0N3q5bSiwMoNHPLxZSOrbx-bf4fniorNH5ypJnke7pc2Q3DFmqfPrB7CE1REjAyCKBHYDAfVexYCkMfCl0E8oMFJinnLbynb7Bqvbp_DqL8h0pNIoXUF4KTTsuKQg8yCCqBhkajxlvh9G7L3Sf76o4B2itB7ldeqXzAE9H60yqhIKEZPNOHUgRC2SkWkWlH6NIaNWQ2Bi2CjnL9YvUuQmO-dpf08KeCgwfVmT4GBTGfTkXwy3pBitacCqEREen2j2iUH9mhi2LOOFaGLh0TXslcBgkGuht6P7gyH2JN6yFInQyIp33xQsqYg7nqOZG1LCrQSqoviTfI72-AC6b7tju8YEn1P0nXGbSzlCztSXl2pa95tr4L5pyX8fNydKYMTLeHEnmNtXlRB6wQYP1ljf4Tzgus7O0etyJs75znsXHZ42znxlEKGhTo3ucFe3CI-vsHF1FDDj2DVeWl21zVOTehTbBaemoD1ekD5F8OHS7SrK9Bw7PTa-lpyls1OxvE_Wsco4_eGbax_DoPm6DbCwj8hWzb5wLEs6TClZKoUJeV1MSVB3OgGBZ3AGzhwfeG0sGi5DnUpAeKqgP6IN8kziNRDmW3YE0qIY2mLs7nI438RTu__6bg1E6SH1QHMNucNbmoDR6VDIUmlYc0xEpygH6PBVqiPD64MnD73_D9IinVNzqW7KQzAvuFFQW_LGDfjuh1D-oTs1gi1wWDylibjxdJabveoJ10NHgeb6SaYHg.kf5iTnjNKsKqhz0iE5K_Yw',
+  });
+  await t.expect(reqIdentify.method).eql('post');
+  await t.expect(reqIdentify.url).eql('http://localhost:3000/idp/idx/identify');
+
+  // expect device activated screen
+  await t.expect(deviceCodeActivatePageObject.getPageTitle()).eql('Device activated');
+  await t.expect(deviceCodeActivatePageObject.getTerminalContent()).eql('Follow the instructions on your device for next steps');
+  await t.expect(deviceCodeActivatePageObject.isTerminalSuccessIconPresent()).eql(true);
+  await t.expect(deviceCodeActivatePageObject.isBeaconTerminalPresent()).eql(false);
+  await t.expect(deviceCodeActivatePageObject.isTryAgainButtonPresent()).eql(false);
 });


### PR DESCRIPTION
## Description:

- QR code functionality in OAuth device flow is missing user confirmation step
- `user_code` is passed in the query parameter which will get returned to SIW in introspect response. Need to read that and pre-populate the user code form if it exists.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/79160458/145090182-2e2433d2-0932-49f3-94ae-d428d4d93078.mov

### Reviewers:
@moushmibanerjee-okta @jakebacher2-okta 

### Issue:

- [OKTA-452108](https://oktainc.atlassian.net/browse/OKTA-452108)


