### PR TITLE
Refactor Okta Verify flow to share the same base view.

### DIFF
--- a/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
+++ b/src/v2/view-builder/internals/BaseOktaVerifyChallengeView.js
@@ -1,0 +1,181 @@
+import { $ } from 'okta';
+import { BaseFormWithPolling } from '../internals';
+import Logger from '../../../util/Logger';
+import {
+  AUTHENTICATOR_CANCEL_ACTION,
+  AUTHENTICATION_CANCEL_REASONS,
+  CHALLENGE_TIMEOUT,
+} from '../utils/Constants';
+import BrowserFeatures from '../../../util/BrowserFeatures';
+import { doChallenge, cancelPollingWithParams } from '../utils/ChallengeViewUtil';
+
+const request = (opts) => {
+  const ajaxOptions = Object.assign({
+    method: 'GET',
+    contentType: 'application/json',
+  }, opts);
+  return $.ajax(ajaxOptions);
+};
+
+const Body = BaseFormWithPolling.extend({
+  noButtonBar: true,
+
+  className: 'ion-form device-challenge-poll',
+
+  events: {
+    'click #launch-ov': function(e) {
+      e.preventDefault();
+      this.doCustomURI();
+    }
+  },
+
+  pollingCancelAction: AUTHENTICATOR_CANCEL_ACTION,
+
+  initialize() {
+    BaseFormWithPolling.prototype.initialize.apply(this, arguments);
+    this.listenTo(this.model, 'error', this.onPollingFail);
+    this.doChallenge();
+    this.startPolling();
+  },
+
+  doChallenge() {
+    doChallenge(this);
+  },
+
+  onPollingFail() {
+    this.$('.spinner').hide();
+    this.stopPolling();
+  },
+
+  remove() {
+    BaseFormWithPolling.prototype.remove.apply(this, arguments);
+    this.stopProbing();
+    this.stopPolling();
+  },
+
+  getDeviceChallengePayload() {
+    throw new Error('getDeviceChallengePayload needs to be implemented');
+  },
+
+  doLoopback(deviceChallenge) {
+    let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
+    let ports = deviceChallenge.ports !== undefined ? deviceChallenge.ports : [];
+    let challengeRequest = deviceChallenge.challengeRequest !== undefined ? deviceChallenge.challengeRequest : '';
+    let probeTimeoutMillis = deviceChallenge.probeTimeoutMillis !== undefined ?
+      deviceChallenge.probeTimeoutMillis : 100;
+    let currentPort;
+    let foundPort = false;
+    let countFailedPorts = 0;
+
+    const getAuthenticatorUrl = (path) => {
+      return `${authenticatorDomainUrl}:${currentPort}/${path}`;
+    };
+
+    const checkPort = () => {
+      return request({
+        url: getAuthenticatorUrl('probe'),
+        /*
+        OKTA-278573 in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional
+        timeout however, increasing timeout is a temporary solution since user will need to wait much longer in
+        worst case.
+        TODO: Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
+        OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
+        customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
+        */
+        timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
+      });
+    };
+
+    const onPortFound = () => {
+      return request({
+        url: getAuthenticatorUrl('challenge'),
+        method: 'POST',
+        data: JSON.stringify({ challengeRequest }),
+        timeout: CHALLENGE_TIMEOUT // authenticator should respond within 5 min (300000ms) for challenge request
+      });
+    };
+
+    const onFailure = () => {
+      Logger.error(`Something unexpected happened while we were checking port ${currentPort}.`);
+    };
+
+    const doProbing = () => {
+      return checkPort()
+        .done(() => {
+          return onPortFound()
+            .done(() => {
+              foundPort = true;
+              // once the OV challenge succeeds,
+              // triggers another polling right away without waiting for the next ongoing polling to be triggered
+              // to make the authentication flow goes faster 
+              return this.trigger('save', this.model);
+            })
+            .fail((xhr) => {
+              countFailedPorts++;
+              // Windows and MacOS return status code 503 when 
+              // there are multiple profiles on the device and
+              // the wrong OS profile responds to the challenge request
+              if (xhr.status !== 503) {
+                // when challenge responds with other errors,
+                // cancel polling right away
+                cancelPollingWithParams(
+                  this.options.appState,
+                  this.pollingCancelAction,
+                  AUTHENTICATION_CANCEL_REASONS.OV_ERROR,
+                  xhr.status
+                );
+              } else if (countFailedPorts === ports.length) {
+                // when challenge is responded by the wrong OS profile and
+                // all the ports are exhausted,
+                // cancel the polling like the probing has failed
+                cancelPollingWithParams(
+                  this.options.appState,
+                  this.pollingCancelAction,
+                  AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE,
+                  null
+                );
+              }
+            });
+        })
+        .fail(onFailure);
+    };
+
+    let probeChain = Promise.resolve();
+    ports.forEach(port => {
+      probeChain = probeChain
+        .then(() => {
+          if (!foundPort) {
+            currentPort = port;
+            return doProbing();
+          }
+        })
+        .catch(() => {
+          countFailedPorts++;
+          Logger.error(`Authenticator is not listening on port ${currentPort}.`);
+          if (countFailedPorts === ports.length) {
+            Logger.error('No available ports. Loopback server failed and polling is cancelled.');
+            cancelPollingWithParams(
+              this.options.appState,
+              this.pollingCancelAction,
+              AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE,
+              null
+            );
+          }
+        });
+    });
+  },
+
+  doCustomURI() {
+    this.ulDom && this.ulDom.remove();
+    this.ulDom = this.add(`
+      <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
+    `).last();
+  },
+
+  stopProbing() {
+    this.checkPortXhr && this.checkPortXhr.abort();
+    this.probingXhr && this.probingXhr.abort();
+  },
+});
+
+export default Body;

