### PR TITLE
Resolves: OKTA-476273 - Fixing SIW hanging scrollbar when we have a dropdown at the very end

### DIFF
--- a/assets/sass/_container.scss
+++ b/assets/sass/_container.scss
@@ -8,7 +8,7 @@
   background-color: $secondary-bg-color;
   color: $medium-text-color;
   position: relative;
-  overflow: auto;
+  overflow: hidden;
 
   // Auth-container styles
   border-radius: 3px;


### PR DESCRIPTION
## Description:
When having a dropdown attribute to the very end of the SIW and clicking it, the SIW main container shows a vertical scrollbar additionally to the scrollbar shown by the page body. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
Normal devices, left image shows the bug and the right image shows after fixing the bug.
![SIW_5](https://user-images.githubusercontent.com/90656212/157294929-dbffbb0a-f9c3-4266-913d-8ae1b58962b4.png)

Small devices, left image shows the bug and the right image shows after fixing the bug.
![SIW_6](https://user-images.githubusercontent.com/90656212/157294954-32e74339-52db-4e7f-9b86-85941e5b4f83.png)


### Reviewers:
@okta/ciamx 

### Issue:
- [OKTA-476273](https://oktainc.atlassian.net/browse/OKTA-476273)


