### PR TITLE
feat: add the custom factor help link to authenticator footer

### DIFF
--- a/src/v2/view-builder/components/AuthenticatorFooter.js
+++ b/src/v2/view-builder/components/AuthenticatorFooter.js
@@ -1,8 +1,9 @@
 import { BaseFooter } from '../internals';
-import { getSwitchAuthenticatorLink } from '../utils/LinksUtil';
+import { getFactorPageCustomLink, getSwitchAuthenticatorLink } from '../utils/LinksUtil';
 
 export default BaseFooter.extend({
   links() {
-    return getSwitchAuthenticatorLink(this.options.appState);
-  }
+    return getFactorPageCustomLink(this.options.appState, this.options.settings)
+      .concat(getSwitchAuthenticatorLink(this.options.appState));
+  },
 });

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -161,6 +161,31 @@ const getSignUpLink = (appState, settings) => {
   return signupLink;
 };
 
+const getFactorPageCustomLink = (appState, settings) => {
+  const factorPageCustomLink = [];
+  const formsNeedFactorPageCustomLink = [
+    RemediationForms.CHALLENGE_AUTHENTICATOR,
+    RemediationForms.SELECT_AUTHENTICATOR_AUTHENTICATE,
+    RemediationForms.CHALLENGE_POLL,
+    RemediationForms.AUTHENTICATOR_VERIFICATION_DATA,
+  ];
+
+  if (!appState.get('isPasswordRecovery') && formsNeedFactorPageCustomLink.includes(appState.get('currentFormName'))) {
+    const helpLinksFactorPageLabel = settings.get('helpLinks.factorPage.text');
+    const helpLinksFactorPageHref = settings.get('helpLinks.factorPage.href');
+
+    if (helpLinksFactorPageLabel && helpLinksFactorPageHref) {
+      factorPageCustomLink.push({
+        type: 'link',
+        label: helpLinksFactorPageLabel,
+        name: 'factorPageHelpLink',
+        href: helpLinksFactorPageHref,
+      });
+    }
+  }
+  return factorPageCustomLink;
+};
+
 export {
   getSwitchAuthenticatorLink,
   getForgotPasswordLink,
@@ -169,5 +194,6 @@ export {
   getSignOutLink,
   getBackToSignInLink,
   getSkipSetupLink,
-  getReloadPageButtonLink
+  getReloadPageButtonLink,
+  getFactorPageCustomLink,
 };

--- a/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
+++ b/src/v2/view-builder/views/SelectAuthenticatorVerifyView.js
@@ -1,5 +1,7 @@
 import { BaseForm, BaseView } from '../internals';
 import { loc } from 'okta';
+import BaseFooter from '../internals/BaseFooter';
+import {getFactorPageCustomLink} from '../utils/LinksUtil';
 
 export const Body = BaseForm.extend({
   title: function() {
@@ -22,4 +24,9 @@ export const Body = BaseForm.extend({
 
 export default BaseView.extend({
   Body,
+  Footer: BaseFooter.extend({
+    links() {
+      return getFactorPageCustomLink(this.options.appState, this.options.settings);
+    },
+  }),
 });

--- a/test/testcafe/framework/page-objects/BasePageObject.js
+++ b/test/testcafe/framework/page-objects/BasePageObject.js
@@ -8,6 +8,7 @@ const SKIP_SET_UP_LINK = '.auth-footer .js-skip-setup';
 const SWITCH_AUTHENTICATOR_LINK = '.auth-footer .js-switchAuthenticator';
 const ionMessagesSelector = '.ion-messages-container';
 const SUBTITLE_SELECTOR = '[data-se="o-form-explain"]';
+const FACTOR_PAGE_HELP_LINK = '[data-se="factorPageHelpLink"]';
 
 export default class BasePageObject {
   constructor(t) {
@@ -174,5 +175,19 @@ export default class BasePageObject {
 
   subtitleExists() {
     return this.form.elementExist(SUBTITLE_SELECTOR);
+  }
+
+  getFactorPageHelpLink() {
+    return Selector(FACTOR_PAGE_HELP_LINK).getAttribute('href');
+  }
+
+  getFactorPageHelpLinksLabel() {
+    return Selector(FACTOR_PAGE_HELP_LINK).textContent;
+  }
+
+  async factorPageHelpLinksExists() {
+    const elCount = await Selector(FACTOR_PAGE_HELP_LINK).count;
+
+    return elCount === 1;
   }
 }

--- a/test/testcafe/spec/AuthenticatorSymantecView_spec.js
+++ b/test/testcafe/spec/AuthenticatorSymantecView_spec.js
@@ -1,6 +1,6 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 import SymantecAuthenticatorPageObject from '../framework/page-objects/SymantecAuthenticatorPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import xhrEnrollSymantecAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-enroll-symantec-vip';
 import xhrVerifySymantecAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-verification-symantec-vip';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
@@ -132,3 +132,19 @@ test
     await t.expect(pageObject.form.getTextBoxErrorMessage(fieldName))
       .eql('Your code doesn\'t match our records. Please try again.');
   });
+
+test.requestHooks(verifyMock)('should show custom factor page link', async t => {
+  const pageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(pageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(pageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/AuthenticatorYubikeyView_spec.js
+++ b/test/testcafe/spec/AuthenticatorYubikeyView_spec.js
@@ -1,5 +1,5 @@
 import { RequestMock, RequestLogger } from 'testcafe';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import YubiKeyAuthenticatorPageObject from '../framework/page-objects/YubiKeyAuthenticatorPageObject';
 import xhrEnrollYubiKeyAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-enroll-yubikey';
 import xhrVerifyYubiKeyAuthenticator from '../../../playground/mocks/data/idp/idx/authenticator-verification-yubikey';
@@ -105,3 +105,19 @@ test
     pageObject.form.waitForErrorBox();
     await t.expect(pageObject.form.getErrorBoxText()).eql('We found some errors. Please review the form and make corrections.');
   });
+
+test.requestHooks(verifyMock)('should show custom factor page link', async t => {
+  const pageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(pageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(pageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorDuo_spec.js
@@ -126,3 +126,19 @@ test.requestHooks(answerRequestLogger, verificationFailedMock)('verification fai
   await duoPageObject.form.waitForErrorBox();
   await t.expect(duoPageObject.form.getErrorBoxText()).eql('We were unable to verify with Duo. Try again.');
 });
+
+test.requestHooks(mock)('should show custom factor page link', async t => {
+  const challengeDuoPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeDuoPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeDuoPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -2,7 +2,7 @@ import { RequestMock, RequestLogger, ClientFunction } from 'testcafe';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeEmailPageObject from '../framework/page-objects/ChallengeEmailPageObject';
 import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 import emailVerification from '../../../playground/mocks/data/idp/idx/authenticator-verification-email';
 import emailVerificationWithoutEmailMagicLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-email-without-emailmagiclink';
@@ -111,7 +111,7 @@ const invalidOTPMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(emailVerification)  
+  .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidOTP, 403);
 
@@ -119,7 +119,7 @@ const invalidOTPMockWithPoll = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
-  .respond(emailVerification)  
+  .respond(emailVerification)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidEmailOTP, 403);
 
@@ -386,7 +386,7 @@ test
     await t.wait(5000);
     await t.expect(challengeEmailPageObject.getInvalidOTPFieldError()).contains('Invalid code. Try again.');
     await t.expect(challengeEmailPageObject.getInvalidOTPError()).contains('We found some errors.');
-  });  
+  });
 
 test
   .requestHooks(invalidOTPTooManyOperationRequestMock)('challenge email authenticator with too many invalid OTP', async t => {
@@ -687,3 +687,19 @@ test
         record.request.url.match(/poll/)
     )).eql(1);
   });
+
+test.requestHooks(sendEmailMock)('should show custom factor page link', async t => {
+  const challengeEmailPageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeEmailPageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeEmailPageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -192,3 +192,21 @@ test.requestHooks(requestLogger, mockChallengeOVTotpMethod)('should show switch 
   await t.expect(pageUrl)
     .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
 });
+
+test.requestHooks(mockChallengeOVTotpMethod)('should show custom factor page link', async t => {
+  const selectAuthenticatorPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await selectAuthenticatorPage.selectFactorByIndex(2);
+
+  await t.expect(selectAuthenticatorPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(selectAuthenticatorPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
@@ -5,7 +5,7 @@ import xhrPasscodeChange from '../../../playground/mocks/data/idp/idx/error-auth
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import ChallengeOnPremPageObject from '../framework/page-objects/ChallengeOnPremPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 const mockChallengeAuthenticatorOnPrem = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -90,4 +90,20 @@ test.requestHooks(mockPasscodeChange)('displays error and clears passcode when p
     .eql('Pin accepted, Wait for token to change, then enter new passcode.');
   await t.expect(challengeOnPremPage.getPasscodeValue())
     .eql('');
+});
+
+test.requestHooks(mockChallengeAuthenticatorOnPrem)('should show custom factor page link', async t => {
+  const challengeOnPremPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeOnPremPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeOnPremPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
 });

--- a/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPassword_spec.js
@@ -191,3 +191,19 @@ test.requestHooks(mockChallengeAuthenticatorPassword)('should add sub labels for
   await t.expect(challengePasswordPage.getPasswordSubLabelValue()).eql('Your password goes here');
   await t.expect(challengePasswordPage.getIdentifier()).eql('testUser@okta.com');
 });
+
+test.requestHooks(mockChallengeAuthenticatorPassword)('should show custom factor page link', async t => {
+  const challengePasswordPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengePasswordPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengePasswordPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -518,3 +518,19 @@ test
     const { authenticator: smsRequestObj } = JSON.parse(smsRequestBody);
     await t.expect(smsRequestObj).eql({ id: 'autxl8PPhwHUpOpW60g3', methodType: 'sms'});
   });
+
+test.requestHooks(smsPrimaryMockEmptyProfile)('should show custom factor page link', async t => {
+  const challengePhonePageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengePhonePageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengePhonePageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorRsa_spec.js
@@ -3,7 +3,7 @@ import xhrAuthenticatorRequiredRsa from '../../../playground/mocks/data/idp/idx/
 import xhrInvalidPasscode from '../../../playground/mocks/data/idp/idx/error-authenticator-verification-rsa';
 import xhrPasscodeChange from '../../../playground/mocks/data/idp/idx/error-authenticator-verification-passcode-change-rsa';
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import ChallengeRsaPageObject from '../framework/page-objects/ChallengeOnPremPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 
@@ -92,4 +92,20 @@ test.requestHooks(mockPasscodeChange)('displays error and clears passcode when p
     .eql('Pin accepted, Wait for token to change, then enter new passcode.');
   await t.expect(challengeRsaPage.getPasscodeValue())
     .eql('');
+});
+
+test.requestHooks(mockPasscodeChange)('should show custom factor page link', async t => {
+  const challengeRsaPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeRsaPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeRsaPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
 });

--- a/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorSecurityQuestion_spec.js
@@ -2,7 +2,7 @@ import { RequestMock, RequestLogger } from 'testcafe';
 
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeSecurityQuestionPageObject from '../framework/page-objects/ChallengeSecurityQuestionPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 import xhrAuthenticatorVerifySecurityQuestion from '../../../playground/mocks/data/idp/idx/authenticator-verification-security-question';
 import success from '../../../playground/mocks/data/idp/idx/success';
@@ -66,4 +66,20 @@ test.requestHooks(answerRequestLogger, authenticatorRequiredSecurityQuestionMock
   });
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/challenge/answer');
+});
+
+test.requestHooks(authenticatorRequiredSecurityQuestionMock)('should show custom factor page link', async t => {
+  const challengeSecurityQuestionPageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeSecurityQuestionPageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeSecurityQuestionPageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
 });

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -1,7 +1,7 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeCustomAppPushPageObject from '../framework/page-objects/ChallengeCustomAppPushPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 import pushPoll from '../../../playground/mocks/data/idp/idx/authenticator-verification-custom-app-push';
 import pushPollReject from '../../../playground/mocks/data/idp/idx/authenticator-verification-custom-app-push-reject';
@@ -119,11 +119,11 @@ test
       method: answerRequestMethod2,
       url: answerRequestUrl2,
     }
-    } = logger.requests[1];    
+    } = logger.requests[1];
     await t.expect(answerRequestMethod2).eql('post');
     await t.expect(answerRequestUrl2).eql('http://localhost:3000/idp/idx/challenge/poll');
   });
