### PR TITLE
feat: siw factor list enhancement

### DIFF
--- a/packages/@okta/i18n/src/properties/login.properties
+++ b/packages/@okta/i18n/src/properties/login.properties
@@ -1133,6 +1133,7 @@ oie.yubikey.passcode.label = Insert then tap your YubiKey
 
 ## Custom App Authenticator
 # {0} refers to the display name of the authenticator
+oie.custom.app.authenticator.title = Get a push notification
 oie.custom.app.authenticator.description = {0} is an authenticator app, installed on your phone, used to prove your identity
 
 ## Select authenticator enrollment

--- a/packages/@okta/i18n/src/properties/login_ok_PL.properties
+++ b/packages/@okta/i18n/src/properties/login_ok_PL.properties
@@ -827,6 +827,7 @@ oie.yubikey.enroll.title = 》Šéţ ûþ ÝûƀîĶéý โ⾼ئ䀕ヸ€홝한
 oie.yubikey.challenge.title = 》Ṽéŕîƒý ŵîţĥ ÝûƀîĶéý 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.yubikey.description = 》Îñšéŕţ ţĥé ÝûƀîĶéý îñţö å ÛŠƁ þöŕţ åñð ţåþ îţ ţö ĝéñéŕåţé å ṽéŕîƒîçåţîöñ çöðé· €홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.yubikey.passcode.label = 》Îñšéŕţ ţĥéñ ţåþ ýöûŕ ÝûƀîĶéý ヸ€홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
+oie.custom.app.authenticator.title = 》Ĝéţ å þûšĥ ñöţîƒîçåţîöñ 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.custom.app.authenticator.description = 》{0} îš åñ åûţĥéñţîçåţöŕ åþþ، îñšţåļļéð öñ ýöûŕ þĥöñé، ûšéð ţö þŕöṽé ýöûŕ îðéñţîţý 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.enroll.title = 》Šéţ ûþ šéçûŕîţý ɱéţĥöðš 한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《
 oie.select.authenticators.enroll.subtitle = 》Šéçûŕîţý ɱéţĥöðš ĥéļþ þŕöţéçţ ýöûŕ åççöûñţ ƀý éñšûŕîñĝ öñļý ýöû ĥåṽé åççéšš· 홝한Ӝฐโ⾼ئ䀕ヸ€홝한Ӝฐโ《

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
@@ -218,10 +218,22 @@
                       },
                       {
                         "name": "methodType",
-                        "value": "signed_nonce",
-                        "required": true,
-                        "mutable": false,
-                        "visible": false
+                        "type": "string",
+                        "required": false,
+                        "options": [
+                          {
+                            "label": "Enter a code",
+                            "value": "totp"
+                          },
+                          {
+                            "label": "Get a push notification",
+                            "value": "push"
+                          },
+                          {
+                            "label": "Use Okta FastPass",
+                            "value": "signed_nonce"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -242,7 +254,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[8]"
+                "relatesTo": "$.authenticatorEnrollments.value[9]"
               },
               {
                 "label": "Atko Custom On-prem",
@@ -264,7 +276,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[9]"
+                "relatesTo": "$.authenticatorEnrollments.value[10]"
               },
               {
                 "label": "RSA SecurID",
@@ -286,7 +298,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[10]"
+                "relatesTo": "$.authenticatorEnrollments.value[11]"
               },
               {
                 "label": "Duo Security",
@@ -308,7 +320,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[11]"
+                "relatesTo": "$.authenticatorEnrollments.value[12]"
               },
               {
                 "label": "IDP Authenticator",
@@ -324,7 +336,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[12]"
+                "relatesTo": "$.authenticatorEnrollments.value[13]"
               },
               {
                 "label": "Atko Custom OTP Authenticator",
@@ -346,7 +358,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[13]"
+                "relatesTo": "$.authenticatorEnrollments.value[14]"
               },
               {
                 "label": "Symantec VIP",
@@ -362,7 +374,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[14]"
+                "relatesTo": "$.authenticatorEnrollments.value[15]"
               },
               {
                 "label": "YubiKey Authenticator",
@@ -378,7 +390,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[15]"
+                "relatesTo": "$.authenticatorEnrollments.value[16]"
               },
               {
                 "label":"Custom Push App",
@@ -405,7 +417,7 @@
                       ]
                    }
                 },
