### PR TITLE
OKTA-461362 Apply biometrics error in SSO extension view

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -421,23 +421,14 @@ const userVerificationLoopback = {
   ],
 };
 
-// user verification: loopback with biometrics error for Windows/MacOS
-const userVerificationDesktopLoopbackBiometricsError = {
+// user verification: loopback with biometrics error
+const userVerificationLoopbackBiometricsError = {
   '/idp/idx/introspect': [
     'authenticator-verification-okta-verify-signed-nonce-loopback'
   ],
   '/idp/idx/authenticators/poll': [
     'error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop',
-  ],
-};
-
-// user verification: loopback with biometrics error for Android
-const userVerificationMobileLoopbackBiometricsError = {
-  '/idp/idx/introspect': [
-    'authenticator-verification-okta-verify-signed-nonce-loopback'
-  ],
-  '/idp/idx/authenticators/poll': [
-    'error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile',
+    // 'error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile',
   ],
 };
 
@@ -452,6 +443,16 @@ const userVerificationCustomUri = {
   '/idp/idx/authenticators/okta-verify/launch': [
     'authenticator-verification-okta-verify-signed-nonce-custom-uri',
   ]
+};
+
+// user verification: custom URI with biometrics error
+const userVerificationCustomUriBiometricsError = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-okta-verify-signed-nonce-custom-uri',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop',
+  ],
 };
 
 // user verification: Android authenticator with app link
@@ -470,13 +471,34 @@ const userVerificationAppLink = {
   ]
 };
 
+// user verification: App link with biometrics error
+const userVerificationAppLinkBiometricsError = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-okta-verify-signed-nonce-app-link',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile',
+  ],
+};
+
 // user verification: Apple authenticator with Credential SSO extension
 const userVerificationCredentialSSOExtension = {
   '/idp/idx/introspect': [
     'authenticator-verification-okta-verify-signed-nonce-credential-sso-extension'
   ],
   '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel': [
-    'identify'
+    'identify'// see index.js for details
+  ],
+};
+
+// user verification: Credential SSO extension with biometrics error
+const userVerificationCredentialSSOExtensionBiometricsError = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-okta-verify-signed-nonce-credential-sso-extension'
+  ],
+  '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify': [
+    'error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile'
+    // 'error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop'
   ],
 };
 
@@ -493,6 +515,16 @@ const userVerificationUniversalLink = {
     'authenticator-verification-okta-verify-signed-nonce-universal-link',
     'authenticator-verification-okta-verify-signed-nonce-universal-link',
     'success',
+  ],
+};
+
+// user verification: universal link with biometrics error
+const userVerificationUniversalLinkBiometricsError = {
+  '/idp/idx/introspect': [
+    'authenticator-verification-okta-verify-signed-nonce-universal-link',
+  ],
+  '/idp/idx/authenticators/poll': [
+    'error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile'
   ],
 };
 
@@ -961,5 +993,5 @@ const selectOktaVerifyMethod = {
 };
 
 module.exports = {
-  mocks: idx,
+  mocks: userVerificationCredentialSSOExtensionBiometricsError,
 };

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -487,7 +487,7 @@ const userVerificationCredentialSSOExtension = {
     'authenticator-verification-okta-verify-signed-nonce-credential-sso-extension'
   ],
   '/idp/idx/authenticators/sso_extension/transactions/:transactionId/verify/cancel': [
-    'identify'// see index.js for details
+    'identify'// see playground/mocks/spec-okta-api/idp/idx/index.js for details
   ],
 };
 
@@ -993,5 +993,5 @@ const selectOktaVerifyMethod = {
 };
 
 module.exports = {
-  mocks: userVerificationCredentialSSOExtensionBiometricsError,
+  mocks: idx,
 };

--- a/playground/mocks/spec-okta-api/idp/idx/index.js
+++ b/playground/mocks/spec-okta-api/idp/idx/index.js
@@ -1,5 +1,9 @@
 const templateHelper = require('../../../config/templateHelper');
 const cancelTransaction = require('../../../data/idp/idx/identify-with-no-sso-extension');
+const biometricsErrorMobile = 
+  require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile');
+const biometricsErrorDesktop = 
+  require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop');
 
 const idx = [
   '/idp/idx',
@@ -47,7 +51,7 @@ const ssoExtension = [
       next();
     },
     // TODO: find a way to improve this, now the mock config is not always on responseConfig
-    template: cancelTransaction,
+    template: cancelTransaction, // To test biometrics error, change it to biometricsErrorMobile/biometricsErrorDesktop
   })
 ];
 

