### PR TITLE
fix: clicking "Back to sign in" on "/signin/forgot-password"

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -793,11 +793,17 @@ const onPremMFAVerify = {
 
 const passwordRecovery = {
   '/idp/idx/introspect': [
+    'identify-with-password',
+  ],
+  '/idp/idx/recover': [
     'identify-recovery',
   ],
   '/idp/idx/identify': [
     // 'error-identify-access-denied',
     'authenticator-verification-select-authenticator',
+  ],
+  '/idp/idx/cancel': [
+    'identify-with-password',
   ],
 };
 

--- a/src/v2/WidgetRouter.js
+++ b/src/v2/WidgetRouter.js
@@ -17,7 +17,7 @@ import ForgotPasswordFormController from './controllers/ForgotPasswordFormContro
 module.exports = BaseLoginRouter.extend({
   routes: {
     '': 'defaultAuth',
-    'signin/forgot-password': 'renderForgotPassword',
+    'signin/forgot-password': 'renderForgotPassword', // TODO: remove route OKTA-466790
     '*wildcard': 'defaultAuth',
   },
 

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -153,12 +153,15 @@ export default Controller.extend({
       // TODO: OKTA-243167 what's the approach to show spinner indicating API in flight?
       actionFn()
         .then((resp) => {
-          if (actionPath === 'cancel' && window.location.pathname === '/signin/forgot-password') {
-            window.location = window.location.origin;
-          } else if (actionPath === 'cancel' && this.options.settings.get('useInteractionCodeFlow')) {
-            // In this case we need to restart login flow and recreate transaction meta
-            // that will be used in interactionCodeFlow function
-            this.options.appState.trigger('restartLoginFlow');
+          const { settings, appState } = this.options;
+          if (actionPath === 'cancel') {
+            if (settings.get('useInteractionCodeFlow')) {
+              // embedded
+              appState.trigger('restartLoginFlow');
+            } else {
+              // federated
+              window.location.assign(window.location.origin);
+            }
           } else {
             this.handleIdxResponse(resp);
           }

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -153,7 +153,9 @@ export default Controller.extend({
       // TODO: OKTA-243167 what's the approach to show spinner indicating API in flight?
       actionFn()
         .then((resp) => {
-          if (actionPath === 'cancel' && this.options.settings.get('useInteractionCodeFlow')) {
+          if (actionPath === 'cancel' && window.location.pathname === '/signin/forgot-password') {
+            window.location = window.location.origin;
+          } else if (actionPath === 'cancel' && this.options.settings.get('useInteractionCodeFlow')) {
             // In this case we need to restart login flow and recreate transaction meta
             // that will be used in interactionCodeFlow function
             this.options.appState.trigger('restartLoginFlow');

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -173,7 +173,9 @@ test.requestHooks(identifyMock)('should show errors when forgot password is not 
 test.requestHooks(identifyWithPasswordMock)('should navigate back when "Back to sign in" clicked on /signin/forgot-password', async t => {
   const page = new IdentityRecoverPageObject(t);
   await page.navigateToPage();
+  await t.expect(await page.getPageUrl()).eql('http://localhost:3000/signin/forgot-password');
   await t.expect(page.form.getTitle()).eql('Reset your password');
   await page.clickSignOutLink();
+  await t.expect(await page.getPageUrl()).eql('http://localhost:3000/');
   await t.expect(page.form.getTitle()).eql('Sign In');
 });


### PR DESCRIPTION
## Description:
Fixes clicking "Back to sign in" on the "Reset your password" view at the "/signin/forgot-password" route.

When "Back to sign in" is clicked and the window path is "/signin/forgot-password", clear the path so the router routes to the sign in form.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-458745](https://oktainc.atlassian.net/browse/OKTA-458745)


