### PR TITLE
Adding config flag to allow optionally hiding the sign out link on password expired page footer

### DIFF
--- a/docs/classic.md
+++ b/docs/classic.md
@@ -1544,6 +1544,8 @@ features: {
 
 - **features.hideSignOutLinkInMFA** - Hides the sign out link for MFA challenge. Defaults to `false`.
 
+- **features.hideSignOutLinkOnPasswordExpired** - Hides the sign out link on password expired page. Defaults to `false`.
+
 - **features.registration** - Display the registration section in the primary auth page. Defaults to `false`.
 
 - **features.idpDiscovery** - Enable [IdP Discovery](#idp-discovery). Defaults to `false`.

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -86,6 +86,7 @@ const local: Record<string, ModelProperty> = {
   'features.multiOptionalFactorEnroll': ['boolean', true, false],
   'features.deviceFingerprinting': ['boolean', false, false],
   'features.hideSignOutLinkInMFA': ['boolean', false, false],
+  'features.hideSignOutLinkOnPasswordExpired': ['boolean', false, false],
   'features.skipIdpFactorVerificationBtn': ['boolean', false, false],
   'features.hideBackToSignInForReset': ['boolean', false, false],
   'features.customExpiredPassword': ['boolean', true, false],

--- a/src/v1/views/expired-password/Footer.js
+++ b/src/v1/views/expired-password/Footer.js
@@ -22,9 +22,11 @@ export default View.extend({
           {{i18n code="password.expiring.later" bundle="login"}}\
         </a>\
       {{/if}}\
+      {{#if showSignOutLink}}\
       <a href="#" class="link help goto js-signout" data-se="signout-link">\
         {{i18n code="signout" bundle="login"}}\
       </a>\
+      {{/if}}\
     '
   ),
   className: 'auth-footer clearfix',
@@ -63,6 +65,9 @@ export default View.extend({
     },
   },
   getTemplateData: function() {
-    return { passwordWarn: this.options.appState.get('isPwdExpiringSoon') };
+    return {
+      passwordWarn: this.options.appState.get('isPwdExpiringSoon'),
+      showSignOutLink: !this.settings.get('features.hideSignOutLinkOnPasswordExpired')
+    };
   },
 });


### PR DESCRIPTION


## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


