### PR TITLE
fs-477714-progressive-profiling-string-with-format

### DIFF
--- a/playground/mocks/data/idp/idx/enroll-profile-new-additional-fields.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-new-additional-fields.json
@@ -44,7 +44,8 @@
                       "value":{
                         "type":"object",
                         "value":{
-                          "inputType":"select_country_code"
+                          "format": "country-code",
+                          "inputType":"select"
                         }
                       }
                     }
@@ -61,6 +62,7 @@
                       "value":{
                         "type":"object",
                         "value":{
+                          "format": "country-code",
                           "inputType":"text"
                         }
                       }

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -148,7 +148,7 @@ const INTERSTITIAL_REDIRECT_VIEW = {
 
 const ATTR_FORMAT = {
   COUNTRY_CODE: 'country-code',
-}
+};
 
 export {
   ACTIONS,

--- a/src/v2/ion/RemediationConstants.js
+++ b/src/v2/ion/RemediationConstants.js
@@ -146,6 +146,9 @@ const INTERSTITIAL_REDIRECT_VIEW = {
   NONE: 'NONE'
 };
 
+const ATTR_FORMAT = {
+  COUNTRY_CODE: 'country-code',
+}
 
 export {
   ACTIONS,
@@ -160,4 +163,5 @@ export {
   TERMINAL_FORMS,
   IDP_FORM_TYPE,
   INTERSTITIAL_REDIRECT_VIEW,
+  ATTR_FORMAT,
 };

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -13,7 +13,7 @@
 /* eslint max-depth: [2, 3] */
 /* eslint complexity: [2, 20] */
 import { loc } from 'okta';
-import { HINTS } from '../RemediationConstants';
+import { HINTS, ATTR_FORMAT } from '../RemediationConstants';
 import CountryUtil from '../../../util/CountryUtil';
 import TimeZone from '../../view-builder/utils/TimeZone';
 
@@ -55,7 +55,7 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
     uiSchema.options = display.options;
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;
-    if (display.format && display.format === 'country-code') {
+    if (display.format && display.format === ATTR_FORMAT.COUNTRY_CODE) {
       uiSchema.options = CountryUtil.getCountryCode();
       uiSchema.value = 'US';
     } else {

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -60,12 +60,12 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
   uiSchema.type = display.inputType;
   if (display.inputType === 'radio') {
     uiSchema.options = display.options;
+  } else if (display.inputType === 'select' && display.format === 'country-code') {
+    Object.assign(uiSchema, countryUISchema);
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;
     //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
     uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
-  } else if (display.inputType === 'select_country_code') {
-    Object.assign(uiSchema, countryUISchema);
   }
 };
 

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -55,7 +55,7 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
     uiSchema.options = display.options;
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;
-    if (display.format && display.format === ATTR_FORMAT.COUNTRY_CODE) {
+    if (display.format === ATTR_FORMAT.COUNTRY_CODE) {
       uiSchema.options = CountryUtil.getCountryCode();
       uiSchema.value = 'US';
     } else {

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -60,12 +60,14 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
   uiSchema.type = display.inputType;
   if (display.inputType === 'radio') {
     uiSchema.options = display.options;
-  } else if (display.inputType === 'select' && !_.isEmpty(display.format) && display.format === 'country-code') {
-    Object.assign(uiSchema, countryUISchema);
   } else if (display.inputType === 'select') {
-    uiSchema.wide = true;
-    //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
-    uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
+    if(!_.isEmpty(display.format) && display.format === 'country-code'){
+      Object.assign(uiSchema, countryUISchema);
+    } else {
+      uiSchema.wide = true;
+      //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
+      uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
+    }
   }
 };
 

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -60,7 +60,7 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
   uiSchema.type = display.inputType;
   if (display.inputType === 'radio') {
     uiSchema.options = display.options;
-  } else if (display.inputType === 'select' && display.format === 'country-code') {
+  } else if (display.inputType === 'select' && !_.isEmpty(display.format) && display.format === 'country-code') {
     Object.assign(uiSchema, countryUISchema);
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;

--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -38,13 +38,6 @@ const getCaptchaUiSchema = () => {
   };
 };
 
-const countryUISchema = {
-  type: 'select',
-  options: CountryUtil.getCountryCode(),
-  wide: true,
-  value: 'US',
-};
-
 const timezoneUISchema = {
   type: 'select',
   options: TimeZone,
@@ -61,10 +54,11 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
   if (display.inputType === 'radio') {
     uiSchema.options = display.options;
   } else if (display.inputType === 'select') {
-    if(!_.isEmpty(display.format) && display.format === 'country-code'){
-      Object.assign(uiSchema, countryUISchema);
+    uiSchema.wide = true;
+    if (display.format && display.format === 'country-code') {
+      uiSchema.options = CountryUtil.getCountryCode();
+      uiSchema.value = 'US';
     } else {
-      uiSchema.wide = true;
       //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
       uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
     }


### PR DESCRIPTION
## Description:

- if get display type as select and format is country-code, render the field as a dropdown with predefined list
- else render as a text box 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:

<img width="498" alt="Screen Shot 2022-03-01 at 1 13 17 PM" src="https://user-images.githubusercontent.com/90279953/157370546-bcae7b45-41bc-4161-9a76-a09c6e5f30e7.png">

<img width="454" alt="Screen Shot 2022-03-09 at 9 03 31 AM" src="https://user-images.githubusercontent.com/90279953/157492801-1077279a-fc5f-4257-bc07-9b9718f2d2d3.png">


### Reviewers:

@okta/ciamx 

### Issue:

- [OKTA-477714](https://oktainc.atlassian.net/browse/OKTA-477714)


