### PR TITLE
fix: Remove send again warning on 'send me an email' view

### DIFF
--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorDataEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorDataEmailView.js
@@ -1,8 +1,8 @@
 import { loc, View } from 'okta';
 import hbs from 'handlebars-inline-precompile';
-import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
+import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
-const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
+const BaseAuthenticatorEmailForm = BaseAuthenticatorView.prototype.Body;
 
 const SubtitleView = View.extend({
   template: hbs`
@@ -58,6 +58,6 @@ const Body = BaseAuthenticatorEmailForm.extend(
   },
 );
 
-export default BaseAuthenticatorEmailView.extend({
+export default BaseAuthenticatorView.extend({
   Body,
 });

--- a/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeEmailPageObject.js
@@ -1,12 +1,18 @@
 import ChallengeFactorPageObject from './ChallengeFactorPageObject';
 
+const RESEND_EMAIL_VIEW_SELECTOR = '.resend-email-view';
+
 export default class ChallengeEmailPageObject extends ChallengeFactorPageObject {
   constructor(t) {
     super(t);
   }
 
   resendEmailView() {
-    return this.form.getElement('.resend-email-view');
+    return this.form.getElement(RESEND_EMAIL_VIEW_SELECTOR);
+  }
+
+  resendEmailViewExists() {
+    return this.form.elementExist(RESEND_EMAIL_VIEW_SELECTOR);
   }
 
   async clickSendAgainLink() {

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -203,6 +203,19 @@ test
   });
 
 test
+  .requestHooks(sendEmailMock)('should not show send again warning after 30 seconds', async t => {
+    const challengeEmailPageObject = await setup(t);
+
+    const pageTitle = challengeEmailPageObject.getFormTitle();
+    const saveBtnText = challengeEmailPageObject.getSaveButtonLabel();
+    await t.expect(pageTitle).eql('Verify with your email');
+    await t.expect(saveBtnText).eql('Send me an email');
+
+    await t.wait(31000);
+    await t.expect(challengeEmailPageObject.resendEmailViewExists()).notOk();
+  });
+
+test
   .requestHooks(sendEmailEmptyProfileMock)('send me an email screen has right labels when profile is empty', async t => {
     const challengeEmailPageObject = await setup(t);
 


### PR DESCRIPTION
OKTA-455909
<<<Jenkins Check-In of Tested SHA: 574b6024c4ccbf7c4ba69f2f2583b3db4115bc6d for eng_productivity_ci_bot_okta@okta.com>>>
Artifact: okta-signin-widget
Files changed count: 3
PR Link: "https://github.com/okta/okta-signin-widget/pull/2341"

## Description:

PR #2341 has already been reviewed/approved. Cherry picked to add it to the next weekly release version (5.16)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-455909](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


