### PR TITLE
Add more devs to codeowners for i18n packages and fix flakey tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,5 @@
 
 # Localization: pseudo-loc, i18n, etc.
 packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @jmelberg-okta
-packages/@okta/i18n/          @nikhilvenkatraman-okta @jmelberg-okta
+packages/@okta/i18n/          @nikhilvenkatraman-okta @jmelberg-okta @mauriciocastillosilva-okta @pradeepdewda-okta
 test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @jmelberg-okta

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -144,6 +144,8 @@ const I18N_OVERRIDE_MAPPINGS = {
 
   'enroll-profile.userProfile.lastName': 'oie.user.profile.lastname',
   'enroll-profile.userProfile.firstName': 'oie.user.profile.firstname',
+  'enroll-profile.userProfile.countryCode': 'oie.user.profile.countryCode',
+  'enroll-profile.userProfile.timezone': 'oie.user.profile.timezone',
   'enroll-profile.userProfile.email': 'oie.user.profile.primary.email',
   'profile-update.userProfile.secondEmail': 'oie.user.profile.secondary.email',
 
@@ -168,6 +170,9 @@ const I18N_OVERRIDE_MAPPINGS = {
   'core.auth.factor.signedNonce.error.invalidFactor': 'core.auth.factor.signedNonce.error',
   'core.auth.factor.signedNonce.error.deletedDevice': 'core.auth.factor.signedNonce.error',
   'core.auth.factor.signedNonce.error.invalidDeviceStatus': 'core.auth.factor.signedNonce.error.invalidDevice',
+
+  // re-map autoPush: Send push automatically for mock authenticator-verification-okta-verify-push-autoChallenge-on
+  'challenge-poll.okta_verify.autoChallenge': 'autoPush'
 };
 
 const I18N_PARAMS_MAPPING = {

--- a/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
+++ b/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
@@ -36,7 +36,7 @@ const BaseEmailMagicLinkOTPTerminalView = View.extend({
 
 const OTPInformationTerminalView = BaseEmailMagicLinkOTPTerminalView.extend({
   template: hbs`
-  <h1 class='otp-value'>{{otp}}</h1>
+  <h1 class='otp-value no-translate'>{{otp}}</h1>
   <div class="enduser-email-consent--info">
     <div>{{i18n code="idx.return.link.otponly.request" bundle="login"}}</div>
   </div>

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -18,13 +18,7 @@ const ignoredMocks = [
   'identify-with-password-with-recaptcha-v2.json', // No english leaks for this, just flaky on bacon due to loading the reCaptcha lib
   'enroll-profile-update-all-optional-params.json', // No english leaks as custom attribute label comes from server
   'enroll-profile-update-params.json', // No english leaks as custom attribute label comes from server
-  'oda-enrollment-ios.json', // already fixed in master but changes are not in 5.12 yet, should be reverted
-  'mdm-enrollment.json', // already fixed in master but changes are not in 5.12 yet, should be reverted
-
-  // flaky on bacon
-  'terminal-return-otp-only-full-location.json',
-  'terminal-return-otp-only-no-location.json',
-  'terminal-return-otp-only-partial-location.json'
+  'enroll-profile-new-additional-fields' // No english leaks on UI. Country and timezone dropdown values are not localized OKTA-454630
 ];
 
 const optionsForInteractionCodeFlow = {

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -76,7 +76,7 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.countryCode')).ok();
   await enrollProfilePage.selectValueFromDropdown('userProfile.countryCode', 1);
 
-  await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.timezone')).eql('Timezone');
+  await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.timezone')).eql('Time zone');
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.timezone')).ok();
   await enrollProfilePage.selectValueFromDropdown('userProfile.timezone', 1);
 });


### PR DESCRIPTION
Resolves: OKTA-454402

## Description:

- Adding few more devs to the codeowners list for i18n package in SIW 
- Fixed some english leaks and flakey tests 


## PR Checklist

- [x] Have you verified the basic functionality for this change?

### Screenshot/Video:


### Reviewers:

@mauriciocastillosilva-okta @pradeepdewda-okta @jmelberg-okta @fangshi-okta @aarongranick-okta 

### Issue:

- [OKTA-454402](https://oktainc.atlassian.net/browse/OKTA-454402)


