### PR TITLE
fix: BaseForm will show all error messages when multiple

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -17,6 +17,7 @@ const idx = {
 
   '/idp/idx/introspect': [
     'identify',
+    // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
     // 'error-401-invalid-otp-passcode',

--- a/playground/mocks/data/idp/idx/error-identify-multiple-errors.json
+++ b/playground/mocks/data/idp/idx/error-identify-multiple-errors.json
@@ -1,0 +1,103 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02f9EONFMnQZtAQHl7Gf4Ye-R4mXc8cOhBUSMc7ubQ",
+  "expiresAt": "2021-11-02T22:10:41.000Z",
+  "step":"IDENTIFY",
+  "intent":"LOGIN",
+  "remediation":{
+     "type":"array",
+     "value":[
+        {
+            "rel":[
+              "create-form"
+            ],
+            "name":"identify",
+            "href":"http://localhost:3000/idp/idx/identify",
+            "method":"POST",
+            "accepts":"application/vnd.okta.v1+json",
+            "value":[
+              {
+                  "name":"identifier",
+                  "label":"Username"
+              },
+              {
+               "name":"rememberMe",
+               "label":"Remember Me",
+               "type":"boolean"
+              },
+              {
+                  "name":"stateHandle",
+                  "required":true,
+                  "value":"",
+                  "visible":false,
+                  "mutable":false
+              }
+            ]
+        },
+        {
+           "rel":[
+              "create-form"
+           ],
+           "name":"select-enroll-profile",
+           "href":"http://localhost:3000/idp/idx/enroll",
+           "method":"POST",
+           "accepts":"application/vnd.okta.v1+json",
+           "value":[
+              {
+                 "name":"stateHandle",
+                 "required":true,
+                 "value":"eyJ6aXAiOiJE",
+                 "visible":false,
+                 "mutable":false
+              }
+           ]
+        }
+     ]
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02f9EONFMnQZtAQHl7Gf4Ye-R4mXc8cOhBUSMc7ubQ",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.username.required"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.password.required"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.expired.session"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}
+  

--- a/playground/mocks/data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile-multiple-errors.json
+++ b/playground/mocks/data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile-multiple-errors.json
@@ -1,0 +1,79 @@
+{
+   "version":"1.0.0",
+   "stateHandle":"02zMxGpO2d8MdP7jxUaCShKzcF441EBXJOnTr7UCb0",
+   "expiresAt":"2021-11-03T17:42:45.000Z",
+   "intent":"LOGIN",
+   "messages":{
+      "type":"array",
+      "value":[
+         {
+            "message":"Your response was received, but your organization requires biometrics. Make sure your device supports biometrics, Okta Verify is up-to-date and biometrics are enabled for your account in Okta Verify, then try again.",
+            "i18n":{
+               "key":"oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.mobile"
+            },
+            "class":"ERROR"
+         },
+         {
+            "message": "",
+            "i18n": {
+              "key": "error.username.required"
+            },
+            "class": "ERROR"
+          },
+          {
+            "message": "",
+            "i18n": {
+              "key": "error.password.required"
+            },
+            "class": "ERROR"
+          },
+          {
+            "message": "",
+            "i18n": {
+              "key": "error.expired.session"
+            },
+            "class": "ERROR"
+          }
+      ]
+   },
+   "user":{
+      "type":"object",
+      "value":{
+         "id":"00uy8atHj1x8T0NrQ0g3",
+         "identifier":"mov@okta.com",
+         "profile":{
+            "firstName":"mov",
+            "lastName":"1",
+            "timeZone":"America/Los_Angeles",
+            "locale":"en_US"
+         }
+      }
+   },
+   "cancel":{
+      "rel":[
+         "create-form"
+      ],
+      "name":"cancel",
+      "href":"https://localhost:3000/idp/idx/cancel",
+      "method":"POST",
+      "produces":"application/ion+json; okta-version=1.0.0",
+      "value":[
+         {
+            "name":"stateHandle",
+            "required":true,
+            "value":"02zMxGpO2d8MdP7jxUaCShKzcF441EBXJOnTr7UCb0",
+            "visible":false,
+            "mutable":false
+         }
+      ],
+      "accepts":"application/json; okta-version=1.0.0"
+   },
+   "app":{
+      "type":"object",
+      "value":{
+         "name":"oidc_client",
+         "label":"OIDC",
+         "id":"0oay76efxzwhirUfx0g3"
+      }
+   }
+}

--- a/playground/mocks/data/idp/idx/error-terminal-multiple-errors.json
+++ b/playground/mocks/data/idp/idx/error-terminal-multiple-errors.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.0.0",
+    "stateHandle": "02f9EONFMnQZtAQHl7Gf4Ye-R4mXc8cOhBUSMc7ubQ",
+    "expiresAt": "2021-11-02T22:10:41.000Z",
+    "intent":"LOGIN",
+    "messages": {
+      "type": "array",
+      "value": [
+        {
+          "message": "",
+          "i18n": {
+            "key": "error.username.required"
+          },
+          "class": "ERROR"
+        },
+        {
+          "message": "",
+          "i18n": {
+            "key": "error.password.required"
+          },
+          "class": "ERROR"
+        },
+        {
+          "message": "",
+          "i18n": {
+            "key": "error.expired.session"
+          },
+          "class": "ERROR"
+        }
+      ]
+    }
+  }
+    

--- a/playground/mocks/data/idp/idx/errors-authenticator-verification-okta-verify-reject-push.json
+++ b/playground/mocks/data/idp/idx/errors-authenticator-verification-okta-verify-reject-push.json
@@ -1,0 +1,292 @@
+{
+  "stateHandle": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+  "version": "1.0.0",
+  "expiresAt": "2020-01-13T21:14:37.000Z",
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "You have chosen to reject this login.",
+        "i18n": {
+          "key": "api.authn.poll.error.push_rejected",
+          "params": []
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.username.required"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.password.required"
+        },
+        "class": "ERROR"
+      },
+      {
+        "message": "",
+        "i18n": {
+          "key": "error.expired.session"
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "remediation": {
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"resend",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge",
+        "method":"POST",
+        "accepts":"application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "label": "Okta Verify",
+            "value": {
+              "form": {
+                "value": [
+                  {
+                    "name": "id",
+                    "value": "auteq0lLiL9o1cYoN0g4",
+                    "required": true,
+                    "mutable": false
+                  },
+                  {
+                    "name": "methodType",
+                    "value" : "push",
+                    "label" :  "PUSH",
+                    "required": true,
+                    "mutable": false
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-authenticate",
+        "href": "http://localhost:3000/idp/idx/challenge",
+        "method": "POST",
+        "accepts": "application/vnd.okta.v1+json",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "value": "auttheidkwh282hv8g3",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "mutable": true,
+                        "visible": false,
+                        "type": "string",
+                        "options": [
+                          {
+                            "value": "signed_nonce",
+                            "label": "Use Okta FastPass"
+                          },
+                          {
+                            "value": "push",
+                            "label": "Get a push notification"
+                          },
+                          {
+                            "value": "totp",
+                            "label": "Enter a code"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Okta Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aidwboITrg4b4yAYd0g3",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticatorEnrollments.value[2]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value": {
+      "type": "app",
+      "key": "okta_verify",
+      "id": "auttheidkwh282hv8g3",
+      "displayName": "",
+      "methods": [
+        { "type": "push" }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "app",
+        "key": "okta_verify",
+        "id": "auteq0lLiL9o1cYoN0g4",
+        "displayName": "",
+        "methods": [
+          {
+            "type": "signed_nonce"
+          },
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "autepwdJFCg0J7vK60g4",
+        "displayName": "Okta Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": [
+      {
+        "displayName": "",
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aen1mz5J4cuNoaR3l0g4",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [ 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
+        ]
+      },
+      {
+        "displayName": "",
+        "type": "app",
+        "key": "okta_verify",
+        "id": "aen1mz5J4cuNoaR3l0g3",
+        "authenticatorId": "auttheidkwh282hv8g3",
+        "methods": [ 
+          { "type": "signed_nonce" },
+          { "type": "push" },
+          { "type": "totp" }
+        ]
+      },
+      {
+        "displayName": "Okta Password",
+        "type": "password",
+        "key": "okta_password",
+        "id": "autwa6eD9o02iBbtv0g1",
+        "authenticatorId": "aidwboITrg4b4yAYd0g3",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      }
+    ]
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00utjm1GstPjCF9Ad0g3"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "https://idx.okta1.com/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/vnd.okta.v1+json",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02im-3M2f6UXHgNfS7Ns7C85EKHzGaKw0u1CC4p9_r",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+     "type": "object",
+     "value": {
+        "name": "oidc_client",
+        "label": "Native client",
+        "id": "0oa2lpzzzJHJy0E6q0g4"
+    }
+  }
+}

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -4,6 +4,7 @@ import { _, Form, loc, internal, createCallout, View } from 'okta';
 import FormInputFactory from './FormInputFactory';
 
 const { FormUtil } = internal.views.forms.helpers;
+const INFO_MESSAGE_CLASS = 'INFO';
 
 export default Form.extend({
 
@@ -157,16 +158,19 @@ export default Form.extend({
     if (Array.isArray(messages.value) && !(options instanceof View)) {
       this.add('<div class="ion-messages-container"></div>', errContainer);
       messages.value.forEach(obj => {
-        if(!obj?.class || obj.class === 'INFO') {
+        const {
+          class: msgClass = '',
+          title = '',
+          message,
+        } = obj;
+        if(!msgClass || msgClass === INFO_MESSAGE_CLASS) {
           // add message as plain text
-          this.add(`<p>${obj.message}</p>`, '.ion-messages-container');
+          this.add(`<p>${message}</p>`, '.ion-messages-container');
         } else {
-          // add error callout with custom options
-          options = Object.assign(_.pick(obj, 'message', 'class'), options);
           this.add(createCallout({
-            content: options.message,
-            type: (options.class || '').toLowerCase(),
-            title: options.title ? options.title : ''
+            content: message,
+            type: msgClass.toLowerCase(),
+            title: title
           }), errContainer);
         }
       });

--- a/src/v2/view-builder/internals/BaseForm.js
+++ b/src/v2/view-builder/internals/BaseForm.js
@@ -158,20 +158,22 @@ export default Form.extend({
     if (Array.isArray(messages.value) && !(options instanceof View)) {
       this.add('<div class="ion-messages-container"></div>', errContainer);
       messages.value.forEach(obj => {
-        const {
-          class: msgClass = '',
-          title = '',
-          message,
-        } = obj;
-        if(!msgClass || msgClass === INFO_MESSAGE_CLASS) {
+        if(!obj?.class || obj.class === INFO_MESSAGE_CLASS) {
           // add message as plain text
-          this.add(`<p>${message}</p>`, '.ion-messages-container');
+          this.add(`<p>${obj.message}</p>`, '.ion-messages-container');
         } else {
+          const errorObj = {
+            class: obj?.class ?? '',
+            message: obj?.message,
+            title: '',
+            ...options
+          };
           this.add(createCallout({
-            content: message,
-            type: msgClass.toLowerCase(),
-            title: title
+            content: errorObj.message,
+            type: errorObj.class.toLowerCase(),
+            title: errorObj.title
           }), errContainer);
+          options = null; // prevent repeating first error message
         }
       });
     } else if (options instanceof View) {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -119,6 +119,10 @@ export default class BaseFormObject {
     return this.el.find(FORM_INFOBOX_ERROR).innerText;
   }
 
+  getAllErrorBoxTexts() {
+    return this.getInnerTexts(FORM_INFOBOX_ERROR);
+  }
+
   // Field error
   /**
    * @deprecated see hasTextBoxErrorMessage

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -11,10 +11,15 @@ import pollingExpired from '../../../playground/mocks/data/idp/idx/terminal-poll
 import unlockFailed from '../../../playground/mocks/data/idp/idx/error-unlock-account';
 import accessDeniedOnOtherDeivce from '../../../playground/mocks/data/idp/idx/terminal-return-email-consent-denied';
 import terminalUnlockAccountFailedPermissions from '../../../playground/mocks/data/idp/idx/error-unlock-account-failed-permissions';
+import errorTerminalMultipleErrors from '../../../playground/mocks/data/idp/idx/error-terminal-multiple-errors';
 
 const terminalTransferredEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalTransferEmail);
+
+const terminalMultipleErrorsMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(errorTerminalMultipleErrors);
 
 const terminalReturnEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -138,4 +143,15 @@ async function setup(t) {
       await t.expect(await terminalViewPage.goBackLinkExists()).notOk();
       await t.expect(await terminalViewPage.signoutLinkExists()).ok();
     });
+});
+
+test.requestHooks(terminalMultipleErrorsMock)('should render each error message when there are multiple', async t => {
+  const terminalViewPage = await setup(t);
+
+  const errors = terminalViewPage.form.getAllErrorBoxTexts();
+  await t.expect(errors).eql([
+    'Please enter a username',
+    'Please enter a password',
+    'Your session has expired. Please try to sign in again.'
+  ]);
 });


### PR DESCRIPTION
## Description:

Before:
<img width="1362" alt="Screen Shot 2022-01-24 at 6 45 21 PM" src="https://user-images.githubusercontent.com/71431120/150904194-27a78fed-3f22-40be-8f4e-2c3405081f10.png">

After:
<img width="1389" alt="Screen Shot 2022-01-24 at 6 44 15 PM" src="https://user-images.githubusercontent.com/71431120/150904199-02ccc5c0-4383-4850-9d51-e74b2d8dd6af.png">

Before:
<img width="341" alt="Screen Shot 2022-01-25 at 1 48 18 PM" src="https://user-images.githubusercontent.com/71431120/151065328-54942524-eda8-4d7d-9339-f07d584dcffa.png">
After:
<img width="376" alt="Screen Shot 2022-01-25 at 1 46 21 PM" src="https://user-images.githubusercontent.com/71431120/151065302-b92a8957-1d79-4b75-a52a-af2133666038.png">
## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-463004](https://oktainc.atlassian.net/browse/OKTA-463004)


