### PR TITLE
Updates saucelabs video/log visibility

### DIFF
--- a/test/e2e/sauce.wdio.conf.js
+++ b/test/e2e/sauce.wdio.conf.js
@@ -184,7 +184,8 @@ exports.config = {
         ['sauce', {
             sauceConnect: true,
             sauceConnectOpts: {
-                tunnelIdentifier: 'SIW-e2e-tunnel'
+                tunnelIdentifier: 'SIW-e2e-tunnel',
+                public: 'share'
             }
         }],
         ['iedriver']


### PR DESCRIPTION
## Description:

- Sauce labs tests are currently set to `public` visibility by default
- We want to restrict access to these logs/videos to only users who have the link (available only in bacon logs)
- This PR changes the visibility to share 
![Screen Shot 2022-03-25 at 9 30 11 AM](https://user-images.githubusercontent.com/27521424/160162023-32c8c917-c620-4ec7-aa11-b929b8416042.png)


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-483221](https://oktainc.atlassian.net/browse/OKTA-483221)