--- a/src/v2/view-builder/internals/index.js
+++ b/src/v2/view-builder/internals/index.js
@@ -2,6 +2,7 @@ export { default as BaseHeader } from './BaseHeader';
 export { default as BaseFooter } from './BaseFooter';
 export { default as BaseForm } from './BaseForm';
 export { default as BaseFormWithPolling } from './BaseFormWithPolling';
+export { default as BaseOktaVerifyChallengeView } from './BaseOktaVerifyChallengeView';
 export { default as BaseModel } from './BaseModel';
 export { default as BaseView } from './BaseView';
 export { addCustomButton, createCustomButtons, createIdpButtons } from './FormInputFactory';

--- a/src/v2/view-builder/utils/ChallengeViewUtil.js
+++ b/src/v2/view-builder/utils/ChallengeViewUtil.js
@@ -13,9 +13,14 @@ import { loc, View, createButton, _ } from 'okta';
 import hbs from 'handlebars-inline-precompile';
 import Enums from '../../../util/Enums';
 import Util from '../../../util/Util';
-import { FASTPASS_FALLBACK_SPINNER_TIMEOUT, IDENTIFIER_FLOW, 
+import {
+  FASTPASS_FALLBACK_SPINNER_TIMEOUT,
+  IDENTIFIER_FLOW,
+  LOOPBACK_RESPONSE_STATUS_CODE,
   OV_UV_ENABLE_BIOMETRICS_FASTPASS_DESKTOP, 
-  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE  } from '../utils/Constants';
+  OV_UV_ENABLE_BIOMETRICS_FASTPASS_MOBILE,
+  REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON,
+} from '../utils/Constants';
 
 export function appendLoginHint(deviceChallengeUrl, loginHint) {
   if (deviceChallengeUrl && loginHint) {
@@ -143,6 +148,13 @@ export function doChallenge(view, fromView) {
     }));
     break;
   }
