### PR TITLE
fix: clears meta when interactionHandle is expired

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,8 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
+    'error-401-session-expired'
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,8 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
-    'error-401-session-expired'
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -186,7 +186,7 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     // }
   }
 
-  /* eslint max-statements: [2, 28], complexity: [2, 11] */
+  /* eslint max-statements: [2, 30], complexity: [2, 13] */
   async render(Controller, options = {}) {
     // If url changes then widget assumes that user's intention was to initiate a new login flow,
     // so clear stored token to use the latest token.

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -219,7 +219,6 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
             idxResp = await handleConfiguredFlow(idxResp, this.settings);
           }
 
-          console.log(idxResp);
           // TODO: OKTA-494979 - temporary fix, remove when auth-js is upgraded to 6.6+
           if (!idxResp.requestDidSucceed && IonHelper.isIdxSessionExpiredError(idxResp)) {
             // clear transaction subsequent page loads do not use stale interactionHandle

--- a/test/unit/spec/v2/BaseLoginRouter_spec.js
+++ b/test/unit/spec/v2/BaseLoginRouter_spec.js
@@ -250,7 +250,7 @@ describe('v2/BaseLoginRouter', function() {
       );
     });
 
-    fit('should clear transaction meta when `idx.session.expired` error occurs on /introspect', async function() {
+    it('should clear transaction meta when `idx.session.expired` error occurs on /introspect', async function() {
       const mockIdxState = {
         rawIdxState: IdxSessionExpiredError,
         requestDidSucceed: false,


### PR DESCRIPTION
## Description:
clears the transaction meta when bootstrapping idx response returns `idx.session.expired` (interactionHandle is expired).
otherwise stale interactionHandle is reused on every page load and user is in an unrecoverable failure state

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
![Screen Shot 2022-05-18 at 15 43 06](https://user-images.githubusercontent.com/90656038/169147847-ff7e7557-b673-4415-a50b-f20394c3044c.png)
(before) `/introspect` call fails due to stale interactionHandle

![Screen Shot 2022-05-18 at 16 10 21](https://user-images.githubusercontent.com/90656038/169147919-065646a6-7329-4af4-8ba6-7454459fa180.png)
(after) 1st `/introspect` call fails due to stale interactionHandle, subsequent page loads invoke `/interact` since meta was cleared 

### Reviewers:


### Issue:

- [OKTA-494979](https://oktainc.atlassian.net/browse/OKTA-494979)