-                "relatesTo":"$.authenticatorEnrollments.value[16]"
+                "relatesTo":"$.authenticatorEnrollments.value[17]"
               }
             ]
           },
@@ -498,15 +510,34 @@
         "id": "autwa6eD9o02iBbaaa82"
       },
       {
-        "displayName": "Okta Verify Device 1",
+        "profile": {
+          "deviceName": "iPhone"
+        },
         "type": "app",
         "key": "okta_verify",
-        "id": "aen1mz5J4cuNoaR3l0g4",
-        "authenticatorId": "auttheidkwh282hv8g3",
+        "id": "pfd4992vzbDhG7FO60g7",
+        "displayName": "Okta Verify",
         "methods": [
-           {
-            "type":  "signed_nonce"
-           }
+          {
+            "type": "push"
+          },
+          {
+            "type": "totp"
+          }
+        ]
+      },
+      {
+        "profile": {
+          "deviceName": "C02G10S7MD6T"
+        },
+        "type": "app",
+        "key": "okta_verify",
+        "id": "pfd49bj635JKDbHlX0g7",
+        "displayName": "Okta Verify",
+        "methods": [
+          {
+            "type": "signed_nonce"
+          }
         ]
       },
       {
@@ -608,7 +639,7 @@
         "key":"custom_app",
         "id":"pfd1bmoy4nH6heq2v0g4",
         "displayName":"Custom Push App",
-        "logoUri":"https://okta.oktacdn.com/assets/img/logos/custompushLogo.svg",
+        "logoUri":"https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4",
         "methods":[
           {
             "type":"push"

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
@@ -218,22 +218,10 @@
                       },
                       {
                         "name": "methodType",
-                        "type": "string",
-                        "required": false,
-                        "options": [
-                          {
-                            "label": "Enter a code",
-                            "value": "totp"
-                          },
-                          {
-                            "label": "Get a push notification",
-                            "value": "push"
-                          },
-                          {
-                            "label": "Use Okta FastPass",
-                            "value": "signed_nonce"
-                          }
-                        ]
+                        "value": "signed_nonce",
+                        "required": true,
+                        "mutable": false,
+                        "visible": false
                       }
                     ]
                   }
@@ -254,7 +242,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[9]"
+                "relatesTo": "$.authenticatorEnrollments.value[8]"
               },
               {
                 "label": "Atko Custom On-prem",
@@ -276,7 +264,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[10]"
+                "relatesTo": "$.authenticatorEnrollments.value[9]"
               },
               {
                 "label": "RSA SecurID",
@@ -298,7 +286,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[11]"
+                "relatesTo": "$.authenticatorEnrollments.value[10]"
               },
               {
                 "label": "Duo Security",
@@ -320,7 +308,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[12]"
+                "relatesTo": "$.authenticatorEnrollments.value[11]"
               },
               {
                 "label": "IDP Authenticator",
@@ -336,7 +324,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[13]"
+                "relatesTo": "$.authenticatorEnrollments.value[12]"
               },
               {
                 "label": "Atko Custom OTP Authenticator",
@@ -358,7 +346,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[14]"
+                "relatesTo": "$.authenticatorEnrollments.value[13]"
               },
               {
                 "label": "Symantec VIP",
@@ -374,7 +362,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[15]"
+                "relatesTo": "$.authenticatorEnrollments.value[14]"
               },
               {
                 "label": "YubiKey Authenticator",
@@ -390,7 +378,7 @@
                     ]
                   }
                 },
-                "relatesTo": "$.authenticatorEnrollments.value[16]"
+                "relatesTo": "$.authenticatorEnrollments.value[15]"
               },
               {
                 "label":"Custom Push App",
@@ -417,7 +405,7 @@
                       ]
                    }
                 },
-                "relatesTo":"$.authenticatorEnrollments.value[17]"
+                "relatesTo":"$.authenticatorEnrollments.value[16]"
               }
             ]
           },