+}
+
+export function cancelPollingWithParams(appState, pollingCancelAction, cancelReason, statusCode) {
+  const actionParams = {};
+  actionParams[REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON] = cancelReason;
+  actionParams[LOOPBACK_RESPONSE_STATUS_CODE] = statusCode;
+  appState.trigger('invokeAction', pollingCancelAction, actionParams);
 }
 
 export function getBiometricsErrorOptions(error, isMessageObj) {

--- a/src/v2/view-builder/utils/Constants.js
+++ b/src/v2/view-builder/utils/Constants.js
@@ -4,6 +4,7 @@ export const CHALLENGE_TIMEOUT = 300000;
 export const MS_PER_SEC = 1000;
 export const UNIVERSAL_LINK_POST_DELAY = 500;
 export const CANCEL_POLLING_ACTION = 'authenticatorChallenge-cancel';
+export const AUTHENTICATOR_CANCEL_ACTION = 'currentAuthenticator-cancel';
 export const WIDGET_FOOTER_CLASS = 'siw-main-footer';
 export const FASTPASS_FALLBACK_SPINNER_TIMEOUT = 4000;
 export const IDENTIFIER_FLOW = 'IDENTIFIER';

--- a/src/v2/view-builder/views/device/DeviceChallengePollView.js
+++ b/src/v2/view-builder/views/device/DeviceChallengePollView.js
@@ -1,199 +1,53 @@
-import { $, loc, createCallout } from 'okta';
-import {BaseFormWithPolling, BaseFooter, BaseView} from '../../internals';
-import Logger from '../../../../util/Logger';
-import BrowserFeatures from '../../../../util/BrowserFeatures';
+import { loc, createCallout } from 'okta';
+import { BaseFooter, BaseView, BaseOktaVerifyChallengeView } from '../../internals';
 import Enums from '../../../../util/Enums';
 import {
   CANCEL_POLLING_ACTION,
-  CHALLENGE_TIMEOUT,
   IDENTIFIER_FLOW,
-  REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON,
-  AUTHENTICATION_CANCEL_REASONS, LOOPBACK_RESPONSE_STATUS_CODE,
+  AUTHENTICATION_CANCEL_REASONS,
 } from '../../utils/Constants';
 import Link from '../../components/Link';
-import { doChallenge } from '../../utils/ChallengeViewUtil';
+import { doChallenge, cancelPollingWithParams } from '../../utils/ChallengeViewUtil';
 import OktaVerifyAuthenticatorHeader from '../../components/OktaVerifyAuthenticatorHeader';
 import { getSignOutLink } from '../../utils/LinksUtil';
 
-const request = (opts) => {
-  const ajaxOptions = Object.assign({
-    method: 'GET',
-    contentType: 'application/json',
-  }, opts);
-  return $.ajax(ajaxOptions);
-};
+const Body = BaseOktaVerifyChallengeView.extend({
+  pollingCancelAction: CANCEL_POLLING_ACTION,
 
-const cancelPollingWithParams = (appState, cancelReason, statusCode) => {
-  const actionParams = {};
-  actionParams[REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON] = cancelReason;
-  actionParams[LOOPBACK_RESPONSE_STATUS_CODE] = statusCode;
-  appState.trigger('invokeAction', CANCEL_POLLING_ACTION, actionParams);
-};
-
-const Body = BaseFormWithPolling.extend(
-  {
-    noButtonBar: true,
-
-    className: 'ion-form device-challenge-poll',
-
-    events: {
-      'click #launch-ov': function(e) {
-        e.preventDefault();
-        this.doCustomURI();
-      }
-    },
-
-    initialize() {
-      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
-      this.listenTo(this.model, 'error', this.onPollingFail);
-      doChallenge(this, IDENTIFIER_FLOW);
-      this.startPolling();
-    },
-
-    onPollingFail() {
-      this.$('.spinner').hide();
-      this.stopPolling();
-      // When SIW receives form error, polling is already stopped
-      // SIW needs to update footer link from /poll/cancel to /idp/idx/cancel
-      const data = { label: loc('loopback.polling.cancel.link.with.form.error', 'login') };
-      this.options.appState.trigger('updateFooterLink', data);
-    },
-
-    remove() {
-      BaseFormWithPolling.prototype.remove.apply(this, arguments);
-      this.stopProbing();
-      this.stopPolling();
-    },
-
-    getDeviceChallengePayload() {
-      return this.options.currentViewState.relatesTo.value;
-    },
-
-    doLoopback(deviceChallenge) {
-      let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
-      let ports = deviceChallenge.ports !== undefined ? deviceChallenge.ports : [];
-      let challengeRequest = deviceChallenge.challengeRequest !== undefined ? deviceChallenge.challengeRequest : '';
-      let probeTimeoutMillis = deviceChallenge.probeTimeoutMillis !== undefined ?
-        deviceChallenge.probeTimeoutMillis : 100;
-      let currentPort;
-      let foundPort = false;
-      let countFailedPorts = 0;
-
-      const getAuthenticatorUrl = (path) => {
-        return `${authenticatorDomainUrl}:${currentPort}/${path}`;
-      };
-
-      const checkPort = () => {
-        return request({
-          url: getAuthenticatorUrl('probe'),
-          /*
-          OKTA-278573 in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional
-          timeout however, increasing timeout is a temporary solution since user will need to wait much longer in
-          worst case.
-          TODO: Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
-          OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
-          customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
-          */
-          timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
-        });
-      };
-
-      const onPortFound = () => {
-        return request({
-          url: getAuthenticatorUrl('challenge'),
-          method: 'POST',
-          data: JSON.stringify({ challengeRequest }),
-          timeout: CHALLENGE_TIMEOUT // authenticator should respond within 5 min (300000ms) for challenge request
-        });
-      };
-
-      const onFailure = () => {
-        Logger.error(`Something unexpected happened while we were checking port ${currentPort}.`);
-      };
-
-      const doProbing = () => {
-        return checkPort()
-          // TODO: can we use standard ES6 promise methods, then/catch?
-          .done(() => {
-            return onPortFound()
-              .done(() => {
-                foundPort = true;
-                // once the OV challenge succeeds,
-                // triggers another polling right away without waiting for the next ongoing polling to be triggered
-                // to make FastPass faster
-                return this.trigger('save', this.model);
-              })
-              .fail((xhr) => {
-                countFailedPorts++;
-                // Windows and MacOS return status code 503 when 
-                // there are multiple profiles on the device and
-                // the wrong OS profile responds to the challenge request
-                if (xhr.status !== 503) {
-                  // when challenge responds with other errors,
-                  // cacel polling right away
-                  cancelPollingWithParams(this.options.appState, AUTHENTICATION_CANCEL_REASONS.OV_ERROR, xhr.status);
-                } else if (countFailedPorts === ports.length) {
-                  // when challenge is responded by the wrong OS profile and
-                  // all the ports are exhausted,
-                  // cancel the polling like the probing has failed
-                  cancelPollingWithParams(this.options.appState, AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE, null);
-                }
-              });
-          })
-          .fail(onFailure);
-      };
-
-      let probeChain = Promise.resolve();
-      ports.forEach(port => {
-        probeChain = probeChain
-          .then(() => {
-            if (!foundPort) {
-              currentPort = port;
-              return doProbing();
-            }
-          })
-          .catch(() => {
-            Logger.error(`Authenticator is not listening on port ${currentPort}.`);
-            countFailedPorts++;
-            if (countFailedPorts === ports.length) {
-              Logger.error('No available ports. Loopback server failed and polling is cancelled.');
-              cancelPollingWithParams(this.options.appState, AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE, null);
-            }
-          });
-      });
-    },
-
-    showCustomFormErrorCallout(error) {
-      const responseJSON = error.responseJSON;
-      const options = {
-        type: 'error',
-        className: 'okta-verify-uv-callout-content',
-        subtitle: responseJSON.errorSummary,
-      };
-
-      const containsSignedNonceError = responseJSON.errorSummaryKeys &&
-        responseJSON.errorSummaryKeys.some((key) => key.includes('auth.factor.signedNonce.error'));
-      if (containsSignedNonceError) {
-        options.title = loc('user.fail.verifyIdentity', 'login');
-      }
-
-      this.showMessages(createCallout(options));
-      return true;
-    },
-
-    doCustomURI() {
-      this.ulDom && this.ulDom.remove();
-      this.ulDom = this.add(`
-        <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
-      `).last();
-    },
-
-    stopProbing() {
-      this.checkPortXhr && this.checkPortXhr.abort();
-      this.probingXhr && this.probingXhr.abort();
-    },
+  getDeviceChallengePayload() {
+    return this.options.currentViewState.relatesTo.value;
   },
-);
+
+  doChallenge() {
+    doChallenge(this, IDENTIFIER_FLOW);
+  },
+
+  onPollingFail() {
+    BaseOktaVerifyChallengeView.prototype.onPollingFail.apply(this, arguments);
+    // When SIW receives form error, polling is already stopped
+    // SIW needs to update footer link from /poll/cancel to /idp/idx/cancel
+    const data = { label: loc('loopback.polling.cancel.link.with.form.error', 'login') };
+    this.options.appState.trigger('updateFooterLink', data);
+  },
+
+  showCustomFormErrorCallout(error) {
+    const responseJSON = error.responseJSON;
+    const options = {
+      type: 'error',
+      className: 'okta-verify-uv-callout-content',
+      subtitle: responseJSON.errorSummary,
+    };
+
+    const containsSignedNonceError = responseJSON.errorSummaryKeys &&
+      responseJSON.errorSummaryKeys.some((key) => key.includes('auth.factor.signedNonce.error'));
+    if (containsSignedNonceError) {
+      options.title = loc('user.fail.verifyIdentity', 'login');
+    }
+
+    this.showMessages(createCallout(options));
+    return true;
+  },
+});
 
 const Footer = BaseFooter.extend({
   initialize() {
@@ -206,7 +60,12 @@ const Footer = BaseFooter.extend({
           name: 'cancel-authenticator-challenge',
           label: loc('loopback.polling.cancel.link', 'login'),
           clickHandler: () => {
-            cancelPollingWithParams(this.options.appState, AUTHENTICATION_CANCEL_REASONS.USER_CANCELED, null);
+            cancelPollingWithParams(
+              this.options.appState,
+              CANCEL_POLLING_ACTION,
+              AUTHENTICATION_CANCEL_REASONS.USER_CANCELED,
+              null
+            );
           },
         }
       }).last();

--- a/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
+++ b/src/v2/view-builder/views/ov/ChallengeOktaVerifyFastPassView.js
@@ -1,176 +1,23 @@
-import { $, createCallout, _ } from 'okta';
-import { BaseFormWithPolling } from '../../internals';
-import Logger from '../../../../util/Logger';
-import {
-  REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON,
-  AUTHENTICATION_CANCEL_REASONS,
-  CHALLENGE_TIMEOUT, LOOPBACK_RESPONSE_STATUS_CODE
-} from '../../utils/Constants';
-import BrowserFeatures from '../../../../util/BrowserFeatures';
-import { doChallenge, getBiometricsErrorOptions } from '../../utils/ChallengeViewUtil';
+import { _, createCallout } from 'okta';
+import { BaseOktaVerifyChallengeView } from '../../internals';
+import { getBiometricsErrorOptions } from '../../utils/ChallengeViewUtil';
 
-const request = (opts) => {
-  const ajaxOptions = Object.assign({
-    method: 'GET',
-    contentType: 'application/json',
-  }, opts);
-  return $.ajax(ajaxOptions);
-};
-
-const Body = BaseFormWithPolling.extend(Object.assign(
-  {
-    noButtonBar: true,
-
-    className: 'ion-form device-challenge-poll',
-
-    events: {
-      'click #launch-ov': function(e) {
-        e.preventDefault();
-        this.doCustomURI();
-      }
-    },
-
-    initialize() {
-      BaseFormWithPolling.prototype.initialize.apply(this, arguments);
-      this.listenTo(this.model, 'error', this.onPollingFail);
-      doChallenge(this);
-      this.startPolling();
-    },
-
-    onPollingFail() {
-      this.$('.spinner').hide();
-      this.stopPolling();
-    },
-
-    remove() {
-      BaseFormWithPolling.prototype.remove.apply(this, arguments);
-      this.stopPolling();
-    },
-
-    getDeviceChallengePayload() {
-      return this.options.currentViewState.relatesTo.value.contextualData.challenge.value;
-    },
-
-    doLoopback(deviceChallenge) {
-      let authenticatorDomainUrl = deviceChallenge.domain !== undefined ? deviceChallenge.domain : '';
-      let ports = deviceChallenge.ports !== undefined ? deviceChallenge.ports : [];
-      let challengeRequest = deviceChallenge.challengeRequest !== undefined ? deviceChallenge.challengeRequest : '';
-      let probeTimeoutMillis = deviceChallenge.probeTimeoutMillis !== undefined ?
-        deviceChallenge.probeTimeoutMillis : 100;
-      let currentPort;
-      let foundPort = false;
-      let countFailedPorts = 0;
-
-      const getAuthenticatorUrl = (path) => {
-        return `${authenticatorDomainUrl}:${currentPort}/${path}`;
-      };
-
-      const checkPort = () => {
-        return request({
-          url: getAuthenticatorUrl('probe'),
-          /*
-          OKTA-278573 in loopback server, SSL handshake sometimes takes more than 100ms and thus needs additional
-          timeout however, increasing timeout is a temporary solution since user will need to wait much longer in
-          worst case.
-          TODO: Android timeout is temporarily set to 3000ms and needs optimization post-Beta.
-          OKTA-365427 introduces probeTimeoutMillis; but we should also consider probeTimeoutMillisHTTPS for
-          customizing timeouts in the more costly Android and other (keyless) HTTPS scenarios.
-          */
-          timeout: BrowserFeatures.isAndroid() ? 3000 : probeTimeoutMillis
-        });
-      };
-
-      const onPortFound = () => {
-        foundPort = true;
-        return request({
-          url: getAuthenticatorUrl('challenge'),
-          method: 'POST',
-          data: JSON.stringify({ challengeRequest }),
-          timeout: CHALLENGE_TIMEOUT // authenticator should respond within 5 min (300000ms) for challenge request
-        });
-      };
-
-      const onFailure = () => {
-        Logger.error(`Something unexpected happened while we were checking port ${currentPort}.`);
-      };
-
-      const cancelPollingWithParams = (cancelReason, statusCode) => {
-        const actionParams = {};
-        actionParams[REQUEST_PARAM_AUTHENTICATION_CANCEL_REASON] = cancelReason;
-        actionParams[LOOPBACK_RESPONSE_STATUS_CODE] = statusCode;
-        this.options.appState.trigger('invokeAction', 'currentAuthenticator-cancel', actionParams);
-      };
-
-      const doProbing = () => {
-        return checkPort()
-          // TODO: can we use standard ES6 promise methods, then/catch?
-          .done(() => {
-            return onPortFound()
-              .done(() => {
-                // once the OV challenge succeeds,
-                // triggers another polling right away without waiting for the next ongoing polling to be triggered
-                // to make the authentication flow goes faster 
-                return this.trigger('save', this.model);
-              })
-              .fail((xhr) => {
-                countFailedPorts++;
-                // Windows and MacOS return status code 503 when 
-                // there are multiple profiles on the device and
-                // the wrong OS profile responds to the challenge request
-                if (xhr.status !== 503) {
-                  // when challenge responds with other errors,
-                  // cacel polling right away
-                  cancelPollingWithParams(AUTHENTICATION_CANCEL_REASONS.OV_ERROR, xhr.status);
-                } else if (countFailedPorts === ports.length) {
-                  // when challenge is responded by the wrong OS profile and
-                  // all the ports are exhausted,
-                  // cancel the polling like the probing has failed
-                  cancelPollingWithParams(AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE, null);
-                }
-              });
-          })
-          .fail(onFailure);
-      };
-
-      let probeChain = Promise.resolve();
-      ports.forEach(port => {
-        probeChain = probeChain
-          .then(() => {
-            if (!foundPort) {
-              currentPort = port;
-              return doProbing();
-            }
-          })
-          .catch(() => {
-            countFailedPorts++;
-            Logger.error(`Authenticator is not listening on port ${currentPort}.`);
-            if (countFailedPorts === ports.length) {
-              Logger.error('No available ports. Loopback server failed and polling is cancelled.');
-              cancelPollingWithParams(AUTHENTICATION_CANCEL_REASONS.LOOPBACK_FAILURE, null);
-            }
-          });
-      });
-    },
-
-    doCustomURI() {
-      this.ulDom && this.ulDom.remove();
-      this.ulDom = this.add(`
-        <iframe src="${this.customURI}" id="custom-uri-container" style="display:none;"></iframe>
-      `).last();
-    },
-
-    showCustomFormErrorCallout(error) {
-      const options = getBiometricsErrorOptions(error, false);
-      
-      // If not biometrics error, just show the returned error message
-      if (_.isEmpty(options)) {
-        return false;
-      }
-
-      this.showMessages(createCallout(options));
-      return true;
-    },
+const Body = BaseOktaVerifyChallengeView.extend({
+  getDeviceChallengePayload() {
+    return this.options.currentViewState.relatesTo.value.contextualData.challenge.value;
   },
-));
+
+  showCustomFormErrorCallout(error) {
+    const options = getBiometricsErrorOptions(error, false);
+    
+    // If not biometrics error, just show the returned error message
+    if (_.isEmpty(options)) {
+      return false;
+    }
+
+    this.showMessages(createCallout(options));
+    return true;
+  },
+});
 
 export default Body;

--- a/test/testcafe/spec/DeviceChallengePollView_spec.js
+++ b/test/testcafe/spec/DeviceChallengePollView_spec.js
@@ -300,17 +300,6 @@ test
         record.request.url.match(/introspect/)
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
-      record => record.response.statusCode === 200 &&
-        record.request.method === 'get' &&
-        record.request.url.match(/6512\/probe/)
-    )).eql(1);
-    await t.expect(loopbackSuccessLogger.count(
-      record => record.response.statusCode === 200 &&
-        record.request.url.match(/6512\/challenge/) &&
-        record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
-    )).eql(1);
-    failureCount = 2;
-    await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 500 &&
         record.request.url.match(/2000/)
     )).eql(1);
@@ -321,8 +310,20 @@ test
     )).eql(1);
     await t.expect(loopbackSuccessLogger.count(
       record => record.response.statusCode === 403 &&
-        record.request.url.match(/6511\/challenge/)
+        record.request.url.match(/6511\/challenge/) &&
+        record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
     )).eql(1);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.method === 'get' &&
+        record.request.url.match(/6512\/probe/)
+    )).eql(1);
+    await t.expect(loopbackSuccessLogger.count(
+      record => record.response.statusCode === 200 &&
+        record.request.url.match(/6512\/challenge/) &&
+        record.request.body.match(/challengeRequest":"eyJraWQiOiI1/)
+    )).eql(1);
+    failureCount = 2;
     await t.expect(loopbackSuccessLogger.contains(record => record.request.url.match(/6513/))).eql(false);
 
     const identityPage = new IdentityPageObject(t);


### PR DESCRIPTION
## Description:

The Okta Verify in MFA flow and FastPass flow share the same logic. Abstract the shared code and make them extend from the `BaseOktaVerifyChallengeView`.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:

@aarongranick-okta  @santoshmale-okta 

### Issue:

- [OKTA-390965](https://oktainc.atlassian.net/browse/OKTA-390965)


