### PR TITLE
fix: registration preSubmit hook may add errorCauses; do not require erroKey

### DIFF
--- a/src/v2/view-builder/views/EnrollProfileView.js
+++ b/src/v2/view-builder/views/EnrollProfileView.js
@@ -50,7 +50,7 @@ const Body = BaseForm.extend({
     if (hasErrors) {
       error.responseJSON.errorCauses.forEach((err) => {
         // only do this for invalid password for password with SSR
-        if (err.errorKey.includes('password.passwordRequirementsNotMet')) {
+        if (err.errorKey?.includes('password.passwordRequirementsNotMet')) {
           err.errorSummary = loc('registration.error.password.passwordRequirementsNotMet', 'login');
         } 
       });


### PR DESCRIPTION
## Description:
A [change in 6.2.1](https://github.com/okta/okta-signin-widget/commit/7aa4e694a85033a6cc25e56b161a5c2f1847e1db#diff-352b703078d6d679795cb9dd15e41380a63fb4b32a44ea9eb6df61b814616913R51) caused a regression for some using the registration hooks. We cannot assume that errorKey will exist in an errorCause.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-496986](https://oktainc.atlassian.net/browse/OKTA-496986)


