### PR TITLE
Updates wdio script to use production test org

### DIFF
--- a/scripts/e2e-wdio.sh
+++ b/scripts/e2e-wdio.sh
@@ -16,9 +16,9 @@ aws s3 --quiet --region us-east-1 cp s3://ci-secret-stash/prod/signinwidget/expo
 source $OKTA_HOME/$REPO/scripts/export-test-credentials.sh
 
 # We use the below OIE enabled org and clients for OIE tests
-export WIDGET_TEST_SERVER=https://oie-widget-tests.sigmanetcorp.us
-export WIDGET_SPA_CLIENT_ID=0oa3mtlnedKzXMeto0g7
-export WIDGET_WEB_CLIENT_ID=0oa3mvgsvrEdck9GO0g7
+export WIDGET_TEST_SERVER=https://oie-signin-widget.okta.com
+export WIDGET_SPA_CLIENT_ID=0oa8lrg7ojTsbJgRQ696
+export WIDGET_WEB_CLIENT_ID=0oa8ls36zUZj7oFJ2696
 
 export ORG_OIE_ENABLED=true
 


### PR DESCRIPTION
## Description:
- Existing e2e-wdio uses a trex cloud org
- The org seems to have issues related to profile enrollment + app sign-on policy configuration (probably created with incorrect OIE LGA feature flags)
- This PR updates the script with a production org with OIE LGA SKU flag set
- All test users, groups, apps are created in the new org


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


