### PR TITLE
SSR - Registration Activation: Update 'Back to Sign-in' link based on settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,14 @@ Set the following config option to override the sign out link URL. If not provid
 signOutLink: 'https://www.signmeout.com'
 ```
 
+#### Back to sign in link
+
+Set the following config option to override the back to sign in link URL. If not provided, the widget will navigate to Primary Auth.
+
+```javascript
+backToSignInLink: 'https://www.backtosignin.com'
+```
+
 #### Sign up link
 
 You can add a registration link to the primary auth page by setting the following config options.

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appLoginUri to redirect to current app
-  if (settings?.get('appLoginUri')) {
+  // backToSignInLink to redirect to current app
+  if (settings?.get('backToSignInLink')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appLoginUri')
+        'href': settings.get('backToSignInLink')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appLoginUri to redirect to current app
-  if (settings?.get('appLoginUri')) {
-    link.href = settings.get('appLoginUri');
+  // backToSignInLink to redirect to current app
+  if (settings?.get('backToSignInLink')) {
+    link.href = settings.get('backToSignInLink');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,7 +97,7 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // backToSignInLink to redirect to current app
+  // backToSignInLink: to override back to sign in link
   if (settings?.get('backToSignInLink')) {
     return [
       {
@@ -131,7 +131,7 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // backToSignInLink to redirect to current app
+  // backToSignInLink: to override back to sign in link
   if (settings?.get('backToSignInLink')) {
     link.href = settings.get('backToSignInLink');
   }

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -105,7 +105,7 @@ const getSignOutLink = (settings, options = {}) => {
         'name': 'cancel',
         'href': settings.get('appTerminationRedirectUri')
       },
-    ]
+    ];
   }
   else if (settings?.get('signOutLink')) {
     return [

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appLoginRedirectUri to redirect to current app
-  if (settings?.get('appLoginRedirectUri')) {
+  // appLoginUri to redirect to current app
+  if (settings?.get('appLoginUri')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appLoginRedirectUri')
+        'href': settings.get('appLoginUri')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appLoginRedirectUri to redirect to current app
-  if (settings?.get('appLoginRedirectUri')) {
-    link.href = settings.get('appLoginRedirectUri');
+  // appLoginUri to redirect to current app
+  if (settings?.get('appLoginUri')) {
+    link.href = settings.get('appLoginUri');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -96,7 +96,18 @@ const getSkipSetupLink = (appState, linkName) => {
 };
 
 const getSignOutLink = (settings, options = {}) => {
-  if (settings?.get('signOutLink')) {
+
+  // appTerminationRedirectUri to redirect to current app
+  if (settings?.get('appTerminationRedirectUri')) {
+    return [
+      {
+        'label': loc('goback', 'login'),
+        'name': 'cancel',
+        'href': settings.get('appTerminationRedirectUri')
+      },
+    ]
+  }
+  else if (settings?.get('signOutLink')) {
     return [
       {
         'label': loc('signout', 'login'),
@@ -120,8 +131,12 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
+  // appTerminationRedirectUri to redirect to current app
+  if (settings?.get('appTerminationRedirectUri')) {
+    link.href = settings.get('appTerminationRedirectUri');
+  }
   // embedded scenarios
-  if (settings?.get('useInteractionCodeFlow')) {
+  else if (settings?.get('useInteractionCodeFlow')) {
     link.clickHandler = () => {
       appState.trigger('restartLoginFlow');
     };

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appTerminationRedirectUri to redirect to current app
-  if (settings?.get('appTerminationRedirectUri')) {
+  // appLoginRedirectUri to redirect to current app
+  if (settings?.get('appLoginRedirectUri')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appTerminationRedirectUri')
+        'href': settings.get('appLoginRedirectUri')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appTerminationRedirectUri to redirect to current app
-  if (settings?.get('appTerminationRedirectUri')) {
-    link.href = settings.get('appTerminationRedirectUri');
+  // appLoginRedirectUri to redirect to current app
+  if (settings?.get('appLoginRedirectUri')) {
+    link.href = settings.get('appLoginRedirectUri');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -1,6 +1,6 @@
 import AppState from 'v2/models/AppState';
 import { FORMS } from 'v2/ion/RemediationConstants';
-import { getSwitchAuthenticatorLink, getFactorPageCustomLink, getBackToSignInLink } from 'v2/view-builder/utils/LinksUtil';
+import { getSwitchAuthenticatorLink, getFactorPageCustomLink, getBackToSignInLink, getSignOutLink } from 'v2/view-builder/utils/LinksUtil';
 import Settings from '../../../../../../src/models/Settings';
 
 describe('v2/utils/LinksUtil', function() {
@@ -152,5 +152,44 @@ describe('v2/utils/LinksUtil', function() {
       });
       expect(result[0].href).toBeUndefined();
     });
+
+    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        useInteractionCodeFlow: true,
+        appTerminationRedirectUri: 'https://okta.com',
+      });
+      const result = getBackToSignInLink({ appState, settings });
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'link',
+        label: expect.any(String),   // this field could change, ignore for testing
+        name: 'go-back',
+        href: 'https://okta.com',
+      });
+      expect(result[0].clickHandler).toBeUndefined();
+    });
+
+  });
+
+  describe('getSignOutLink', () => {
+    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        useInteractionCodeFlow: false,
+        appTerminationRedirectUri: 'https://okta.com',
+      });
+      const result = getSignOutLink(settings);
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        label: expect.any(String),   // this field could change, ignore for testing
+        name: 'cancel',
+        href: 'https://okta.com',
+      });
+      expect(result[0].clickHandler).toBeUndefined();
+    });
+
   });
 });

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appLoginUri`', () => {
+    it('returns `href` with value of `backToSignInLink`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appLoginUri: 'https://okta.com',
+        backToSignInLink: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appLoginUri`', () => {
+    it('returns `href` with value of `backToSignInLink`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appLoginUri: 'https://okta.com',
+        backToSignInLink: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+    it('returns `href` with value of `appLoginRedirectUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appTerminationRedirectUri: 'https://okta.com',
+        appLoginRedirectUri: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+    it('returns `href` with value of `appLoginRedirectUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appTerminationRedirectUri: 'https://okta.com',
+        appLoginRedirectUri: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appLoginRedirectUri`', () => {
+    it('returns `href` with value of `appLoginUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appLoginRedirectUri: 'https://okta.com',
+        appLoginUri: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appLoginRedirectUri`', () => {
+    it('returns `href` with value of `appLoginUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appLoginRedirectUri: 'https://okta.com',
+        appLoginUri: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);


### PR DESCRIPTION
## Description:
- Make `Back to Sign-in` link on Email Authenticator View, point back to app specified in `backToSignInLink` in settings
  - Based on okta-core PR here: https://github.com/okta/okta-core/pull/65836
- Update README as we are adding a new config option to the SIW


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
- [Demo video](https://okta.box.com/s/sr1y4kzwg1xisfvdeaudbfh837fsizga)
  - When hovering over the `Back to Sign in` link, you can see in the bottom left of the screen that the link points to https://www.okta.com/ instead of the default of localhost:3000
- [Demo w/ okta-core](https://okta.box.com/s/ut879hwdlwml7uw8als8g3bueo4h3j6i)
  - Shows the back to sign in link works after link expiry
  - Here I hardcoded the `appTerminationRedirectUri` value in the `settings` object to be `https://www.okta.com/` and can see the link in the bottom left corner when I hover over the `Back to Sign in` link
### Reviewers:


### Issue:

- [OKTA-489026](https://oktainc.atlassian.net/browse/OKTA-489026)

