### PR TITLE
fs-okta-435140-support-radio-for-boolean

### DIFF
--- a/playground/mocks/data/idp/idx/enroll-profile-new-boolean-fields.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new-boolean-fields.json
@@ -1,0 +1,118 @@
+{
+  "stateHandle": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+  "version": "1.0.0",
+  "expiresAt": "2019-07-24T21:25:33.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "firstName",
+                  "label": "First name",
+                  "required": true
+                },
+                {
+                  "name": "lastName",
+                  "label": "Last name",
+                  "required": true
+                },
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true
+                },
+                {
+                  "name": "pet",
+                  "type": "boolean",
+                  "label": "Do you have a pet?",
+                  "required": false,
+                  "options": [
+                    {
+                      "label": "display",
+                      "value": {
+                        "type": "object",
+                        "value": {
+                          "inputType": "radio",
+                          "options": [
+                            {
+                              "label": "Yes",
+                              "value": "true"
+                            },
+                            {
+                              "label": "No",
+                              "value": "false"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "subscribe",
+                  "type": "boolean",
+                  "label": "Subscribe me",
+                  "required": false
+                }
+              ]
+            }
+          },
+          {
+            "name": "stateHandle",
+            "value": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+            "visible": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "identifier",
+            "label": "identifier"
+          },
+          {
+            "name": "stateHandle",
+            "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+            "visible": false
+          }
+        ]
+      }
+    ]
+  },
+  "context": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "context",
+    "href": "http://localhost:3000/idp/idx/context",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "value": "01r2p5S9qaAjESMFuPzt7r3ZMcZZQ_vvS0Tzg56ajB",
+        "visible": false
+      }
+    ]
+  }
+}

--- a/src/v2/ion/ui-schema/ion-boolean-handler.js
+++ b/src/v2/ion/ui-schema/ion-boolean-handler.js
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 import { FORMS } from '../RemediationConstants';
+import { loc } from 'okta';
 
 const getCheckboxUiSchema = ({ label, type, required }) => ({
   // For Remember Me checkbox, we need the label only on the right side of it.
@@ -23,6 +24,14 @@ const getCheckboxUiSchema = ({ label, type, required }) => ({
   required: required || false,
 });
 
+const getRadioUiSchema = ({ label, required, options }) => ({
+  displayName: label,
+  type: 'radio',
+  required: required,
+  options: options[0].value.value.options,
+  sublabel: required? null : loc('oie.form.field.optional', 'login'),
+});
+
 const createUiSchemaForBoolean = (ionFormField, remediationForm) => {
   if ([FORMS.CONSENT_ENDUSER, FORMS.CONSENT_ADMIN].includes(remediationForm.name)) {
     const scopes = remediationForm.scopes.map(({name, label, desc}) => {
@@ -33,6 +42,8 @@ const createUiSchemaForBoolean = (ionFormField, remediationForm) => {
     const type = remediationForm.name;
 
     return {type, scopes, options: ionFormField.options};
+  } else if (Array.isArray(ionFormField.options) && ionFormField.options[0]?.value?.value?.inputType === 'radio') {
+    return getRadioUiSchema(ionFormField);
   } else {
     return getCheckboxUiSchema(ionFormField);
   }

--- a/test/testcafe/framework/page-objects/EnrollProfileViewPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollProfileViewPageObject.js
@@ -13,4 +13,16 @@ export default class EnrollProfileViewPageObject extends BasePageObject {
     return this.form.selectValueChozenDropdown(fieldName, index);
   }
 
+  clickRadioButton(fieldName, index) {
+    return this.form.selectRadioButtonOption(fieldName, index);
+  }
+
+  setCheckbox(fieldName){
+    this.form.setCheckbox(fieldName);
+  }
+
+  getCheckboxValue(fieldName){
+    return this.form.getCheckboxValue(fieldName);
+  }
+
 }

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -5,6 +5,7 @@ import Identify from '../../../playground/mocks/data/idp/idx/identify-with-passw
 import EnrollProfileSubmit from '../../../playground/mocks/data/idp/idx/enroll-profile-submit';
 import EnrollProfileSignUp from '../../../playground/mocks/data/idp/idx/enroll-profile-new';
 import EnrollProfileSignUpWithAdditionalFields from '../../../playground/mocks/data/idp/idx/enroll-profile-new-additional-fields';
+import EnrollProfileSignUpWithBooleanFields from '../../../playground/mocks/data/idp/idx/enroll-profile-new-boolean-fields';
 
 
 const EnrollProfileSignUpMock = RequestMock()
@@ -24,6 +25,12 @@ const EnrollProfileSignUpWithAdditionalFieldsMock = RequestMock()
   .respond(Identify)
   .onRequestTo('http://localhost:3000/idp/idx/enroll')
   .respond(EnrollProfileSignUpWithAdditionalFields);
+
+const EnrollProfileSignUpWithBooleanFieldsMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(Identify)
+  .onRequestTo('http://localhost:3000/idp/idx/enroll')
+  .respond(EnrollProfileSignUpWithBooleanFields);
 
 const requestLogger = RequestLogger(
   /idx\/*/,
@@ -80,3 +87,17 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.timezone')).ok();
   await enrollProfilePage.selectValueFromDropdown('userProfile.timezone', 1);
 });
+
+test.requestHooks(requestLogger, EnrollProfileSignUpWithBooleanFieldsMock)('should show radio and checkbox display for boolean data type fields', async t => {
+  const enrollProfilePage = new EnrollProfileViewPageObject(t);
+  const identityPage = await setup(t);
+  await identityPage.clickSignUpLink();
+
+  requestLogger.clear();
+
+  await t.expect(await enrollProfilePage.clickRadioButton('userProfile.pet', 0)).eql('Yes');
+
+  await t.expect(await enrollProfilePage.getCheckboxValue('userProfile.subscribe')).eql(false);
+  await enrollProfilePage.setCheckbox('userProfile.subscribe');
+});
+


### PR DESCRIPTION
## Description:
Boolean data types attributes can be rendered as a collection of radio buttons (The decision is taken by the administrator in profile enrollment).


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

<img width="516" alt="Screen Shot 2022-01-12 at 6 01 27 PM" src="https://user-images.githubusercontent.com/90279953/149254725-10d61199-7745-466e-afd3-9a4b73e9118a.png">

<img width="546" alt="Screen Shot 2022-01-13 at 8 34 06 AM" src="https://user-images.githubusercontent.com/90279953/149370619-6e025d9f-eafc-42bf-aee4-adb69a4328ac.png">


### Reviewers:
@okta/ciamx 

### Issue:

- [OKTA-435140](https://oktainc.atlassian.net/browse/OKTA-435140)


