### PR TITLE
feat: preserve username when navigating to forgot password page

### DIFF
--- a/src/v1/controllers/ForgotPasswordController.js
+++ b/src/v1/controllers/ForgotPasswordController.js
@@ -190,6 +190,10 @@ export default FormController.extend({
       return formChildren;
     },
     initialize: function() {
+      if (!_.isEmpty(this.options.appState.get('username'))) {
+        this.model.set('username', this.options.appState.get('username'));
+      }
+
       this.listenTo(this.state, 'contactSupport', function() {
         this.add(ContactSupport, '.o-form-error-container');
       });
@@ -220,8 +224,4 @@ export default FormController.extend({
     },
   },
   Footer: ForgotPasswordControllerFooter,
-
-  initialize: function() {
-    this.options.appState.unset('username');
-  },
 });


### PR DESCRIPTION
## Description:
If user has already entered username on the login page, we could try to preserve the username when they navigate to the forgot password page.

Current behaviour would see the username cleared when navigating from the main login screen to forgot password.

### Screenshot/Video:
Current Behaviour:

https://user-images.githubusercontent.com/4397605/148003632-c7bd7003-ff0c-42c9-a2a5-087bd036b5f5.mov

Proposed new change:

https://user-images.githubusercontent.com/4397605/148003844-822e5e21-7133-4a1f-ba7d-3600c123be64.mov




