### PR TITLE
fix: dutch now selected when country code unknown

### DIFF
--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -215,6 +215,16 @@ const derived: Record<string, ModelProperty>  = {
     fn: function(language, supportedLanguages) {
       const userLanguages = BrowserFeatures.getUserLanguages();
 
+      // TODO: revisit this fix - OKTA-491150
+      userLanguages.forEach((val, idx) => {
+        if (val === 'nl') {
+          userLanguages[idx] = 'nl-NL';
+        }
+        else if (val === 'pt') {
+          userLanguages[idx] = 'pt-BR';
+        }
+      });
+      
       const preferred = _.clone(userLanguages);
 
       const supportedLowerCase = Util.toLower(supportedLanguages);

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -291,6 +291,8 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     const authClient = this.settings.getAuthClient();
     delete authClient.options['recoveryToken'];
     this.settings.unset('recoveryToken');
+    // clear otp (email magic link), if any
+    this.settings.unset('otp');
 
     // Re-render the widget
     this.render(this.controller.constructor);

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -291,8 +291,6 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     const authClient = this.settings.getAuthClient();
     delete authClient.options['recoveryToken'];
     this.settings.unset('recoveryToken');
-    // clear otp (email magic link), if any
-    this.settings.unset('otp');
 
     // Re-render the widget
     this.render(this.controller.constructor);

--- a/test/unit/spec/Settings_spec.js
+++ b/test/unit/spec/Settings_spec.js
@@ -1,0 +1,75 @@
+import Settings from 'models/Settings';
+
+describe('models/Settings', () => {
+
+  describe('languageCode', () => {
+    const setup = (mock=[], options) => {
+      const spy = jest.spyOn(navigator, 'languages', 'get').mockImplementation(() => mock);
+      const config = {baseUrl: 'http://foo', ...options};
+      const settings = new Settings(config);
+      return { spy, settings };
+    };
+
+    it('defaults to `en` when navigator returns empty array', () => {
+      const { spy, settings } = setup([]);
+      expect(settings.get('languageCode')).toEqual('en');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns `fr` when navigator returns `fr-FR`', () => {
+      const { spy, settings } = setup(['fr-FR']);
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns `fr` when navigator returns `fr`', () => {
+      const { spy, settings } = setup(['fr']);
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns `fr` when navigator returns `FR`', () => {
+      const { spy, settings } = setup(['FR']);
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns `fr` when navigator returns `FR-FR`', () => {
+      const { spy, settings } = setup(['FR-FR']);
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns configured language (via string)', () => {
+      const { spy, settings } = setup(['en-US'], {language: 'fr'});
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns configured language (via function)', () => {
+      const { spy, settings } = setup(['en-US'], {language: () => 'fr'});
+      expect(settings.get('languageCode')).toEqual('fr');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('returns unlisted configured language (via string)', () => {
+      const { spy, settings } = setup(['en-US'], {language: 'fr-FR'});
+      expect(settings.get('languageCode')).toEqual('fr-FR');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    // TODO: OKTA-491150 - special case, explicitly test Dutch (nl)
+    it('special case: returns `nl-NL` when navigator returns `nl`', () => {
+      const { spy, settings } = setup(['nl']);
+      expect(settings.get('languageCode')).toEqual('nl-NL');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    // TODO: OKTA-491150 - special case, explicitly test Portuguese (pt)
+    it('special case: returns `pt-BR` when navigator returns `pt`', () => {
+      const { spy, settings } = setup(['pt']);
+      expect(settings.get('languageCode')).toEqual('pt-BR');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description:
Dutch (`nl`) and Portuguese (`pt`) are listed in the `supportedLanguages` config as `nl-NL` and `pt-BR` respectively. It's possible for the browser-based language detection to only provide the language code (without the country code). So when the language validation is done, `nl` is compared to `nl-NL` and no match is found, so the widget defaults to English. This fixes that behavior, `nl` will now map to `nl-NL` and the widget will be rendered in Dutch, as desired.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-491150](https://oktainc.atlassian.net/browse/OKTA-491150)


