### PR TITLE
added error handler

### DIFF
--- a/src/v1/controllers/BarcodePushController.js
+++ b/src/v1/controllers/BarcodePushController.js
@@ -54,10 +54,9 @@ export default FormController.extend({
   Footer: Footer,
 
   initialize: function() {
-    this.pollForEnrollment().catch((error)=>{
-      if (!(error instanceof AuthPollStopError)) {
-        this.trigger('error', this, error);
-      }
+    this.pollForEnrollment().catch(()=>{
+      // Ignoring the errors for now. 
+      // clean up will be done based on OKTA-324849
     });
   },
 

--- a/src/v1/controllers/BarcodePushController.js
+++ b/src/v1/controllers/BarcodePushController.js
@@ -10,7 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AuthPollStopError } from '@okta/okta-auth-js';
 import { loc } from 'okta';
 import FactorUtil from 'util/FactorUtil';
 import FormController from 'v1/util/FormController';

--- a/src/v1/controllers/BarcodePushController.js
+++ b/src/v1/controllers/BarcodePushController.js
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { AuthPollStopError } from '@okta/okta-auth-js';
 import { loc } from 'okta';
 import FactorUtil from 'util/FactorUtil';
 import FormController from 'v1/util/FormController';
@@ -53,7 +54,11 @@ export default FormController.extend({
   Footer: Footer,
 
   initialize: function() {
-    this.pollForEnrollment();
+    this.pollForEnrollment().catch((error)=>{
+      if (!(error instanceof AuthPollStopError)) {
+        this.trigger('error', this, error);
+      }
+    });
   },
 
   pollForEnrollment: function() {


### PR DESCRIPTION
## Description:

Auth-js throws an error when polling is stopped manually. In this case, user is moving to next screen which is a valid scenario and hence no need to show any error to user. 

For now the errors are ignored. We will be doing a cleanup based on the outcome of [OKTA-324849](https://oktainc.atlassian.net/browse/OKTA-324849)

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
For Before Video refer the the attachment in the [bug](https://oktainc.atlassian.net/browse/OKTA-482298).

After fix:

https://user-images.githubusercontent.com/94395085/168682582-ffb4cc51-805a-4a4d-8cd6-66b6e0edfbfa.mov


### Reviewers:
@indirathirumalaimurugan-okta @aarongranick-okta 

### Issue:

- [OKTA-482298](https://oktainc.atlassian.net/browse/OKTA-482298)


