### PR TITLE
Support prompting for password with SSR

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -108,6 +108,7 @@ const idx = {
   ],
   '/idp/idx/enroll': [
     'enroll-profile-new',
+    // 'enroll-profile-with-password',
     // 'error-enroll-regisration-unavailable',
   ],
   '/idp/idx/credential/enroll': [

--- a/playground/mocks/data/idp/idx/enroll-profile-with-password-returns-error.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-with-password-returns-error.json
@@ -1,0 +1,158 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "NON_NULL_VALUE",
+  "expiresAt": "DATE",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application/ion+json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true
+                },
+                {
+                  "name": "firstName",
+                  "label": "First name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                {
+                  "name": "lastName",
+                  "label": "Last name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                }
+              ]
+            }
+          },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter Password",
+                  "required": true,
+                  "secret": true,
+                  "messages": {
+                    "type": "array",
+                    "value": [
+                      {
+                        "message": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username. Your password cannot be any of your last 4 passwords.",
+                        "i18n": {
+                          "key": "password.passwordRequirementsNotMet",
+                          "params": [
+                            "Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username. Your password cannot be any of your last 4 passwords."
+                          ]
+                        },
+                        "class": "ERROR"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "required": true,
+            "relatesTo": "$.currentAuthenticator"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify/select",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "NON_NULL_VALUE",
+      "displayName": "Password",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 1,
+          "minUpperCase": 1,
+          "minNumber": 1,
+          "minSymbol": 0,
+          "excludeUsername": true,
+          "excludeAttributes": []
+        },
+        "age": {
+          "minAgeMinutes": 0,
+          "historyCount": 4
+        }
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/ion+json; okta-version=1.0.0",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "NON_NULL_VALUE",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": "OBJECT"
+  }
+}

--- a/playground/mocks/data/idp/idx/enroll-profile-with-password-returns-multiple-errors.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-with-password-returns-multiple-errors.json
@@ -1,0 +1,183 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "NON_NULL_VALUE",
+  "expiresAt": "DATE",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application/ion+json; okta-version=1.0.0",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true,
+                  "messages": {
+                    "type": "array",
+                    "value": [
+                      {
+                        "message": "Provided value for property 'Primary email' does not match required pattern",
+                        "i18n": {
+                          "key": "registration.error.doesNotMatchPattern",
+                          "params": [
+                            "Primary email"
+                          ]
+                        },
+                        "class": "ERROR"
+                      },
+                      {
+                        "message": "'Primary email' must be in the form of an email address",
+                        "i18n": {
+                          "key": "registration.error.invalidLoginEmail",
+                          "params": [
+                            "Primary email"
+                          ]
+                        },
+                        "class": "ERROR"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "firstName",
+                  "label": "First name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                {
+                  "name": "lastName",
+                  "label": "Last name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                }
+              ]
+            }
+          },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter Password",
+                  "required": true,
+                  "secret": true,
+                  "messages": {
+                    "type": "array",
+                    "value": [
+                      {
+                        "message": "Password requirements were not met. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username. Your password cannot be any of your last 4 passwords.",
+                        "i18n": {
+                          "key": "password.passwordRequirementsNotMet",
+                          "params": [
+                            "Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username. Your password cannot be any of your last 4 passwords."
+                          ]
+                        },
+                        "class": "ERROR"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "required": true,
+            "relatesTo": "$.currentAuthenticator"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify/select",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "NON_NULL_VALUE",
+      "displayName": "Password",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 1,
+          "minUpperCase": 1,
+          "minNumber": 1,
+          "minSymbol": 0,
+          "excludeUsername": true,
+          "excludeAttributes": []
+        },
+        "age": {
+          "minAgeMinutes": 0,
+          "historyCount": 4
+        }
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application/ion+json; okta-version=1.0.0",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "NON_NULL_VALUE",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": "OBJECT"
+  }
+}

--- a/playground/mocks/data/idp/idx/enroll-profile-with-password.json
+++ b/playground/mocks/data/idp/idx/enroll-profile-with-password.json
@@ -1,0 +1,143 @@
+{
+  "stateHandle": "NON_NULL_VALUE",
+  "version": "1.0.0",
+  "expiresAt": "DATE",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-profile",
+        "href": "http://localhost:3000/idp/idx/enroll/new",
+        "method": "POST",
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true
+                },
+                {
+                  "name": "firstName",
+                  "label": "First name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                },
+                {
+                  "name": "lastName",
+                  "label": "Last name",
+                  "required": true,
+                  "minLength": 1,
+                  "maxLength": 50
+                }
+              ]
+            }
+          },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter Password",
+                  "required": true,
+                  "secret": true
+                }
+              ]
+            },
+            "required": true,
+            "relatesTo": "$.currentAuthenticator"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-identify",
+        "href": "http://localhost:3000/idp/idx/identify/select",
+        "method": "POST",
+        "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "NON_NULL_VALUE",
+            "visible": false,
+            "mutable": false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "NON_NULL_VALUE",
+      "displayName": "NON_NULL_VALUE",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": "NUMBER",
+          "minLowerCase": "NUMBER",
+          "minUpperCase": "NUMBER",
+          "minNumber": "NUMBER",
+          "minSymbol": "NUMBER",
+          "excludeUsername": "BOOLEAN",
+          "excludeAttributes": []
+        },
+        "age": {
+          "minAgeMinutes": "NUMBER",
+          "historyCount": "NUMBER"
+        }
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "accepts": "application\\/json; okta-version=\\d+\\.\\d+\\.\\d+",
+    "produces": "application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "NON_NULL_VALUE",
+        "visible": false,
+        "mutable": false
+      }
+    ]
+  },
+  "app": {
+    "type": "object",
+    "value": "OBJECT"
+  }
+}

