### PR TITLE
fs-okta-476180-progressive-profile-country-code-time-zone-default-value

### DIFF
--- a/src/v2/ion/ui-schema/ion-string-handler.js
+++ b/src/v2/ion/ui-schema/ion-string-handler.js
@@ -40,7 +40,6 @@ const getCaptchaUiSchema = () => {
 
 const timezoneUISchema = {
   type: 'select',
-  options: TimeZone,
   wide: true
 };
 
@@ -56,8 +55,7 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
   } else if (display.inputType === 'select') {
     uiSchema.wide = true;
     if (display.format === ATTR_FORMAT.COUNTRY_CODE) {
-      uiSchema.options = CountryUtil.getCountryCode();
-      uiSchema.value = 'US';
+      uiSchema.options = Object.assign({'': ''}, CountryUtil.getCountryCode());
     } else {
       //it will create a placeholder for dropdowns, by default it will show 'Select an Option'
       uiSchema.options = Object.assign({'': ''}, ionOptionsToUiOptions(display.options));
@@ -68,7 +66,7 @@ const populateUISchemaForDisplay = (uiSchema, ionField) => {
 const populateUISchemaForRadio = (uiSchema, ionFormField) => {
   // e.g. { name: 'methodType', options: [ {label: 'sms'} ], type: 'string' | null }
   uiSchema.type = 'radio';
-  // set the default value to the first value..
+  // set the default value to the first value.
   ionFormField.value = ionFormField.options[0].value;
 };
 
@@ -88,6 +86,7 @@ const createUiSchemaForString = (ionFormField, remediationForm, transformedResp,
 
   if(ionFormField.name === 'userProfile.timezone'){
     Object.assign(uiSchema, timezoneUISchema);
+    uiSchema.options = Object.assign({'': ''}, TimeZone);
   }
 
   if (Array.isArray(ionFormField.options) && ionFormField.options[0] && ionFormField.options[0].value) {

--- a/test/testcafe/framework/page-objects/EnrollProfileViewPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollProfileViewPageObject.js
@@ -17,6 +17,10 @@ export default class EnrollProfileViewPageObject extends BasePageObject {
     return this.form.selectValueChozenDropdown(fieldName, index);
   }
 
+  getValueFromDropdown(fieldName) {
+    return this.form.getValueFromDropdown(fieldName);
+  }
+
   clickRadioButton(fieldName, index) {
     return this.form.selectRadioButtonOption(fieldName, index);
   }

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -155,6 +155,11 @@ export default class BaseFormObject {
   // Chozen Dropdown
   // =====================================
 
+  getValueFromDropdown(fieldName) {
+    const selectContainer = this.findFormFieldInput(fieldName).find('.chzn-container');
+    return selectContainer.innerText;
+  }
+
   async selectValueChozenDropdown(fieldName, index) {
     const selectContainer = await this.findFormFieldInput(fieldName)
       .find('.chzn-container');

--- a/test/testcafe/spec/EnrollProfileView_spec.js
+++ b/test/testcafe/spec/EnrollProfileView_spec.js
@@ -107,6 +107,7 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
   requestLogger.clear();
   await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.country')).eql('Country');
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.country')).ok();
+  await t.expect(await enrollProfilePage.getValueFromDropdown('userProfile.country')).eql('Select an Option');
   await enrollProfilePage.selectValueFromDropdown('userProfile.country', 1);
 
   await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.countryCode')).eql('Country code');
@@ -114,6 +115,7 @@ test.requestHooks(requestLogger, EnrollProfileSignUpWithAdditionalFieldsMock)('s
 
   await t.expect(await enrollProfilePage.getFormFieldLabel('userProfile.timezone')).eql('Time zone');
   await t.expect(await enrollProfilePage.isDropdownVisible('userProfile.timezone')).ok();
+  await t.expect(await enrollProfilePage.getValueFromDropdown('userProfile.timezone')).eql('Select an Option');
   await enrollProfilePage.selectValueFromDropdown('userProfile.timezone', 1);
 });
 


### PR DESCRIPTION
## Description:

- Unset default value for Country code and Timezone  in the SIW so when it is an option field, no data needed to added. 


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:

<img width="438" alt="Screen Shot 2022-04-25 at 12 47 10" src="https://user-images.githubusercontent.com/90279953/165164433-12afb9ae-8dc8-49f1-b750-a1322ce2f2ec.png">


### Reviewers:
@okta/ciamx 

### Issue:

- [OKTA-476180](https://oktainc.atlassian.net/browse/OKTA-476180)


