### PR TITLE
Differentiate user and loopback cancel

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -308,6 +308,10 @@ const fastpassUnassignedApp = {
 };
 
 // device probe: Windows authenticator with loopback server
+//
+// To mimic the loopback failure flow (ex. loopback server does not exist),
+// update package.json's script for mock:device-authenticator and
+// change port 6512 to 6518 (identify-with-device-probing-loopback does not list this port)
 const windowAuthnLoopback = {
   '/idp/idx/introspect': [
     'identify-with-device-probing-loopback', // 1 (response order)
@@ -317,6 +321,9 @@ const windowAuthnLoopback = {
     'identify-with-device-probing-loopback-3', // 3
     'identify', // 4: as a signal of success
   ],
+  '/idp/idx/authenticators/poll/cancel': [
+    'authenticator-verification-select-authenticator',
+  ]
 };
 
 // device probe: Windows authenticator with loopback server polling error (device not registered deny access)

--- a/src/v2/controllers/FormController.js
+++ b/src/v2/controllers/FormController.js
@@ -129,7 +129,7 @@ export default Controller.extend({
     this.options.appState.set('currentFormName', formName);
   },
 
-  handleInvokeAction(actionPath = '') {
+  handleInvokeAction(actionPath = '', actionParams = {}) {
     const idx = this.options.appState.get('idx');
 
     if (actionPath === 'cancel') {
@@ -151,7 +151,7 @@ export default Controller.extend({
 
     if (_.isFunction(actionFn)) {
       // TODO: OKTA-243167 what's the approach to show spinner indicating API in flight?
-      actionFn()
+      actionFn(actionParams)
         .then((resp) => {
           if (actionPath === 'cancel' && this.options.settings.get('useInteractionCodeFlow')) {
             // In this case we need to restart login flow and recreate transaction meta

--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -11,4 +11,4 @@ export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP
     = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.desktop';
 export const OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE 
     = 'oie.authenticator.oktaverify.method.fastpass.verify.enable.biometrics.mobile';
-
+export const REQUEST_PARAM_LOOPBACK_CANCEL_TRIGGER = 'triggeredByUser';

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,7 +1,7 @@
 import { $, createCallout, _ } from 'okta';
 import { BaseFormWithPolling } from '../../internals';
 import Logger from '../../../../util/Logger';
-import { CHALLENGE_TIMEOUT } from '../../utils/Constants';
+import { CHALLENGE_TIMEOUT, REQUEST_PARAM_LOOPBACK_CANCEL_TRIGGER } from '../../utils/Constants';
 import BrowserFeatures from '../../../../util/BrowserFeatures';
 import { doChallenge, getBiometricsErrorOptions } from '../../utils/ChallengeViewUtil';
 
@@ -90,10 +90,20 @@ const Body = BaseFormWithPolling.extend(Object.assign(
         Logger.error(`Something unexpected happened while we were checking port ${currentPort}.`);
       };
 
+      const cancelPolling = (triggeredByUser = false) => {
+        const actionParams = {};
+        actionParams[REQUEST_PARAM_LOOPBACK_CANCEL_TRIGGER] = triggeredByUser;
+        this.options.appState.trigger('invokeAction', 'currentAuthenticator-cancel', actionParams);
+      };
+
       const doProbing = () => {
         return checkPort()
           // TODO: can we use standard ES6 promise methods, then/catch?
-          .done(onPortFound)
+          .done(() => {
+            return onPortFound().fail(() => {
+              cancelPolling(false);
+            });
+          })
           .fail(onFailure);
       };
 
@@ -111,7 +121,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
             Logger.error(`Authenticator is not listening on port ${currentPort}.`);
             if (countFailedPorts === ports.length) {
               Logger.error('No available ports. Loopback server failed and polling is cancelled.');
-              this.options.appState.trigger('invokeAction', 'currentAuthenticator-cancel');
+              cancelPolling(false);
             }
           });
       });

--- a/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
+++ b/test/testcafe/framework/page-objects/DeviceChallengePollPageObject.js
@@ -72,6 +72,10 @@ export default class DeviceChallengePollViewPageObject extends BasePageObject {
     return Selector('[data-se="o-form-fieldset-container"] .button-primary', { timeout: 4500 });
   }
 
+  async clickCancelAndGoBackLink() {
+    await this.t.click(Selector('a[data-se="cancel-authenticator-challenge"]'));
+  }
+
   async clickUniversalLink() {
     await this.t.click(Selector('.ul-button'));
   }

--- a/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
+++ b/test/testcafe/spec/ChallengeOktaVerifyFastPassView_spec.js
@@ -10,6 +10,7 @@ import identifyWithUserVerificationBiometricsErrorDesktop from '../../../playgro
 import identifyWithUserVerificationCustomURI from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-custom-uri';
 import identifyWithSSOExtensionFallback from '../../../playground/mocks/data/idp/idx/identify-with-apple-sso-extension-fallback';
 import identifyWithUserVerificationLaunchUniversalLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-universal-link';
+import mfaSelect from '../../../playground/mocks/data/idp/idx/authenticator-verification-select-authenticator';
 import loopbackChallengeNotReceived from '../../../playground/mocks/data/idp/idx/identify-with-device-probing-loopback-challenge-not-received';
 import assureWithLaunchAppLink from '../../../playground/mocks/data/idp/idx/authenticator-verification-okta-verify-signed-nonce-app-link';
 import { renderWidget } from '../framework/shared';
@@ -75,7 +76,34 @@ const loopbackBiometricsErrorDesktopMock = RequestMock()
     }
   });
 
-const loopbackFallbackLogger = RequestLogger(/introspect|probe|cancel|launch|poll/);
+const loopbackBiometricsNoResponseErrorLogger = RequestLogger(
+  /introspect|probe|cancel|challenge|poll/,
+  { logRequestBody: true, stringifyRequestBody: true }
+);
+const loopbackBiometricsNoResponseErrorMock = RequestMock()
+  .onRequestTo(/\/idp\/idx\/introspect/)
+  .respond(identifyWithUserVerificationLoopback)
+  .onRequestTo(/2000|6511\/probe/)
+  .respond(null, 500, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/probe/)
+  .respond(null, 200, {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'X-Okta-Xsrftoken, Content-Type'
+  })
+  .onRequestTo(/6512\/challenge/)
+  .respond(null, 500)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll\/cancel/)
+  .respond(mfaSelect)
+  .onRequestTo(/\/idp\/idx\/authenticators\/poll/)
+  .respond(identifyWithUserVerificationLoopback);
+
+const loopbackFallbackLogger = RequestLogger(
+  /introspect|probe|cancel|launch|poll/,
+  { logRequestBody: true, stringifyRequestBody: true }
+);
 const loopbackFallbackMock = RequestMock()
   .onRequestTo(/idp\/idx\/introspect/)
   .respond(identifyWithUserVerificationLoopback)
@@ -219,6 +247,28 @@ test
   });
 
 test
+  .requestHooks(loopbackBiometricsNoResponseErrorLogger, loopbackBiometricsNoResponseErrorMock)('in loopback server, when user does not respond to biometrics request, cancel the polling', async t => {
+    await setup(t);
+    const secondSelectAuthenticatorPageObject = new SelectAuthenticatorPageObject(t);
+    await t.expect(secondSelectAuthenticatorPageObject.getFormTitle()).eql('Verify it\'s you with a security method');
+    await t.expect(loopbackBiometricsNoResponseErrorLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.method !== 'options' &&
+        record.request.url.match(/introspect|probe/)
+    )).eql(2);
+    await t.expect(loopbackBiometricsNoResponseErrorLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.method !== 'options' &&
+        record.request.url.match(/cancel/) &&
+        JSON.parse(record.request.body).triggeredByUser === false
+    )).eql(1);
+    await t.expect(loopbackBiometricsNoResponseErrorLogger.count(
+      record => record.response.statusCode === 500 &&
+        record.request.url.match(/probe|challenge/)
+    )).eql(3);
+  });
+
+test
   .requestHooks(loopbackBiometricsErrorMobileMock)('show biometrics error for mobile platform in loopback', async t => {
     const deviceChallengePollPageObject = await setup(t);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
@@ -263,6 +313,11 @@ test
     loopbackFallbackLogger.clear();
     await setupLoopbackFallback(t);
     const deviceChallengePollPageObject = new DeviceChallengePollPageObject(t);
+    await t.expect(loopbackFallbackLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/authenticators\/poll\/cancel/) &&
+        JSON.parse(record.request.body).triggeredByUser === false
+    )).eql(1);
     await t.expect(deviceChallengePollPageObject.getBeaconClass()).contains(BEACON_CLASS);
     await t.expect(deviceChallengePollPageObject.getHeader()).eql('Click "Open Okta Verify" on the browser prompt');
     const content = deviceChallengePollPageObject.getContent();


### PR DESCRIPTION
## Description:

Pass `triggeredByUser` value to the polling cancel request in order to differentiate loopback failure vs user cancelation.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
#### loopback fails, SIW cancels the polling
<img width="996" alt="Screen Shot 2022-03-10 at 5 33 47 PM" src="https://user-images.githubusercontent.com/5066836/158054955-302b875c-a8c1-4aff-af42-af8ceddffad4.png">

#### user clicks on cancel and go back link
<img width="1029" alt="Screen Shot 2022-03-10 at 5 43 48 PM" src="https://user-images.githubusercontent.com/5066836/158054957-117624cd-7bf9-4f19-9866-4931025b81f6.png">


### Reviewers:
@pradeepdewda-okta @santoshmale-okta 

### Issue:

- [OKTA-469749](https://oktainc.atlassian.net/browse/OKTA-469749)
