### PR TITLE
SSR: Show EML text on SIW when useEmailMagicLink in IdxResponse

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -184,11 +184,11 @@ const idx = {
     'error-authenticator-phone-voice-ratelimit',
   ],
   '/idp/idx/enroll/new': [
-    //'authenticator-enroll-email',
-    //'authenticator-enroll-email-emailmagiclink-true',
-    //'authenticator-enroll-email-emailmagiclink-false',
     'error-new-signup-email',
     'error-new-signup-email-exists'
+    // 'authenticator-enroll-email',
+    // 'authenticator-enroll-email-emailmagiclink-true',
+    //'authenticator-enroll-email-emailmagiclink-false'
   ],
   '/idp/idx/cancel': [
     'identify',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -165,6 +165,8 @@ const idx = {
     // 'error-429-api-limit-exceeded',
     // 'enroll-profile-new'
     // 'authenticator-enroll-email',
+    // 'authenticator-enroll-email-emailmagiclink-true',
+    // 'authenticator-enroll-email-emailmagiclink-false',
     // 'authenticator-verification-okta-verify-push',
     // 'authenticator-verification-custom-app-push',
     // 'authenticator-verification-custom-app-push-reject',
@@ -182,6 +184,9 @@ const idx = {
     'error-authenticator-phone-voice-ratelimit',
   ],
   '/idp/idx/enroll/new': [
+    //'authenticator-enroll-email',
+    //'authenticator-enroll-email-emailmagiclink-true',
+    //'authenticator-enroll-email-emailmagiclink-false',
     'error-new-signup-email',
     'error-new-signup-email-exists'
   ],

--- a/playground/mocks/config/test-configs/EnrollAuthenticatorEmail.js
+++ b/playground/mocks/config/test-configs/EnrollAuthenticatorEmail.js
@@ -1,0 +1,96 @@
+// These response configs match the mocks configured in EnrollAuthenticatorEmail_spec.js
+
+const validOTPMock = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email'
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-enroll-email'
+  ],
+  '/idp/idx/challenge/resend': [
+    'authenticator-enroll-email'
+  ]
+};
+
+const invalidOTPMock = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-enroll-email'
+  ],
+  '/idp/idx/challenge/answer': [
+    'error-authenticator-enroll-email-invalid-otp'
+  ]
+};
+
+const sendEmailMockWithoutEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ]
+};
+
+const sendEmailMockWithEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ],
+  '/idp/idx/challenge': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ]
+};
+
+const validOTPmockWithEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ],
+  '/idp/idx/challenge/resend': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ]
+};
+
+const validOTPmockWithoutEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ],
+  '/idp/idx/challenge/poll': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ],
+  '/idp/idx/challenge/resend': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ]
+};
+
+const invalidOTPMockWithoutEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-false'
+  ]
+};
+
+const invalidOTPMockWithEmailMagicLink = {
+  '/idp/idx/introspect': [
+    'authenticator-enroll-email-emailmagiclink-true'
+  ]
+};
+
+module.exports = {
+  validOTPMock,
+  invalidOTPMock,
+  sendEmailMockWithoutEmailMagicLink,
+  sendEmailMockWithEmailMagicLink,
+  validOTPmockWithEmailMagicLink,
+  validOTPmockWithoutEmailMagicLink,
+  invalidOTPMockWithoutEmailMagicLink,
+  invalidOTPMockWithEmailMagicLink
+};

--- a/playground/mocks/config/test-configs/index.js
+++ b/playground/mocks/config/test-configs/index.js
@@ -19,4 +19,5 @@ module.exports = {
   SelectAuthenticatorForEnroll: require('./SelectAuthenticatorForEnroll'),
   SessionStorage: require('./SessionStorage'),
   WidgetCustomization: require('./WidgetCustomization'),
+  EnrollAuthenticatorEmail: require('./EnrollAuthenticatorEmail'),
 };

