### PR TITLE
fs-okta-472423-progressive-profiling-country-code-siw

### DIFF
--- a/playground/mocks/data/idp/idx/enroll-profile-new-additional-fields.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new-additional-fields.json
@@ -34,7 +34,25 @@
                   "required": true
                 },
                 {
+                  "name":"country",
+                  "type":"string",
+                  "label":"Country",
+                  "required":true,
+                  "options":[
+                    {
+                      "label":"display",
+                      "value":{
+                        "type":"object",
+                        "value":{
+                          "inputType":"select_country_code"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
                   "name":"countryCode",
+                  "type":"string",
                   "label":"Country code",
                   "required":true
                 },

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -64,6 +64,8 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
     uiSchema.wide = true;
     //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
     uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
+  } else if (display.inputType === 'select_country_code') {
+    Object.assign(uiSchema, countryUISchema);
   }
 };
 
@@ -86,10 +88,6 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
 
   if (ionFormField.hint === HINTS.CAPTCHA) {
     Object.assign(uiSchema, getCaptchaUiSchema());
-  }
-
-  if(ionFormField.name === 'userProfile.countryCode'){
-    Object.assign(uiSchema, countryUISchema);
   }
 
   if(ionFormField.name === 'userProfile.timezone'){

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -79,9 +79,11 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
   await identityPage.clickSignUpLink();
 
   requestLogger.clear();
+  await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.country')).eql('Country');
+  await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.country')).ok();
+  await enrollProfilePage.selectValueFromDropdown('userProfile.country', 1);
+
   await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.countryCode')).eql('Country code');
-  await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.countryCode')).ok();
-  await enrollProfilePage.selectValueFromDropdown('userProfile.countryCode', 1);
 
   await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.timezone')).eql('Time zone');
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.timezone')).ok();


### PR DESCRIPTION


## Description:

1. if get display type as `select_country_code`, render the field as a dropdown with predefined list
2. else render as a text box for country code


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:


### Reviewers:
@vicentevillegas-okta 

### Issue:

- [OKTA-472423](https://oktainc.atlassian.net/browse/OKTA-472423)


