### PR TITLE
fixes language override error

### DIFF
--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -213,7 +213,7 @@ const derived: Record<string, ModelProperty>  = {
   languageCode: {
     deps: ['language', 'supportedLanguages'],
     fn: function(language, supportedLanguages) {
-      const userLanguages = BrowserFeatures.getUserLanguages();
+      let userLanguages = BrowserFeatures.getUserLanguages();
 
       // TODO: revisit this fix - OKTA-491150
       userLanguages.forEach((val, idx) => {


### PR DESCRIPTION
when set to const can't override the locale. We got error in our Okta preview environment.