--- a/playground/mocks/spec-okta-api/idp/idx/index.js
+++ b/playground/mocks/spec-okta-api/idp/idx/index.js
@@ -1,9 +1,9 @@
 const templateHelper = require('../../../config/templateHelper');
 const cancelTransaction = require('../../../data/idp/idx/identify-with-no-sso-extension');
-const biometricsErrorMobile = 
-  require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile');
-const biometricsErrorDesktop = 
-  require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop');
+// const biometricsErrorMobile = 
+//   require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-mobile');
+// const biometricsErrorDesktop = 
+//   require('../../../data/idp/idx/error-okta-verify-uv-fastpass-verify-enable-biometrics-desktop');
 
 const idx = [
   '/idp/idx',

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -13,7 +13,9 @@ import { loc, View, createButton, _ } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import Enums from '../../../util/Enums';
 import Util from '../../../util/Util';
-import { FASTPASS_FALLBACK_SPINNER_TIMEOUT, IDENTIFIER_FLOW } from '../utils/Constants';
+import { FASTPASS_FALLBACK_SPINNER_TIMEOUT, IDENTIFIER_FLOW, 
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE  } from '../utils/Constants';
 
 export function appendLoginHint(deviceChallengeUrl, loginHint) {
   if (deviceChallengeUrl && loginHint) {
@@ -141,4 +143,40 @@ export function doChallenge(view, fromView) {
     }));
     break;
   }
+}
+
+export function getBiometricsErrorOptions(error) {
+  const errorSummaryKeys = error?.responseJSON?.errorSummaryKeys;
+  const isBiometricsRequiredMobile = errorSummaryKeys 
+      && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE);
+  const isBiometricsRequiredDesktop = errorSummaryKeys 
+      && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP);
+  let options = [];
+
+  if (!isBiometricsRequiredMobile && !isBiometricsRequiredDesktop) {
+    return  options;
+  }
+
+  const bulletPoints = [
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
+    loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login')
+  ];
+
+  // Add an additional bullet point for desktop devices
+  if (isBiometricsRequiredDesktop) {
+    bulletPoints.push(
+      loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login')
+    );
+  }
+
+  options = {
+    type: 'error',
+    className: 'okta-verify-uv-callout-content',
+    title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
+    subtitle: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
+    bullets: bulletPoints,
+  };
+
+  return options;
 }

--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -7,3 +7,8 @@ export const CANCEL_POLLING_ACTION = 'authenticatorChallenge-cancel';
 export const WIDGET_FOOTER_CLASS = 'siw-main-footer';
 export const FASTPASS_FALLBACK_SPINNER_TIMEOUT = 4000;
 export const IDENTIFIER_FLOW = 'IDENTIFIER';
+export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP 
+    = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.desktop';
+export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE 
+    = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.mobile';
+

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,14 +1,11 @@
 import { $, loc, createCallout } from 'okta';
 import { BaseFormWithPolling } from '../../internals';
 import Logger from '../../../../util/Logger';
