### PR TITLE
Adds linting to prevent accidental only() in testcafe

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-local-rules": "^0.1.1",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-testcafe-extended": "^0.2.0",
     "eslint-plugin-webdriverio": "^1.0.1",
     "expect": "^27.4.6",
     "fibers": "^5.0.0",

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -171,7 +171,8 @@ const I18N_OVERRIDE_MAPPINGS = {
   // re-map autoPush: "Send push automatically"
   'challenge-poll.okta_verify.autoChallenge': 'autoPush', // authenticator-verification-okta-verify-push-autoChallenge-on
   'authenticator-verification-data.authenticator.autoChallenge': 'autoPush', // authenticator-verification-data-okta-verify-push-autoChallenge-off.json
-
+  '"authenticator-verification-data.okta_verify.authenticator.autoChallenge"': 'autoPush',
+  
   // Existing overrides
   ...I18N_BASE_ATTRIBUTE_ENROLL_PROFILE_MAPPINGS, //enroll-profile strings
 };

--- a/test/testcafe/.eslintrc.js
+++ b/test/testcafe/.eslintrc.js
@@ -1,5 +1,11 @@
 /* eslint-env node */
 module.exports = {
+  plugins: [
+    'testcafe-extended'
+  ],
+  extends: [
+    'plugin:testcafe-extended/recommended'
+  ],
   'parserOptions': {
     'ecmaVersion': 2017,
     'sourceType': 'module'

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -643,7 +643,7 @@ test
 
 // TODO: avoid 60 second timeout. OKTA-460622
 test
-  .requestHooks(logger, tooManyRequestPollMock).only('pause polling when encounter 429 too many request', async t => {
+  .requestHooks(logger, tooManyRequestPollMock)('pause polling when encounter 429 too many request', async t => {
     const challengeEmailPageObject = await setup(t);
 
     await t.wait(5000); // wait for first poll

--- a/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorEmail_spec.js
@@ -676,6 +676,8 @@ test
   .requestHooks(logger, apiLimitExceededPollMock)('pause polling when encounter 429 api limit exceeded', async t => {
     const challengeEmailPageObject = await setup(t);
 
+    await t.wait(5000); // wait for first poll
+
     // Encounter 429
     await t.expect(logger.count(
       record => record.response.statusCode === 429 &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -7192,6 +7192,13 @@ eslint-plugin-no-only-tests@^2.4.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
   integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
 
+eslint-plugin-testcafe-extended@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testcafe-extended/-/eslint-plugin-testcafe-extended-0.2.0.tgz#2ecc34687ac9e30e2cc6aae2d014831da06a987e"
+  integrity sha512-mD95Kt2CWy64pi0f8RGzY8/gAvOa7wuaSvxqXnE2gwlnQYG2SgSHhhY7UPUBY+yKMX/6QDRcfwhjJ68vHWCBpA==
+  dependencies:
+    chalk "^3.0.0"
+
 eslint-plugin-webdriverio@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-webdriverio/-/eslint-plugin-webdriverio-1.0.1.tgz#51fe982fb9d49408ea0dad2fd2ae6e81b89425ce"


### PR DESCRIPTION
## Description:
- adds new linting rules for testcafe
- adds delay to prevent flakiness in polling test
- fixes english leak


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:


- [OKTA-481999](https://oktainc.atlassian.net/browse/OKTA-481999)