--- a/src/v2/view-builder/views/enroll-profile/i18nBaseAttributeMappings.js
+++ b/src/v2/view-builder/views/enroll-profile/i18nBaseAttributeMappings.js
@@ -33,6 +33,7 @@ const I18N_BASE_ATTRIBUTE_ENROLL_PROFILE_MAPPINGS = {
   'enroll-profile.userProfile.department': 'oie.user.profile.department',
   'enroll-profile.userProfile.managerId': 'oie.user.profile.managerId',
   'enroll-profile.userProfile.manager': 'oie.user.profile.manager',
+  'enroll-profile.credentials.passcode': 'oie.password.label',
 };
 
 export {

--- a/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
+++ b/src/v2/view-builder/views/password/EnrollAuthenticatorPasswordView.js
@@ -1,10 +1,10 @@
-import { loc, View } from 'okta';
+import { loc } from 'okta';
 import { BaseForm, BaseView } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 import {
   getPasswordComplexityDescriptionForHtmlList,
   removeRequirementsFromError } from '../../utils/AuthenticatorUtil';
-import hbs from 'handlebars-inline-precompile';
+import { generatePasswordPolicyHtml } from './PasswordPolicyUtil';
 
 const Body = BaseForm.extend({
   title() {
@@ -23,26 +23,7 @@ const Body = BaseForm.extend({
   displayPasswordPolicy(policy) {
     if (policy) {
       const rulesList = getPasswordComplexityDescriptionForHtmlList( policy );
-      this.add(
-        View.extend({
-          tagName: 'section',
-          template:
-            hbs`<div class="password-authenticator--heading">
-              {{i18n code="password.complexity.requirements.header" bundle="login"}}
-            </div>
-            <ul class="password-authenticator--list">
-              {{#each rulesList}}<li>{{this}}</li>{{/each}}
-            </ul>`,
-          getTemplateData: () => ({ rulesList }),
-          attributes: {
-            'data-se': 'password-authenticator--rules'
-          }
-        }),
-        {
-          prepend: true,
-          selector: '.o-form-fieldset-container',
-        }
-      );
+      generatePasswordPolicyHtml(this, rulesList, true);
     }
   },
 

--- a/src/v2/view-builder/views/password/PasswordPolicyUtil.js
+++ b/src/v2/view-builder/views/password/PasswordPolicyUtil.js
@@ -1,0 +1,29 @@
+import { View } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+
+const generatePasswordPolicyHtml = function(form, rulesList, prepend) {
+  form.add(
+    View.extend({
+      tagName: 'section',
+      template:
+        hbs`<div class="password-authenticator--heading">
+        {{i18n code="password.complexity.requirements.header" bundle="login"}}
+      </div>
+      <ul class="password-authenticator--list">
+        {{#each rulesList}}<li>{{this}}</li>{{/each}}
+      </ul>`,
+      getTemplateData: () => ({ rulesList }),
+      attributes: {
+        'data-se': 'password-authenticator--rules'
+      }
+    }),
+    {
+      prepend,
+      selector: '.o-form-fieldset-container',
+    }
+  );
+};
+
+export {
+  generatePasswordPolicyHtml,
+};


### PR DESCRIPTION
## Description:

- If password with SSR is enabled, the SIW needs to support it
  - A password field is shown on the `enroll-profile` view
    - Field contains an eye icon to allow user to toggle their password input
  - Password requirements are also shown under the password field

### Bacon test
- With okta-core master [Bacon](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&sha=f08c21716dac8e3d37450413f0d1b727b7ebcbf2) 🟢 

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
[Box folder with screenshots and video](https://okta.box.com/s/3fe5cyignfxl6dj3wdr17a0t9a0kkcdq)

### Reviewers:


### Issue:

- [Working demo after okta-core changes merged](https://okta.box.com/s/iktieq32f093me6v8gz2r9nl5kyq2oyd)  
- [OKTA-449726](https://oktainc.atlassian.net/browse/OKTA-449726)


