### PR TITLE
feat: assets.languages to provide list of hosted languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ var config = {
   - `zh-CN` - Chinese (PRC)
   - `zh-TW` - Chinese (Taiwan)
 
-  **Note:** If you want to use language that is not supported by widget, you need to host `login_{lang}.json` and `country_{lang}.json` files that should be accesible under path `{assets.baseUrl}/labels/json/`, where `{lang}` is your language code and `{assets.baseUrl}` is url to your assets (can be `/` to point on current domain). Example of JSON language files you can find after building widget in folder `packages/@okta/i18n/src/json`.
+  **Note:** If you want to use language that is not supported by widget, you need to host `login_{lang}.json` and `country_{lang}.json` files that should be accesible under path `{assets.baseUrl}/labels/json/`, where `{lang}` is your language code and `{assets.baseUrl}` is url to your assets (can be `/` to point on current domain). Example of JSON language files you can find after building widget in folder `packages/@okta/i18n/src/json`. The list of supported languages can be specified with the `assets.languages` option.
 
 - **defaultCountryCode:** Set the default countryCode of the widget. If no `defaultCountryCode` is provided, defaults to `US`. It sets the country calling code for phone number accordingly in the widget.
 
@@ -1000,6 +1000,8 @@ var config = {
     ```
 
     **Note:** The json files can be accessed from the `dist/labels/json` folder that is published in the [npm module](https://www.npmjs.com/package/@okta/okta-signin-widget).
+
+- **assets.languages** Specify the list of supported languages which are hosted and accesible under the path `{assets.baseUrl}/labels/json/`. This option supersedes the default list of supported languages. If an unsupported language is requested (explicitly using the `language` option or automatically by browser detection), the default language (`en`) will be used.
 
 - **assets.rewrite:** You can use this function to rewrite the asset path and filename. Use this function if you will host the asset files on your own host, and plan to change the path or filename of the assets. This is useful, for example, if you want to cachebust the files.
 

--- a/docs/interaction_code_flow.md
+++ b/docs/interaction_code_flow.md
@@ -15,11 +15,13 @@
     - [colors](#colors)
       - [colors.brand](#colorsbrand)
   - [Localization](#localization)
+    - [Supported languages](#supported-languages)
     - [language](#language)
     - [defaultCountryCode](#defaultcountrycode)
     - [i18n](#i18n)
   - [assets](#assets)
     - [assets.baseUrl](#assetsbaseurl)
+    - [assets.languages](#assetslanguages)
     - [assets.rewrite](#assetsrewrite)
   - [Links](#links)
     - [Sign out link](#sign-out-link)
@@ -167,27 +169,7 @@ If you want even more customization, you can modify the [Sass source files](http
 
 ### Localization
 
-#### language
-
-Set the language of the widget. If no language is specified, the widget will choose a language based on the user's browser preferences if it is supported, or defaults to `en`.
-
-  ```javascript
-  // You can simply pass the languageCode as a string:
-  language: 'ja'
-
-  // Or, if you need to determine it dynamically, you can pass a
-  // callback function:
-  language: (supportedLanguages, userLanguages) => {
-    // supportedLanguages is an array of languageCodes, i.e.:
-    // ['cs', 'da', ...]
-    //
-    // userLanguages is an array of languageCodes that come from the user's
-    // browser preferences
-    return supportedLanguages[0];
-  }
-  ```
-
-  Supported languages:
+#### Supported languages
 
 - `cs` - Czech
 - `da` - Danish
@@ -215,6 +197,28 @@ Set the language of the widget. If no language is specified, the widget will cho
 - `uk` - Ukrainian
 - `zh-CN` - Chinese (PRC)
 - `zh-TW` - Chinese (Taiwan)
+
+Support for additional languages can be added with the [assets.languages](#assetslanguages) option.
+
+#### language
+
+Set the language of the widget. If no language is specified, the widget will choose a language based on the user's browser preferences if it is supported, or defaults to `en`.
+
+  ```javascript
+  // You can simply pass the languageCode as a string:
+  language: 'ja'
+
+  // Or, if you need to determine it dynamically, you can pass a
+  // callback function:
+  language: (supportedLanguages, userLanguages) => {
+    // supportedLanguages is an array of languageCodes, i.e.:
+    // ['cs', 'da', ...]
+    //
+    // userLanguages is an array of languageCodes that come from the user's
+    // browser preferences
+    return supportedLanguages[0];
+  }
+  ```
 
 #### defaultCountryCode
 
@@ -273,6 +277,10 @@ Override the base url the widget pulls its language files from. The widget is on
   ```
 
   **Note:** The json files can be accessed from the `dist/labels/json` folder that is published in the [npm module](https://www.npmjs.com/package/@okta/okta-signin-widget).
+
+#### assets.languages
+
+Specify the list of supported languages which are hosted and accesible under the path `{assets.baseUrl}/labels/json/`. This option supersedes the [default list of supported languages](#supported-languages). If an unsupported language is requested (explicitly using the [language option](#language) or automatically by browser detection), the default language (`en`) will be used.
 
 #### assets.rewrite
 

--- a/playground/mocks/labels/json/country_foo.json
+++ b/playground/mocks/labels/json/country_foo.json
@@ -1,0 +1,3 @@
+{
+  "US": "Foonited States"
+}

--- a/playground/mocks/labels/json/login_foo.json
+++ b/playground/mocks/labels/json/login_foo.json
@@ -1,0 +1,3 @@
+{
+  "oie.phone.enroll.title":"Set up foo authentication"
+}

--- a/scripts/buildtools/commands/generate-language-config.js
+++ b/scripts/buildtools/commands/generate-language-config.js
@@ -7,13 +7,16 @@ const packageJson = require(ROOT_DIR + '/package.json');
 const languageGlob = ROOT_DIR + '/packages/@okta/i18n/src/json/login_*.json';
 const OUTPUT_DIR = resolve(ROOT_DIR, 'src/config');
 const OUTPUT_FILE = resolve(OUTPUT_DIR, 'config.json');
+const DEFAULT_LANGUAGE = 'en';
 
 exports.command = 'generate-language-config';
 exports.describe = 'generate-language-config';
 exports.handler = () => {
   mkdirpSync(OUTPUT_DIR);
 
-  const config = {};
+  const config = {
+    defaultLanguage: DEFAULT_LANGUAGE
+  };
 
   // 1. Add current widget version number
   config.version = packageJson.version;
@@ -31,8 +34,8 @@ exports.handler = () => {
     // login_zh_TW.json -> zh-TW
     return re.exec(file)[1].replace('_', '-');
   });
-  // English is special - it is just login.json, and is ignored in our glob.
-  supportedLanguages.unshift('en');
+  // Default language is special - it is just login.json, and is ignored in our glob.
+  supportedLanguages.unshift(DEFAULT_LANGUAGE);
   config.supportedLanguages = supportedLanguages;
   console.log('config.supportedLanguages:');
   console.log(config.supportedLanguages.join(', '));

--- a/src/util/Bundles.js
+++ b/src/util/Bundles.js
@@ -157,10 +157,10 @@ function fetchJson(bundle, language, assets) {
 
 function getBundles(language, assets, supportedLanguages) {
   // Two special cases:
-  // 1. English is already bundled with the widget
+  // 1. Default language is already bundled with the widget
   // 2. If the language is not in our config file, it means that they've
   //    probably defined it on their own.
-  if (language === 'en' || !_.contains(supportedLanguages, language)) {
+  if (language === config.defaultLanguage || !_.contains(supportedLanguages, language)) {
     return Q({});
   }
 

--- a/src/util/LanguageUtil.js
+++ b/src/util/LanguageUtil.js
@@ -1,7 +1,8 @@
 import Bundles from 'util/Bundles';
+import config from 'config/config.json';
 
 function loadLanguage(appState, settings) {
-  const languageCode = appState.get('languageCode') || settings.get('languageCode');
+  const languageCode = appState.get('languageCode') || settings.get('languageCode') || config.defaultLanguage;
   const i18n = settings.get('i18n');
   const assetBaseUrl = settings.get('assets.baseUrl');
   const assetRewrite = settings.get('assets.rewrite');

--- a/test/testcafe/spec/BYOL_spec.js
+++ b/test/testcafe/spec/BYOL_spec.js
@@ -1,0 +1,121 @@
+import { ClientFunction, RequestMock } from 'testcafe';
+import BasePageObject from '../framework/page-objects/BasePageObject';
+import xhrAuthenticatorEnrollDataPhone from '../../../playground/mocks/data/idp/idx/authenticator-enroll-data-phone';
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrAuthenticatorEnrollDataPhone);
+
+
+fixture('BYOL (Bring Your Own Language)');
+
+const renderWidget = ClientFunction((settings) => {
+  // function `renderPlaygroundWidget` is defined in playground/main.js
+  window.renderPlaygroundWidget(settings);
+});
+
+const overrideNavigatorLanguages = ClientFunction(languages => {
+  delete window.navigator;
+  window.navigator = {
+    languages
+  };
+});
+
+async function setup(t, options = {}) {
+  const pageObject = new BasePageObject(t);
+  await pageObject.navigateToPage({ render: false });
+
+  if (options.navigatorLanguages) {
+    await overrideNavigatorLanguages(options.navigatorLanguages);
+  }
+
+  // Render the widget for interaction code flow
+  await pageObject.mockCrypto();
+  await renderWidget({
+    stateToken: 'abc',
+    ...options
+  });
+
+  return pageObject;
+}
+
+test.requestHooks(mock)('unsupported language, set with "language" option, is not loaded by default', async t => {
+  const pageObject = await setup(t, {
+    language: 'foo'
+  });
+
+  // Check title (login_foo.json)
+  await t.expect(pageObject.getFormTitle()).eql('Set up phone authentication');
+
+  // Check country dropdown (country_foo.json)
+  const selectOption = await pageObject.form.findFormFieldInput('country')
+    .find('.chzn-container > .chzn-single > span');
+
+  await t.expect(pageObject.getTextContent(selectOption))
+    .eql('United States');
+
+});
+
+test.requestHooks(mock)('unsupported language, set with "language" option, can be loaded when assets.baseUrl is set to a path containing the language assets', async t => {
+  const pageObject = await setup(t, {
+    language: 'foo',
+    assets: {
+      baseUrl: '/mocks'
+    }
+  });
+
+  // Check title (login_foo.json)
+  await t.expect(pageObject.getFormTitle()).eql('Set up foo authentication');
+
+  // Check country dropdown (country_foo.json)
+  const selectOption = await pageObject.form.findFormFieldInput('country')
+    .find('.chzn-container > .chzn-single > span');
+
+  await t.expect(pageObject.getTextContent(selectOption))
+    .eql('Foonited States');
+
+});
+
+
+test.requestHooks(mock)('unsupported language from navigator.languages will not load by default, even with assets.baseUrl set to a path containing the language assets', async t => {
+  const pageObject = await setup(t, {
+    navigatorLanguages: ['foo'],
+    assets: {
+      baseUrl: '/mocks'
+    }
+  });
+
+  // Check title (login_foo.json)
+  await t.expect(pageObject.getFormTitle()).eql('Set up phone authentication');
+
+  // Check country dropdown (country_foo.json)
+  const selectOption = await pageObject.form.findFormFieldInput('country')
+    .find('.chzn-container > .chzn-single > span');
+
+  await t.expect(pageObject.getTextContent(selectOption))
+    .eql('United States');
+
+});
+
+test.requestHooks(mock)('unsupported language from navigator.languages will load with assets.baseUrl and assets.languages set', async t => {
+  const pageObject = await setup(t, {
+    navigatorLanguages: ['foo'],
+    assets: {
+      baseUrl: '/mocks',
+      languages: [
+        'foo'
+      ]
+    }
+  });
+
+  // Check title (login_foo.json)
+  await t.expect(pageObject.getFormTitle()).eql('Set up foo authentication');
+
+  // Check country dropdown (country_foo.json)
+  const selectOption = await pageObject.form.findFormFieldInput('country')
+    .find('.chzn-container > .chzn-single > span');
+
+  await t.expect(pageObject.getTextContent(selectOption))
+    .eql('Foonited States');
+
+});


### PR DESCRIPTION
## Description:
- adds new config option "assets.languages" for hosted language files
- moves default language to config


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-461089](https://oktainc.atlassian.net/browse/OKTA-461089)


