### PR TITLE
fix: custom button not render text from i18nKey config - OKTA-454191

### DIFF
--- a/src/v2/view-builder/internals/FormInputFactory.js
+++ b/src/v2/view-builder/internals/FormInputFactory.js
@@ -207,7 +207,7 @@ const createCustomButtons = (settings) => {
         'data-se': customButton.dataAttr
       },
       className: customButton.className + ' default-custom-button',
-      title: customButton.title,
+      title: customButton.title || loc(customButton.i18nKey, 'login'),
       click: customButton.click
     };
     return button;

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -132,6 +132,42 @@ describe('v2/view-builder/views/IdentifierView', function() {
     });
   });
 
+  it('view renders custom button with customButtons config', function() {
+    settings.set('customButtons', [{
+      title: 'Click Me',
+      className: 'btn-customAuth'
+    }]);
+
+    jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
+    testContext.init(XHRIdentifyWithPassword.remediation.value);
+    
+    const $customButton = testContext.view.$el.find('.o-form-button-bar .custom-buttons .btn-customAuth');
+    expect($customButton.text()).toEqual('Click Me');
+  });
+
+  it('view renders custom button title based on i18n config', function() {
+    settings.set('i18n', {
+      en: {
+        'customButton.title': 'Custom Button Title',
+      }
+    });
+    settings.set('customButtons', [{
+      i18nKey: 'customButton.title',
+      className: 'btn-customAuth'
+    }]);
+    Bundles['en'] = i18n.en;
+
+    jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);
+    jest.spyOn(AppState.prototype, 'isIdentifierOnlyView').mockReturnValue(false);
+    testContext.init(XHRIdentifyWithPassword.remediation.value);
+    
+    const $customButton = testContext.view.$el.find('.o-form-button-bar .custom-buttons .btn-customAuth');
+    expect($customButton.text()).toEqual('Custom Button Title');
+  });
+
   it('view updates model and view correctly if "username" config is passed in', function() {
     settings.set('username', 'testUsername');
 

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -158,7 +158,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
       i18nKey: 'customButton.title',
       className: 'btn-customAuth'
     }]);
-    Bundles['en'] = i18n.en;
+    Bundles['login_en'] = i18n.en;
 
     jest.spyOn(AppState.prototype, 'hasRemediationObject').mockReturnValue(true);
     jest.spyOn(AppState.prototype, 'getActionByPath').mockReturnValue(true);

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -148,11 +148,12 @@ describe('v2/view-builder/views/IdentifierView', function() {
   });
 
   it('view renders custom button title based on i18n config', function() {
-    settings.set('i18n', {
+    const i18n = {
       en: {
         'customButton.title': 'Custom Button Title',
       }
-    });
+    };
+    settings.set('i18n', i18n);
     settings.set('customButtons', [{
       i18nKey: 'customButton.title',
       className: 'btn-customAuth'


### PR DESCRIPTION
## Description:
Resolves https://github.com/okta/okta-signin-widget/issues/2327


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-454191](https://oktainc.atlassian.net/browse/OKTA-454191)


