### PR TITLE
Adds new config option: "backToSignInLink"

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,14 +980,6 @@ assets: {
 
 ### Links
 
-#### Sign out link
-
-Set the following config option to override the sign out link URL. If not provided, the widget will navigate to Primary Auth.
-
-```javascript
-signOutLink: 'https://www.signmeout.com'
-```
-
 #### Back to sign in link
 
 Set the following config option to override the back to sign in link URL. If not provided, the widget will navigate to Primary Auth.
@@ -995,6 +987,8 @@ Set the following config option to override the back to sign in link URL. If not
 ```javascript
 backToSignInLink: 'https://www.backtosignin.com'
 ```
+
+> **Note:** For compatibility with previous widget versions, `signOutLink` is accepted as an alias for `backToSignInLink`
 
 #### Sign up link
 

--- a/README.md
+++ b/README.md
@@ -988,6 +988,14 @@ Set the following config option to override the sign out link URL. If not provid
 signOutLink: 'https://www.signmeout.com'
 ```
 
+#### Back to sign in link
+
+Set the following config option to override the back to sign in link URL. If not provided, the widget will navigate to Primary Auth.
+
+```javascript
+backToSignInLink: 'https://www.backtosignin.com'
+```
+
 #### Sign up link
 
 You can add a registration link to the primary auth page by setting the following config options.

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -33,8 +33,11 @@ const local: Record<string, ModelProperty> = {
   recoveryToken: ['string', false, undefined],
   stateToken: ['string', false, undefined],
   username: ['string', false],
-  signOutLink: ['string', false],
   relayState: ['string', false],
+
+  // These two settings are aliases. Setting either value will set `backToSignInUri` 
+  signOutLink: ['string', false], // for backward compatibility
+  backToSignInLink: ['string', false], // preferred setting
 
   redirect: {
     type: 'string',
@@ -176,6 +179,12 @@ const local: Record<string, ModelProperty> = {
 };
 
 const derived: Record<string, ModelProperty>  = {
+  backToSignInUri: {
+    deps: ['backToSignInLink', 'signOutLink'],
+    fn: function(backToSignInLink, signOutLink) {
+      return backToSignInLink || signOutLink;
+    }
+  },
   showPasswordToggle: {
     deps: ['features.showPasswordToggleOnSignInPage'],
     fn: function() {

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -182,7 +182,7 @@ const derived: Record<string, ModelProperty>  = {
   backToSignInUri: {
     deps: ['backToSignInLink', 'signOutLink'],
     fn: function(backToSignInLink, signOutLink) {
-      return backToSignInLink || signOutLink;
+      return backToSignInLink || signOutLink; // prefer backToSignInLink over signOutLink, but they are aliases
     }
   },
   showPasswordToggle: {

--- a/src/v1/views/expired-password/Footer.js
+++ b/src/v1/views/expired-password/Footer.js
@@ -47,8 +47,8 @@ export default View.extend({
           }
         })
         .then(function() {
-          if (self.settings.get('signOutLink')) {
-            Util.redirect(self.settings.get('signOutLink'));
+          if (self.settings.get('backToSignInUri')) {
+            Util.redirect(self.settings.get('backToSignInUri'));
           } else {
             self.state.set('navigateDir', Enums.DIRECTION_BACK);
             self.options.appState.trigger('navigate', '');

--- a/src/v1/views/shared/FooterSignout.js
+++ b/src/v1/views/shared/FooterSignout.js
@@ -38,8 +38,8 @@ export default View.extend({
         return transaction.cancel();
       })
       .then(() => {
-        if (this.settings.get('signOutLink') && !isSMSPasswordRecovery) {
-          Util.redirect(this.settings.get('signOutLink'));
+        if (this.settings.get('backToSignInUri') && !isSMSPasswordRecovery) {
+          Util.redirect(this.settings.get('backToSignInUri'));
         } else {
           this.state.set('navigateDir', Enums.DIRECTION_BACK);
           appState.trigger('navigate', '');

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -95,27 +95,18 @@ const getSkipSetupLink = (appState, linkName) => {
   return [];
 };
 
+// When there is a 'cancel' object in remediation
 const getSignOutLink = (settings, options = {}) => {
-
-  // backToSignInLink: to override back to sign in link
-  if (settings?.get('backToSignInLink')) {
+  if (settings?.get('backToSignInUri')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('backToSignInLink')
+        'href': settings.get('backToSignInUri')
       },
     ];
   }
-  else if (settings?.get('signOutLink')) {
-    return [
-      {
-        'label': loc('signout', 'login'),
-        'name': 'cancel',
-        'href': settings.get('signOutLink')
-      },
-    ];
-  } else {
+  else {
     return [
       {
         'actionPath': 'cancel',
@@ -131,9 +122,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // backToSignInLink: to override back to sign in link
-  if (settings?.get('backToSignInLink')) {
-    link.href = settings.get('backToSignInLink');
+  // If backToSignInLink is set, use this value for all scenarios
+  if (settings?.get('backToSignInUri')) {
+    link.href = settings.get('backToSignInUri');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {
@@ -141,7 +132,7 @@ const getBackToSignInLink = ({settings, appState}) => {
       appState.trigger('restartLoginFlow');
     };
   }
-  // okta-hosted scenarios
+  // fallback for okta-hosted scenarios (backend should set signOutLink or backToSignOutLink)
   else {
     link.href = settings?.get('baseUrl');
   }

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -106,16 +106,15 @@ const getSignOutLink = (settings, options = {}) => {
       },
     ];
   }
-  else {
-    return [
-      {
-        'actionPath': 'cancel',
-        'label': !options.label ? loc('goback', 'login') : options.label,
-        'name': 'cancel',
-        'type': 'link'
-      },
-    ];
-  }
+
+  return [
+    {
+      'actionPath': 'cancel',
+      'label': !options.label ? loc('goback', 'login') : options.label,
+      'name': 'cancel',
+      'type': 'link'
+    },
+  ];
 };
 
 // Use it to create a widget configured link in the absence of `cancel` object in remediation

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appLoginUri to redirect to current app
-  if (settings?.get('appLoginUri')) {
+  // backToSignInLink to redirect to current app
+  if (settings?.get('backToSignInLink')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appLoginUri')
+        'href': settings.get('backToSignInLink')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appLoginUri to redirect to current app
-  if (settings?.get('appLoginUri')) {
-    link.href = settings.get('appLoginUri');
+  // backToSignInLink to redirect to current app
+  if (settings?.get('backToSignInLink')) {
+    link.href = settings.get('backToSignInLink');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,7 +97,7 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // backToSignInLink to redirect to current app
+  // backToSignInLink: to override back to sign in link
   if (settings?.get('backToSignInLink')) {
     return [
       {
@@ -131,7 +131,7 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // backToSignInLink to redirect to current app
+  // backToSignInLink: to override back to sign in link
   if (settings?.get('backToSignInLink')) {
     link.href = settings.get('backToSignInLink');
   }

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -105,7 +105,7 @@ const getSignOutLink = (settings, options = {}) => {
         'name': 'cancel',
         'href': settings.get('appTerminationRedirectUri')
       },
-    ]
+    ];
   }
   else if (settings?.get('signOutLink')) {
     return [

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appLoginRedirectUri to redirect to current app
-  if (settings?.get('appLoginRedirectUri')) {
+  // appLoginUri to redirect to current app
+  if (settings?.get('appLoginUri')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appLoginRedirectUri')
+        'href': settings.get('appLoginUri')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appLoginRedirectUri to redirect to current app
-  if (settings?.get('appLoginRedirectUri')) {
-    link.href = settings.get('appLoginRedirectUri');
+  // appLoginUri to redirect to current app
+  if (settings?.get('appLoginUri')) {
+    link.href = settings.get('appLoginUri');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -96,7 +96,18 @@ const getSkipSetupLink = (appState, linkName) => {
 };
 
 const getSignOutLink = (settings, options = {}) => {
-  if (settings?.get('signOutLink')) {
+
+  // appTerminationRedirectUri to redirect to current app
+  if (settings?.get('appTerminationRedirectUri')) {
+    return [
+      {
+        'label': loc('goback', 'login'),
+        'name': 'cancel',
+        'href': settings.get('appTerminationRedirectUri')
+      },
+    ]
+  }
+  else if (settings?.get('signOutLink')) {
     return [
       {
         'label': loc('signout', 'login'),
@@ -120,8 +131,12 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
+  // appTerminationRedirectUri to redirect to current app
+  if (settings?.get('appTerminationRedirectUri')) {
+    link.href = settings.get('appTerminationRedirectUri');
+  }
   // embedded scenarios
-  if (settings?.get('useInteractionCodeFlow')) {
+  else if (settings?.get('useInteractionCodeFlow')) {
     link.clickHandler = () => {
       appState.trigger('restartLoginFlow');
     };

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -97,13 +97,13 @@ const getSkipSetupLink = (appState, linkName) => {
 
 const getSignOutLink = (settings, options = {}) => {
 
-  // appTerminationRedirectUri to redirect to current app
-  if (settings?.get('appTerminationRedirectUri')) {
+  // appLoginRedirectUri to redirect to current app
+  if (settings?.get('appLoginRedirectUri')) {
     return [
       {
         'label': loc('goback', 'login'),
         'name': 'cancel',
-        'href': settings.get('appTerminationRedirectUri')
+        'href': settings.get('appLoginRedirectUri')
       },
     ];
   }
@@ -131,9 +131,9 @@ const getSignOutLink = (settings, options = {}) => {
 const getBackToSignInLink = ({settings, appState}) => {
   const link = {};
 
-  // appTerminationRedirectUri to redirect to current app
-  if (settings?.get('appTerminationRedirectUri')) {
-    link.href = settings.get('appTerminationRedirectUri');
+  // appLoginRedirectUri to redirect to current app
+  if (settings?.get('appLoginRedirectUri')) {
+    link.href = settings.get('appLoginRedirectUri');
   }
   // embedded scenarios
   else if (settings?.get('useInteractionCodeFlow')) {

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -114,6 +114,7 @@ test.requestHooks(xhrSelectAuthenticatorMock)('should show custom signout link',
     'signOutLink': 'https://okta.okta.com/',
   });
   await t.expect(selectAuthenticatorPageObject.getCustomSignOutLink()).eql('https://okta.okta.com/');
+  await t.expecct(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
 });
 
 test.requestHooks(identifyMock)('should show custom buttons links', async t => {

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -117,6 +117,16 @@ test.requestHooks(xhrSelectAuthenticatorMock)('should show custom signout link',
   await t.expecct(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
 });
 
+test.requestHooks(xhrSelectAuthenticatorMock)('can customize back to signin link using `backToSignInLink`', async t => {
+  // setup selectAuthenticatorPageObject to see the signout link
+  const selectAuthenticatorPageObject = await setupSelectAuthenticator(t);
+  await rerenderWidget({
+    'backToSignInLink': 'https://okta.okta.com/',
+  });
+  await t.expect(selectAuthenticatorPageObject.getCustomSignOutLink()).eql('https://okta.okta.com/');
+  await t.expecct(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
+});
+
 test.requestHooks(identifyMock)('should show custom buttons links', async t => {
   const identityPage = await setup(t);
   await rerenderWidget({

--- a/test/testcafe/spec/WidgetCustomization_spec.js
+++ b/test/testcafe/spec/WidgetCustomization_spec.js
@@ -114,7 +114,7 @@ test.requestHooks(xhrSelectAuthenticatorMock)('should show custom signout link',
     'signOutLink': 'https://okta.okta.com/',
   });
   await t.expect(selectAuthenticatorPageObject.getCustomSignOutLink()).eql('https://okta.okta.com/');
-  await t.expecct(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
+  await t.expect(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
 });
 
 test.requestHooks(xhrSelectAuthenticatorMock)('can customize back to signin link using `backToSignInLink`', async t => {
@@ -124,7 +124,7 @@ test.requestHooks(xhrSelectAuthenticatorMock)('can customize back to signin link
     'backToSignInLink': 'https://okta.okta.com/',
   });
   await t.expect(selectAuthenticatorPageObject.getCustomSignOutLink()).eql('https://okta.okta.com/');
-  await t.expecct(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
+  await t.expect(selectAuthenticatorPageObject.getSignoutLinkText()).eql('Back to sign in');
 });
 
 test.requestHooks(identifyMock)('should show custom buttons links', async t => {

--- a/test/unit/spec/Settings_spec.js
+++ b/test/unit/spec/Settings_spec.js
@@ -72,4 +72,19 @@ describe('models/Settings', () => {
       expect(spy).toHaveBeenCalled();
     });
   });
+
+  describe('backToSignInUri', () => {
+    it('can be set using `signOutLink`', () => {
+      const settings = new Settings({ baseUrl: 'http://base', signOutLink: 'http://foo' });
+      expect(settings.get('backToSignInUri')).toBe('http://foo');
+    });
+    it('can be set using `backToSignInLink`', () => {
+      const settings = new Settings({ baseUrl: 'http://base', backToSignInLink: 'http://foo' });
+      expect(settings.get('backToSignInUri')).toBe('http://foo');
+    });
+    it('`backToSignInLink` takes precedence over `signOutLink`', () => {
+      const settings = new Settings({ baseUrl: 'http://base', backToSignInLink: 'http://foo', signOutLink: 'http://bar' });
+      expect(settings.get('backToSignInUri')).toBe('http://foo');
+    });
+  });
 });

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -2456,7 +2456,10 @@ Expect.describe('MFA Verify', function() {
               spyOn(SharedUtil, 'redirect');
               Util.resetAjaxRequests();
               test.setNextResponse(resCancel);
-              test.form.signoutLink($sandbox).click();
+              const $signOut = test.form.signoutLink($sandbox);
+              expect($signOut.text()).toBe('Back to sign in');
+              expect($signOut.attr('href')).toBe('http://www.goodbye.com');
+              $signOut.click();
               return Expect.wait(function() {
                 return RouterUtil.routeAfterAuthStatusChange.calls.count() > 0;
               }, test);

--- a/test/unit/spec/v1/MfaVerify_spec.js
+++ b/test/unit/spec/v1/MfaVerify_spec.js
@@ -2458,7 +2458,6 @@ Expect.describe('MFA Verify', function() {
               test.setNextResponse(resCancel);
               const $signOut = test.form.signoutLink($sandbox);
               expect($signOut.text()).toBe('Back to sign in');
-              expect($signOut.attr('href')).toBe('http://www.goodbye.com');
               $signOut.click();
               return Expect.wait(function() {
                 return RouterUtil.routeAfterAuthStatusChange.calls.count() > 0;

--- a/test/unit/spec/v1/PasswordExpired_spec.js
+++ b/test/unit/spec/v1/PasswordExpired_spec.js
@@ -346,6 +346,9 @@ Expect.describe('PasswordExpiration', function() {
               resSessionActive,
               resSessionDeleted
             ]);
+            const $signOut = test.form.signoutLink($sandbox);
+            expect($signOut.text()).toBe('Back to sign in');
+            expect($signOut.attr('href')).toBe('http://www.goodbye.com');
             test.form.signout();
             return Expect.waitForAjaxRequest(test);
           })

--- a/test/unit/spec/v1/PasswordExpired_spec.js
+++ b/test/unit/spec/v1/PasswordExpired_spec.js
@@ -348,7 +348,6 @@ Expect.describe('PasswordExpiration', function() {
             ]);
             const $signOut = test.form.signoutLink($sandbox);
             expect($signOut.text()).toBe('Back to sign in');
-            expect($signOut.attr('href')).toBe('http://www.goodbye.com');
             test.form.signout();
             return Expect.waitForAjaxRequest(test);
           })

--- a/test/unit/spec/v1/PasswordExpired_spec.js
+++ b/test/unit/spec/v1/PasswordExpired_spec.js
@@ -347,7 +347,7 @@ Expect.describe('PasswordExpiration', function() {
               resSessionDeleted
             ]);
             const $signOut = test.form.signoutLink($sandbox);
-            expect($signOut.text()).toBe('Back to sign in');
+            expect($signOut.text()).toBe('Sign Out'); // The link on this view says "Sign Out" instead of "Back to sign in"
             test.form.signout();
             return Expect.waitForAjaxRequest(test);
           })

--- a/test/unit/spec/v1/PasswordReset_spec.js
+++ b/test/unit/spec/v1/PasswordReset_spec.js
@@ -168,7 +168,6 @@ Expect.describe('PasswordReset', function() {
         test.setNextResponse(res200);
         const $signOut = test.form.signoutLink($sandbox);
         expect($signOut.text()).toBe('Back to sign in');
-        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
         $signOut.click();
         return Expect.waitForAjaxRequest(test);
       })

--- a/test/unit/spec/v1/PasswordReset_spec.js
+++ b/test/unit/spec/v1/PasswordReset_spec.js
@@ -166,11 +166,10 @@ Expect.describe('PasswordReset', function() {
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
-        const $link = test.form.signoutLink();
-
-        expect($link.length).toBe(1);
-        expect($link.text()).toBe('Back to sign in');
-        $link.click();
+        const $signOut = test.form.signoutLink($sandbox);
+        expect($signOut.text()).toBe('Back to sign in');
+        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
+        $signOut.click();
         return Expect.waitForAjaxRequest(test);
       })
       .then(test => {

--- a/test/unit/spec/v1/RecoveryChallenge_spec.js
+++ b/test/unit/spec/v1/RecoveryChallenge_spec.js
@@ -123,11 +123,10 @@ Expect.describe('RecoveryChallenge', function() {
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
-        const $link = test.form.signoutLink();
-
-        expect($link.length).toBe(1);
-        expect($link.text()).toBe('Back to sign in');
-        $link.click();
+        const $signOut = test.form.signoutLink($sandbox);
+        expect($signOut.text()).toBe('Back to sign in');
+        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
+        $signOut.click();
         return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
       })
       .then(function(test) {

--- a/test/unit/spec/v1/RecoveryChallenge_spec.js
+++ b/test/unit/spec/v1/RecoveryChallenge_spec.js
@@ -125,7 +125,6 @@ Expect.describe('RecoveryChallenge', function() {
         test.setNextResponse(res200);
         const $signOut = test.form.signoutLink($sandbox);
         expect($signOut.text()).toBe('Back to sign in');
-        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
         $signOut.click();
         return Expect.waitForSpyCall(test.router.controller.options.appState.clearLastAuthResponse, test);
       })

--- a/test/unit/spec/v1/RecoveryQuestion_spec.js
+++ b/test/unit/spec/v1/RecoveryQuestion_spec.js
@@ -98,7 +98,6 @@ Expect.describe('RecoveryQuestion', function() {
         test.setNextResponse(res200);
         const $signOut = test.form.signoutLink($sandbox);
         expect($signOut.text()).toBe('Back to sign in');
-        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
         $signOut.click();
         return Expect.waitForSpyCall(SharedUtil.redirect, test);
       })

--- a/test/unit/spec/v1/RecoveryQuestion_spec.js
+++ b/test/unit/spec/v1/RecoveryQuestion_spec.js
@@ -96,11 +96,10 @@ Expect.describe('RecoveryQuestion', function() {
         spyOn(SharedUtil, 'redirect');
         Util.resetAjaxRequests();
         test.setNextResponse(res200);
-        const $link = test.form.signoutLink();
-
-        expect($link.length).toBe(1);
-        expect($link.text()).toBe('Back to sign in');
-        $link.click();
+        const $signOut = test.form.signoutLink($sandbox);
+        expect($signOut.text()).toBe('Back to sign in');
+        expect($signOut.attr('href')).toBe('http://www.goodbye.com');
+        $signOut.click();
         return Expect.waitForSpyCall(SharedUtil.redirect, test);
       })
       .then(function(test) {

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -113,82 +113,183 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getBackToSignInLink', () => {
-    const appState = {
-      set: jest.fn(),
-      trigger: jest.fn(),
-    };
-
-    jest.spyOn(appState, 'set');
-    jest.spyOn(appState, 'trigger');
-
-    it('returns `href` with value of `baseUrl`', () => {
-      const settings = new Settings({
-        baseUrl: 'https://foo',
-        useInteractionCodeFlow: false
-      });
-      const result = getBackToSignInLink({appState, settings});
-      expect(result).toBeInstanceOf(Array);
-      expect(result[0]).toMatchObject({
-        type: 'link',
-        label: expect.any(String),   // this field could change, ignore for testing
-        name: 'go-back',
-        href: 'https://foo',
-      });
-      expect(result[0].clickHandler).toBeUndefined();
+    let appState;
+    beforeEach(() => {
+      appState = {
+        set: jest.fn(),
+        trigger: jest.fn(),
+      };
+  
+      jest.spyOn(appState, 'set');
+      jest.spyOn(appState, 'trigger');
     });
 
-    it('returns `clickHandler` instead of `href` whe using interactionCodeFlow', () => {
-      const settings = new Settings({
-        baseUrl: 'https://foo',
-        useInteractionCodeFlow: true
+    describe('stateToken flow', () => {
+      it('by default, returns `href` with value of `baseUrl`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo'
+        });
+        const result = getBackToSignInLink({appState, settings});
+        expect(result).toBeInstanceOf(Array);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          href: 'https://foo',
+        });
+        expect(result[0].clickHandler).toBeUndefined();
       });
-      const result = getBackToSignInLink({appState, settings});
-      expect(result).toBeInstanceOf(Array);
-      expect(result[0]).toMatchObject({
-        type: 'link',
-        label: expect.any(String),   // this field could change, ignore for testing
-        name: 'go-back',
-        clickHandler: expect.any(Function)
+
+      it('if `backToSignInLink` is set, returns `href` with value of `backToSignInLink`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo',
+          backToSignInLink: 'https://okta.com',
+        });
+        const result = getBackToSignInLink({ appState, settings });
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          href: 'https://okta.com',
+        });
+        expect(result[0].clickHandler).toBeUndefined();
       });
-      expect(result[0].href).toBeUndefined();
+
+      it('(compat) if `signOutLink` is set, returns `href` with value of `signOutLink`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo',
+          signOutLink: 'https://okta.com',
+        });
+        const result = getBackToSignInLink({ appState, settings });
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          href: 'https://okta.com',
+        });
+        expect(result[0].clickHandler).toBeUndefined();
+      });
     });
 
-    it('returns `href` with value of `backToSignInLink`', () => {
-      const settings = new Settings({
-        baseUrl: 'https://foo',
-        useInteractionCodeFlow: true,
-        backToSignInLink: 'https://okta.com',
+    describe('interaction code flow', () => {
+      it('by default, returns `clickHandler` instead of `href`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo',
+          useInteractionCodeFlow: true
+        });
+        const result = getBackToSignInLink({appState, settings});
+        expect(result).toBeInstanceOf(Array);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          clickHandler: expect.any(Function)
+        });
+        expect(result[0].href).toBeUndefined();
       });
-      const result = getBackToSignInLink({ appState, settings });
-      expect(result).toBeInstanceOf(Array);
-      expect(result).toHaveLength(1);
-      expect(result[0]).toMatchObject({
-        type: 'link',
-        label: expect.any(String),   // this field could change, ignore for testing
-        name: 'go-back',
-        href: 'https://okta.com',
-      });
-      expect(result[0].clickHandler).toBeUndefined();
-    });
 
+      it('if `backToSignInLink` is set, returns `href` with value of `backToSignInLink`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo',
+          useInteractionCodeFlow: true,
+          backToSignInLink: 'https://okta.com',
+        });
+        const result = getBackToSignInLink({ appState, settings });
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          href: 'https://okta.com',
+        });
+        expect(result[0].clickHandler).toBeUndefined();
+      });
+
+      it('(compat) if `signOutLink` is set, returns `href` with value of `signOutLink`', () => {
+        const settings = new Settings({
+          baseUrl: 'https://foo',
+          useInteractionCodeFlow: true,
+          signOutLink: 'https://okta.com',
+        });
+        const result = getBackToSignInLink({ appState, settings });
+        expect(result).toBeInstanceOf(Array);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          type: 'link',
+          label: 'Back to sign in',
+          name: 'go-back',
+          href: 'https://okta.com',
+        });
+        expect(result[0].clickHandler).toBeUndefined();
+      });
+    });
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `backToSignInLink`', () => {
+
+    it('by default returns a link to cancel action', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo'
+      });
+      const result = getSignOutLink(settings);
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        label: 'Back to sign in',
+        name: 'cancel',
+        type: 'link',
+        actionPath: 'cancel'
+      });
+    });
+
+    it('can override the label', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo'
+      });
+      const result = getSignOutLink(settings, { label: 'foo' });
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        label: 'foo',
+        name: 'cancel',
+        type: 'link',
+        actionPath: 'cancel'
+      });
+    });
+
+    it('if `backToSignInLink` is set, returns `href` with value of `backToSignInLink`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
-        useInteractionCodeFlow: false,
         backToSignInLink: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
-        label: expect.any(String),   // this field could change, ignore for testing
+        label: 'Back to sign in',
         name: 'cancel',
         href: 'https://okta.com',
       });
-      expect(result[0].clickHandler).toBeUndefined();
+    });
+
+    it('(compat) if `signOutLink` is set, returns `href` with value of `signOutLink`', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        signOutLink: 'https://okta.com',
+      });
+      const result = getSignOutLink(settings);
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        label: 'Back to sign in',
+        name: 'cancel',
+        href: 'https://okta.com',
+      });
     });
 
   });

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -1,6 +1,6 @@
 import AppState from 'v2/models/AppState';
 import { FORMS } from 'v2/ion/RemediationConstants';
-import { getSwitchAuthenticatorLink, getFactorPageCustomLink, getBackToSignInLink } from 'v2/view-builder/utils/LinksUtil';
+import { getSwitchAuthenticatorLink, getFactorPageCustomLink, getBackToSignInLink, getSignOutLink } from 'v2/view-builder/utils/LinksUtil';
 import Settings from '../../../../../../src/models/Settings';
 
 describe('v2/utils/LinksUtil', function() {
@@ -152,5 +152,44 @@ describe('v2/utils/LinksUtil', function() {
       });
       expect(result[0].href).toBeUndefined();
     });
+
+    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        useInteractionCodeFlow: true,
+        appTerminationRedirectUri: 'https://okta.com',
+      });
+      const result = getBackToSignInLink({ appState, settings });
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'link',
+        label: expect.any(String),   // this field could change, ignore for testing
+        name: 'go-back',
+        href: 'https://okta.com',
+      });
+      expect(result[0].clickHandler).toBeUndefined();
+    });
+
+  });
+
+  describe('getSignOutLink', () => {
+    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+      const settings = new Settings({
+        baseUrl: 'https://foo',
+        useInteractionCodeFlow: false,
+        appTerminationRedirectUri: 'https://okta.com',
+      });
+      const result = getSignOutLink(settings);
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        label: expect.any(String),   // this field could change, ignore for testing
+        name: 'cancel',
+        href: 'https://okta.com',
+      });
+      expect(result[0].clickHandler).toBeUndefined();
+    });
+
   });
 });

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appLoginUri`', () => {
+    it('returns `href` with value of `backToSignInLink`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appLoginUri: 'https://okta.com',
+        backToSignInLink: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appLoginUri`', () => {
+    it('returns `href` with value of `backToSignInLink`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appLoginUri: 'https://okta.com',
+        backToSignInLink: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+    it('returns `href` with value of `appLoginRedirectUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appTerminationRedirectUri: 'https://okta.com',
+        appLoginRedirectUri: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appTerminationRedirectUri`', () => {
+    it('returns `href` with value of `appLoginRedirectUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appTerminationRedirectUri: 'https://okta.com',
+        appLoginRedirectUri: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -153,11 +153,11 @@ describe('v2/utils/LinksUtil', function() {
       expect(result[0].href).toBeUndefined();
     });
 
-    it('returns `href` with value of `appLoginRedirectUri`', () => {
+    it('returns `href` with value of `appLoginUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: true,
-        appLoginRedirectUri: 'https://okta.com',
+        appLoginUri: 'https://okta.com',
       });
       const result = getBackToSignInLink({ appState, settings });
       expect(result).toBeInstanceOf(Array);
@@ -174,11 +174,11 @@ describe('v2/utils/LinksUtil', function() {
   });
 
   describe('getSignOutLink', () => {
-    it('returns `href` with value of `appLoginRedirectUri`', () => {
+    it('returns `href` with value of `appLoginUri`', () => {
       const settings = new Settings({
         baseUrl: 'https://foo',
         useInteractionCodeFlow: false,
-        appLoginRedirectUri: 'https://okta.com',
+        appLoginUri: 'https://okta.com',
       });
       const result = getSignOutLink(settings);
       expect(result).toBeInstanceOf(Array);


### PR DESCRIPTION
## Description:

- New config option "backToSignInLink" aliases existing option "signOutLink" (retained for backward compatibility) to set the value of the "href" in the "Back to sign in" link appearing on almost every screen
- Option is supported for both Okta-hosted and embedded deployments
- Option is supported for both V1 and V2
- Fixes a bug where "Sign Out" was used as the text on this button when "signOutLink" option is used OKTA-498519
- Retains behavior where "Sign Out" is set as label on PasswordExpired screen in V1 (not related to "signOutLink" option)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-499623](https://oktainc.atlassian.net/browse/OKTA-499623)


