### PR TITLE
fix: open custom help links on the new tab

### DIFF
--- a/src/v2/view-builder/components/Link.js
+++ b/src/v2/view-builder/components/Link.js
@@ -23,7 +23,8 @@ const Link = View.extend({
     let href = this.options.href || '#';
     return {
       'data-se': this.options.name,
-      href: href
+      href: href,
+      target: this.options.target,
     };
   },
 

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -180,6 +180,7 @@ const getFactorPageCustomLink = (appState, settings) => {
         label: helpLinksFactorPageLabel,
         name: 'factorPageHelpLink',
         href: helpLinksFactorPageHref,
+        target: '_blank',
       });
     }
   }

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -57,7 +57,9 @@ describe('v2/utils/LinksUtil', function() {
         'helpLinks.factorPage.text': 'custom factor page link',
         'helpLinks.factorPage.href': 'https://acme.com/what-is-okta-autheticators',
       });
-      expect(getFactorPageCustomLink(appState, settings).length).toEqual(1);
+      const factorPageCustomLink = getFactorPageCustomLink(appState, settings);
+      expect(factorPageCustomLink.length).toEqual(1);
+      expect(factorPageCustomLink[0].target).toEqual('_blank');
     });
 
     it('returns empty when is not select-authenticator-authenticate', function() {


### PR DESCRIPTION
## Description:
open custom help links on the new tab


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

### Screenshot/Video:
![open_in_new_tab](https://user-images.githubusercontent.com/47287459/158895694-423d46ff-1bca-44f7-bbaa-e406368227cc.gif)

### Reviewers:
@mauriciocastillosilva-okta @indirathirumalaimurugan-okta 

### Issue:

- [OKTA-479148](https://oktainc.atlassian.net/browse/OKTA-479148)


