### PR TITLE
fix: clears recoveryToken before restarting login flow

### DIFF
--- a/src/v2/BaseLoginRouter.js
+++ b/src/v2/BaseLoginRouter.js
@@ -167,7 +167,7 @@ export default Router.extend({
     // }
   },
 
-  /* eslint max-statements: [2, 27], complexity: [2, 11] */
+  /* eslint max-statements: [2, 28], complexity: [2, 11] */
   render: async function(Controller, options = {}) {
     // If url changes then widget assumes that user's intention was to initiate a new login flow,
     // so clear stored token to use the latest token.
@@ -204,6 +204,7 @@ export default Router.extend({
       } catch (exception) {
         this.appState.trigger('error', exception);
       } finally {
+        // These settings should only be used one time, for initial render
         this.settings.unset('stateToken');
         this.settings.unset('proxyIdxResponse');
       }
@@ -264,6 +265,12 @@ export default Router.extend({
   },
 
   restartLoginFlow() {
+    // Clear the recoveryToken, if any
+    const authClient = this.settings.getAuthClient();
+    delete authClient.options['recoveryToken'];
+    this.settings.unset('recoveryToken');
+
+    // Re-render the widget
     this.render(this.controller.constructor);
   },
 

--- a/src/v2/client/startLoginFlow.js
+++ b/src/v2/client/startLoginFlow.js
@@ -57,8 +57,7 @@ export async function startLoginFlow(settings) {
         );
       }
       // start new transaction
-      const recoveryToken = settings.get('recoveryToken');
-      return authClient.idx.start({ ...idxOptions, recoveryToken }); // calls interact
+      return authClient.idx.start(idxOptions); // calls interact
     }
 
     // continue saved transaction

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -43,6 +43,7 @@ const mocksWithAlert = [
 ];
 
 const mocksWithPreventRedirect = [
+  'identify-with-only-one-third-party-idp-app-use',
   'error-with-failure-redirect.json'
 ];
 const mocksWithoutInitialRender = [

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -204,18 +204,4 @@ describe('v2/client/startLoginFlow', () => {
     }
   });
 
-  it('passes "recoveryToken" to interact', async () => {
-    const { settings, start } = testContext;
-    const recoveryToken = 'abcdef';
-    settings.set('useInteractionCodeFlow', true);
-    settings.set('recoveryToken', recoveryToken);
-    const result = await startLoginFlow(settings);
-    expect(result).toEqual({
-      fake: 'fake start response'
-    });
-    expect(start).toHaveBeenCalledWith({
-      exchangeCodeForTokens: false,
-      recoveryToken
-    });
-  });
 });


### PR DESCRIPTION
## Description:
Fixes an issue where clicking 'Back to Signin' in the password recovery flow will return the user to password recovery view instead of the primary auth view. The `recoveryToken` is cleared from settings and authClient options to ensure that the transaction will be restarted in "default" flow.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-462943](https://oktainc.atlassian.net/browse/OKTA-462943)


