### PR TITLE
Remove the background image from the custom-checkbox label class

### DIFF
--- a/assets/sass/modules/_forms.scss
+++ b/assets/sass/modules/_forms.scss
@@ -223,7 +223,7 @@
 
 .custom-checkbox {
   label {
-    background-image: url('../img/ui/forms/checkbox-sign-in-widget.png');
+    background-image: none;
   }
 
   label.focus {
@@ -240,8 +240,7 @@
   only screen and (min-resolution: 2dppx) {
   .custom-checkbox {
     label {
-      background-image: url('../img/ui/forms/checkbox-sign-in-widget@2x.png');
-      background-size: 50px 1155px;
+      background-image: none;
     }
   }
 }


### PR DESCRIPTION
## Description:
The background image in the label of the `custom-checkbox` css class is showing up in our css outside of the Okta widget, and it does not seem clear that the image should be there in the first place since it seems to be an example of different possible checkbox states.  This PR is to remove that image from the label so it doesn't affect the css of projects which include this project.


## PR Checklist

- [✓] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)
No
### Screenshot/Video:

Image of checkbox with the image:
<img width="279" alt="chechbox-bg-image" src="https://user-images.githubusercontent.com/15058686/171937590-c03bf3d0-51c5-4415-96df-634f6307b71d.png">

Image of corrected checkbox label class rendering:
<img width="257" alt="chechbox-no-bg-image" src="https://user-images.githubusercontent.com/15058686/171937570-ed0f06a9-8818-4d34-8c01-284796ab8915.png">

### Reviewers:


### Issue:

I didn't create an issue, just the PR