@@ -510,34 +498,15 @@
         "id": "autwa6eD9o02iBbaaa82"
       },
       {
-        "profile": {
-          "deviceName": "iPhone"
-        },
+        "displayName": "Okta Verify Device 1",
         "type": "app",
         "key": "okta_verify",
-        "id": "pfd4992vzbDhG7FO60g7",
-        "displayName": "Okta Verify",
+        "id": "aen1mz5J4cuNoaR3l0g4",
+        "authenticatorId": "auttheidkwh282hv8g3",
         "methods": [
-          {
-            "type": "push"
-          },
-          {
-            "type": "totp"
-          }
-        ]
-      },
-      {
-        "profile": {
-          "deviceName": "C02G10S7MD6T"
-        },
-        "type": "app",
-        "key": "okta_verify",
-        "id": "pfd49bj635JKDbHlX0g7",
-        "displayName": "Okta Verify",
-        "methods": [
-          {
-            "type": "signed_nonce"
-          }
+           {
+            "type":  "signed_nonce"
+           }
         ]
       },
       {

--- a/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
+++ b/playground/mocks/data/idp/idx/authenticator-verification-select-authenticator.json
@@ -608,7 +608,7 @@
         "key":"custom_app",
         "id":"pfd1bmoy4nH6heq2v0g4",
         "displayName":"Custom Push App",
-        "logoUri":"https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4",
+        "logoUri":"/img/logos/default.png",
         "methods":[
           {
             "type":"push"

--- a/src/v2/ion/i18nTransformer.js
+++ b/src/v2/ion/i18nTransformer.js
@@ -88,6 +88,7 @@ const I18N_OVERRIDE_MAPPINGS = {
   'select-authenticator-authenticate.authenticator.symantec_vip': 'factor.totpHard.symantecVip',
   'select-authenticator-authenticate.authenticator.webauthn': 'oie.webauthn.label',
   'select-authenticator-authenticate.authenticator.yubikey_token': 'oie.yubikey.label',
+  'select-authenticator-authenticate.authenticator.custom_app': 'oie.custom.app.authenticator.title',
 
   'select-authenticator-unlock-account.authenticator.okta_email': 'oie.email.label',
   'select-authenticator-unlock-account.authenticator.phone_number': 'oie.phone.label',

--- a/src/v2/view-builder/utils/AuthenticatorUtil.js
+++ b/src/v2/view-builder/utils/AuthenticatorUtil.js
@@ -84,7 +84,7 @@ const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   case AUTHENTICATOR_KEY.OV:
     Object.assign(authenticatorData, {
       description: isVerifyAuthenticator
-        ? ''
+        ? loc('oie.okta_verify.label', 'login')
         : loc('oie.okta_verify.authenticator.description', 'login'),
       iconClassName: 'mfa-okta-verify',
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),
@@ -182,7 +182,7 @@ const getAuthenticatorData = function(authenticator, isVerifyAuthenticator) {
   case AUTHENTICATOR_KEY.CUSTOM_APP: {
     Object.assign(authenticatorData, {
       description: isVerifyAuthenticator
-        ? ''
+        ? authenticator?.relatesTo?.displayName
         : loc('oie.custom.app.authenticator.description', 'login', [authenticator.label]),
       buttonDataSeAttr: getButtonDataSeAttr(authenticator),
       logoUri : authenticator?.relatesTo?.logoUri || ''

--- a/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOktaVerify_spec.js
@@ -54,7 +54,7 @@ fixture('Select Method screen for Okta verify');
 
 async function verifyFactorByIndex(t, selectAuthenticatorPage, index, expectedLabel) {
   await t.expect(selectAuthenticatorPage.getFactorLabelByIndex(index)).eql(expectedLabel);
-  await t.expect(await selectAuthenticatorPage.factorDescriptionExistsByIndex(index)).eql(false);
+  await t.expect(selectAuthenticatorPage.getFactorDescriptionByIndex(index)).eql('Okta Verify');
   await t.expect(selectAuthenticatorPage.getFactorIconClassByIndex(index)).contains('mfa-okta-verify');
   await t.expect(selectAuthenticatorPage.getFactorSelectButtonByIndex(index)).eql('Select');
 }

--- a/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
+++ b/test/testcafe/spec/SelectAuthenticatorForVerification_spec.js
@@ -173,7 +173,7 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(5)).eql('security_question');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(6)).eql('Use Okta FastPass');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(6)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(6)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(6)).contains('mfa-okta-verify');
   await t.expect(await selectFactorPage.factorCustomLogoExist(6)).eql(false);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(6)).eql('Select');
@@ -236,8 +236,8 @@ test.requestHooks(mockChallengePassword)('should load select authenticator list'
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(14)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(14)).eql('yubikey_token');
 
-  await t.expect(selectFactorPage.getFactorLabelByIndex(15)).eql('Custom Push App');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(15)).eql(false);
+  await t.expect(selectFactorPage.getFactorLabelByIndex(15)).eql('Get a push notification');
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(15)).eql('Custom Push App');
   await t.expect(await selectFactorPage.factorCustomLogoExist(15)).eql(true);
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(15)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(15)).eql('custom_app');
@@ -359,13 +359,13 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
   await t.expect(selectFactorPage.getFactorsCount()).eql(4);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Get a push notification');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(0)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('okta_verify-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Enter a code');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(1)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('okta_verify-totp');
@@ -377,7 +377,7 @@ test.requestHooks(mockChallengeOVTotp)(`should load signed_nonce at bottom when 
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('okta_password');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(3)).eql('Use Okta FastPass');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(3)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(3)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(3)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(3)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(3)).eql('okta_verify-signed_nonce');
@@ -395,19 +395,19 @@ test.requestHooks(mockSelectAuthenticatorKnownDevice)('should load signed_nonce 
   await t.expect(selectFactorPage.getFactorsCount()).eql(4);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Use Okta FastPass');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(0)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('okta_verify-signed_nonce');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Get a push notification');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(1)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('okta_verify-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(2)).eql('Enter a code');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(2)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(2)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(2)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(2)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(2)).eql('okta_verify-totp');
@@ -435,13 +435,13 @@ test.requestHooks(mockSelectAuthenticatorNoSignedNonce)('should not display sign
   await t.expect(selectFactorPage.getFactorsCount()).eql(3);
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(0)).eql('Get a push notification');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(0)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(0)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(0)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(0)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(0)).eql('okta_verify-push');
 
   await t.expect(selectFactorPage.getFactorLabelByIndex(1)).eql('Enter a code');
-  await t.expect(await selectFactorPage.factorDescriptionExistsByIndex(1)).eql(false);
+  await t.expect(selectFactorPage.getFactorDescriptionByIndex(1)).eql('Okta Verify');
   await t.expect(selectFactorPage.getFactorIconClassByIndex(1)).contains('mfa-okta-verify');
   await t.expect(selectFactorPage.getFactorSelectButtonByIndex(1)).eql('Select');
   await t.expect(selectFactorPage.getFactorSelectButtonDataSeByIndex(1)).eql('okta_verify-totp');

--- a/test/unit/spec/v2/ion/i18nTransformer_spec.js
+++ b/test/unit/spec/v2/ion/i18nTransformer_spec.js
@@ -55,6 +55,7 @@ describe('v2/ion/i18nTransformer', function() {
       'oie.post.password.update.auth.failure.error': 'Authentication failed after password update.',
       'oie.phone.invalid': 'Invalid Phone',
       'oie.user.profile.firstname': 'User first name',
+      'oie.custom.app.authenticator.title': 'Get a push notification'
     }, (value) => `unit test - ${value}`);
   });
   afterAll(() => {
@@ -315,7 +316,15 @@ describe('v2/ion/i18nTransformer', function() {
                     'methodType': 'otp'
                   },
                   'authenticatorKey': 'rsa_token'
-                }
+                },
+                {
+                  'label': 'Get a push notification',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'push'
+                  },
+                  'authenticatorKey': 'custom_app'
+                },
               ],
               'label-top': true
             }
@@ -413,7 +422,15 @@ describe('v2/ion/i18nTransformer', function() {
                     'methodType': 'otp'
                   },
                   'authenticatorKey': 'rsa_token'
-                }
+                },
+                {
+                  'label': 'unit test - Get a push notification',
+                  'value': {
+                    'id': 'aid568g3mXgtID0HHSLH',
+                    'methodType': 'push'
+                  },
+                  'authenticatorKey': 'custom_app'
+                },
               ],
               'label-top': true
             }

--- a/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/FormInputFactory_spec.js
@@ -135,20 +135,75 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
           authenticatorKey: 'security_question',
         },
         {
-          label: 'Okta Verify',
+          label: 'Enter a code',
+          value: {
+            id: 'auttheidkwh282hv8g3',
+            methodType: 'totp',
+          },
+          relatesTo: {
+            profile: {
+              deviceName: 'iPhone',
+            },
+            type: 'app',
+            key: 'okta_verify',
+            id: 'pfd4992vzbDhG7FO60g7',
+            displayName: 'Okta Verify',
+            methods: [
+              {
+                type: 'push',
+              },
+              {
+                type: 'totp',
+              },
+            ],
+          },
+          authenticatorKey: 'okta_verify',
+        },
+        {
+          label: 'Get a push notification',
+          value: {
+            id: 'auttheidkwh282hv8g3',
+            methodType: 'push',
+          },
+          relatesTo: {
+            profile: {
+              deviceName: 'iPhone',
+            },
+            type: 'app',
+            key: 'okta_verify',
+            id: 'pfd4992vzbDhG7FO60g7',
+            displayName: 'Okta Verify',
+            methods: [
+              {
+                type: 'push',
+              },
+              {
+                type: 'totp',
+              },
+            ],
+          },
+          authenticatorKey: 'okta_verify',
+        },
+        {
+          label: 'Use Okta FastPass',
           value: {
             id: 'auttheidkwh282hv8g3',
             methodType: 'signed_nonce',
           },
           relatesTo: {
-            displayName: 'Okta Verify Device 1',
+            profile: {
+              deviceName: 'iPhone',
+            },
             type: 'app',
             key: 'okta_verify',
-            id: 'aen1mz5J4cuNoaR3l0g4',
-            authenticatorId: 'auttheidkwh282hv8g3',
+            id: 'pfd4992vzbDhG7FO60g7',
+            displayName: 'Okta Verify',
             methods: [
               {
-                type: 'signed_nonce',
+                type: 'push',
+              },
+              {
+                type: 'totp',
               },
             ],
           },
@@ -172,7 +227,30 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
             ]
           },
           authenticatorKey:'google_otp',
-        }
+        },
+        {
+          label: 'Get a push notification',
+          value: {
+            id: 'aut198w4v0f8dr8gT0g4',
+          },
+          relatesTo: {
+            profile: {
+              deviceName: 'Todd’s iPhone',
+            },
+            type: 'app',
+            key: 'custom_app',
+            id: 'pfd1bmoy4nH6heq2v0g4',
+            displayName: 'Custom Push App',
+            logoUri:
+              'https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4',
+            methods: [
+              {
+                type: 'push',
+              },
+            ],
+          },
+          authenticatorKey: 'custom_app',
+        },
       ],
     };
     // Create a copy of input object.
@@ -319,26 +397,87 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
         buttonDataSeAttr: 'security_question',
       },
       {
-        label: 'Okta Verify',
+        label: 'Enter a code',
+        value: {
+          id: 'auttheidkwh282hv8g3',
+          methodType: 'totp',
+        },
+        relatesTo: {
+          profile: {
+            deviceName: 'iPhone',
+          },
+          type: 'app',
+          key: 'okta_verify',
+          id: 'pfd4992vzbDhG7FO60g7',
+          displayName: 'Okta Verify',
+          methods: [
+            {
+              type: 'push',
+            },
+            {
+              type: 'totp',
+            },
+          ],
+        },
+        authenticatorKey: 'okta_verify',
+        description: 'Okta Verify',
+        iconClassName: 'mfa-okta-verify',
+        buttonDataSeAttr: 'okta_verify-totp',
+      },
+      {
+        label: 'Get a push notification',
+        value: {
+          id: 'auttheidkwh282hv8g3',
+          methodType: 'push',
+        },
+        relatesTo: {
+          profile: {
+            deviceName: 'iPhone',
+          },
+          type: 'app',
+          key: 'okta_verify',
+          id: 'pfd4992vzbDhG7FO60g7',
+          displayName: 'Okta Verify',
+          methods: [
+            {
+              type: 'push',
+            },
+            {
+              type: 'totp',
+            },
+          ],
+        },
+        authenticatorKey: 'okta_verify',
+        description: 'Okta Verify',
+        iconClassName: 'mfa-okta-verify',
+        buttonDataSeAttr: 'okta_verify-push',
+      },
+      {
+        label: 'Use Okta FastPass',
         value: {
           id: 'auttheidkwh282hv8g3',
           methodType: 'signed_nonce',
         },
         relatesTo: {
-          displayName: 'Okta Verify Device 1',
+          profile: {
+            deviceName: 'iPhone',
+          },
           type: 'app',
           key: 'okta_verify',
-          id: 'aen1mz5J4cuNoaR3l0g4',
-          authenticatorId: 'auttheidkwh282hv8g3',
+          id: 'pfd4992vzbDhG7FO60g7',
+          displayName: 'Okta Verify',
           methods: [
             {
-              'type':'signed_nonce'
-            }
-          ]
+              type: 'push',
+            },
+            {
+              type: 'totp',
+            },
+          ],
         },
-        'authenticatorKey':'okta_verify',
-        'description': '',
-        'iconClassName':'mfa-okta-verify',
+        authenticatorKey: 'okta_verify',
+        description: 'Okta Verify',
+        iconClassName: 'mfa-okta-verify',
         buttonDataSeAttr: 'okta_verify-signed_nonce',
       },
       {
@@ -362,7 +501,32 @@ describe('v2/view-builder/internals/FormInputFactory', function() {
         description:'',
         iconClassName:'mfa-google-auth',
         buttonDataSeAttr: 'google_otp',
-      }
+      },
+      {
+        label: 'Get a push notification',
+        value: {
+          id: 'aut198w4v0f8dr8gT0g4',
+        },
+        relatesTo: {
+          profile: {
+            deviceName: 'Todd’s iPhone',
+          },
+          type: 'app',
+          key: 'custom_app',
+          id: 'pfd1bmoy4nH6heq2v0g4',
+          displayName: 'Custom Push App',
+          logoUri: 'https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4',
+          methods: [
+            {
+              type: 'push',
+            },
+          ],
+        },
+        authenticatorKey: 'custom_app',
+        description: 'Custom Push App',
+        buttonDataSeAttr: 'custom_app',
+        logoUri: 'https://cdn.okta1.com/bc/globalFileStoreRecord?id=gfs3sti6DQ7A9vS3h0g4',
+      },
     ]);
     // make sure input parameter is not mutated.
     expect(opt).toEqual(input);


### PR DESCRIPTION
## Description:

Enhance Factor listing page (Authenticator Verify) to support below changes

Okta Verify Push will always show appName (Okta Verify) as subtext
Okta Verify TOTP will always show appName (Okta Verify) as subtext
Okta Verify FastPass will always show appName (Okta Verify) as subtext (Okta Verify)
Custom Authenticators will always show Authenticator Name as subtext 

See [JIRA](https://oktainc.atlassian.net/browse/OKTA-480735) for more details and figma link.

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [X] Added unit tests?

- [X] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES)

Monolith [bacon](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-b3be88d-6283c0ad&page=1&pageSize=6) is Green.

### Screenshot/Video:

![Screen Shot 2022-05-17 at 10 15 55 AM](https://user-images.githubusercontent.com/94395085/168843900-1024bb12-6dad-4a82-8048-552c6198e4a1.png)
![Screen Shot 2022-05-17 at 10 48 28 AM](https://user-images.githubusercontent.com/94395085/168843911-fb71a084-7520-4ae2-8907-52436e3f226d.png)

### Reviewers:

@indirathirumalaimurugan-okta @aarongranick-okta 

### Issue:

- [OKTA-480735](https://oktainc.atlassian.net/browse/OKTA-480735)


