### PR TITLE
refines downstream build

### DIFF
--- a/.bacon.yml
+++ b/.bacon.yml
@@ -1,30 +1,51 @@
 test_suites:
-    - name: lint
+    - name: publish
       script_path: /root/okta/okta-signin-widget/scripts
       sort_order: '1'
+      timeout: '10'
+      script_name: publish
+      criteria: MERGE
+      queue_name: small
+    - name: verify-package
+      script_path: /root/okta/okta-signin-widget/scripts
+      sort_order: '2'
+      timeout: '10'
+      script_name: verify-package
+      criteria: MERGE
+      queue_name: small
+    - name: lint
+      script_path: /root/okta/okta-signin-widget/scripts
+      sort_order: '3'
       timeout: '10'
       script_name: lint
       criteria: MERGE
       queue_name: small
-    - name: unit-karma
-      script_path: /root/okta/okta-signin-widget/scripts
-      sort_order: '2'
-      timeout: '15'
-      script_name: unit-karma
-      criteria: MERGE
-      queue_name: small
     - name: unit-jest
       script_path: /root/okta/okta-signin-widget/scripts
-      sort_order: '3'
+      sort_order: '4'
       timeout: '15'
       script_name: unit-jest
       criteria: MERGE
       queue_name: small
     - name: testcafe
       script_path: /root/okta/okta-signin-widget/scripts
-      sort_order: '4'
+      sort_order: '5'
       timeout: '30'
       script_name: testcafe
+      criteria: MERGE
+      queue_name: small
+    - name: e2e
+      script_path: /root/okta/okta-signin-widget/scripts
+      sort_order: '6'
+      timeout: '20'
+      script_name: e2e
+      criteria: MERGE
+      queue_name: small
+    - name: tsd
+      script_path: /root/okta/okta-signin-widget/scripts
+      sort_order: '7'
+      timeout: '15'
+      script_name: tsd
       criteria: MERGE
       queue_name: small
     - name: detect-english-leaks
@@ -34,24 +55,10 @@ test_suites:
       script_name: detect-english-leaks
       criteria: MERGE
       queue_name: small
-    - name: e2e
-      script_path: /root/okta/okta-signin-widget/scripts
-      sort_order: '5'
-      timeout: '20'
-      script_name: e2e
-      criteria: MERGE
-      queue_name: small
-    - name: publish
-      script_path: /root/okta/okta-signin-widget/scripts
-      sort_order: '7'
-      timeout: '10'
-      script_name: publish
-      criteria: MERGE
-      queue_name: small
-    - name: tsd
+    - name: unit-karma
       script_path: /root/okta/okta-signin-widget/scripts
       sort_order: '9'
       timeout: '15'
-      script_name: tsd
+      script_name: unit-karma
       criteria: MERGE
       queue_name: small

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ target
 test-reports
 
 packages/**/*.js
-scripts
 assets
 vendor
 test/unit/helpers/xhr/

