### PR TITLE
Cancel loopback polling on challenge failure

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -443,6 +443,11 @@ const identifierAndroidAppLink = {
 };
 
 // user verification: Windows/Android authenticator with loopback server
+//
+// to mimic the challenge error flow (user does not respond to biometric request),
+// change the path in challenge.js to a non-existing URL (ex. 'fake/challenge') and
+// rerun `yarn mock:device-authenticator`
+// the UI should ends on the MFA selection UI instead of the success UI
 const userVerificationLoopback = {
   '/idp/idx/introspect': [
     'authenticator-verification-okta-verify-signed-nonce-loopback'
@@ -450,9 +455,11 @@ const userVerificationLoopback = {
   '/idp/idx/authenticators/poll': [
     'authenticator-verification-okta-verify-signed-nonce-loopback',
     'authenticator-verification-okta-verify-signed-nonce-loopback',
-    'authenticator-verification-okta-verify-signed-nonce-loopback',
     'success',
   ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'authenticator-verification-select-authenticator'
+  ]
 };
 
 // user verification: loopback with biometrics error

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -90,10 +90,17 @@ const Body = BaseFormWithPolling.extend(Object.assign(
         Logger.error(`Something unexpected happened while we were checking port ${currentPort}.`);
       };
 
+
+      const cancelPolling = () => {
+        this.options.appState.trigger('invokeAction', 'currentAuthenticator-cancel');
+      };
+
       const doProbing = () => {
         return checkPort()
           // TODO: can we use standard ES6 promise methods, then/catch?
-          .done(onPortFound)
+          .done(() => {
+            return onPortFound().fail(cancelPolling);
+          })
           .fail(onFailure);
       };
 
@@ -111,7 +118,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
             Logger.error(`Authenticator is not listening on port ${currentPort}.`);
             if (countFailedPorts === ports.length) {
               Logger.error('No available ports. Loopback server failed and polling is cancelled.');
-              this.options.appState.trigger('invokeAction', 'currentAuthenticator-cancel');
+              cancelPolling();
             }
           });
       });

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -10,6 +10,7 @@ import identifyWithUserVerificationBiometricsErrorDesktop from '../../../playgro
 import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri';
 import identifyWithSSOExtensionFallback from '../../../playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback';
 import identifyWithUserVerificationLaunchUniversalLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link';
+import mfaSelect from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator';
 import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received';
 import assureWithLaunchAppLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-app-link';
 import { renderWidget } from '../framework/shared';
@@ -31,12 +32,12 @@ const loopbackSuccesskMock = RequestMock()
     }
   })
   .onRequestTo(/2000|6511\/probe/)
-  .respond(null, 500, { 
+  .respond(null, 500, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   })
   .onRequestTo(/6512\/probe/)
-  .respond(null, 200, { 
+  .respond(null, 200, {
     'access-control-allow-origin': '*',
     'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
   })
@@ -74,6 +75,27 @@ const loopbackBiometricsErrorDesktopMock = RequestMock()
       res.setBody(identifyWithUserVerificationLoopback);
     }
   });
+
+const loopbackBiometricsNoResponseErrorLogger = RequestLogger(/introspect|probe|cancel|challenge|poll/);
+const loopbackBiometricsNoResponseErrorMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
+  .respond(identifyWithUserVerificationLoopback)
+  .onRequestTo(/2000|6511\/probe/)
+  .respond(null, 500, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 500)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
+  .respond(mfaSelect)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithUserVerificationLoopback);
 
 const loopbackFallbackLogger = RequestLogger(/introspect|probe|cancel|launch|poll/);
 const loopbackFallbackMock = RequestMock()
@@ -216,6 +238,22 @@ test
     const identityPage = new IdentityPageObject(t);
     await identityPage.fillIdentifierField('Test Identifier');
     await t.expect(identityPage.getIdentifierValue()).eql('Test Identifier');
+  });
+
+test
+  .requestHooks(loopbackBiometricsNoResponseErrorLogger, loopbackBiometricsNoResponseErrorMock)('in loopback server, when user does not respond to biometrics request, cancel the polling', async t => {
+    await setup(t);
+    const secondSelectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with a security method');
+    await t.expect(loopbackBiometricsNoResponseErrorLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.method !== 'options' &&
+        record.request.url.match(/introspect|probe|cancel/)
+    )).eql(3);
+    await t.expect(loopbackBiometricsNoResponseErrorLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/probe|challenge/)
+    )).eql(3);
   });
 
 test


### PR DESCRIPTION
## Description:
For the Okta Verify assurance step, with loopback approach, cancel the polling as soon as challenge responds with error (ex. user does not respond to the biometrics request and challenge times out)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
#### Challenge succeeds:
- probing succeeds at the 3rd try
- challenge request is made and responded with 200
- polling continues
- UI is changed to the success UI
![challenge-success](https://user-images.githubusercontent.com/5066836/156476994-8fad73ff-4414-45d4-ba05-1a1fcf8927a6.gif)


#### Challenge fails:
- probing succeeds at the 3rd try
- challenge request is made but responded with 500
- polling is canceled
- UI is changed to the MFA select UI
![challenge-failure](https://user-images.githubusercontent.com/5066836/156477022-83e05fdd-68ba-4cab-9860-ffec95c741c6.gif)


### Reviewers:
@pradeepdewda-okta @diptishiralkar-okta @hansreichenbach-okta @manishagarwal-okta 

### Issue:

- [OKTA-467278](https://oktainc.atlassian.net/browse/OKTA-467278)


