### PR TITLE
Resolves: OKTA-436670 - Allow to render String type attributes with Enums as radio button or select

### DIFF
--- a/playground/mocks/data/idp/idx/profile-enrollment-string-fields-options.json
+++ b/playground/mocks/data/idp/idx/profile-enrollment-string-fields-options.json
@@ -1,0 +1,188 @@
+{
+  "stateHandle": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+  "version": "1.0.0",
+  "expiresAt": "2019-07-24T21:25:33.000Z",
+
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": ["create-form"],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "firstName",
+                  "type": "string",
+                  "label": "First name",
+                  "required": true
+                },
+                {
+                  "name": "lastName",
+                  "type": "string",
+                  "label": "Last name",
+                  "required": true
+                },
+                {
+                  "name": "email",
+                  "type": "string",
+                  "label": "Email",
+                  "required": true
+                },
+                {
+                  "name": "colores",
+                  "type": "string",
+                  "label": "Colors",
+                  "required": false,
+                  "options": [
+                    {
+                      "label": "display",
+                      "value": {
+                        "type": "object",
+                        "value": {
+                          "inputType": "select",
+                          "options": [
+                            {
+                              "label": "Red",
+                              "value": "red"
+                            },
+                            {
+                              "label": "Blue",
+                              "value": "blue"
+                            },
+                            {
+                              "label": "Green",
+                              "value": "green"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "favpizza",
+                  "type": "string",
+                  "label": "Favorite Pizza",
+                  "required": false,
+                  "options": [
+                    {
+                      "label": "display",
+                      "value": {
+                        "type": "object",
+                        "value": {
+                          "inputType": "radio",
+                          "options": [
+                            {
+                              "label": "Lucali",
+                              "value": "lucali"
+                            },
+                            {
+                              "label": "Razza",
+                              "value": "razza"
+                            },
+                            {
+                              "label": "Di Fara Pizza",
+                              "value": "difara"
+                            },
+                            {
+                              "label": "Bread And Salt",
+                              "value": "breadsalt"
+                            },
+                            {
+                              "label": "Ops",
+                              "value": "ops"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "favsong",
+                  "type": "string",
+                  "label": "Favorite Song",
+                  "required": false,
+                  "options": [
+                    {
+                      "label": "display",
+                      "value": {
+                        "type": "object",
+                        "value": {
+                          "inputType": "select",
+                          "options": [
+                            {
+                              "label": "Smells Like Teen Spirit - Nirvana",
+                              "value": "smells"
+                            },
+                            {
+                              "label": "Imagine - John Lennon",
+                              "value": "imagine"
+                            },
+                            {
+                              "label": "One - U2",
+                              "value": "one"
+                            },
+                            {
+                              "label": "Billie Jean - Michael Jackson",
+                              "value": "billie"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+            "visible": false
+          }
+        ]
+      },
+      {
+        "rel": ["create-form"],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "identifier",
+            "label": "identifier"
+          },
+          {
+            "name": "stateHandle",
+            "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+            "visible": false
+          }
+        ]
+      }
+    ]
+  },
+  "context": {
+    "rel": ["create-form"],
+    "name": "context",
+    "href": "http://localhost:3000/idp/idx/context",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+        "visible": false
+      }
+    ]
+  }
+}

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -97,7 +97,7 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
   }
 
   if (Array.isArray(ionFormField.options) && ionFormField.options[0] && ionFormField.options[0].value) {
-    let ionField = ionFormField.options[0];
+    const ionField = ionFormField.options[0];
     if (ionField.label === 'display') {
       populateUISchemaForDisplay(uiSchema, ionField);
     } else if (shouldRenderAsRadio(ionFormField.name)) {

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -53,6 +53,8 @@ const timezoneUISchema = {
 
 const shouldRenderAsRadio = (name) => name.indexOf('methodType') >= 0 || name.indexOf('channel') >= 0;
 
+const isDisplayPresent = (ionField) => ionField.label === 'display' && ionField.value !== undefined;
+
 const createUiSchemaForString = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
   const uiSchema = {
     type: 'text'
@@ -76,7 +78,17 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
   }
 
   if (Array.isArray(ionFormField.options) && ionFormField.options[0] && ionFormField.options[0].value) {
-    if (shouldRenderAsRadio(ionFormField.name)) {
+    if (isDisplayPresent(ionFormField.options[0])) {
+      let display = ionFormField.options[0].value.value;
+      uiSchema.type = display.inputType;
+      if (display.inputType === 'radio') {
+        uiSchema.options = display.options;
+      } else if (display.inputType === 'select') {
+        uiSchema.wide = true;
+        //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
+        uiSchema.options = Object.assign({0: ''}, ionOptionsToUiOptions(display.options));
+      }
+    } else if (shouldRenderAsRadio(ionFormField.name)) {
       // e.g. { name: 'methodType', options: [ {label: 'sms'} ], type: 'string' | null }
       uiSchema.type = 'radio';
       // set the default value to the first value..

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -102,7 +102,8 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
   }
 
   // set optional label for text boxes
-  if(ionFormField.required === false && uiSchema.type === 'text') {
+  if(ionFormField.required === false && (uiSchema.type === 'text' || uiSchema.type === 'radio' ||
+      uiSchema.type === 'select')) {
     uiSchema.sublabel = loc('oie.form.field.optional', 'login');
   }
 

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -53,6 +53,25 @@ const timezoneUISchema = {
 
 const shouldRenderAsRadio = (name) => name.indexOf('methodType') >= 0 || name.indexOf('channel') >= 0;
 
+const populateUISchemaForDisplay = (uiSchema, ionField) => {
+  let display = ionField.value.value;
+  uiSchema.type = display.inputType;
+  if (display.inputType === 'radio') {
+    uiSchema.options = display.options;
+  } else if (display.inputType === 'select') {
+    uiSchema.wide = true;
+    //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
+    uiSchema.options = Object.assign({0: ''}, ionOptionsToUiOptions(display.options));
+  }
+};
+
+const populateUISchemaForRadio = (uiSchema, ionFormField) => {
+  // e.g. { name: 'methodType', options: [ {label: 'sms'} ], type: 'string' | null }
+  uiSchema.type = 'radio';
+  // set the default value to the first value..
+  ionFormField.value = ionFormField.options[0].value;
+};
+
 const createUiSchemaForString = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
   const uiSchema = {
     type: 'text'
@@ -78,20 +97,9 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
   if (Array.isArray(ionFormField.options) && ionFormField.options[0] && ionFormField.options[0].value) {
     let ionField = ionFormField.options[0];
     if (ionField.label === 'display') {
-      let display = ionField.value.value;
-      uiSchema.type = display.inputType;
-      if (display.inputType === 'radio') {
-        uiSchema.options = display.options;
-      } else if (display.inputType === 'select') {
-        uiSchema.wide = true;
-        //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
-        uiSchema.options = Object.assign({0: ''}, ionOptionsToUiOptions(display.options));
-      }
+      populateUISchemaForDisplay(uiSchema, ionField);
     } else if (shouldRenderAsRadio(ionFormField.name)) {
-      // e.g. { name: 'methodType', options: [ {label: 'sms'} ], type: 'string' | null }
-      uiSchema.type = 'radio';
-      // set the default value to the first value..
-      ionFormField.value = ionFormField.options[0].value;
+      populateUISchemaForRadio(uiSchema, ionFormField);
     } else {
       // default to select (dropdown). no particular reason (certainly can default to radio.)
       // e.g. { name: 'questionKey', options: [], type: 'string' | null }

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -111,7 +111,7 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
     }
   }
 
-  // set optional label for text boxes, radio buttons and dropdowns
+  // set a label as 'Optional' for supported optional element types
   if(ionFormField.required === false && optionalType.includes(uiSchema.type)) {
     uiSchema.sublabel = loc('oie.form.field.optional', 'login');
   }

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -53,15 +53,17 @@ const timezoneUISchema = {
 
 const shouldRenderAsRadio = (name) => name.indexOf('methodType') >= 0 || name.indexOf('channel') >= 0;
 
+const optionalType = ['text', 'radio', 'select'];
+
 const populateUISchemaForDisplay = (uiSchema, ionField) => {
-  let display = ionField.value.value;
+  const display = ionField?.value?.value;
   uiSchema.type = display.inputType;
   if (display.inputType === 'radio') {
     uiSchema.options = display.options;
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;
     //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
-    uiSchema.options = Object.assign({0: ''}, ionOptionsToUiOptions(display.options));
+    uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
   }
 };
 
@@ -109,9 +111,8 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
     }
   }
 
-  // set optional label for text boxes
-  if(ionFormField.required === false && (uiSchema.type === 'text' || uiSchema.type === 'radio' ||
-      uiSchema.type === 'select')) {
+  // set optional label for text boxes, radio buttons and dropdowns
+  if(ionFormField.required === false && optionalType.includes(uiSchema.type)) {
     uiSchema.sublabel = loc('oie.form.field.optional', 'login');
   }
 

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -53,8 +53,6 @@ const timezoneUISchema = {
 
 const shouldRenderAsRadio = (name) => name.indexOf('methodType') >= 0 || name.indexOf('channel') >= 0;
 
-const isDisplayPresent = (ionField) => ionField.label === 'display' && ionField.value !== undefined;
-
 const createUiSchemaForString = (ionFormField, remediationForm, transformedResp, createUISchema, settings) => {
   const uiSchema = {
     type: 'text'
@@ -78,8 +76,9 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
   }
 
   if (Array.isArray(ionFormField.options) && ionFormField.options[0] && ionFormField.options[0].value) {
-    if (isDisplayPresent(ionFormField.options[0])) {
-      let display = ionFormField.options[0].value.value;
+    let ionField = ionFormField.options[0];
+    if (ionField.label === 'display') {
+      let display = ionField.value.value;
       uiSchema.type = display.inputType;
       if (display.inputType === 'radio') {
         uiSchema.options = display.options;

--- a/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
+++ b/test/testcafe/framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject.js
@@ -1,0 +1,19 @@
+import BasePageObject from './BasePageObject';
+
+export default class ProfileEnrollmentStringOptionsViewPageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+  }
+
+  getDropDownComponent(fieldName) {
+    return this.form.findFormFieldInput(fieldName).visible;
+  }
+
+  selectValueFromDropdown(fieldName, index) {
+    return this.form.selectValueChozenDropdown(fieldName, index);
+  }
+
+  clickRadioButton(fieldName, index) {
+    return this.form.selectRadioButtonOption(fieldName, index);
+  }
+}

--- a/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
+++ b/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
@@ -26,7 +26,7 @@ async function setup(t) {
   return identityPage;
 }
 
-test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should show dropdown values for colores and favsong; and should show collection of radio buttons for favpizza on registration form', async t => {
+test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should show dropdown values for select and radio buttons', async t => {
   const profileEnrollmentString = new ProfileEnrollmentStringOptionsViewPageObject(t);
   const identityPage = await setup(t);
   await identityPage.clickSignUpLink();

--- a/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
+++ b/test/testcafe/spec/ProfileEnrollmentWithStringOptions_spec.js
@@ -1,0 +1,53 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import ProfileEnrollmentStringOptionsViewPageObject from '../framework/page-objects/ProfileEnrollmentStringOptionsViewPageObject';
+import Identify from '../../../playground/mocks/data/idp/idx/identify-with-password';
+import ProfileEnrollmentStringFieldsOptions from '../../../playground/mocks/data/idp/idx/profile-enrollment-string-fields-options';
+
+const ProfileEnrollmentSignUpWithStringFieldsMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(Identify)
+  .onRequestTo('http://localhost:3000/idp/idx/enroll')
+  .respond(ProfileEnrollmentStringFieldsOptions);
+
+const requestLogger = RequestLogger(
+  /idx\/*/,
+  {
+    logRequestBody: true,
+    stringifyRequestBody: true,
+  }
+);
+
+fixture('Enroll Profile');
+
+async function setup(t) {
+  const identityPage = new IdentityPageObject(t);
+  await identityPage.navigateToPage();
+  return identityPage;
+}
+
+test.requestHooks(requestLogger, ProfileEnrollmentSignUpWithStringFieldsMock)('should show dropdown values for colores and favsong; and should show collection of radio buttons for favpizza on registration form', async t => {
+  const profileEnrollmentString = new ProfileEnrollmentStringOptionsViewPageObject(t);
+  const identityPage = await setup(t);
+  await identityPage.clickSignUpLink();
+
+  requestLogger.clear();
+  await t.expect(profileEnrollmentString.getFormTitle()).eql('Sign up');
+
+  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.firstName')).eql('First name');
+  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.lastName')).eql('Last name');
+  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.email')).eql('Email');
+
+  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.colores')).eql('Colors');
+  await t.expect(await profileEnrollmentString.getDropDownComponent('userProfile.colores')).ok();
+  await profileEnrollmentString.selectValueFromDropdown('userProfile.colores', 1);
+
+  await t.expect(await profileEnrollmentString.getFormFieldLabel('userProfile.favsong')).eql('Favorite Song');
+  await t.expect(await profileEnrollmentString.getDropDownComponent('userProfile.favsong')).ok();
+  await profileEnrollmentString.selectValueFromDropdown('userProfile.favsong', 1);
+
+  const favPizza = await profileEnrollmentString.clickRadioButton('userProfile.favpizza', 1);
+  await t.expect(favPizza).eql('Razza');
+
+  await t.expect(await profileEnrollmentString.getSaveButtonLabel()).eql('Sign Up');
+});


### PR DESCRIPTION
## Description:
String data types attributes with Enumerations defined in UD will be rendered as a collection of radio buttons or single select (The decision is taken by the administrator in profile enrollment).


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
**Defining the attribute "user.favsong" with an enumerated list in UD.**
![image](https://user-images.githubusercontent.com/90656212/148995040-109084dd-d7d4-44b6-9979-f5167513a1d5.png)

**Adding favsong and other attributes to the Profile Enrollment Rule**
![image](https://user-images.githubusercontent.com/90656212/148994768-3971abc0-7e3d-4c65-ac98-cc6d6c569f50.png)

**Rendering all these "String" attributes in the SIW (colores and favpizza) are optional attributes and favsong is required.**
![image](https://user-images.githubusercontent.com/90656212/148994826-4c031817-a60c-4c5d-9b74-81fac5761028.png)
![image](https://user-images.githubusercontent.com/90656212/148994877-a2d2c9b1-e48f-43b7-b1dc-db1711095b15.png)
![image](https://user-images.githubusercontent.com/90656212/148994927-18786b79-9e01-400f-abfd-4e7121a0e170.png)

**Required fields.**
![image](https://user-images.githubusercontent.com/90656212/149195206-96be028f-51a7-4071-bda5-78d5628987d8.png)

![image](https://user-images.githubusercontent.com/90656212/148995973-39e6cd71-95c2-40e8-8fe0-050fd2e7e8be.png)


### Reviewers:
@okta/ciamx 

### Issue:
- [OKTA-436670](https://oktainc.atlassian.net/browse/OKTA-436670)