### PR TITLE
OKTA-462156 l10n error on password expiry warning

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -66,7 +66,8 @@ const idx = {
     // 'authenticator-expired-password',
     // 'authenticator-expired-password-no-complexity',
     // 'authenticator-expired-password-with-enrollment-authenticator',
-    // 'authenticator-expiry-warning-password',
+    'authenticator-expiry-warning-password',
+    'authenticator-expiry-warning-password-with-brand-name',
     // 'device-code-activate',
     // 'enroll-profile',
     // 'enroll-profile-new',

--- a/playground/mocks/data/idp/idx/authenticator-expiry-warning-password-with-brand-name.json
+++ b/playground/mocks/data/idp/idx/authenticator-expiry-warning-password-with-brand-name.json
@@ -1,0 +1,165 @@
+{
+  "stateHandle":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+  "version":"1.0.0",
+  "expiresAt":"2020-06-30T20:53:44.000Z",
+  "intent":"LOGIN",
+  "remediation":{
+    "type":"array",
+    "value":[
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"reenroll-authenticator-warning",
+        "relatesTo":[
+          "$.currentAuthenticator"
+        ],
+        "href":"http://localhost:3000/idp/idx/challenge/answer",
+        "method":"POST",
+        "value":[
+          {
+            "name":"credentials",
+            "type":"object",
+            "form":{
+              "value":[
+                {
+                  "name":"passcode",
+                  "label":"New password",
+                  "secret":true
+                }
+              ]
+            },
+            "required":true
+          },
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible":false,
+            "mutable":false
+          }
+        ],
+        "accepts":"application/ion+json; okta-version=1.0.0"
+      },
+      {
+        "rel":[
+          "create-form"
+        ],
+        "name":"skip",
+        "href":"http://localhost:3000/idp/idx/skip",
+        "method":"POST",
+        "accepts":"application\\/ion\\+json; okta-version=\\d+\\.\\d+\\.\\d+",
+        "value":[
+          {
+            "name":"stateHandle",
+            "required":true,
+            "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+            "visible":false,
+            "mutable":false
+          }
+        ]
+      }
+    ]
+  },
+  "currentAuthenticator":{
+    "type":"object",
+    "value":{
+      "type":"password",
+      "key": "okta_password",
+      "id":"aut6ci0ZJwJCQ5v6f0g4",
+      "displayName":"Okta Password",
+      "methods":[
+        {
+          "type":"password"
+        }
+      ],
+      "settings":{
+        "complexity":{
+          "minLength":8,
+          "minLowerCase":1,
+          "minUpperCase":1,
+          "minNumber":1,
+          "minSymbol":1,
+          "excludeUsername":true,
+          "excludeFirstName":true,
+          "excludeLastName":true
+        },
+        "age":{
+          "minAgeMinutes":0,
+          "historyCount":4
+        },
+        "daysToExpiry":4
+      }
+    }
+  },
+  "authenticators":{
+    "type":"array",
+    "value":[
+
+    ]
+  },
+  "authenticatorEnrollments":{
+    "type":"array",
+    "value":[
+      {
+        "type":"password",
+        "key": "okta_password",
+        "id":"laeh5oe8s68GfRKkf0g3",
+        "displayName":"Okta Password",
+        "methods":[
+          {
+            "type":"password"
+          }
+        ]
+      }
+    ]
+  },
+  "user":{
+    "type":"object",
+    "value":{
+      "id": "00u6ci9LYMwaOkjBL0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel":{
+    "rel":[
+      "create-form"
+    ],
+    "name":"cancel",
+    "href":"http://localhost:3000/idp/idx/cancel",
+    "method":"POST",
+    "value":[
+      {
+        "name":"stateHandle",
+        "required":true,
+        "value":"022P5Fd8jBy3b77XEdFCqnjz__5wQxksRfrAS4z6wP",
+        "visible":false,
+        "mutable":false
+      }
+    ],
+    "accepts":"application/ion+json; okta-version=1.0.0"
+  },
+  "app":{
+    "type":"object",
+    "value":{
+      "name":"oidc_client",
+      "label":"myApp",
+      "id":"0oa6ch0s7dCszUFz00g4"
+    }
+  },
+  "messages":{
+    "type":"array",
+    "value":[
+      {
+        "message":"When your password expires you will be locked out of your Acme, Inc account.",
+        "i18n":{
+          "key":"idx.password.expiring.message",
+          "params": [
+            "Acme, Inc"
+          ]
+        },
+        "class":"INFO"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description:

### Bug:
Customer reports seeing `L10N_ERROR` instead of the correct warning message about an expiring password. This bug only occurs when the widget is on a custom URL domain (vs. Okta-hosted).

### Expected:
Widget displays the message "When your password expires you will be locked out of your {company_name} account."

### Actual:
Widget displays the message: "L10N_ERROR[idx.password.expiring.message]"

### Cause:
An unexpected i18n param in the IDX API response for introspect causes the widget to display  on customer-hosted widget.

Okta-hosted returns:
https://github.com/okta/okta-signin-widget/blob/b9d2e70e911168f1da95b7bb14ae9cc15121fc52/playground/mocks/data/idp/idx/authenticator-expiry-warning-password.json#L150-L164

Customer-hosted returns:
https://github.com/okta/okta-signin-widget/blob/b9d2e70e911168f1da95b7bb14ae9cc15121fc52/playground/mocks/data/idp/idx/authenticator-expiry-warning-password-with-brand-name.json#L150-L164

l10n:
https://github.com/okta/okta-signin-widget/blob/b9d2e70e911168f1da95b7bb14ae9cc15121fc52/packages/%40okta/i18n/src/properties/login.properties#L898

### Fix:
- ~~Option 1: update the API to use a new i18n key that expects a param for company name + send "Okta" as default param~~
- **Option 2: update the API to remove the company name param, and re-word message.**
- ~~Option 3: update the SIW (or i18n lib?) to handle the case conditionally~~

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:

![localhost_3000_](https://user-images.githubusercontent.com/77294605/160204772-e699f2f2-e163-4d81-b7dc-8954581709c2.png)

### Reviewers:


### Issue:

- [OKTA-462156](https://oktainc.atlassian.net/browse/OKTA-462156)


