### PR TITLE
feat: adds support for recoveryToken in OIE

### DIFF
--- a/src/v2/client/startLoginFlow.js
+++ b/src/v2/client/startLoginFlow.js
@@ -57,11 +57,12 @@ export async function startLoginFlow(settings) {
         );
       }
       // start new transaction
-      return authClient.idx.start(idxOptions);
+      const recoveryToken = settings.get('recoveryToken');
+      return authClient.idx.start({ ...idxOptions, recoveryToken }); // calls interact
     }
 
     // continue saved transaction
-    return authClient.idx.proceed(idxOptions);
+    return authClient.idx.proceed(idxOptions); // calls introspect
   }
 
   // Use stateToken from session storage if exists

--- a/src/widget/getAuthClient.js
+++ b/src/widget/getAuthClient.js
@@ -1,20 +1,32 @@
 import { OktaAuth } from '@okta/okta-auth-js';
 import Util from 'util/Util';
 import config from 'config/config.json';
-import _ from 'underscore';
 
 export default function(options) {
-  var authParams = _.extend({
-    issuer: options.issuer,
-    clientId: options.clientId,
-    redirectUri: options.redirectUri,
-    state: options.state,
-    scopes: options.scopes,
-    flow: options.flow,
-    codeChallenge: options.codeChallenge,
-    codeChallengeMethod: options.codeChallengeMethod,
+  const {
+    issuer,
+    clientId,
+    redirectUri,
+    state,
+    scopes,
+    flow,
+    codeChallenge,
+    codeChallengeMethod,
+    recoveryToken
+  } = options;
+  const authParams = {
+    issuer,
+    clientId,
+    redirectUri,
+    state,
+    scopes,
+    flow,
+    codeChallenge,
+    codeChallengeMethod,
     transformErrorXHR: Util.transformErrorXHR,
-  }, options.authParams);
+    recoveryToken,
+    ...options.authParams
+  };
 
   if (!authParams.issuer) {
     authParams.issuer = options.baseUrl + '/oauth2/default';

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -98,6 +98,10 @@ describe('v2/client/startLoginFlow', () => {
     });
 
     expect(start).toHaveBeenCalledTimes(1);
+
+    expect(start).toHaveBeenCalledWith({
+      exchangeCodeForTokens: false
+    });
     expect(proceed).not.toHaveBeenCalled();
   });
 
@@ -198,5 +202,20 @@ describe('v2/client/startLoginFlow', () => {
         'Set "useInteractionCodeFlow" to true in configuration to enable the ' +
         'interaction_code" flow for self-hosted widget.');
     }
+  });
+
+  it('passes "recoveryToken" to interact', async () => {
+    const { settings, start } = testContext;
+    const recoveryToken = 'abcdef';
+    settings.set('useInteractionCodeFlow', true);
+    settings.set('recoveryToken', recoveryToken);
+    const result = await startLoginFlow(settings);
+    expect(result).toEqual({
+      fake: 'fake start response'
+    });
+    expect(start).toHaveBeenCalledWith({
+      exchangeCodeForTokens: false,
+      recoveryToken
+    });
   });
 });


### PR DESCRIPTION
## Description:
Supports existing option `recoveryToken` in OIE flows (embedded with `useInteractionCodeFlow` set to `true`)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

https://user-images.githubusercontent.com/47947204/150874267-9e7d2de5-5c1e-43f2-90ff-05c276d4b91e.mov



### Reviewers:


### Issue:

- [OKTA-452036](https://oktainc.atlassian.net/browse/OKTA-452036)