-import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
+import { CHALLENGE_TIMEOUT, 
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import { doChallenge } from '../../utils/ChallengeViewUtil';
-
-const OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP 
-    = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.desktop';
-const OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE 
-    = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.mobile';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,11 +1,9 @@
-import { $, loc, createCallout } from 'okta';
+import { $, createCallout, _ } from 'okta';
 import { BaseFormWithPolling } from '../../internals';
 import Logger from '../../../../util/Logger';
-import { CHALLENGE_TIMEOUT, 
-  OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
-  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE } from '../../utils/Constants';
+import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
-import { doChallenge } from '../../utils/ChallengeViewUtil';
+import { doChallenge, getBiometricsErrorOptions } from '../../utils/ChallengeViewUtil';
 
 const request = (opts) => {
   const ajaxOptions = Object.assign({
@@ -127,36 +125,14 @@ const Body = BaseFormWithPolling.extend(Object.assign(
     },
 
     showCustomFormErrorCallout(error) {
-      const errorSummaryKeys = error?.responseJSON?.errorSummaryKeys;
-      const isBiometricsRequiredMobile = errorSummaryKeys 
-          && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE);
-      const isBiometricsRequiredDesktop = errorSummaryKeys 
-          && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP);
-
-      if (isBiometricsRequiredMobile || isBiometricsRequiredDesktop) {
-        const bulletPoints = [
-          loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
-          loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
-          loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login')
-        ];
-
-        // Add an additional bullet point for desktop devices
-        if (isBiometricsRequiredDesktop) {
-          bulletPoints.push(
-            loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login')
-          );
-        }
-
-        const options = {
-          type: 'error',
-          className: 'okta-verify-uv-callout-content',
-          title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
-          subtitle: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
-          bullets: bulletPoints,
-        };
-        this.showMessages(createCallout(options));
-        return true;
+      const options = getBiometricsErrorOptions(error);
+      
+      if (_.isEmpty(options)) {
+        return false;
       }
+
+      this.showMessages(createCallout(options));
+      return true;
     },
   },
 ));

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
@@ -1,6 +1,8 @@
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { BaseForm } from '../../internals';
-import { loc } from 'okta';
+import { loc, createCallout } from 'okta';
+import { OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE } from '../../utils/Constants';
 
 // for EA,
 // redirect is needed for Apple SSO Extension to intercept the request, because
@@ -27,7 +29,40 @@ const Body = BaseForm.extend({
     const isGetMethod = this.options.currentViewState?.method?.toLowerCase() === 'get';
     this.model.set('useRedirect', isGetMethod);
     this.trigger('save', this.model);
-  }
+  },
+
+  showCustomFormErrorCallout(error) {
+    const errorSummaryKeys = error?.responseJSON?.errorSummaryKeys;
+    const isBiometricsRequiredMobile = errorSummaryKeys 
+        && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE);
+    const isBiometricsRequiredDesktop = errorSummaryKeys 
+        && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP);
+
+    if (isBiometricsRequiredMobile || isBiometricsRequiredDesktop) {
+      const bulletPoints = [
+        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
+        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
+        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login')
+      ];
+
+      // Add an additional bullet point for desktop devices
+      if (isBiometricsRequiredDesktop) {
+        bulletPoints.push(
+          loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login')
+        );
+      }
+
+      const options = {
+        type: 'error',
+        className: 'okta-verify-uv-callout-content',
+        title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
+        subtitle: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
+        bullets: bulletPoints,
+      };
+      this.showMessages(createCallout(options));
+      return true;
+    }
+  },
 });
 
 export default BaseAuthenticatorView.extend({

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifySSOExtensionView.js
@@ -1,8 +1,7 @@
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import { BaseForm } from '../../internals';
-import { loc, createCallout } from 'okta';
-import { OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
-  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE } from '../../utils/Constants';
+import { loc, createCallout, _ } from 'okta';
+import { getBiometricsErrorOptions } from '../../utils/ChallengeViewUtil';
 
 // for EA,
 // redirect is needed for Apple SSO Extension to intercept the request, because
@@ -32,36 +31,14 @@ const Body = BaseForm.extend({
   },
 
   showCustomFormErrorCallout(error) {
-    const errorSummaryKeys = error?.responseJSON?.errorSummaryKeys;
-    const isBiometricsRequiredMobile = errorSummaryKeys 
-        && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE);
-    const isBiometricsRequiredDesktop = errorSummaryKeys 
-        && errorSummaryKeys.includes(OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP);
-
-    if (isBiometricsRequiredMobile || isBiometricsRequiredDesktop) {
-      const bulletPoints = [
-        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point1', 'login'),
-        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point2', 'login'),
-        loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point3', 'login')
-      ];
-
-      // Add an additional bullet point for desktop devices
-      if (isBiometricsRequiredDesktop) {
-        bulletPoints.push(
-          loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.point4', 'login')
-        );
-      }
-
-      const options = {
-        type: 'error',
-        className: 'okta-verify-uv-callout-content',
-        title: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.title', 'login'),
-        subtitle: loc('oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.description', 'login'),
-        bullets: bulletPoints,
-      };
-      this.showMessages(createCallout(options));
-      return true;
+    const options = getBiometricsErrorOptions(error);
+    
+    if (_.isEmpty(options)) {
+      return false;
     }
+
+    this.showMessages(createCallout(options));
+    return true;
   },
 });
 


### PR DESCRIPTION
## Description:
- Previously, the biometrics error was showed in loopback/custom uri/universal link/app links. SSO extension uses a different view so we need to apply the change to it separately.
- Added test cafe tests for all binding methods.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
- e2e demo: https://okta.box.com/s/7mfgl7q9wappfs2pf8ogpczt3bpq9z3z
- playground screenshot:
![Screen Shot 2022-01-26 at 5 13 35 PM](https://user-images.githubusercontent.com/49395917/151273853-66e06e97-d58c-46db-95e0-5e84e6d4ca29.png)


### Reviewers:
@okta/device-platform @jhe-okta


### Issue:

- [OKTA-461362](https://oktainc.atlassian.net/browse/OKTA-461362)