-  
+
 
 test
   .requestHooks(logger, pushRejectMock)('challenge Custom App reject push and then resend', async t => {
@@ -134,14 +134,14 @@ test
     await t.expect(challengeCustomAppPushPageObject.form.getSaveButtonLabel())
       .eql('Resend push notification');
     await t.expect(logger.count(() => true)).eql(1);
-    
+
     // To make sure polling stops after reject
     await t.wait(5000);
     await t.expect(logger.count(() => true)).eql(1);
-    
+
     await challengeCustomAppPushPageObject.clickNextButton();
     await t.expect(logger.count(() => true)).eql(2);
-    
+
     const { request: {
       body: requestBodyString,
       method: requestMethod,
@@ -170,3 +170,19 @@ test
     await t.expect(warningBox.innerText)
       .eql('Haven\'t received a push notification yet? Try opening Custom Push on your phone.');
   });
+
+test.requestHooks(pushSuccessMock)('should show custom factor page link', async t => {
+  const challengeCustomAppPushPageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeCustomAppPushPageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeCustomAppPushPageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
+++ b/test/testcafe/spec/ChallengeCustomOTPAuthenticatorView_spec.js
@@ -4,7 +4,7 @@ import xhrInvalidOTP from '../../../playground/mocks/data/idp/idx/error-authenti
 import xhrSuccess from '../../../playground/mocks/data/idp/idx/success';
 import ChallengeCustomOTPPageObject from '../framework/page-objects/ChallengeCustomOTPPageObject';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 const mockChallengeAuthenticatorCustomOTP = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -69,3 +69,18 @@ test.requestHooks(mockInvalidPasscode)('challege custom otp authenticator with i
     .eql('Invalid code. Try again.');
 });
 
+test.requestHooks(mockChallengeAuthenticatorCustomOTP)('should show custom factor page link', async t => {
+  const challengeOnPremPage = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeOnPremPage.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeOnPremPage.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
+++ b/test/testcafe/spec/ChallengeGoogleAuthenticatorOtp_spec.js
@@ -1,7 +1,7 @@
 import { RequestMock, RequestLogger } from 'testcafe';
 import SuccessPageObject from '../framework/page-objects/SuccessPageObject';
 import ChallengeGoogleAuthenticatorPageObject from '../framework/page-objects/ChallengeGoogleAuthenticatorPageObject';
-import { checkConsoleMessages } from '../framework/shared';
+import { checkConsoleMessages, renderWidget } from '../framework/shared';
 
 import otpChallenge from '../../../playground/mocks/data/idp/idx/authenticator-verification-google-authenticator';
 import success from '../../../playground/mocks/data/idp/idx/success';
@@ -105,3 +105,19 @@ test
     await challengeGoogleAuthenticatorPageObject.clickNextButton();
     await t.expect(challengeGoogleAuthenticatorPageObject.getAnswerInlineError()).eql('Each code can only be used once. Please wait for a new code and try again.');
   });
+
+test.requestHooks(validOTPmock)('should show custom factor page link', async t => {
+  const challengeGoogleAuthenticatorPageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(challengeGoogleAuthenticatorPageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(challengeGoogleAuthenticatorPageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -550,3 +550,34 @@ test.requestHooks(mockChallengeCustomOTP)('should navigate to Custom OTP challen
   const challengeFactorPage = new ChallengeFactorPageObject(t);
   await t.expect(challengeFactorPage.getFormTitle()).eql('Verify with Atko Custom OTP Authenticator');
 });
+
+test.requestHooks(mockChallengePassword)('should show custom factor page link', async t => {
+  const pageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(pageObject.getFactorPageHelpLinksLabel()).eql('custom factor page link');
+  await t.expect(pageObject.getFactorPageHelpLink()).eql('https://acme.com/what-is-okta-autheticators');
+});
+
+test.requestHooks(mockSelectAuthenticatorForRecovery)('should not show custom factor page link', async t => {
+  const pageObject = await setup(t);
+
+  await renderWidget({
+    helpLinks: {
+      factorPage: {
+        text: 'custom factor page link',
+        href: 'https://acme.com/what-is-okta-autheticators'
+      }
+    }
+  });
+
+  await t.expect(await pageObject.factorPageHelpLinksExists()).notOk();
+});

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -1,15 +1,24 @@
 import AppState from 'v2/models/AppState';
 import { FORMS } from 'v2/ion/RemediationConstants';
-import { getSwitchAuthenticatorLink } from 'v2/view-builder/utils/LinksUtil';
+import { getSwitchAuthenticatorLink, getFactorPageCustomLink } from 'v2/view-builder/utils/LinksUtil';
+import Settings from '../../../../../../src/models/Settings';
 
 describe('v2/utils/LinksUtil', function() {
-  const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator) => {
+  const mockAppState = (remediationFormName, hasMoreThanOneAuthenticator, isPasswordRecovery) => {
     const appState = new AppState();
     jest.spyOn(appState, 'getRemediationAuthenticationOptions').mockImplementation(formName => {
       if (formName === remediationFormName && hasMoreThanOneAuthenticator) {
         return [ { label: 'some authenticator '}, { label: 'another authenticator' } ];
       }
       return [];
+    });
+    jest.spyOn(appState, 'get').mockImplementation(attribute => {
+      if (attribute === 'currentFormName') {
+        return remediationFormName;
+      }
+      if (attribute === 'isPasswordRecovery') {
+        return isPasswordRecovery;
+      }
     });
     return appState;
   };
@@ -37,6 +46,58 @@ describe('v2/utils/LinksUtil', function() {
         const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_ENROLL, false);
         expect(getSwitchAuthenticatorLink(appState).length).toEqual(0);
       });
+    });
+  });
+
+  describe('getFactorPageCustomLink', () => {
+    it('returns a link when it is in select-authenticator-authenticate, and not a password recover flow', function() {
+      const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE, true, false);
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        'helpLinks.factorPage.text': 'custom factor page link',
+        'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
+      });
+      expect(getFactorPageCustomLink(appState, settings).length).toEqual(1);
+    });
+
+    it('returns empty when is not select-authenticator-authenticate', function() {
+      const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_ENROLL, true, false);
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        'helpLinks.factorPage.text': 'custom factor page link',
+        'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
+      });
+      expect(getFactorPageCustomLink(appState, settings).length).toEqual(0);
+    });
+
+    it('returns empty when  it is in select-authenticator-authenticate but in a password recover flow', function() {
+      const appState = mockAppState(FORMS.SELECT_AUTHENTICATOR_AUTHENTICATE, true, true);
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        'helpLinks.factorPage.text': 'custom factor page link',
+        'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
+      });
+      expect(getFactorPageCustomLink(appState, settings).length).toEqual(0);
+    });
+
+    it('returns a link when it is in challenge-authenticator, and not a password recover flow', function() {
+      const appState = mockAppState(FORMS.CHALLENGE_AUTHENTICATOR, true, false);
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        'helpLinks.factorPage.text': 'custom factor page link',
+        'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
+      });
+      expect(getFactorPageCustomLink(appState, settings).length).toEqual(1);
+    });
+
+    it('returns empty when it is in challenge-authenticator, and in a password recover flow', function() {
+      const appState = mockAppState(FORMS.CHALLENGE_AUTHENTICATOR, true, true);
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        'helpLinks.factorPage.text': 'custom factor page link',
+        'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
+      });
+      expect(getFactorPageCustomLink(appState, settings).length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
## Description:
Add the "custom factor help link" support on the authenticator footer


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/47287459/157575222-1429fbfd-95f5-459a-ad97-273c702fbbd4.png)

### Reviewers:
@mauriciocastillosilva-okta @indirathirumalaimurugan-okta 

### Issue:

- [OKTA-476037](https://oktainc.atlassian.net/browse/OKTA-476037)