--- a/scripts/buildtools/commands/verify-package.js
+++ b/scripts/buildtools/commands/verify-package.js
@@ -2,7 +2,7 @@ exports.command = 'verify-package';
 exports.describe = 'Verifies that the NPM package has the correct format';
 
 function verifyAuthJSVersion() {
-  if (/^d16t-okta-auth-js-.*/.test(process.env['BRANCH'])) {
+  if (/^d16t-okta-auth-js-.*/.test(process.env.BRANCH)) {
     console.log('Skipping verification of okta-auth-js version for downstream artifact build');
     return;
   }

--- a/scripts/buildtools/commands/verify-package.js
+++ b/scripts/buildtools/commands/verify-package.js
@@ -1,17 +1,32 @@
 exports.command = 'verify-package';
 exports.describe = 'Verifies that the NPM package has the correct format';
-exports.handler = function() {
-  const expect = require('expect');
-  const package = require('../../../package.json');
-  const report = require('../../../test-reports/pack-report.json');
 
-  expect(package.version).toBeTruthy();
+function verifyAuthJSVersion() {
+  if (/^d16t-okta-auth-js-.*/.test(process.env['BRANCH'])) {
+    console.log('Skipping verification of okta-auth-js version for downstream artifact build');
+    return;
+  }
+
+  const version = require('../../../node_modules/@okta/okta-auth-js/package.json').version;
+  const regex = /^(\d)+\.(\d)+\.(\d)+$/;
+  if (regex.test(version) !== true) {
+    throw new Error(`Invalid/beta version for okta-auth-js: ${version}`);
+  }
+  console.log(`okta-auth-js version is valid: ${version}`);
+}
+
+function verifyPackageContents() {
+  const expect = require('expect');
+  const pkg = require('../../../package.json');
+  const report = require('../../../test-reports/verify-package/pack-report.json');
+
+  expect(pkg.version).toBeTruthy();
   expect(report.length).toBe(1);
 
   const manifest = report[0];
   expect(manifest.name).toEqual('@okta/okta-signin-widget');
-  expect(manifest.version).toEqual(package.version);
-  expect(manifest.filename).toBe(`okta-okta-signin-widget-${package.version}.tgz`);
+  expect(manifest.version).toEqual(pkg.version);
+  expect(manifest.filename).toBe(`okta-okta-signin-widget-${pkg.version}.tgz`);
 
   // package size
   const ONE_MB = 1000000;
@@ -44,7 +59,17 @@ exports.handler = function() {
       throw new Error(`Expected file ${filename} was not found in the package`);
     }
   });
+  console.log(`Package size is within expected range: ${manifest.size / ONE_MB} MB, ${manifest.entryCount} files`);
+}
 
-  console.log('verify-package finished successfully');
+exports.handler = function() {
+  try {
+    verifyAuthJSVersion();
+    verifyPackageContents();
+    console.log('verify-package finished successfully');
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
 };
 

--- a/scripts/buildtools/webpack/plugins.js
+++ b/scripts/buildtools/webpack/plugins.js
@@ -31,7 +31,7 @@ function devMode() {
 }
 
 function failOnBuildFail() {
-  const FailOnBuildPlugin = function () {};
+  const FailOnBuildPlugin = function() {};
   FailOnBuildPlugin.prototype.apply = function(compiler) {
     compiler.hooks.done.tap('Fail on build', (stats) => {
 

--- a/scripts/downstream/create-downstream-for-authjs.sh
+++ b/scripts/downstream/create-downstream-for-authjs.sh
@@ -9,7 +9,12 @@ if [[ -z "${upstream_artifact_version}" ]]; then
 fi
 
 pushd ${OKTA_HOME}/okta-signin-widget/scripts > /dev/null
-sdk_version_number="$(echo ${upstream_artifact_version} | cut -d'@' -f3)"
-echo "Update okta-auth-js version in scripts/setup.sh to ${sdk_version_number}"
-sed -i "s/\(AUTHJS_VERSION\=\).*/\1\"${sdk_version_number}\"/g" setup.sh
+
+# Get the AuthJS version to use
+AUTHJS_VERSION="$(echo ${upstream_artifact_version} | cut -d'@' -f3)"
+
+# Update setup script
+echo "Update okta-auth-js version in scripts/setup.sh to ${AUTHJS_VERSION}"
+sed -i "s/\(AUTHJS_VERSION\=\).*/\1\"${AUTHJS_VERSION}\"/g" setup.sh
+
 popd > /dev/null

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -22,12 +22,6 @@ if ! yarn build:release; then
   exit ${TEST_FAILURE}
 fi
 
-# Verify package
-if ! $OKTA_HOME/$REPO/scripts/verify-package.sh; then
-  echo "package verification failed! Exiting..."
-  exit ${TEST_FAILURE}
-fi
-
 pushd ./dist
 
 ### Not able to use 'yarn publish' which failed at

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,7 +18,7 @@ if [ ! -z "$AUTHJS_VERSION" ]; then
   echo "Installing AUTHJS_VERSION: ${AUTHJS_VERSION}"
   npm config set strict-ssl false
 
-  if ! yarn add -DW --no-lockfile https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz ; then
+  if ! yarn add -DW --force https://artifacts.aue1d.saasure.com/artifactory/npm-topic/@okta/okta-auth-js/-/@okta/okta-auth-js-${AUTHJS_VERSION}.tgz ; then
     echo "AUTHJS_VERSION could not be installed: ${AUTHJS_VERSION}"
     exit ${FAILED_SETUP}
   fi

--- a/scripts/update-se-drivers.js
+++ b/scripts/update-se-drivers.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 const axios = require('axios');
 const { execSync, execFileSync } = require('child_process');
 
@@ -40,7 +41,7 @@ axios.get(chromeDriverUrl).then((response) => {
   const chromeDriverVersion = response.data;
   console.log(`Chrome Driver Version - ${chromeDriverVersion}`);
 
-  execFileSync(`${__dirname}/../node_modules/protractor/bin/webdriver-manager`, ["update",  "--versions.chrome", chromeDriverVersion, "--gecko", "false", "--versions.standalone", "latest"]);
+  execFileSync(`${__dirname}/../node_modules/protractor/bin/webdriver-manager`, ['update',  '--versions.chrome', chromeDriverVersion, '--gecko', 'false', '--versions.standalone', 'latest']);
   console.log('Webdriver was updated');
 }).catch((err) => {
   console.log(err);

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,9 +1,31 @@
-#!/bin/bash -xe
+#!/bin/bash
 
-mkdir -p test-reports
+source $OKTA_HOME/$REPO/scripts/setup.sh
+
+export PATH="${PATH}:$(yarn global bin)"
+export TEST_SUITE_TYPE="build"
+export TEST_RESULT_FILE_DIR="${REPO}/test-reports/verify-package"
+echo $TEST_SUITE_TYPE > $TEST_SUITE_TYPE_FILE
+echo $TEST_RESULT_FILE_DIR > $TEST_RESULT_FILE_DIR_FILE
+
+# Build
+if ! yarn build:release; then
+  echo "build failed! Exiting..."
+  exit ${TEST_FAILURE}
+fi
+
+mkdir -p test-reports/verify-package
 
 pushd dist
-npm pack --dry-run --json > ../test-reports/pack-report.json
+npm pack --dry-run --json > ../test-reports/verify-package/pack-report.json
 popd
 
-node ./scripts/buildtools verify-package
+if ! node ./scripts/buildtools verify-package 2> ./test-reports/verify-package/error.log
+then
+  value=`cat ./test-reports/verify-package/error.log`
+  log_custom_message "Verification Failed" "${value}"
+  echo "verification failed! Exiting..."
+  exit ${PUBLISH_TYPE_AND_RESULT_DIR_BUT_ALWAYS_FAIL}
+fi
+
+exit $SUCCESS

--- a/test/testcafe/spec/Identify_spec.js
+++ b/test/testcafe/spec/Identify_spec.js
@@ -9,6 +9,8 @@ import xhrAuthenticatorOVTotp from '../../../playground/mocks/data/idp/idx/authe
 import xhrIdentifyWithUser from '../../../playground/mocks/data/idp/idx/identify-with-user';
 import xhrErrorIdentifyMultipleErrors from '../../../playground/mocks/data/idp/idx/error-identify-multiple-errors';
 
+import config from '../../../src/config/config.json';
+
 const baseIdentifyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(xhrIdentify);
@@ -123,6 +125,7 @@ test.requestHooks(identifyRequestLogger, identifyMock)('should be able to submit
   await t.expect(req.method).eql('post');
   await t.expect(req.url).eql('http://localhost:3000/idp/idx/identify');
   await t.expect(reqHeaders['x-device-fingerprint']).notOk(); // only enabled if `features.deviceFingerprinting` is true
+  await t.expect(reqHeaders['x-okta-user-agent-extended']).contains(` okta-signin-widget-${config.version}`);
 
   identifyRequestLogger.clear();
   await identityPage.fillIdentifierField('another foobar');


### PR DESCRIPTION
## Description:
Refines downstream build process:

- verify package includes check for beta AuthJS version, will fail if using non published version and will log custom message
- verify package is separated from publish.sh, allows testing of artifact even if built using a beta AuthJS version
- beta check is skipped on downstream branches (build will pass)
- changes order of bacon tasks so publish is at the top
- adds lint to scripts folder
- restores check on user agent (was merged out in previous PR).

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-468777](https://oktainc.atlassian.net/browse/OKTA-468777)


