### PR TITLE
improve handling for unsupported server response

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -65,6 +65,7 @@ const buildDynamicForm = function(url = '', method) {
   return form;
 };
 
+// eslint-disable-next-line complexity
 Util.transformErrorXHR = function(xhr) {
   // Handle network connection error
   if (xhr.status === 0 && _.isEmpty(xhr.responseJSON)) {
@@ -73,10 +74,21 @@ Util.transformErrorXHR = function(xhr) {
   }
   if (!xhr.responseJSON) {
     if (!xhr.responseText) {
-      xhr.responseJSON = { errorSummary: loc('oform.error.unexpected', 'login') };
+      // Empty server response
+      xhr.responseJSON = { errorSummary: loc('error.unsupported.response', 'login') };
       return xhr;
     }
-    xhr.responseJSON = xhr.responseText;
+    if (typeof xhr.responseText === 'string') {
+      try {
+        xhr.responseJSON = JSON.parse(xhr.responseText);
+      } catch (e) {
+        // Malformed server response
+        xhr.responseJSON = { errorSummary: loc('error.unsupported.response', 'login') };
+        return xhr;
+      }
+    } else if (typeof xhr.responseText === 'object') {
+      xhr.responseJSON = xhr.responseText;
+    } 
   }
   // Temporary solution to display field errors
   // Assuming there is only one field error in a response

--- a/test/unit/spec/Util_spec.js
+++ b/test/unit/spec/Util_spec.js
@@ -17,15 +17,25 @@ describe('util/Util', () => {
       );
     });
 
-    it('errorSummary shows internal error when there are no responseJSON and no responseText', () => {
+    it('errorSummary shows unsupported response from server when there are no responseJSON and no responseText', () => {
       const xhr = {
         status: 400,
       };
 
       Util.transformErrorXHR(xhr);
-      expect(xhr.responseJSON.errorSummary).toEqual('There was an unexpected internal error. Please try again.');
+      expect(xhr.responseJSON.errorSummary).toEqual('There was an unsupported response from server.');
     });
   
+    it('errorSummary shows unsupported response from server when there are no responseJSON and responseText is not valid JSON', () => {
+      const xhr = {
+        status: 400,
+        responseText: '<html>'
+      };
+
+      Util.transformErrorXHR(xhr);
+      expect(xhr.responseJSON.errorSummary).toEqual('There was an unsupported response from server.');
+    });
+
     it('errorSummary is set from responseText when there is no responseJSON', () => {
       const responseText = { errorSummary: 'errorSummary from responseText' };
       const xhr = {


### PR DESCRIPTION
## Description:
improves handling for "unsupported" server response. This includes cases where the response is empty, or is not valid JSON.

Recent upgrade of okta-auth-js returns throws some errors on invalid IDX responses that were ignored by idx-js.  Adding this handling also fixes some downstream build errors.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-488771](https://oktainc.atlassian.net/browse/OKTA-488771)


