### PR TITLE
fix: clears otp from settings on restartLoginFlow

### DIFF
--- a/playground/mocks/data/idp/idx/terminal-return-otp-unexpected-response.json
+++ b/playground/mocks/data/idp/idx/terminal-return-otp-unexpected-response.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.0.0",
+  "intent":"LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "FAKE MESSAGE",
+        "i18n": {
+          "key": "idx.enter.otp.in.original.tab"
+        },
+        "class": "INFO"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "contextualData": {
+        "otp": "123456"
+      },
+      "type": "email",
+      "key": "okta_email",
+      "id": "aut5gn8p1c0jGB5nO0g4",
+      "displayName": "Email",
+      "methods": [
+        {
+          "type": "email"
+        }
+      ]
+    }
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "my 3rd magic link spa",
+      "id": "0oa5u4b54akg0cVYw0g4"
+    }
+  }
+}

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -300,6 +300,8 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     const authClient = this.settings.getAuthClient();
     delete authClient.options['recoveryToken'];
     this.settings.unset('recoveryToken');
+    // clear otp (email magic link), if any
+    this.settings.unset('otp');
 
     // Re-render the widget
     this.render(this.controller.constructor);

--- a/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
+++ b/src/v2/view-builder/views/consent/EmailMagicLinkOTPTerminalView.js
@@ -26,7 +26,9 @@ const getTerminalOtpEmailMagicLinkContext = (settings, appState) => {
   const client = appState.get('client');
   const challengeIntent = challengeIntentToFlowMap[appState.get('idx').context.intent];
   let enterCodeOnFlowPage, appName, browserOnOsString, isMobileDevice, geolocation;
-  enterCodeOnFlowPage = loc('idx.return.link.otponly.enter.code.on.page', 'login', [challengeIntent]);
+  enterCodeOnFlowPage = challengeIntent
+    ? loc('idx.return.link.otponly.enter.code.on.page', 'login', [challengeIntent])
+    : loc('idx.enter.otp.in.original.tab', 'login');
   if (app) {
     appName = loc('idx.return.link.otponly.app', 'login', [app.label]);
   }

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -6,6 +6,7 @@ import terminalReturnOtpOnlyFullLocationMobileIconAuthentication from '../../../
 import terminalReturnOtpOnlyFullLocationMobileIconEnrollment from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-enrollment.json';
 import terminalReturnOtpOnlyFullLocationMobileIconRecovery from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-recovery.json';
 import terminalReturnOtpOnlyFullLocationMobileIconUnlock from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-unlock.json';
+import identify from '../../../playground/mocks/data/idp/idx/identify.json';
 import TerminalOtpOnlyPageObject from '../framework/page-objects/TerminalOtpOnlyPageObject';
 
 const terminalReturnOtpOnlyFullLocationMock = RequestMock()
@@ -35,6 +36,10 @@ const terminalReturnOtpOnlyFullLocationMobileIconRecoveryMock = RequestMock()
 const terminalReturnOtpOnlyFullLocationMobileIconUnlockMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalReturnOtpOnlyFullLocationMobileIconUnlock);
+
+const identifyMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(identify);
 
 fixture('Email Magic Link OTP Terminal view');
 
@@ -118,4 +123,12 @@ async function setupOtpOnly(t) {
       await t.expect(terminalOtpOnlyPage.getUserEmailElement().innerText).eql('test@okta.com');
       await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).eql(intent);
     });
+});
+
+// See OKTA-495883
+test.requestHooks(identifyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
+  // broken message: L10N_ERROR[idx.return.link.otponly.enter.code.on.page]
+  const terminalOtpOnlyPage = await setupOtpOnly(t);
+  await t.expect(await terminalOtpOnlyPage.doesFormTitleExist()).ok();
+  await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
 });

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -129,6 +129,6 @@ async function setupOtpOnly(t) {
 test.requestHooks(identifyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
   // broken message: L10N_ERROR[idx.return.link.otponly.enter.code.on.page]
   const terminalOtpOnlyPage = await setupOtpOnly(t);
-  await t.expect(await terminalOtpOnlyPage.doesFormTitleExist()).ok();
-  await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
+  await t.expect(await terminalOtpOnlyPage.getEnterCodeOnPageElement()).ok();
+  await t.expect(await terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
 });

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -6,7 +6,7 @@ import terminalReturnOtpOnlyFullLocationMobileIconAuthentication from '../../../
 import terminalReturnOtpOnlyFullLocationMobileIconEnrollment from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-enrollment.json';
 import terminalReturnOtpOnlyFullLocationMobileIconRecovery from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-recovery.json';
 import terminalReturnOtpOnlyFullLocationMobileIconUnlock from '../../../playground/mocks/data/idp/idx/terminal-return-otp-only-full-location-mobile-icon-unlock.json';
-import identify from '../../../playground/mocks/data/idp/idx/identify.json';
+import terminalReturnOtpUnexpectedResponse from '../../../playground/mocks/data/idp/idx/terminal-return-otp-unexpected-response.json';
 import TerminalOtpOnlyPageObject from '../framework/page-objects/TerminalOtpOnlyPageObject';
 
 const terminalReturnOtpOnlyFullLocationMock = RequestMock()
@@ -37,9 +37,9 @@ const terminalReturnOtpOnlyFullLocationMobileIconUnlockMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalReturnOtpOnlyFullLocationMobileIconUnlock);
 
