### PR TITLE
'unit-whitelist' has been deprecated and replaced with 'unit-allowed-list'

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -65,7 +65,7 @@ module.exports = {
     'selector-no-vendor-prefix': null,
     'shorthand-property-no-redundant-values': true,
     /* eslint-disable-next-line @okta/okta/no-exclusive-language */
-    'unit-whitelist': [
+    'unit-allowed-list': [
       'ch',
       'em',
       'ex',


### PR DESCRIPTION


Detail: https://github.com/stylelint/stylelint/blob/13.7.0/lib/rules/unit-whitelist/README.md

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


