### PR TITLE
Add synthetic imports for Angular apps

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -28,6 +28,20 @@ The existing `.widgetrc` file used to configure the Widget has been **removed**.
 
 ## Migrating from 5.x to 6.x
 
+### Enable synthetic imports for TypeScript apps
+
+If you're using TypeScript, you'll need to enable synthetic imports in your `tsconfig.json`.
+
+```json
+{
+  ...
+  "angularCompilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    ...
+  }
+}
+```
+
 ### Minimum version of `@okta/okta-auth-js` is `6.0.0`
 
 If you are creating an instance of [@okta/okta-auth-js](https://github.com/okta/okta-auth-js) and passing it to the widget using the [authClient](https://github.com/okta/okta-signin-widget#authClient) option, the instance must be version `6.0.0` or higher.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,18 @@ npm install @okta/okta-signin-widget --save
 
 This installs the latest version of the Sign-in Widget to your project's `node_modules` directory.
 
+**NOTE:** If you're using TypeScript, you'll need to enable synthetic imports in your `tsconfig.json`.
+
+```json
+{
+  ...
+  "angularCompilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    ...
+  }
+}
+```
+
 The widget source files and assets are installed to `node_modules/@okta/okta-signin-widget/dist`, and have this directory structure:
 
 ```bash


### PR DESCRIPTION
## Description:

I get a ton of errors when upgrading the Okta CLI’s Angular widget sample to use Sign-In Widget 6.3.3. Here’s a sampling:

```
Error: node_modules/@okta/okta-signin-widget/types/packages/@okta/courage-dist/types/courage/util/handlebars/helper-i18n.d.ts:1:8 - error TS1259: Module '"handlebars"' can only be default-imported using the 'allowSyntheticDefaultImports' flag

1 import Handlebars from 'handlebars';
```

### Reviewers:

@aarongranick-okta 

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


