### PR TITLE
fixes dutch/portuguese issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/src/util/BrowserFeatures.ts
+++ b/src/util/BrowserFeatures.ts
@@ -86,7 +86,7 @@ fn.isIOS = function() {
 fn.getUserLanguages = function() {
   // Chrome, Firefox
   if (navigator.languages) {
-    return navigator.languages;
+    return [...navigator.languages];
   }
 
   const languages = [];

--- a/test/unit/spec/UtilBrowserFeatures_spec.js
+++ b/test/unit/spec/UtilBrowserFeatures_spec.js
@@ -8,7 +8,7 @@ describe('util/BrowserFeatures', () => {
       let result = null;
       try {
         result = BrowserFeatures.getUserLanguages();
-        result[0] = 'foo'
+        result[0] = 'foo';
       }
       catch (err) {
         errorThrown = true;

--- a/test/unit/spec/UtilBrowserFeatures_spec.js
+++ b/test/unit/spec/UtilBrowserFeatures_spec.js
@@ -1,0 +1,20 @@
+import BrowserFeatures from 'util/BrowserFeatures';
+
+describe('util/BrowserFeatures', () => {
+  describe('getUserLanguages', () => {
+    it('returns a non-read-only array on Chrome/Firefox', () => {
+      jest.spyOn(navigator, 'languages', 'get').mockImplementation(() => Object.freeze(['en_US', 'en']));
+      let errorThrown = false;
+      let result = null;
+      try {
+        result = BrowserFeatures.getUserLanguages();
+        result[0] = 'foo'
+      }
+      catch (err) {
+        errorThrown = true;
+      }
+      expect(errorThrown).toBe(false);
+      expect(result[0]).toBe('foo');
+    });
+  });
+});


### PR DESCRIPTION
## Description:
SIW language detection logic uses `navigator.languages`, a browser API which returns a _read only_ array of user preferred languages. An attempt is made to manipulate this array (indirectly), but doing so causes an error to be throw

```javascript
Uncaught TypeError: Cannot assign to read only property '0' of object '[object Array]'
```

This PR fixes this issue by cloning the array returned from `navigator.languages`, so it is no longer read-only when consumed.

Issue was introduced by OKTA-491150 changes

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:

https://user-images.githubusercontent.com/90656038/170540506-30f11306-5508-4f43-b2b5-7c6f800c49f9.mov


### Reviewers:


### Issue:
- [OKTA-501779](https://oktainc.atlassian.net/browse/OKTA-501779)


