### PR TITLE
fix: include compressed css into sourcemap

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,26 @@ module.exports = function(grunt) {
         ]
       },
 
+      'css-to-mincss': {
+        files: [
+          {
+            expand: true,
+            cwd: 'target/css/',
+            src: ['*.css', '*.css.map'],
+            dest: 'target/css/',
+            rename: function(dest, src) {
+              if (src === 'okta-sign-in.css') {
+                return path.resolve(dest, 'okta-sign-in.min.css');
+              }
+              if (src === 'okta-sign-in.css.map') {
+                return path.resolve(dest, 'okta-sign-in.min.css.map');
+              }
+              return path.resolve(dest, src);
+            },
+          },
+        ],
+      },
+
       'app-to-target': {
         files: [
           // i18n files
@@ -118,14 +138,9 @@ module.exports = function(grunt) {
           {
             expand: true,
             cwd: 'target/css',
-            src: ['*.css', '*.css.map'],
+            // copy minified stylesheet and its sourcemap only
+            src: ['*.css', '*.css.map', '!okta-sign-in.css', '!okta-sign-in.css.map'],
             dest: DIST + '/css',
-            rename: function(dest, src) {
-              if (src === 'okta-sign-in.css') {
-                return path.resolve(dest, 'okta-sign-in.min.css');
-              }
-              return path.resolve(dest, src);
-            }
           }
         ]
       },
@@ -285,7 +300,7 @@ module.exports = function(grunt) {
             cssnano
           ]
         },
-        src: 'target/css/okta-sign-in.css'
+        src: 'target/css/okta-sign-in.min.css'
       }
     },
 
@@ -408,6 +423,9 @@ module.exports = function(grunt) {
     ];
 
     if (prodBuild) {
+      // okta-sign-in.css is renamed to okta-sign-in.min.css in the npm bundle
+      // include okta-sign-in.css.min into source map so it can be resolved
+      buildTasks.push('copy:css-to-mincss');
       buildTasks.push('postcss:minify');
     } else {
       buildTasks.push('postcss:build');

--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ To embed the Sign-in Widget via CDN, include links to the JS and CSS files in yo
 
 ```html
 <!-- Latest CDN production Javascript and CSS -->
-<script src="https://global.oktacdn.com/okta-signin-widget/6.3.1/js/okta-sign-in.min.js" type="text/javascript"></script>
+<script src="https://global.oktacdn.com/okta-signin-widget/6.3.2/js/okta-sign-in.min.js" type="text/javascript"></script>
 
-<link href="https://global.oktacdn.com/okta-signin-widget/6.3.1/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
+<link href="https://global.oktacdn.com/okta-signin-widget/6.3.2/css/okta-sign-in.min.css" type="text/css" rel="stylesheet"/>
 ```
 
 The CDN URLs contain a version number. This number should be the same for both the Javascript and the CSS file and match a version on the [releases page](https://github.com/okta/okta-signin-widget/releases).

--- a/assets/sass/v1/_all.scss
+++ b/assets/sass/v1/_all.scss
@@ -1,1 +1,1 @@
-@import "assets/sass/v1/device-code-terminal";
+@import "./device-code-terminal";

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/buildtools/commands/verify-package.js
+++ b/scripts/buildtools/commands/verify-package.js
@@ -65,7 +65,7 @@ function verifyPackageContents() {
 }
 
 function verifySassSourceMap() {
-  const data = readFileSync(path.join(__dirname, '../../../dist/dist/css/okta-sign-in.css.map'), 'utf-8');
+  const data = readFileSync(path.join(__dirname, '../../../dist/dist/css/okta-sign-in.min.css.map'), 'utf-8');
   const sourceMap = JSON.parse(data);
   let hasAbsolutePaths = false;
   sourceMap.sources.forEach(source => {


### PR DESCRIPTION
## Description:
* specify correct entry for compressed .css in the sourcemap
* correct relative path for v1 stylesheets index


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


