### PR TITLE
fix: recover password flow in identifier-first mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@babel/runtime": "^7.10.3",
     "@babel/runtime-corejs3": "^7.10.3",
     "@okta/eslint-plugin-okta": "0.5.0",
-    "@okta/okta-auth-js": "^6.4.0",
+    "@okta/okta-auth-js": "^6.4.3",
     "@sindresorhus/to-milliseconds": "^1.0.0",
     "@types/backbone": "^1.4.15",
     "@types/jqueryui": "^1.12.16",

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1048,5 +1048,5 @@ const selectOktaVerifyMethod = {
 };
 
 module.exports = {
-  mocks: Test.EnrollAuthenticatorWebAuthn.mock
+  mocks: idx
 };

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -1048,5 +1048,5 @@ const selectOktaVerifyMethod = {
 };
 
 module.exports = {
-  mocks: idx
+  mocks: Test.EnrollAuthenticatorWebAuthn.mock
 };

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
   npm config set strict-ssl false
 
-  if ! yarn add -DW --force https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz ; then
+  if ! yarn add -DW --no-lockfile https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
     exit ${FAILED_SETUP}
   fi

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,20 +1,3 @@
-
-export interface FieldError {
-  errorSummary: string;
-  reason?: string;
-  location?: string;
-  locationType?: string;
-  domain?: string;
-}
-
-export interface ApiError {
-  errorSummary: string;
-  errorCode?: string;
-  errorId?: string;
-  errorLink?: string;
-  errorCauses?: Array<FieldError>;
-}
-
 export interface ErrorXHR {
   status: number;
   responseType?: string;

--- a/src/types/registration.ts
+++ b/src/types/registration.ts
@@ -1,4 +1,4 @@
-import { ApiError } from './errors';
+import { APIError } from '@okta/okta-auth-js';
 import {
   SimpleCallback
 } from './results';
@@ -109,7 +109,7 @@ export interface RegistrationData {
 export type RegistrationSchemaCallback = (schema: RegistrationSchema) => void;
 export type RegistrationDataCallback = (data: RegistrationData) => void;
 export type RegistrationPostSubmitCallback = (response: string) => void;
-export type RegistrationErrorCallback = (error: ApiError) => void
+export type RegistrationErrorCallback = (error: APIError) => void
 export interface RegistrationOptions {
   click?: SimpleCallback;
   parseSchema?: (

--- a/src/v2/client/emailVerifyCallback.ts
+++ b/src/v2/client/emailVerifyCallback.ts
@@ -10,8 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { ProceedOptions } from '@okta/okta-auth-js';
+
 export async function emailVerifyCallback(settings) {
   const authClient = settings.getAuthClient();
+  const idxOptions: ProceedOptions = {
+    exchangeCodeForTokens: false, // we handle this in interactionCodeFlow.js
+    shouldProceedWithEmailAuthenticator: false, // do not auto-select email authenticator
+  };
   const meta = await authClient.idx.getSavedTransactionMeta(); // meta can load in another tab using state if it matches
   if (!meta || !meta.interactionHandle) {
     // Flow can not continue in this tab. Create a synthetic server response and use it to display a message to the user
@@ -45,7 +51,7 @@ export async function emailVerifyCallback(settings) {
   // Proceed using the OTP code
   const otp = settings.get('otp');
   const idxResponse = await authClient.idx.proceed({
-    exchangeCodeForTokens: false,
+    ...idxOptions,
     otp
   });
   return idxResponse;

--- a/src/widget/getAuthClient.ts
+++ b/src/widget/getAuthClient.ts
@@ -38,10 +38,6 @@ export default function(options: WidgetOptions = {}): OktaAuth {
       authParams.issuer = options.baseUrl + '/oauth2/default';
     }
 
-    authParams.transactionManager = authParams.transactionManager || {};
-    Object.assign(authParams.transactionManager, {
-      saveLastResponse: false
-    });
     authClient = new OktaAuth(authParams);
   }
 

--- a/test/unit/spec/v2/client/emailVerifyCallback_spec.js
+++ b/test/unit/spec/v2/client/emailVerifyCallback_spec.js
@@ -35,6 +35,7 @@ describe('email verify callback', () => {
       await emailVerifyCallback(settings);
       expect(authClient.idx.proceed).toHaveBeenCalledWith({
         exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
         otp
       });
     });
@@ -45,6 +46,7 @@ describe('email verify callback', () => {
       const res = await emailVerifyCallback(settings);
       expect(authClient.idx.proceed).toHaveBeenCalledWith({
         exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
         otp
       });
       expect(res).toBe(idxResponse);

--- a/test/unit/spec/v2/client/startLoginFlow_spec.js
+++ b/test/unit/spec/v2/client/startLoginFlow_spec.js
@@ -100,89 +100,100 @@ describe('v2/client/startLoginFlow', () => {
     expect(start).toHaveBeenCalledTimes(1);
 
     expect(start).toHaveBeenCalledWith({
-      exchangeCodeForTokens: false
+      exchangeCodeForTokens: false,
+      shouldProceedWithEmailAuthenticator: false
     });
     expect(proceed).not.toHaveBeenCalled();
   });
 
-  it('shall introspect on "settings.stateToken"', async () => {
+  it('shall call start on "settings.stateToken"', async () => {
     const { settings, start, proceed, introspect } = testContext;
     const result = await startLoginFlow(settings);
     expect(result).toEqual({
-      fake: 'fake introspect response'
+      fake: 'fake start response'
     });
 
-    expect(start).not.toHaveBeenCalled();
+    expect(introspect).not.toHaveBeenCalled();
     expect(proceed).not.toHaveBeenCalled();
-    expect(introspect).toHaveBeenCalledTimes(1);
-    expect(introspect).toHaveBeenCalledWith({
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith({
+      exchangeCodeForTokens: false,
+      shouldProceedWithEmailAuthenticator: false,
       stateHandle: 'a test state token from settings'
     });
     expect(settings.get('stateToken')).toBe('a test state token from settings');
   });
 
-  it('shall introspect on "settings.stateToken" when overrideExistingStateToken is true', async () => {
+  it('shall start on "settings.stateToken" when overrideExistingStateToken is true', async () => {
     const { settings, start, proceed, introspect } = testContext;
     sessionStorageHelper.setStateHandle('fake state handle from session storage');
     settings.set('overrideExistingStateToken', 'true');
     const result = await startLoginFlow(settings);
     expect(result).toEqual({
-      fake: 'fake introspect response'
+      fake: 'fake start response'
     });
 
-    expect(start).not.toHaveBeenCalled();
+    expect(introspect).not.toHaveBeenCalled();
     expect(proceed).not.toHaveBeenCalled();
-    expect(introspect).toHaveBeenCalledTimes(1);
-    expect(introspect).toHaveBeenCalledWith({
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith({
+      exchangeCodeForTokens: false,
+      shouldProceedWithEmailAuthenticator: false,
       stateHandle: 'a test state token from settings'
     });
     expect(settings.get('stateToken')).toBe('a test state token from settings');
   });
 
-  it('shall introspect on "sessionStorage.stateToken"', async () => {
+  it('shall start on "sessionStorage.stateToken"', async () => {
     const { settings, start, proceed, introspect } = testContext;
     sessionStorageHelper.setStateHandle('fake state handle from session storage');
     const result = await startLoginFlow(settings);
     expect(result).toEqual({
-      fake: 'fake introspect response'
+      fake: 'fake start response'
     });
 
-    expect(start).not.toHaveBeenCalled();
+    expect(introspect).not.toHaveBeenCalled();
     expect(proceed).not.toHaveBeenCalled();
-    expect(introspect).toHaveBeenCalledTimes(1);
-    expect(introspect).toHaveBeenCalledWith({
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith({
+      exchangeCodeForTokens: false,
+      shouldProceedWithEmailAuthenticator: false,
       stateHandle: 'fake state handle from session storage'
     });
     expect(settings.get('stateToken'))
       .toBe('fake state handle from session storage');
   });
 
-  it('shall introspect on "settings.stateToken" when "sessionStorage.stateToken" is invalid', async () => {
+  it('shall start on "settings.stateToken" when "sessionStorage.stateToken" is invalid', async () => {
     const { settings, start, proceed, introspect } = testContext;
-    introspect.mockReset();
-    introspect
+    start.mockReset();
+    start
       .mockRejectedValueOnce({
-        fake: 'ERROR - introspect response'
+        fake: 'ERROR - start response'
       })
       .mockResolvedValueOnce({
-        fake: 'another introspect response'
+        fake: 'another start response'
       });
 
     sessionStorageHelper.setStateHandle('fake state handle from session storage');
     const result = await startLoginFlow(settings);
     expect(result).toEqual({
-      fake: 'another introspect response'
+      fake: 'another start response'
     });
 
-    expect(start).not.toHaveBeenCalled();
+    expect(introspect).not.toHaveBeenCalled();
     expect(proceed).not.toHaveBeenCalled();
-    expect(introspect).toHaveBeenCalledTimes(2);
-    expect(introspect.mock.calls[0][0])
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(start.mock.calls[0][0])
       .toEqual({
+        exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
         stateHandle: 'fake state handle from session storage'
       });
-    expect(introspect.mock.calls[1][0])
+    expect(start.mock.calls[1][0])
       .toEqual({
+        exchangeCodeForTokens: false,
+        shouldProceedWithEmailAuthenticator: false,
         stateHandle: 'a test state token from settings'
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     node-properties-parser "^0.0.2"
     properties-to-json "^0.1.7"
 
-"@okta/okta-auth-js@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.4.0.tgz#96ffa804e299b5284ab128409249923b17e5a42c"
-  integrity sha512-Y9bPPwK/Ic8f5Yb0l97SIK/UeyACoOU4m3WkqnQ9RpG3beZkXDc5D5HRgMcB0vAvZjdiBEWvP6lCR3aiGwNJkg==
+"@okta/okta-auth-js@^6.4.3":
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.4.3.tgz#2a2ef19405f2aa855065ddd3432d2efded3626fb"
+  integrity sha512-mqOxVyQ3Bz/FqIiyLDLqvqFq6n2Mmq7aAnBCpTmxD9/zcLVhYE88mVFvfIku2bjnWA6tuaoX5jvN2iBLejMV+A==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.17.0"


### PR DESCRIPTION
## Description:
password recovery flow has extra steps in identifier-first flow. In order to keep the user experience consistent with identify-recovery flow, the `okta_password` authenticator should be specified after the `identify` remediation.

- shows `identify-recovery` UI instead of `identify` when running with flow = `resetPassword`
- selects `okta_password` as the authenticator on submission of the `identify` remediation
- also fixes autocomplete on identify recovery view

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-462165](https://oktainc.atlassian.net/browse/OKTA-462165)