--- a/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json
@@ -1,0 +1,278 @@
+{
+  "stateHandle": "eyJ6aXAiOiJER",
+  "version": "1.0.0",
+  "expiresAt": "2020-07-23T17:53:58.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter code"
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2nnGGzJy8uO80g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "email",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2obdbULCQSVC0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2qDuPf0GCbOI0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "security_question",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "useEmailMagicLink":false
+      },
+      "resend": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "resend",
+        "href": "http://localhost:3000/idp/idx/challenge/resend",
+        "method": "POST",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      "poll": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "poll",
+        "href": "http://localhost:3000/idp/idx/challenge/poll",
+        "method": "POST",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      "type": "email",
+      "key": "okta_email",
+      "id": "aut2m2nnGGzJy8uO80g4",
+      "displayName": "Email",
+      "methods": [
+        {
+          "type": "email"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "key": "okta_email",
+        "id": "aut2m2nnGGzJy8uO80g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "aut2m2obdbULCQSVC0g4",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      },
+      {
+        "type": "security_question",
+        "key": "security_question",
+        "id": "aut2m2qDuPf0GCbOI0g4",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "email",
+      "key": "okta_email",
+      "id": "aut2m2nnGGzJy8uO80g4",
+      "displayName": "Email",
+      "methods": [
+        {
+          "type": "email"
+        }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u2m55pu8UZyeMMl0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "eyJ6aXAiOiJER",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Native client",
+      "id": "0oa2m3t6w7G9nErL00g4"
+    }
+  }
+}

--- a/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-true.json
+++ b/playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-true.json
@@ -1,0 +1,278 @@
+{
+  "stateHandle": "eyJ6aXAiOiJER",
+  "version": "1.0.0",
+  "expiresAt": "2020-07-23T17:53:58.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "http://localhost:3000/idp/idx/challenge/answer",
+        "method": "POST",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter code"
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "http://localhost:3000/idp/idx/credential/enroll",
+        "method": "POST",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2nnGGzJy8uO80g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "email",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2obdbULCQSVC0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              },
+              {
+                "label": "Security Question",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut2m2qDuPf0GCbOI0g4",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "security_question",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[2]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "useEmailMagicLink":true
+      },
+      "resend": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "resend",
+        "href": "http://localhost:3000/idp/idx/challenge/resend",
+        "method": "POST",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      "poll": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "poll",
+        "href": "http://localhost:3000/idp/idx/challenge/poll",
+        "method": "POST",
+        "refresh": 4000,
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "eyJ6aXAiOiJER",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/ion+json; okta-version=1.0.0"
+      },
+      "type": "email",
+      "key": "okta_email",
+      "id": "aut2m2nnGGzJy8uO80g4",
+      "displayName": "Email",
+      "methods": [
+        {
+          "type": "email"
+        }
+      ]
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "key": "okta_email",
+        "id": "aut2m2nnGGzJy8uO80g4",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "aut2m2obdbULCQSVC0g4",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      },
+      {
+        "type": "security_question",
+        "key": "security_question",
+        "id": "aut2m2qDuPf0GCbOI0g4",
+        "displayName": "Security Question",
+        "methods": [
+          {
+            "type": "security_question"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "email",
+      "key": "okta_email",
+      "id": "aut2m2nnGGzJy8uO80g4",
+      "displayName": "Email",
+      "methods": [
+        {
+          "type": "email"
+        }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u2m55pu8UZyeMMl0g4",
+      "identifier": "testUser@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
+    "method": "POST",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "eyJ6aXAiOiJER",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/ion+json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Native client",
+      "id": "0oa2m3t6w7G9nErL00g4"
+    }
+  }
+}

--- a/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
+++ b/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
@@ -1,6 +1,7 @@
 import hbs from 'handlebars-inline-precompile';
 import { View } from 'okta';
 
+// Courage doesn't support HTML, hence creating a subtitle here.
 const CheckYourEmailTitle = View.extend({
   className: 'okta-form-subtitle',
   attributes: {

--- a/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
+++ b/src/v2/view-builder/views/email/AuthenticatorEmailViewUtil.js
@@ -1,0 +1,58 @@
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'okta';
+
+const CheckYourEmailTitle = View.extend({
+  className: 'okta-form-subtitle',
+  attributes: {
+    'data-se': 'o-form-explain',
+  },
+  template: hbs`
+      {{#if email}}
+        {{i18n 
+            code="oie.email.verify.alternate.magicLinkToEmailAddress" 
+            bundle="login" 
+            arguments="email" 
+            $1="<span class='strong'>$1</span>"
+        }}
+      {{else}}
+        {{i18n 
+          code="oie.email.verify.alternate.magicLinkToYourEmail" 
+          bundle="login"
+        }}
+      {{/if}}
+      
+      {{#if useEmailMagicLinkValue}}
+        {{i18n 
+          code="oie.email.verify.alternate.instructions" 
+          bundle="login" 
+        }}
+      {{else}}
+        {{i18n 
+          code="oie.email.verify.alternate.verificationCode.instructions" 
+          bundle="login" 
+        }}
+      {{/if}}
+    `,
+  
+  getTemplateData() {
+    return this.options;
+  },
+});
+  
+const EnterCodeLink = View.extend({
+  template: hbs`
+      <button 
+        class="button-link enter-auth-code-instead-link"
+      >
+          {{i18n code="oie.email.verify.alternate.showCodeTextField"}}
+      </button>
+    `,
+});
+
+export function getCheckYourEmailTitle() {
+  return CheckYourEmailTitle;
+}
+
+export function getEnterCodeLink() {
+  return EnterCodeLink;
+}

--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
@@ -1,57 +1,9 @@
-import { View } from 'okta';
-import hbs from 'handlebars-inline-precompile';
 import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
+import { getCheckYourEmailTitle, getEnterCodeLink } from './AuthenticatorEmailViewUtil';
 
 const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
 
 // Courage doesn't support HTML, hence creating a subtitle here.
-const CheckYourEmailTitle = View.extend({
-  className: 'okta-form-subtitle',
-  attributes: {
-    'data-se': 'o-form-explain',
-  },
-  template: hbs`
-    {{#if email}}
-      {{i18n 
-          code="oie.email.verify.alternate.magicLinkToEmailAddress" 
-          bundle="login" 
-          arguments="email" 
-          $1="<span class='strong'>$1</span>"
-      }}
-    {{else}}
-      {{i18n 
-        code="oie.email.verify.alternate.magicLinkToYourEmail" 
-        bundle="login"
-      }}
-    {{/if}}
-    
-    {{#if useEmailMagicLinkValue}}
-      {{i18n 
-        code="oie.email.verify.alternate.instructions" 
-        bundle="login" 
-      }}
-    {{else}}
-      {{i18n 
-        code="oie.email.verify.alternate.verificationCode.instructions" 
-        bundle="login" 
-      }}
-    {{/if}}
-  `,
-
-  getTemplateData() {
-    return this.options;
-  },
-});
-
-const EnterCodeLink = View.extend({
-  template: hbs`
-    <button 
-      class="button-link enter-auth-code-instead-link"
-    >
-        {{i18n code="oie.email.verify.alternate.showCodeTextField"}}
-    </button>
-  `,
-});
 
 const Body = BaseAuthenticatorEmailForm.extend(
   Object.assign({
@@ -71,13 +23,13 @@ const Body = BaseAuthenticatorEmailForm.extend(
       const useEmailMagicLinkValue = this.isUseEmailMagicLink();
 
       if (useEmailMagicLinkValue) {
-        this.add(EnterCodeLink, {
+        this.add(getEnterCodeLink(), {
           prepend: true,
           selector: '.o-form-error-container',
         });
       } 
 
-      this.add(CheckYourEmailTitle, {
+      this.add(getCheckYourEmailTitle(), {
         prepend: true,
         selector: '.o-form-error-container',
         options: { email, useEmailMagicLinkValue },

--- a/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/ChallengeAuthenticatorEmailView.js
@@ -3,8 +3,6 @@ import { getCheckYourEmailTitle, getEnterCodeLink } from './AuthenticatorEmailVi
 
 const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
 
-// Courage doesn't support HTML, hence creating a subtitle here.
-
 const Body = BaseAuthenticatorEmailForm.extend(
   Object.assign({
     noButtonBar: true,

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -1,16 +1,129 @@
 import { loc } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+import { View } from 'okta';
 import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
 
 const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
 
-const Body = BaseAuthenticatorEmailForm.extend(Object.assign({
-
-  resendEmailAction: 'currentAuthenticator-resend',
-
-  subtitle() {
-    return loc('oie.email.enroll.subtitle', 'login');
+const CheckYourEmailTitle = View.extend({
+  className: 'okta-form-subtitle',
+  attributes: {
+    'data-se': 'o-form-explain',
   },
-}));
+  template: hbs`
+    {{#if email}}
+      {{i18n 
+          code="oie.email.verify.alternate.magicLinkToEmailAddress" 
+          bundle="login" 
+          arguments="email" 
+          $1="<span class='strong'>$1</span>"
+      }}
+    {{else}}
+      {{i18n 
+        code="oie.email.verify.alternate.magicLinkToYourEmail" 
+        bundle="login"
+      }}
+    {{/if}}
+    
+    {{#if useEmailMagicLinkValue}}
+      {{i18n 
+        code="oie.email.verify.alternate.instructions" 
+        bundle="login" 
+      }}
+    {{else}}
+      {{i18n 
+        code="oie.email.verify.alternate.verificationCode.instructions" 
+        bundle="login" 
+      }}
+    {{/if}}
+  `,
+
+  getTemplateData() {
+    return this.options;
+  },
+});
+
+const EnterCodeLink = View.extend({
+  template: hbs`
+    <button 
+      class="button-link enter-auth-code-instead-link"
+    >
+        {{i18n code="oie.email.verify.alternate.showCodeTextField"}}
+    </button>
+  `,
+});
+
+const Body = BaseAuthenticatorEmailForm.extend(
+  Object.assign({
+    resendEmailAction: 'currentAuthenticator-resend',
+
+    initialize() {
+      BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
+
+      const { email } =
+        this.options.currentViewState.relatesTo?.value?.profile || {};
+
+      const useEmailMagicLinkValue = this.isUseEmailMagicLink();
+
+      if (useEmailMagicLinkValue !== undefined) {
+        
+        this.noButtonBar = true;
+        this.events['click .enter-auth-code-instead-link'] = 'showAuthCodeEntry';
+
+        if (useEmailMagicLinkValue) {
+          this.add(EnterCodeLink, {
+            prepend: true,
+            selector: '.o-form-error-container',
+          });
+        } 
+  
+        this.add(CheckYourEmailTitle, {
+          prepend: true,
+          selector: '.o-form-error-container',
+          options: { email, useEmailMagicLinkValue },
+        });
+      } else {
+        this.subtitle = loc('oie.email.enroll.subtitle', 'login');
+      }
+    },
+
+    postRender() {
+      if (this.isUseEmailMagicLink() !== undefined) {
+        BaseAuthenticatorEmailForm.prototype.postRender.apply(this, arguments);
+        if (this.isUseEmailMagicLink()) {
+          this.showCodeEntryField(false);
+        } else {
+          this.noButtonBar = false;
+        }
+      }
+    },
+
+    isUseEmailMagicLink() {
+      return this.options.appState.get('currentAuthenticator')?.
+      contextualData?.useEmailMagicLink;;
+    },
+
+    showAuthCodeEntry() {
+      this.noButtonBar = false;
+      this.render();
+
+      this.showCodeEntryField(true);
+      this.showEnterAuthCodeInsteadLink(false);
+    },
+
+    showCodeEntryField(show = true) {
+      const $textField = this.$el.find('.o-form-fieldset-container');
+      $textField.toggle(show);
+    },
+
+    showEnterAuthCodeInsteadLink(show = true) {
+      const $enterAuthCodeInsteadLink = this.$el.find(
+        '.enter-auth-code-instead-link'
+      );
+      $enterAuthCodeInsteadLink.toggle(show);
+    },
+  })
+);
 
 export default BaseAuthenticatorEmailView.extend({
   Body,

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -100,7 +100,7 @@ const Body = BaseAuthenticatorEmailForm.extend(
 
     isUseEmailMagicLink() {
       return this.options.appState.get('currentAuthenticator')?.
-      contextualData?.useEmailMagicLink;;
+      contextualData?.useEmailMagicLink;
     },
 
     showAuthCodeEntry() {

--- a/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
+++ b/src/v2/view-builder/views/email/EnrollAuthenticatorEmailView.js
@@ -1,57 +1,8 @@
 import { loc } from 'okta';
-import hbs from 'handlebars-inline-precompile';
-import { View } from 'okta';
 import BaseAuthenticatorEmailView from './BaseAuthenticatorEmailView';
+import { getCheckYourEmailTitle, getEnterCodeLink } from './AuthenticatorEmailViewUtil';
 
 const BaseAuthenticatorEmailForm = BaseAuthenticatorEmailView.prototype.Body;
-
-const CheckYourEmailTitle = View.extend({
-  className: 'okta-form-subtitle',
-  attributes: {
-    'data-se': 'o-form-explain',
-  },
-  template: hbs`
-    {{#if email}}
-      {{i18n 
-          code="oie.email.verify.alternate.magicLinkToEmailAddress" 
-          bundle="login" 
-          arguments="email" 
-          $1="<span class='strong'>$1</span>"
-      }}
-    {{else}}
-      {{i18n 
-        code="oie.email.verify.alternate.magicLinkToYourEmail" 
-        bundle="login"
-      }}
-    {{/if}}
-    
-    {{#if useEmailMagicLinkValue}}
-      {{i18n 
-        code="oie.email.verify.alternate.instructions" 
-        bundle="login" 
-      }}
-    {{else}}
-      {{i18n 
-        code="oie.email.verify.alternate.verificationCode.instructions" 
-        bundle="login" 
-      }}
-    {{/if}}
-  `,
-
-  getTemplateData() {
-    return this.options;
-  },
-});
-
-const EnterCodeLink = View.extend({
-  template: hbs`
-    <button 
-      class="button-link enter-auth-code-instead-link"
-    >
-        {{i18n code="oie.email.verify.alternate.showCodeTextField"}}
-    </button>
-  `,
-});
 
 const Body = BaseAuthenticatorEmailForm.extend(
   Object.assign({
@@ -60,8 +11,7 @@ const Body = BaseAuthenticatorEmailForm.extend(
     initialize() {
       BaseAuthenticatorEmailForm.prototype.initialize.apply(this, arguments);
 
-      const { email } =
-        this.options.currentViewState.relatesTo?.value?.profile || {};
+      const email = this.options.appState.get('user')?.identifier || {};
 
       const useEmailMagicLinkValue = this.isUseEmailMagicLink();
 
@@ -71,13 +21,13 @@ const Body = BaseAuthenticatorEmailForm.extend(
         this.events['click .enter-auth-code-instead-link'] = 'showAuthCodeEntry';
 
         if (useEmailMagicLinkValue) {
-          this.add(EnterCodeLink, {
+          this.add(getEnterCodeLink(), {
             prepend: true,
             selector: '.o-form-error-container',
           });
         } 
   
-        this.add(CheckYourEmailTitle, {
+        this.add(getCheckYourEmailTitle(), {
           prepend: true,
           selector: '.o-form-error-container',
           options: { email, useEmailMagicLinkValue },

--- a/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollEmailPageObject.js
@@ -1,7 +1,9 @@
 import BasePageObject from './BasePageObject';
 import ResendEmailObject from './components/ResendEmailObject';
+import { Selector } from 'testcafe';
 
 const CODE_FIELD_NAME = 'credentials.passcode';
+const ENTER_CODE_FROM_EMAIL = '.enter-auth-code-instead-link';
 
 export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
@@ -16,6 +18,15 @@ export default class EnrollAuthenticatorPhonePageObject extends BasePageObject {
 
   getCodeFieldError() {
     return this.form.getTextBoxErrorMessage(CODE_FIELD_NAME);
+  }
+
+  async enterCodeFromEmailLinkExists() {
+    const elCount = await Selector(ENTER_CODE_FROM_EMAIL).count;
+    return elCount === 1;
+  }
+
+  async clickElement(selector) {
+    await this.form.clickElement(selector);
   }
 
 }

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -4,6 +4,8 @@ import EnrollEmailPageObject from '../framework/page-objects/EnrollEmailPageObje
 import { checkConsoleMessages } from '../framework/shared';
 
 import xhrEnrollEmail from '../../../playground/mocks/data/idp/idx/authenticator-enroll-email';
+import xhrEnrollEmailWithoutEmailMagicLink from '../../../playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-false.json';
+import xhrEnrollEmailWithEmailMagicLink from '../../../playground/mocks/data/idp/idx/authenticator-enroll-email-emailmagiclink-true.json';
 import success from '../../../playground/mocks/data/idp/idx/success';
 import invalidOTP from '../../../playground/mocks/data/idp/idx/error-authenticator-enroll-email-invalid-otp';
 
@@ -27,6 +29,50 @@ const validOTPmock = RequestMock()
 const invalidOTPMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrEnrollEmail)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(invalidOTP, 403);
+
+const sendEmailMockWithoutEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink);
+
+const sendEmailMockWithEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge')
+  .respond(xhrEnrollEmailWithEmailMagicLink);
+
+const validOTPmockWithEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(xhrEnrollEmailWithEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/resend')
+  .respond(xhrEnrollEmailWithEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(success);
+
+const validOTPmockWithoutEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/resend')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(success);
+
+const invalidOTPMockWithoutEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithoutEmailMagicLink)
+  .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
+  .respond(invalidOTP, 403);
+
+const invalidOTPMockWithEmailMagicLink = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrEnrollEmailWithEmailMagicLink)
   .onRequestTo('http://localhost:3000/idp/idx/challenge/answer')
   .respond(invalidOTP, 403);
 
@@ -60,6 +106,66 @@ test
     await t.expect(enrollEmailPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
     await t.expect(enrollEmailPageObject.form.getErrorBoxText()).contains('We found some errors.');
   });
+
+test
+  .requestHooks(invalidOTPMockWithEmailMagicLink)('enroll with invalid OTP and with EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+    
+    await enrollEmailPageObject.clickElement('.enter-auth-code-instead-link');
+    
+    await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
+    await enrollEmailPageObject.enterCode('123456');
+    await enrollEmailPageObject.form.clickSaveButton();
+
+    await t.expect(enrollEmailPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
+    await t.expect(enrollEmailPageObject.form.getErrorBoxText()).contains('We found some errors.');
+});
+
+test
+  .requestHooks(invalidOTPMockWithoutEmailMagicLink)('enroll with invalid OTP and without EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+    await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
+    await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();
+    await enrollEmailPageObject.enterCode('123456');
+    await enrollEmailPageObject.form.clickSaveButton();
+
+    await t.expect(enrollEmailPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
+    await t.expect(enrollEmailPageObject.form.getErrorBoxText()).contains('We found some errors.');
+});
+
+test
+  .requestHooks(sendEmailMockWithoutEmailMagicLink)('send me an email button should take to challenge email authenticator screen without email magic link text', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+    
+    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
+    await t.expect(enrollEmailPageObject.getFormSubtitle())
+      .eql(`We sent an email to ${emailAddress}. Enter the verification code in the text box.`);
+
+    await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();
+    await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
+    await t.expect(enrollEmailPageObject.getSignoutLinkText()).eql('Back to sign in');
+});
+
+test
+  .requestHooks(sendEmailMockWithEmailMagicLink)('send me an email button should take to challenge email authenticator screen with email magic link text', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+
+    const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
+    await t.expect(enrollEmailPageObject.getFormSubtitle())
+      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+
+    await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).ok();
+    await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
+    await t.expect(enrollEmailPageObject.getSignoutLinkText()).eql('Back to sign in');
+});
 
 test
   .requestHooks(logger, validOTPmock)('enroll with valid OTP', async t => {
@@ -100,6 +206,89 @@ test
     await t.expect(answerRequestMethod).eql('post');
     await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
   });
+
+test
+  .requestHooks(logger, validOTPmockWithEmailMagicLink)('enroll with valid OTP and with EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+    const emailAddress = xhrEnrollEmailWithEmailMagicLink.user.value.identifier;
+    await t.expect(enrollEmailPageObject.getFormSubtitle())
+      .eql(`We sent an email to ${emailAddress}. Click the verification link in your email to continue or enter the code below.`);
+    await enrollEmailPageObject.clickElement('.enter-auth-code-instead-link');
+    await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
+
+    // Verify links
+    await t.expect(await enrollEmailPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(enrollEmailPageObject.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+    await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
+
+    await enrollEmailPageObject.enterCode('561234');
+    await enrollEmailPageObject.form.clickSaveButton();
+
+    const successPage = new SuccessPageObject(t);
+    const pageUrl = await successPage.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+
+    await t.expect(logger.count(() => true)).eql(1);
+    const { request: {
+      body: answerRequestBodyString,
+      method: answerRequestMethod,
+      url: answerRequestUrl,
+    }
+    } = logger.requests[0];
+    const answerRequestBody = JSON.parse(answerRequestBodyString);
+    await t.expect(answerRequestBody).eql({
+      credentials: {
+        passcode: '561234',
+      },
+      stateHandle: 'eyJ6aXAiOiJER'
+    });
+    await t.expect(answerRequestMethod).eql('post');
+    await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
+});
+
+test
+  .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('enroll with valid OTP and without EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+
+    await t.expect(enrollEmailPageObject.form.getTitle()).eql('Verify with your email');
+    const emailAddress = xhrEnrollEmailWithoutEmailMagicLink.user.value.identifier;
+    await t.expect(enrollEmailPageObject.getFormSubtitle())
+      .eql(`We sent an email to ${emailAddress}. Enter the verification code in the text box.`);
+    await t.expect(enrollEmailPageObject.form.getSaveButtonLabel()).eql('Verify');
+
+    // Verify links
+    await t.expect(await enrollEmailPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(enrollEmailPageObject.getSwitchAuthenticatorLinkText()).eql('Return to authenticator list');
+    await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
+
+    await enrollEmailPageObject.enterCode('561234');
+    await enrollEmailPageObject.form.clickSaveButton();
+
+    const successPage = new SuccessPageObject(t);
+    const pageUrl = await successPage.getPageUrl();
+    await t.expect(pageUrl)
+      .eql('http://localhost:3000/app/UserHome?stateToken=mockedStateToken123');
+
+    await t.expect(logger.count(() => true)).eql(1);
+    const { request: {
+      body: answerRequestBodyString,
+      method: answerRequestMethod,
+      url: answerRequestUrl,
+    }
+    } = logger.requests[0];
+    const answerRequestBody = JSON.parse(answerRequestBodyString);
+    await t.expect(answerRequestBody).eql({
+      credentials: {
+        passcode: '561234',
+      },
+      stateHandle: 'eyJ6aXAiOiJER'
+    });
+    await t.expect(answerRequestMethod).eql('post');
+    await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
+});
 
 test
   .requestHooks(logger, validOTPmock)('resend after 30 seconds', async t => {
@@ -147,6 +336,96 @@ test
   });
 
 test
+  .requestHooks(logger, validOTPmockWithEmailMagicLink)('resend after 30 seconds with EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.wait(31000);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
+    await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    // 8 poll requests in 31 seconds and 1 resend request after click.
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/poll/)
+    )).eql(8);
+
+    await enrollEmailPageObject.resendEmail.click();
+
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/resend/)
+    )).eql(1);
+
+    const { request: {
+      body: firstRequestBody,
+      method: firstRequestMethod,
+      url: firstRequestUrl,
+    }
+    } = logger.requests[0];
+    const { request: {
+      body: lastRequestBody,
+      method: lastRequestMethod,
+      url: lastRequestUrl,
+    }
+    } = logger.requests[logger.requests.length - 1];
+    let jsonBody = JSON.parse(firstRequestBody);
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
+    await t.expect(firstRequestMethod).eql('post');
+    await t.expect(firstRequestUrl).eql('http://localhost:3000/idp/idx/challenge/poll');
+
+    jsonBody = JSON.parse(lastRequestBody);
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
+    await t.expect(lastRequestMethod).eql('post');
+    await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
+});
+
+test
+  .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('resend after 30 seconds without EML', async t => {
+    const enrollEmailPageObject = await setup(t);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.wait(31000);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
+    await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+
+    // 8 poll requests in 31 seconds and 1 resend request after click.
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/poll/)
+    )).eql(8);
+
+    await enrollEmailPageObject.resendEmail.click();
+
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.expect(logger.count(
+      record => record.response.statusCode === 200 &&
+      record.request.url.match(/resend/)
+    )).eql(1);
+
+    const { request: {
+      body: firstRequestBody,
+      method: firstRequestMethod,
+      url: firstRequestUrl,
+    }
+    } = logger.requests[0];
+    const { request: {
+      body: lastRequestBody,
+      method: lastRequestMethod,
+      url: lastRequestUrl,
+    }
+    } = logger.requests[logger.requests.length - 1];
+    let jsonBody = JSON.parse(firstRequestBody);
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
+    await t.expect(firstRequestMethod).eql('post');
+    await t.expect(firstRequestUrl).eql('http://localhost:3000/idp/idx/challenge/poll');
+
+    jsonBody = JSON.parse(lastRequestBody);
+    await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
+    await t.expect(lastRequestMethod).eql('post');
+    await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
+});
+
+test
   .requestHooks(logger, validOTPmock)('resend after 30 seconds at most even after re-render', async t => {
     const enrollEmailPageObject = await setup(t);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
@@ -156,3 +435,25 @@ test
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
   });
+
+test
+  .requestHooks(logger, validOTPmockWithEmailMagicLink)('resend after 30 seconds at most even after re-render', async t => {
+    const enrollEmailPageObject = await setup(t);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.wait(15000);
+    enrollEmailPageObject.navigateToPage();
+    await t.wait(15500);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
+    await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+});
+
+test
+  .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('resend after 30 seconds at most even after re-render', async t => {
+    const enrollEmailPageObject = await setup(t);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).ok();
+    await t.wait(15000);
+    enrollEmailPageObject.navigateToPage();
+    await t.wait(15500);
+    await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
+    await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
+});

--- a/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorEmail_spec.js
@@ -121,7 +121,7 @@ test
 
     await t.expect(enrollEmailPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
     await t.expect(enrollEmailPageObject.form.getErrorBoxText()).contains('We found some errors.');
-});
+  });
 
 test
   .requestHooks(invalidOTPMockWithoutEmailMagicLink)('enroll with invalid OTP and without EML', async t => {
@@ -135,7 +135,7 @@ test
 
     await t.expect(enrollEmailPageObject.getCodeFieldError()).contains('Invalid code. Try again.');
     await t.expect(enrollEmailPageObject.form.getErrorBoxText()).contains('We found some errors.');
-});
+  });
 
 test
   .requestHooks(sendEmailMockWithoutEmailMagicLink)('send me an email button should take to challenge email authenticator screen without email magic link text', async t => {
@@ -150,7 +150,7 @@ test
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).notOk();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
     await t.expect(enrollEmailPageObject.getSignoutLinkText()).eql('Back to sign in');
-});
+  });
 
 test
   .requestHooks(sendEmailMockWithEmailMagicLink)('send me an email button should take to challenge email authenticator screen with email magic link text', async t => {
@@ -165,7 +165,7 @@ test
     await t.expect(await enrollEmailPageObject.enterCodeFromEmailLinkExists()).ok();
     await t.expect(await enrollEmailPageObject.signoutLinkExists()).ok();
     await t.expect(enrollEmailPageObject.getSignoutLinkText()).eql('Back to sign in');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmock)('enroll with valid OTP', async t => {
@@ -247,7 +247,7 @@ test
     });
     await t.expect(answerRequestMethod).eql('post');
     await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('enroll with valid OTP and without EML', async t => {
@@ -288,7 +288,7 @@ test
     });
     await t.expect(answerRequestMethod).eql('post');
     await t.expect(answerRequestUrl).eql('http://localhost:3000/idp/idx/challenge/answer');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmock)('resend after 30 seconds', async t => {
@@ -378,7 +378,7 @@ test
     await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
     await t.expect(lastRequestMethod).eql('post');
     await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('resend after 30 seconds without EML', async t => {
@@ -423,7 +423,7 @@ test
     await t.expect(jsonBody).eql({'stateHandle':'eyJ6aXAiOiJER'});
     await t.expect(lastRequestMethod).eql('post');
     await t.expect(lastRequestUrl).eql('http://localhost:3000/idp/idx/challenge/resend');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmock)('resend after 30 seconds at most even after re-render', async t => {
@@ -445,7 +445,7 @@ test
     await t.wait(15500);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
-});
+  });
 
 test
   .requestHooks(logger, validOTPmockWithoutEmailMagicLink)('resend after 30 seconds at most even after re-render', async t => {
@@ -456,4 +456,4 @@ test
     await t.wait(15500);
     await t.expect(enrollEmailPageObject.resendEmail.isHidden()).notOk();
     await t.expect(enrollEmailPageObject.resendEmail.getText()).eql('Haven\'t received an email? Send again');
-});
+  });


### PR DESCRIPTION
## OKTA-484931: https://oktainc.atlassian.net/browse/OKTA-484931
- Show EmailMagicLink text for SSR on SIW screen when `useEmailMagicLink` is available in `IdxResponse`
- When not present in IdxResponse, show the text which was shown before this PR i.e. `subtitle`
- Backend Jira- OKTA-488861, PR- https://github.com/okta/okta-core/pull/65000
- Video: https://okta.box.com/s/zsgf1om88uimd3rv35xe5zns0gswztrg 
- Video with backend changes : https://okta.box.com/s/95vmimrw363s6bzfgiqq04yhdrpy2alz
- Green Bacon of Core with this version: https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&sha=bed539f7e3f06d8dc1b953afa360f1611a199149

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
https://okta.box.com/s/zsgf1om88uimd3rv35xe5zns0gswztrg

### Reviewers:
@okta/ciamx 

### Issue:

- [OKTA-484931](https://oktainc.atlassian.net/browse/OKTA-484931)