-const identifyMock = RequestMock()
+const terminalReturnOtpUnexpectedResponseyMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
-  .respond(identify);
+  .respond(terminalReturnOtpUnexpectedResponse);
 
 fixture('Email Magic Link OTP Terminal view');
 
@@ -125,10 +125,10 @@ async function setupOtpOnly(t) {
     });
 });
 
-// See OKTA-495883
-test.requestHooks(identifyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
+// Confirms fix for OKTA-495883
+test.only.requestHooks(terminalReturnOtpUnexpectedResponseyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
   // broken message: L10N_ERROR[idx.return.link.otponly.enter.code.on.page]
   const terminalOtpOnlyPage = await setupOtpOnly(t);
-  await t.expect(await terminalOtpOnlyPage.getEnterCodeOnPageElement()).ok();
+  await t.expect(await terminalOtpOnlyPage.doesEnterCodeOnPageExist()).ok();
   await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
 });

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -130,5 +130,5 @@ test.requestHooks(identifyMock)('should gracefully handle unexpected idx respons
   // broken message: L10N_ERROR[idx.return.link.otponly.enter.code.on.page]
   const terminalOtpOnlyPage = await setupOtpOnly(t);
   await t.expect(await terminalOtpOnlyPage.getEnterCodeOnPageElement()).ok();
-  await t.expect(await terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
+  await t.expect(terminalOtpOnlyPage.getEnterCodeOnPageElement().innerText).notContains('L10N_ERROR');
 });

--- a/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
+++ b/test/testcafe/spec/EmailMagicLinkOTPTerminalView_spec.js
@@ -126,7 +126,7 @@ async function setupOtpOnly(t) {
 });
 
 // Confirms fix for OKTA-495883
-test.only.requestHooks(terminalReturnOtpUnexpectedResponseyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
+test.requestHooks(terminalReturnOtpUnexpectedResponseyMock)('should gracefully handle unexpected idx response and render a default message', async t => {
   // broken message: L10N_ERROR[idx.return.link.otponly.enter.code.on.page]
   const terminalOtpOnlyPage = await setupOtpOnly(t);
   await t.expect(await terminalOtpOnlyPage.doesEnterCodeOnPageExist()).ok();

--- a/test/unit/spec/v2/BaseLoginRouter_spec.js
+++ b/test/unit/spec/v2/BaseLoginRouter_spec.js
@@ -143,6 +143,26 @@ describe('v2/BaseLoginRouter', function() {
       expect(router.render).toHaveBeenCalled();
       expect(clearInsideRender).toBe(true);
     });
+    it('clears the otp (before render)', () => {
+      const otp = '123456';
+      setup({
+        useInteractionCodeFlow: true,
+        otp
+      });
+      const { router } = testContext;
+      const { settings } = router;
+      expect(settings.get('otp')).toBe(otp);
+
+      router.controller = {};
+      let clearInsideRender = false;
+      jest.spyOn(router, 'render').mockImplementation(() => {
+        expect(settings.get('otp')).toBe(undefined);
+        clearInsideRender = true;
+      });
+      router.appState.trigger('restartLoginFlow');
+      expect(router.render).toHaveBeenCalled();
+      expect(clearInsideRender).toBe(true);
+    });
   });
 
   describe('ephemeral settings', () => {


### PR DESCRIPTION
## Description:
fixes issue where widget is loaded via email magic link then 'Back to sign in' is clicked displays a terminal otp error.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


https://user-images.githubusercontent.com/90656038/169121097-35569e03-8ba3-4050-9490-788de6dc04dc.mov
(before)

![Screen Shot 2022-05-18 at 10 46 50](https://user-images.githubusercontent.com/90656038/169121169-0aeacd3f-84eb-4cc6-95a3-f481016061f9.png)
(after - message fix)

https://user-images.githubusercontent.com/90656038/169121244-88e5cc72-ca18-481e-90ea-f9c5702eabb5.mov
(after - behavior)

### Reviewers:


### Issue:

- [OKTA-495883](https://oktainc.atlassian.net/browse/OKTA-495883)


