### PR TITLE
Adds new option "useClassicEngine"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -441,6 +441,7 @@ module.exports = function(grunt) {
 
     if (prodBuild) {
       buildTasks.push('exec:build-release');
+      buildTasks.push('exec:retirejs');
       postBuildTasks.push('copy:target-to-dist');
       postBuildTasks.push('exec:prepack');
     } else {
@@ -451,7 +452,6 @@ module.exports = function(grunt) {
       'exec:clean',
       `assets:${target}`,
       ...buildTasks,
-      'exec:retirejs',
       ...postBuildTasks,
     ]);
   });

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,8 +1,33 @@
+[interaction code]: https://developer.okta.com/docs/concepts/interaction-code/
+[Classic Engine]: https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md
+[Identity Engine]: https://github.com/okta/okta-signin-widget/blob/master/README.md#okta-identity-engine
+
 # Okta Sign-in Widget Migration guide
 
 This library uses semantic versioning and follows Okta's [library version policy](https://developer.okta.com/code/library-versions/). In short, we don't make breaking changes unless the major version changes!
 
-## Migrating `.widgetrc` to `.widgetrc.js`
+
+## Migrating from 6.x to 7.x
+
+### Identity Engine is on by default
+
+- `useInteractionCodeFlow` option is removed
+- `useClassicEngine` option is added
+
+The widget will run against the [Identity Engine][] by default, using the [interaction code][] flow for OIDC applications. Support for the [Classic Engine][] is still available by setting the `useClassicEngine` option to `true`. This option, along with support for the [Classic Engine][], will be removed in a future widget version. All customers are encouraged to migrate from the [Classic Engine][] to the [Identity Engine][]. Visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details on migrating to [Identity Engine][].
+
+Documentation for configuring the Okta Sign-in Widget using the [interaction code][] flow is in the main [README](https://github.com/okta/okta-signin-widget/blob/master/README.md).
+
+
+## Migrating from 5.x to 6.x
+
+### Minimum version of `@okta/okta-auth-js` is `6.0.0`
+
+If you are creating an instance of [@okta/okta-auth-js](https://github.com/okta/okta-auth-js) and passing it to the widget using the [authClient](https://github.com/okta/okta-signin-widget#authClient) option, the instance must be version `6.0.0` or higher.
+
+## Migrating from 4.x to 5.x
+
+### Migrating `.widgetrc` to `.widgetrc.js`
 
 The existing `.widgetrc` file used to configure the Widget has been **removed**. Simply rename the existing file to `.widgetrc.js` export the contents:
 
@@ -26,13 +51,6 @@ The existing `.widgetrc` file used to configure the Widget has been **removed**.
 - }
 ```
 
-## Migrating from 5.x to 6.x
-
-### Minimum version of `@okta/okta-auth-js` is `6.0.0`
-
-If you are creating an instance of [@okta/okta-auth-js](https://github.com/okta/okta-auth-js) and passing it to the widget using the [authClient](https://github.com/okta/okta-signin-widget#authClient) option, the instance must be version `6.0.0` or higher.
-
-## Migrating from 4.x to 5.x
 
 ### `showSignInToGetTokens` no longer redirects
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See the [Usage Guide](#usage-guide) for more information on how to get started u
     - [issuer](#issuer)
     - [clientId](#clientid)
     - [redirectUri](#redirecturi)
-    - [useInteractionCodeFlow](#useinteractioncodeflow)
+    - [useClassicEngine](#useclassicengine)
     - [codeChallenge](#codechallenge)
     - [state](#state)
     - [otp](#otp)
@@ -357,7 +357,6 @@ var signIn = new OktaSignIn(
     issuer: 'https://{yourOktaDomain}/oauth2/default',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
-    useInteractionCodeFlow: true
   }
 );
 
@@ -386,7 +385,6 @@ var signIn = new OktaSignIn(
     issuer: 'https://{yourOktaDomain}/oauth2/default',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
-    useInteractionCodeFlow: true,
     state: '{{state passed from backend}}', // state can be any string, it will be passed on redirect callback
     codeChallenge: '{{PKCE code challenge from backend}}', // PKCE is required for interaction code flow
   }
@@ -483,7 +481,6 @@ var signIn = new OktaSignIn(
     issuer: 'https://{yourOktaDomain}/oauth2/default',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
-    useInteractionCodeFlow: true,
     state: '{{state from URL}}',
     otp: '{{otp from URL}}'
   }
@@ -508,7 +505,6 @@ var signIn = new OktaSignIn(
     issuer: 'https://{yourOktaDomain}/oauth2/default',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
-    useInteractionCodeFlow: true
   }
 );
 ```
@@ -528,7 +524,6 @@ var signIn = new OktaSignIn({
   issuer: 'https://{yourOktaDomain}/oauth2/default'
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true
 });
 
 oktaSignIn.showSignIn({
@@ -556,7 +551,6 @@ var signIn = new OktaSignIn({
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true,
   state: '{{state passed from backend}}', // state can be any string, it will be passed on redirect callback
   codeChallenge: '{{PKCE code challenge from backend}}', // PKCE is required for interaction code flow
 });
@@ -643,7 +637,6 @@ var authClient = new OktaAuth({
 var config = {
   baseUrl: 'https://{yourOktaDomain}',
   authClient: authClient,
-  useInteractionCodeFlow: true
 };
 
 var signIn = new OktaSignIn(config);
@@ -652,12 +645,13 @@ var signIn = new OktaSignIn(config);
 
 If no `authClient` option is set, an instance will be created using the options passed to the widget and `authParams`:
 
+> **Note**: When using the `authClient` configuration option, make sure to install and use the **same version** of `@okta/okta-auth-js` as that used by the installed widget. This version can be found in the `package.json` file of the installed widget.
+
 ```javascript
 var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   clientId: '{yourClientId}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true,
   authParams: {
     ignoreSignature: true
   }
@@ -679,7 +673,6 @@ var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   clientId: '{yourClientId}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true
 };
 var signIn = new OktaSignIn(config);
 signIn.before('success-redirect', async () => {
@@ -701,7 +694,6 @@ var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   clientId: '{yourClientId}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true,
 };
 var signIn = new OktaSignIn(config);
 signIn.after('identify', async () => {
@@ -716,7 +708,7 @@ If you are using the [default Okta-hosted signin page](#okta-hosted-sign-in-page
 
 If you are using the [custom Okta-hosted signin page](#okta-hosted-sign-in-page-customizable), a configuration object is included on the page which contains all necessary values. You will probably not need to modify this object, but you may use this object as a starting point and add additional customizations.
 
-For embedded widgets, you should set the `issuer`, `clientId`, and `redirectUri`. Additionally you should set `useInteractionCodeFlow` to `true` to enable the OIE engine. (See [this document](https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md) for details on running in [Classic Engine][].
+For embedded widgets, you should set the `issuer`, `clientId`, and `redirectUri`. By default, the widget will run on the  [Identity Engine][] using the  [interaction code][] flow. The widget can also run against the [Classic Engine][] by setting the [useClassicEngine](#useClassicEngine) option to `true`. (See [this document](https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md) for more details on running in [Classic Engine][].
 
 ### Basic config options
 
@@ -737,7 +729,6 @@ var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true
 }
 ```
 
@@ -748,7 +739,6 @@ var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/custom',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true
 }
 ```
 
@@ -759,7 +749,6 @@ var config = {
   issuer: 'https://{yourOktaDomain}',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  useInteractionCodeFlow: true
 }
 ```
 
@@ -777,9 +766,11 @@ Client Id of the application.
 
 The URI to use for the [OAuth callback](#oauth-callback).
 
-#### useInteractionCodeFlow
+#### useClassicEngine
 
-Enables the [interaction code][] flow in the widget. This is the only supported authentication method for embedded widgets on the [Identity Engine][]. (See [this document](https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md) for details on running in [Classic Engine][]).
+Defaults to `false`. By default, the widget will use the [interaction code][] flow on the [Identity Engine][]. Setting the `useClassicEngine` option to `true` will cause the widget to run against the [Classic Engine][] instead. (See [this document](https://github.com/okta/okta-signin-widget/blob/master/docs/classic.md) for more details on configuring a widget running in [Classic Engine][]).
+
+> **Note**: This option, along with support for the [Classic Engine][], will be removed in a future widget version. All customers are encouraged to migrate from the [Classic Engine][] to the [Identity Engine][]. Visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details on migrating to [Identity Engine][].
 
 #### codeChallenge
 
@@ -1391,7 +1382,6 @@ We use Yarn as our node package manager. To install Yarn, check out their [insta
       issuer: 'https://{yourOktaDomain}/oauth2/default',
       clientId: '{{clientId of your OIDC app}}',
       redirectUri: '{{redirectUri configured in OIDC app}}',
-      useInteractionCodeFlow: true,
       logoText: 'Windico',
       features: {
         rememberMe: true,

--- a/docs/classic.md
+++ b/docs/classic.md
@@ -297,7 +297,8 @@ var signIn = new OktaSignIn(
   {
     baseUrl: 'https://{yourOktaDomain}',
     clientId: '{{clientId of your OIDC app}}',
-    redirectUri: '{{redirectUri configured in OIDC app}}'
+    redirectUri: '{{redirectUri configured in OIDC app}}',
+    useClassicEngine: true
   }
 );
 
@@ -319,6 +320,7 @@ var signIn = new OktaSignIn(
     baseUrl: 'https://{yourOktaDomain}',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
+    useClassicEngine: true,
     authParams: {
       pkce: false,
     }
@@ -336,6 +338,7 @@ var signIn = new OktaSignIn(
     baseUrl: 'https://{yourOktaDomain}',
     clientId: '{{clientId of your OIDC app}}',
     redirectUri: '{{redirectUri configured in OIDC app}}',
+    useClassicEngine: true,
     authParams: {
       pkce: false,
       responseType: 'code'
@@ -384,7 +387,7 @@ signIn.renderEl({
 
 ### Interaction Code Flow
 
-Support for the interaction code grant is available for organizations with the [Identity Engine](#okta-identity-engine) feature enabled. Please visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details.
+The widget will run against the [Identity Engine](#okta-identity-engine) by default, using the [interaction code][] flow. Support for the `Classic Engine` is still available by setting `useClassicEngine` to `true`. (Please visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details on migrating to [Identity Engine][].
 
 Documentation for configuring the Okta Sign-in Widget for the [interaction code][] flow is in the [README](https://github.com/okta/okta-signin-widget/blob/master/README.md).
 
@@ -411,7 +414,8 @@ var signIn = new OktaSignIn(
   {
     baseUrl: 'https://{yourOktaDomain}',
     clientId: '{{clientId of your OIDC app}}',
-    redirectUri: '{{redirectUri configured in OIDC app}}'
+    redirectUri: '{{redirectUri configured in OIDC app}}',
+    useClassicEngine: true
   }
 );
 ```
@@ -439,6 +443,7 @@ var signIn = new OktaSignIn({
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
   baseUrl: ‘https://{yourOktaDomain},
+  useClassicEngine: true,
   authParams: {
     issuer: 'https://{yourOktaDomain}/oauth2/default'
   }
@@ -471,7 +476,8 @@ var signIn = new OktaSignIn({
   el: '#osw-container',
   clientId: '{{myClientId}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
-  baseUrl: 'https://{yourOktaDomain}'
+  baseUrl: 'https://{yourOktaDomain}',
+  useClassicEngine: true
 });
 
 signIn.showSignInToGetTokens({
@@ -500,6 +506,7 @@ var signIn = new OktaSignIn({
   baseUrl: 'https://{yourOktaDomain}',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
+  useClassicEngine: true,
   authParams: {
     pkce: false,
     responseType: 'code'
@@ -668,50 +675,6 @@ var signIn = new OktaSignIn(config);
 // signIn.authClient.options.clientId === '{yourClientId}'
 ```
 
-### before
-
-> **Note**: This function is only supported when using the [Okta Identity Engine](#okta-identity-engine)
-
-Adds an asynchronous [hook](#hooks) function which will execute before a view is rendered.
-
-```javascript
-var config = {
-  baseUrl: 'https://{yourOktaDomain}',
-  authParams: {
-    issuer: 'https://{yourOktaDomain}/oauth2/default',
-    clientId: '{yourClientId}'  
-  },
-  useInteractionCodeFlow: true
-};
-var signIn = new OktaSignIn(config);
-signIn.before('success-redirect', async () => {
-  // custom logic can go here. when the function resolves, execution will continue.
-});
-
-```
-
-### after
-
-> **Note**: This function is only supported when using the [Okta Identity Engine](#okta-identity-engine)
-
-Adds an asynchronous [hook](#hooks) function which will execute after a view is rendered.
-
-```javascript
-var config = {
-  baseUrl: 'https://{yourOktaDomain}',
-  authParams: {
-    issuer: 'https://{yourOktaDomain}/oauth2/default',
-    clientId: '{yourClientId}'  
-  },
-  useInteractionCodeFlow: true
-};
-var signIn = new OktaSignIn(config);
-signIn.after('identify', async () => {
-  // custom logic can go here. when the function resolves, execution will continue.
-});
-
-```
-
 ## Configuration
 
 For non-OIDC applications, the only required configuration option is `baseUrl`. All others are optional.
@@ -744,11 +707,15 @@ var signIn = new OktaSignIn(config);
 
 For OIDC applications, you need to set the `clientId` and `redirectUri`. If `issuer` is not set, it will be inferred from `baseUrl`.
 
+**Note:** 
+The widget now uses [Identity Engine][] by default. To continue using the `Classic Engine`, you must set `useClassicEngine` to `true`.
+
 ```javascript
 var config = {
   baseUrl: 'https://{yourOktaDomain}', // issuer will be https://{yourOktaDomain}/oauth2/default
   clientId: '{{clientId of your OIDC app}}',
-  redirectUri: '{{redirectUri configured in OIDC app}}'
+  redirectUri: '{{redirectUri configured in OIDC app}}',
+  useClassicEngine: true
 }
 ```
 
@@ -765,7 +732,8 @@ A different [Custom Authorization Server][] can be specified by setting the `iss
 var config = {
   issuer: 'https://{yourOktaDomain}/oauth2/custom',
   clientId: '{{clientId of your OIDC app}}',
-  redirectUri: '{{redirectUri configured in OIDC app}}'
+  redirectUri: '{{redirectUri configured in OIDC app}}',
+  useClassicEngine: true
 }
 ```
 
@@ -778,10 +746,19 @@ var config = {
   issuer: 'https://{yourOktaDomain}',
   clientId: '{{clientId of your OIDC app}}',
   redirectUri: '{{redirectUri configured in OIDC app}}',
+  useClassicEngine: true
 }
 ```
 
 ### Basic config options
+
+- **useClassicEngine**
+
+Defaults to `false`. By default, the widget will use the [interaction code][] flow on the [Identity Engine][]. If `useClassicEngine` option is set to `true`,  the `Classic Engine` will be used instead.  This option, along with support for the `Classic Engine`, will be removed in a future widget version. All customers are encouraged to migrate from the `Classic Engine` to the [Identity Engine][].
+
+Please visit [Migrating to OIE](https://developer.okta.com/docs/guides/migrate-to-oie/) for more details on migrating to [Identity Engine][].
+
+Documentation for configuring the Okta Sign-in Widget for the [interaction code][] flow is in the [README](https://github.com/okta/okta-signin-widget/blob/master/README.md).
 
 - **baseUrl:** The base URL for your Okta organization
 

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -4,7 +4,7 @@ const Test = require('./test-configs');
 const idx = {
   // ===== IDX
 
-  // PKCE must be enabled with "useInteractionCodeFlow" option
+  // PKCE must be enabled with interaction code flow
   '/oauth2/default/.well-known/openid-configuration': [
     'well-known-openid-configuration'
   ],

--- a/src/models/Settings.ts
+++ b/src/models/Settings.ts
@@ -29,6 +29,7 @@ const UnsupportedBrowserError = Errors.UnsupportedBrowserError;
 const assetBaseUrlTpl = hbs('https://global.oktacdn.com/okta-signin-widget/{{version}}');
 
 const local: Record<string, ModelProperty> = {
+  authClient: ['object', false, undefined],
   baseUrl: ['string', true],
   recoveryToken: ['string', false, undefined],
   stateToken: ['string', false, undefined],
@@ -176,6 +177,9 @@ const local: Record<string, ModelProperty> = {
 
   //Email verify callback
   otp: 'string',
+
+  //Support classic engine
+  useClassicEngine: ['boolean', false, false]
 };
 
 const derived: Record<string, ModelProperty>  = {
@@ -276,25 +280,21 @@ const derived: Record<string, ModelProperty>  = {
     },
   },
   mode: {
-    deps: ['useInteractionCodeFlow', 'codeChallenge'],
-    fn: function(useInteractionCodeFlow, codeChallenge) {
-      if (useInteractionCodeFlow && codeChallenge) {
+    deps: ['codeChallenge'],
+    fn: function(codeChallenge) {
+      if (codeChallenge) {
         return 'remediation';
       }
       return 'relying-party';
     }
   },
   oauth2Enabled: {
-    deps: ['clientId', 'authScheme'],
-    fn: function(clientId, authScheme) {
+    deps: ['clientId', 'authScheme', 'authClient'],
+    fn: function(clientId, authScheme, authClient) {
+       if (!clientId && authClient) {
+        clientId = authClient.options.clientId;
+      }
       return (!!clientId) && authScheme.toLowerCase() === 'oauth2';
-    },
-    cache: true,
-  },
-  oieEnabled: {
-    deps: ['stateToken', 'proxyIdxResponse', 'useInteractionCodeFlow'],
-    fn: function(stateToken, proxyIdxResponse, useInteractionCodeFlow) {
-      return stateToken || proxyIdxResponse || useInteractionCodeFlow;
     },
     cache: true,
   },
@@ -377,6 +377,15 @@ type SettingsProps = typeof local & typeof derived;
 export default class Settings extends Model {
   authClient:OktaAuth;
 
+  constructor(attributes, options) {
+    // base class constructor will call preinitialize() and initialize() and compute derived properties
+    super(attributes, options);
+
+    // apply languageCode
+    const authClient = this.getAuthClient();
+    this.setAcceptLanguageHeader(authClient);
+  }
+
   get<A extends Backbone._StringKey<SettingsProps>>(attributeName: A): any {
     return Model.prototype.get.call(this, attributeName);
   }
@@ -388,15 +397,17 @@ export default class Settings extends Model {
   }
 
   initialize(options) {
-    const { colors } = options;
+    options = options || {};
+    const { colors, authClient } = options;
     let { baseUrl } = options;
+
     if (!baseUrl) {
       // infer baseUrl from the issuer
-      const { authClient } = options;
+      // favor authClient API first
       if (authClient) {
         baseUrl = authClient.getIssuerOrigin();
       } else {
-        // issuer can be passed at top-level or in authParams
+        // issuer can also be passed a top-level option or exist in authParams
         const { authParams } = options;
         let { issuer } = options;
         issuer = issuer || authParams?.issuer;
@@ -421,12 +432,12 @@ export default class Settings extends Model {
   }
 
   setAuthClient(authClient) {
+    this.set('authClient', authClient);
     this.setAcceptLanguageHeader(authClient);
-    this.authClient = authClient;
   }
 
   getAuthClient() {
-    return this.authClient;
+    return this.get('authClient');
   }
 
   set(...args: any[]) {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -95,7 +95,7 @@ export interface WidgetOptions extends Partial<Pick<OktaAuthOptions,
   consent?: {
     cancel?: SimpleCallback;
   };
-  useInteractionCodeFlow?: boolean;
+  useClassicEngine?: boolean;
   hooks?: HooksOptions;
   proxyIdxResponse?: any;
 }

--- a/src/v1/BaseLoginRouter.js
+++ b/src/v1/BaseLoginRouter.js
@@ -62,8 +62,7 @@ export default Router.extend({
       };
     }
 
-    this.settings = new Settings(_.omit(options, 'el', 'authClient'), { parse: true });
-    this.settings.setAuthClient(options.authClient);
+    this.settings = new Settings(_.omit(options, 'el'), { parse: true });
 
     if (!options.el) {
       this.settings.callGlobalError(new Errors.ConfigError(loc('error.required.el')));

--- a/src/v1/controllers/ForceIDPDiscoveryController.js
+++ b/src/v1/controllers/ForceIDPDiscoveryController.js
@@ -34,7 +34,7 @@ export default BaseLoginController.extend({
       requestContext: stateToken,
     };
 
-    options.appState.settings.authClient
+    options.appState.settings.getAuthClient()
       .webfinger(webfingerArgs)
       .then(res => {
         if (res?.links && res.links[0]) {

--- a/src/v1/models/IDPDiscovery.js
+++ b/src/v1/models/IDPDiscovery.js
@@ -48,7 +48,7 @@ export default PrimaryAuthModel.extend({
       resource: resource,
       requestContext: requestContext,
     };
-    const authClient = this.appState.settings.authClient;
+    const authClient = this.appState.settings.getAuthClient();
 
     authClient
       .webfinger(webfingerArgs)

--- a/src/v1/models/PrimaryAuth.js
+++ b/src/v1/models/PrimaryAuth.js
@@ -99,7 +99,7 @@ export default BaseLoginModel.extend({
     let primaryAuthPromise;
 
     if (this.appState.get('isUnauthenticated')) {
-      const authClient = this.appState.settings.authClient;
+      const authClient = this.appState.settings.getAuthClient();
 
       // bootstrapped with stateToken
       if (this.appState.get('isIdxStateToken')) {

--- a/src/v1/views/expired-password/Footer.js
+++ b/src/v1/views/expired-password/Footer.js
@@ -32,7 +32,7 @@ export default View.extend({
     'click .js-signout': function(e) {
       e.preventDefault();
       const self = this;
-      const authClient = self.settings.authClient;
+      const authClient = self.settings.getAuthClient();
 
       this.model
         .doTransaction(function(transaction) {

--- a/src/v2/client/formatError.ts
+++ b/src/v2/client/formatError.ts
@@ -56,7 +56,7 @@ export function formatInvalidRecoveryTokenError(error: StandardApiError) {
 }
 
 export function isOIENotEnabledError(error): error is StandardApiError {
-  // special case: error from interact. `useInteractionCodeFlow` is true but the Org does not have OIE enabled
+  // special case: error from interact when the Org does not have OIE enabled
   // The response is not in IDX format. See playground/mocks/data/oauth2/error-feature-not-enabled.json
   return (error?.error === 'access_denied' && error.error_description);
 }

--- a/src/v2/client/startLoginFlow.ts
+++ b/src/v2/client/startLoginFlow.ts
@@ -46,7 +46,7 @@ export async function startLoginFlow(settings) {
     return emailVerifyCallback(settings);
   }
 
-  if (settings.get('useInteractionCodeFlow')) {
+  if (settings.get('oauth2Enabled')) {
     const meta: IdxTransactionMeta = await authClient.idx.getSavedTransactionMeta();
     if (!meta) {
       // no saved transaction
@@ -101,6 +101,5 @@ export async function startLoginFlow(settings) {
     });
   }
 
-  throw new Errors.ConfigError('Set "useInteractionCodeFlow" to true in configuration to enable the ' +
-    'interaction_code" flow for self-hosted widget.');
+  throw new Errors.ConfigError('Invalid OIDC configuration. Set "clientId" and "redirectUri" in the widget options.');
 }

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -167,7 +167,7 @@ export default Controller.extend({
       sessionStorageHelper.removeStateHandle();
       appState.clearAppStateCache();
 
-      if (settings.get('useInteractionCodeFlow')) {
+      if (settings.get('oauth2Enabled')) {
         // In this case we need to restart login flow and recreate transaction meta
         // that will be used in interactionCodeFlow function
         appState.trigger('restartLoginFlow');

--- a/src/v2/view-builder/utils/LinksUtil.js
+++ b/src/v2/view-builder/utils/LinksUtil.js
@@ -125,8 +125,8 @@ const getBackToSignInLink = ({settings, appState}) => {
   if (settings?.get('backToSignInUri')) {
     link.href = settings.get('backToSignInUri');
   }
-  // embedded scenarios
-  else if (settings?.get('useInteractionCodeFlow')) {
+  // fallback for embedded scenarios
+  else if (settings?.get('oauth2Enabled')) {
     link.clickHandler = () => {
       appState.trigger('restartLoginFlow');
     };

--- a/src/widget/OktaSignIn.ts
+++ b/src/widget/OktaSignIn.ts
@@ -45,9 +45,9 @@ export default class OktaSignIn implements OktaSignInAPI {
     this.authClient = getAuthClient(options);
 
     // validate authClient configuration against widget options
-    if (options.useInteractionCodeFlow  && this.authClient.isPKCE() === false) {
+    if (options.useClassicEngine !== true && this.authClient.options.clientId && this.authClient.isPKCE() === false) {
       throw new Errors.ConfigError(
-        'The "useInteractionCodeFlow" option requires PKCE to be enabled on the authClient.'
+        'OAuth2 with interaction code flow requires PKCE to be enabled on the authClient.'
       );
     }
 
@@ -57,13 +57,13 @@ export default class OktaSignIn implements OktaSignInAPI {
     });
 
     let Router: AbstractRouter;
-    if ((options.stateToken && !Util.isV1StateToken(options.stateToken)) 
-        // Self hosted widget can use `useInteractionCodeFlow` to use V2Router
-        || options.useInteractionCodeFlow 
-        || options.proxyIdxResponse) {
-      Router = V2Router;
-    } else {
+    if ((options.stateToken && Util.isV1StateToken(options.stateToken))
+      // Self hosted widget can set the `useClassicEngine` option to use V1Router
+      || options.useClassicEngine === true)
+    {
       Router = V1Router;
+    } else {
+      Router = V2Router;
     }
     this.Router = Router;
 

--- a/test/app/src/config.ts
+++ b/test/app/src/config.ts
@@ -50,7 +50,7 @@ export function getDefaultConfig(): Config {
     issuer: ISSUER,
     clientId: CLIENT_ID,
     redirectUri: REDIRECT_URI,
-    useInteractionCodeFlow: true
+    useClassicEngine: false
   };
   return removeNils(config) as Config;
 }

--- a/test/app/src/configForm.ts
+++ b/test/app/src/configForm.ts
@@ -27,9 +27,9 @@ export const ConfigForm = `
       <label for="redirectUri">Redirect URI</label><input id="f_redirectUri" name="redirectUri" type="text" />
     </div>
     <div class="pure-control-group">
-      <label for="useInteractionCodeFlow">Use <strong>interaction code flow</strong></label>
-      <input id="f_useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES
-      <input id="f_useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO
+      <label for="useClassicEngine">Use <strong>classic engine</strong></label>
+      <input id="f_useClassicEngine-on" name="useClassicEngine" type="radio" value="true"/>YES
+      <input id="f_useClassicEngine-off" name="useClassicEngine" type="radio" value="false"/>NO
     </div>
     <div class="pure-control-group">
     <label for="flow">Flow</label>
@@ -49,13 +49,13 @@ export function getConfigFromForm(): Config {
   const issuer = (document.getElementById('f_issuer') as HTMLInputElement).value;
   const redirectUri = (document.getElementById('f_redirectUri') as HTMLInputElement).value;
   const clientId = (document.getElementById('f_clientId') as HTMLInputElement).value;
-  const useInteractionCodeFlow = (document.getElementById('f_useInteractionCodeFlow-on') as HTMLInputElement).checked;
+  const useClassicEngine = (document.getElementById('f_useClassicEngine-on') as HTMLInputElement).checked;
   const flow = (document.querySelector('#f_flow') as HTMLSelectElement).value;
   const config: Config = {
     issuer,
     clientId,
     redirectUri,
-    useInteractionCodeFlow,
+    useClassicEngine,
     flow
   }
   return removeNils(config) as Config;
@@ -70,10 +70,10 @@ export function updateFormFromConfig(config: Config): void {
   (document.getElementById('f_redirectUri') as HTMLInputElement).value = config.redirectUri;
   (document.getElementById('f_clientId') as HTMLInputElement).value = config.clientId;
  
-  if (config.useInteractionCodeFlow) {
-    (document.getElementById('f_useInteractionCodeFlow-on') as HTMLInputElement).checked = true;
+  if (config.useClassicEngine) {
+    (document.getElementById('f_useClassicEngine-on') as HTMLInputElement).checked = true;
   } else {
-    (document.getElementById('f_useInteractionCodeFlow-off') as HTMLInputElement).checked = true;
+    (document.getElementById('f_useClassicEngine-off') as HTMLInputElement).checked = true;
   }
 
   (document.querySelector(`#f_flow`) as HTMLOptionElement).value = flow;

--- a/test/app/src/types.ts
+++ b/test/app/src/types.ts
@@ -19,8 +19,8 @@ export interface Config {
   clientId?: string;
   redirectUri?: string;
   authParams?: OktaAuthOptions;
-  useInteractionCodeFlow: boolean;
   flow?: string;
+  useClassicEngine?: boolean;
 }
 
 // https://github.com/microsoft/TypeScript/issues/36217

--- a/test/e2e/specs/basic-dev.e2e.js
+++ b/test/e2e/specs/basic-dev.e2e.js
@@ -22,6 +22,7 @@ describe('Dev Mode flows', () => {
     config = {
       baseUrl: WIDGET_TEST_SERVER,
       redirectUri: 'http://localhost:3000/done',
+      useClassicEngine: true,
       el: '#okta-login-container',
       authParams: {
         pkce: false

--- a/test/e2e/specs/basic.e2e.js
+++ b/test/e2e/specs/basic.e2e.js
@@ -7,6 +7,7 @@ const {
   WIDGET_TEST_SERVER,
   WIDGET_BASIC_USER,
   WIDGET_BASIC_PASSWORD,
+  WIDGET_SPA_CLIENT_ID
 } = process.env;
 
 describe('Basic flows', () => {
@@ -14,6 +15,9 @@ describe('Basic flows', () => {
   beforeEach(async () => {
     config = {
       baseUrl: WIDGET_TEST_SERVER,
+      clientId: WIDGET_SPA_CLIENT_ID,
+      redirectUri: 'http://localhost:3000/done',
+      useClassicEngine: true,
       authParams: {
         pkce: false
       }

--- a/test/e2e/specs/csp.e2e.js
+++ b/test/e2e/specs/csp.e2e.js
@@ -31,6 +31,7 @@ describe('CSP', () => {
         baseUrl: WIDGET_TEST_SERVER,
         clientId,
         redirectUri: 'http://localhost:3000/done',
+        useClassicEngine: true,
         authParams: {
           pkce: false,
           responseType: 'id_token',

--- a/test/e2e/specs/interactionCode.e2e.js
+++ b/test/e2e/specs/interactionCode.e2e.js
@@ -18,7 +18,6 @@ describe('Interaction code flows', () => {
       redirectUri: 'http://localhost:3000/done',
       el: '#okta-login-container',
       clientId: WIDGET_SPA_CLIENT_ID,
-      useInteractionCodeFlow: true,
       scopes: ['openid', 'email', 'profile']
     };
     console.log(JSON.stringify(config)); // for manual testing in browser
@@ -46,7 +45,6 @@ describe('Interaction code flows', () => {
         clientId: WIDGET_SPA_CLIENT_ID,
         responseType: 'code',
         redirectUri: 'http://localhost:3000/done',
-        useInteractionCodeFlow: true,
         authParams: {
           pkce: true,
           display: 'page',

--- a/test/e2e/specs/oidc.e2e.js
+++ b/test/e2e/specs/oidc.e2e.js
@@ -38,6 +38,7 @@ describe('OIDC flows', () => {
       config = {
         baseUrl: WIDGET_TEST_SERVER,
         redirectUri: 'http://localhost:3000/done',
+        useClassicEngine: true,
         authParams: {
           pkce: false,
           scopes: ['openid', 'email', 'profile', 'address', 'phone']
@@ -105,6 +106,7 @@ describe('OIDC flows', () => {
           baseUrl: WIDGET_TEST_SERVER,
           clientId: WIDGET_SPA_CLIENT_ID,
           redirectUri: 'http://localhost:3000/done',
+          useClassicEngine: true,
           authParams: {
             pkce: true,
             display: 'page',

--- a/test/e2e/steps/given.ts
+++ b/test/e2e/steps/given.ts
@@ -27,7 +27,6 @@ const config = {
   redirectUri: 'http://localhost:3000/done',
   el: '#okta-login-container',
   clientId: WIDGET_SPA_CLIENT_ID,
-  useInteractionCodeFlow: true,
   scopes: ['openid', 'email', 'profile']
 };
 
@@ -74,7 +73,6 @@ Given(
       redirectUri: 'http://localhost:3000/done',
       el: '#okta-login-container',
       clientId: WIDGET_SPA_CLIENT_ID,
-      useInteractionCodeFlow: true,
       scopes: ['openid', 'email', 'profile'],
       state: 'abc'
     };

--- a/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
+++ b/test/testcafe/spec-en-leaks/EnglishLeaks_spec.js
@@ -28,7 +28,6 @@ const ignoredMocks = [
 
 const optionsForInteractionCodeFlow = {
   clientId: 'fake',
-  useInteractionCodeFlow: true,
   authParams: {
     ignoreSignature: true,
     pkce: true,

--- a/test/testcafe/spec/FailureRedirect_spec.js
+++ b/test/testcafe/spec/FailureRedirect_spec.js
@@ -22,7 +22,11 @@ test.requestHooks(userNotAssignedMock)('oauth: shows the error message', async t
   await terminalPage.navigateToPage({ render: false });
   await renderWidget({
     clientId: 'fake',
-    redirectUri: 'http://totally-fake'
+    redirectUri: 'http://totally-fake',
+    codeChallenge: 'abc', // cannot do PKCE calcs on http://localhost
+    authParams: {
+      pkce: true // required for interaction code flow
+    }
   });
   await terminalPage.waitForErrorBox();
   await t.expect(terminalPage.getErrorMessages().getTextContent()).eql('You are not allowed to access this app. To request access, contact an admin.');
@@ -34,6 +38,10 @@ test.requestHooks(userNotAssignedMock)('oauth: will redirect if `redirect === "a
   await renderWidget({
     clientId: 'fake',
     redirectUri: 'http://totally-fake',
+    codeChallenge: 'abc', // cannot do PKCE calcs on http://localhost
+    authParams: {
+      pkce: true // required for interaction code flow
+    },
     redirect: 'always'
   });
   const errorPage = new PlaygroundErrorPageObject(t);

--- a/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
+++ b/test/testcafe/spec/IdentifyWithThirdPartyIdps_spec.js
@@ -66,10 +66,14 @@ async function setupDirectAuth(t) {
   const identityPage = new IdentityPageObject(t);
   await identityPage.navigateToPage({ render: false });
   await renderWidget({
-    stateToken: 'abc',
     clientId: 'fake',
     redirectUri: 'http://doesnot-matter',
+    codeChallenge: 'abc', // cannot do PKCE calcs on http://localhost
+    authParams: {
+      pkce: true // required for interaction code flow
+    }
   });
+  await identityPage.form.el.exists;
   return identityPage;
 }
 
@@ -139,6 +143,7 @@ test.requestHooks(logger, mockOnlyOneIdp)('should auto redirect to 3rd party IdP
 test.requestHooks(logger, mockOnlyOneIdp)('Direct auth: does not auto redirect to 3rd party IDP on initial load', async t => {
   const identityPage = await setupDirectAuth(t);
 
+  // await t.wait(100);
   await checkConsoleMessages({
     controller: null,
     formName: 'redirect-idp',

--- a/test/testcafe/spec/IdxSessionExpired_spec.js
+++ b/test/testcafe/spec/IdxSessionExpired_spec.js
@@ -54,7 +54,6 @@ async function setupInteractionCodeFlow(t) {
     stateToken: undefined,
     clientId: 'fake',
     redirectUri: 'http://doesnot-matter',
-    useInteractionCodeFlow: true,
     authParams: {
       pkce: true,
       state: 'mock-state'

--- a/test/testcafe/spec/Interact_spec.js
+++ b/test/testcafe/spec/Interact_spec.js
@@ -113,7 +113,6 @@ async function setup(t, options = {}) {
     recoveryToken: options.recoveryToken,
     clientId: 'fake',
     redirectUri: 'http://doesnot-matter',
-    useInteractionCodeFlow: true,
     authParams: {
       pkce: true,
       state: 'mock-state'

--- a/test/testcafe/spec/SessionStorage_spec.js
+++ b/test/testcafe/spec/SessionStorage_spec.js
@@ -304,7 +304,6 @@ test.requestHooks(identifyChallengeMock)('shall back to sign-in and authenticate
   // Setup widget with interaction code flow
   const optionsForInteractionCodeFlow = {
     clientId: 'fake',
-    useInteractionCodeFlow: true,
     authParams: {
       ignoreSignature: true,
       pkce: true,

--- a/test/unit/spec/OAuth2Util_spec.js
+++ b/test/unit/spec/OAuth2Util_spec.js
@@ -34,9 +34,9 @@ describe('util/OAuth2Util', function() {
         authParams: { issuer: 'https://foo/default' }
       });
       settings = new Settings({
-        baseUrl: 'https://foo'
+        baseUrl: 'https://foo',
+        authClient
       });
-      settings.setAuthClient(authClient);
     });
 
     it('exists', () => {
@@ -115,11 +115,11 @@ describe('util/OAuth2Util', function() {
       const settingsWithAdditionalParams = new Settings({
         baseUrl: 'https://foo',
         clientId: 'foobar',
-        authOptions: {
+        authClient,
+        authParams: {
           responseMode: 'token'
         }
       });
-      settingsWithAdditionalParams.setAuthClient(authClient);
 
       return new Promise(function(resolve) {
         spyOn(authClient.token, 'getWithPopup').and.callFake(resolve);
@@ -138,8 +138,8 @@ describe('util/OAuth2Util', function() {
       const settingsWithRemediationMode = new Settings({
         baseUrl: 'https://foo',
         redirect: 'always',
+        authClient
       });
-      settingsWithRemediationMode.setAuthClient(authClient);
 
       return new Promise(function(resolve) {
         spyOn(authClient.token, 'getWithRedirect').and.callFake(resolve);

--- a/test/unit/spec/OktaSignInV2Bootstrap_spec.js
+++ b/test/unit/spec/OktaSignInV2Bootstrap_spec.js
@@ -149,8 +149,7 @@ describe('OktaSignIn v2 bootstrap', function() {
       const form = new IdentifierForm($sandbox);
       setupLoginFlow({
         clientId: 'someClientId',
-        redirectUri: 'http://0.0.0.0:9999',
-        useInteractionCodeFlow: true
+        redirectUri: 'http://0.0.0.0:9999'
       }, responses);
       jest.spyOn(signIn.authClient.transactionManager, 'exists').mockReturnValue(false);
       render();
@@ -180,7 +179,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId: 'someClientId',
           redirectUri: 'http://0.0.0.0:9999',
-          useInteractionCodeFlow: true,
           language: 'en',
           i18n: {
             en: {
@@ -211,7 +209,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId: 'someClientId',
           redirectUri: 'http://0.0.0.0:9999',
-          useInteractionCodeFlow: true,
         }, [
           errorFeatureNotEnabled
         ]);
@@ -236,7 +233,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId: 'someClientId',
           redirectUri: 'http://0.0.0.0:9999',
-          useInteractionCodeFlow: true
         }, responses);
 
         jest.spyOn(signIn.authClient.transactionManager, 'exists').mockReturnValue(false);
@@ -271,7 +267,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId: 'someClientId',
           redirectUri: 'http://0.0.0.0:9999',
-          useInteractionCodeFlow: true,
           flow: 'login'
         }, responses);
 
@@ -307,7 +302,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId: 'someClientId',
           redirectUri: 'http://0.0.0.0:9999',
-          useInteractionCodeFlow: true,
           codeChallenge: 'custom',
           codeChallengeMethod: 'custom-method'
         }, responses);
@@ -351,7 +345,6 @@ describe('OktaSignIn v2 bootstrap', function() {
       setupLoginFlow({
         clientId,
         redirectUri,
-        useInteractionCodeFlow: true
       }, [idxResponse]);
 
       const savedInteractionHandle = 'saved-interaction-handle';
@@ -407,7 +400,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           idxSuccessInteractionCode, 
           // token success
@@ -435,7 +427,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           // email verify terminal success (flow continued in other tab)
           {
@@ -460,7 +451,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           // terminal success with a cancel action
           {
@@ -484,7 +474,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           idxErrorSessionExpired
         ]);
@@ -503,7 +492,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           idxErrorUserIsNotAssigned
         ]);
@@ -522,7 +510,6 @@ describe('OktaSignIn v2 bootstrap', function() {
         setupLoginFlow({
           clientId,
           redirectUri,
-          useInteractionCodeFlow: true
         }, [
           interactResponse,
           idxVerifyPassword,

--- a/test/unit/spec/OktaSignIn_spec.js
+++ b/test/unit/spec/OktaSignIn_spec.js
@@ -12,27 +12,29 @@ import V1Router from 'v1/LoginRouter';
 import V1AppState from 'v1/models/AppState';
 import V2AppState from 'v2/models/AppState';
 import Hooks from 'models/Hooks';
+import RAW_IDX_RESPONSE from 'helpers/v2/idx/fullFlowResponse';
 
 const url = 'https://foo.com';
 const itp = Expect.itp;
 
-Expect.describe('OktaSignIn initialization', function() {
+describe('OktaSignIn initialization', function() {
   let signIn;
 
-  /* eslint jasmine/no-global-setup:0 */
+  function mockXhr(jsonResponse, status=200) {
+    return {
+      status,
+      responseType: 'json',
+      response: jsonResponse,
+    };
+  }
+
   beforeEach(function() {
-    jasmine.Ajax.install();
-    jasmine.Ajax.stubRequest(/https:\/\/foo.com.*/).andReturn({
-      status: 200,
-      responseText: '',
-    });
     spyOn(Logger, 'warn');
     signIn = new Widget({
       baseUrl: url,
     });
   });
   afterEach(function() {
-    jasmine.Ajax.uninstall();
     $sandbox.empty();
   });
 
@@ -130,18 +132,33 @@ Expect.describe('OktaSignIn initialization', function() {
         });
       });
 
-      it('"useInteractionCodeFlow" without PKCE throws a config error', function() {
+      it('OAuth with interaction code flow without PKCE throws a config error', function() {
         const fn = () => {
           signIn = new Widget({
             baseUrl: url,
-            useInteractionCodeFlow: true,
+            clientId: 'abc',
             authParams: {
               pkce: false
             }
           });
         };
-        expect(fn).toThrowError('The "useInteractionCodeFlow" option requires PKCE to be enabled on the authClient.');
+        expect(fn).toThrowError('OAuth2 with interaction code flow requires PKCE to be enabled on the authClient.');
       });
+
+      it('Classic OAuth flow without PKCE does not throw a config error', function() {
+        const fn = () => {
+          signIn = new Widget({
+            baseUrl: url,
+            clientId: 'abc',
+            useClassicEngine: true,
+            authParams: {
+              pkce: false
+            }
+          });
+        };
+        expect(fn).not.toThrow();
+      });
+
     });
 
     Expect.describe('Session', function() {
@@ -220,7 +237,7 @@ Expect.describe('OktaSignIn initialization', function() {
     });
   });
 
-  Expect.describe('events', function() {
+  describe('events', function() {
     beforeEach(function() {
       spyOn(Logger, 'error');
     });
@@ -228,82 +245,127 @@ Expect.describe('OktaSignIn initialization', function() {
       signIn.remove();
       signIn.off();
     });
-    it('triggers an afterRender event when the Widget renders a page', function(done) {
-      signIn.renderEl({ el: $sandbox });
-      signIn.on('afterRender', function(context) {
-        expect(context).toEqual({ controller: 'primary-auth' });
-        done();
-      });
-    });
 
-    it('triggers a ready event when the Widget renders a page', function(done) {
-      signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function(context) {
-        expect(context).toEqual({ controller: 'primary-auth' });
-        done();
-      });
-    });
-
-    it('triggers a ready event when the Widget is loaded with a recoveryToken', function(done) {
-      signIn = new Widget({
-        baseUrl: url,
-        recoveryToken: 'foo',
-      });
-      signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function(context) {
-        expect(context).toEqual({ controller: 'recovery-loading' });
-        done();
-      });
-    });
-    it('triggers a ready event when the Widget is loaded with using idpDiscovery', function(done) {
-      signIn = new Widget({
-        baseUrl: url,
-        features: { idpDiscovery: true },
-      });
-      signIn.renderEl({ el: $sandbox });
-      signIn.on('ready', function(context) {
-        expect(context).toEqual({ controller: 'idp-discovery' });
-        done();
-      });
-    });
-    it('does not trigger a ready event twice', function(done) {
-      signIn.renderEl({ el: '#sandbox' });
-      signIn.on('ready', function(context) {
-        expect(context).toEqual({ controller: 'primary-auth' });
-        // Navigate directly to forgot-password page
-        const forgotPasswordLink = document.getElementsByClassName('link js-forgot-password');
-
-        forgotPasswordLink[0].click();
-      });
-      signIn.on('afterRender', function(context) {
-        if (context.controller === 'forgot-password') {
+    function testEvents(widgetOptions, isOIE) {
+      it('triggers an afterRender event when the Widget renders a page', function(done) {
+        signIn = new Widget(widgetOptions);
+        signIn.renderEl({ el: $sandbox });
+        signIn.on('afterRender', function(context) {
+          expect(context).toMatchObject({ controller: 'primary-auth' });
           done();
-        }
+        });
       });
-    });
-    ['ready', 'afterError', 'afterRender'].forEach(event => {
-      it(`traps third party errors (for ${event} event) in callbacks`, function() {
+
+      it('triggers a ready event when the Widget renders a page', function(done) {
+        signIn = new Widget(widgetOptions);
+        signIn.renderEl({ el: $sandbox });
+        signIn.on('ready', function(context) {
+          expect(context).toMatchObject({ controller: 'primary-auth' });
+          done();
+        });
+      });
+
+      it('triggers a ready event when the Widget is loaded with a recoveryToken', function(done) {
+        // TODO: this feature does not have parity with classic
+        if (isOIE) {
+          done();
+          return;
+        }
+
+        signIn = new Widget({
+          ...widgetOptions,
+          recoveryToken: 'foo',
+        });
+        signIn.renderEl({ el: $sandbox });
+        signIn.on('ready', function(context) {
+          expect(context).toMatchObject({ controller: 'recovery-loading' });
+          done();
+        });
+      });
+
+      it('triggers a ready event when the Widget is loaded with using idpDiscovery', function(done) {
+        // TODO: this feature does not have parity with classic
+        if (isOIE) {
+          done();
+          return;
+        }
+        signIn = new Widget({
+          ...widgetOptions,
+          features: { idpDiscovery: true },
+        });
+        signIn.renderEl({ el: $sandbox });
+        signIn.on('ready', function(context) {
+          expect(context).toMatchObject({ controller: 'idp-discovery' });
+          done();
+        });
+      });
+      it('does not trigger a ready event twice', function(done) {
+        // TODO: this feature does not have parity with classic
+        if (isOIE) {
+          done();
+          return;
+        }
+        signIn = new Widget(widgetOptions);
+        signIn.renderEl({ el: '#sandbox' });
+        signIn.on('ready', function(context) {
+          expect(context).toMatchObject({ controller: 'primary-auth' });
+          // Navigate directly to forgot-password page
+          const forgotPasswordLink = document.getElementsByClassName('link js-forgot-password');
+
+          forgotPasswordLink[0].click();
+        });
+        signIn.on('afterRender', function(context) {
+          if (context.controller === 'forgot-password') {
+            done();
+          }
+        });
+      });
+      ['ready', 'afterError', 'afterRender'].forEach(event => {
+        it(`traps third party errors (for ${event} event) in callbacks`, function() {
+          signIn = new Widget(widgetOptions);
+          const mockError = new Error('mockerror');
+          const fn = function() {
+            signIn.on(event, function() {
+              throw mockError;
+            });
+            signIn.trigger(event);
+          };
+          expect(fn).not.toThrowError(mockError);
+          expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
+        });
+      });
+      it('does not trap errors non-registered events', () => {
+        signIn = new Widget(widgetOptions);
         const mockError = new Error('mockerror');
         const fn = function() {
-          signIn.on(event, function() {
+          signIn.on('not-widget-event', function() {
             throw mockError;
           });
-          signIn.trigger(event);
+          signIn.trigger('not-widget-event');
         };
-        expect(fn).not.toThrowError(mockError);
-        expect(Logger.error).toHaveBeenCalledWith(`[okta-signin-widget] "${event}" event handler error:`, mockError);
+        expect(fn).toThrowError(mockError);
+        expect(Logger.error).not.toHaveBeenCalled();
       });
+    }
+
+    describe('OIE', () => {
+      beforeEach(() => {
+        MockUtil.mockAjax([
+          mockXhr(RAW_IDX_RESPONSE)
+        ]);
+      });
+
+      testEvents( {
+        baseUrl: url,
+        stateToken: 'abc'
+      }, true);
     });
-    it('does not trap errors non-registered events', () => {
-      const mockError = new Error('mockerror');
-      const fn = function() {
-        signIn.on('not-widget-event', function() {
-          throw mockError;
-        });
-        signIn.trigger('not-widget-event');
-      };
-      expect(fn).toThrowError(mockError);
-      expect(Logger.error).not.toHaveBeenCalled();
+
+    describe('Classic', () => {
+      testEvents({
+        baseUrl: url,
+        useClassicEngine: true
+      });
     });
   });
 });
@@ -325,6 +387,7 @@ describe('OktaSignIn object API', function() {
   function createWidget(options = {}) {
     signIn = new Widget(Object.assign({
       baseUrl: url,
+      useClassicEngine: true, // TODO: also test these features with OIE
       features: {
         router: true,
       },
@@ -626,7 +689,7 @@ describe('OktaSignIn object API', function() {
 
     describe('after render v2', () => {
       beforeEach(() => {
-        createWidget({ stateToken: 'fakeV2Token' });
+        createWidget({ stateToken: 'fakeV2Token', useClassicEngine: false });
         signIn.renderEl({ el: $sandbox });
       });
       it('returns result from appState', () => {

--- a/test/unit/spec/Settings_spec.js
+++ b/test/unit/spec/Settings_spec.js
@@ -1,6 +1,104 @@
 import Settings from 'models/Settings';
 
 describe('models/Settings', () => {
+  let testContext;
+  beforeEach(() => {
+    const baseUrl = 'http://foo';
+    const authClient = mockAuthClient(baseUrl);
+    testContext = {
+      authClient,
+      baseUrl
+    };
+  });
+  
+  function mockAuthClient(baseUrl) {
+    const authClient = {
+      options: {},
+      http: {
+        setRequestHeader: () => {}
+      },
+      getIssuerOrigin: () => baseUrl
+    };
+    return authClient;
+  }
+
+  describe('baseUrl', () => {
+    it('cannot create settings without a baseUrl', () => {
+      const fn = () => {
+        return new Settings();
+      };
+      expect(fn).toThrowError('"baseUrl" is a required widget parameter');
+    });
+    it('accepts a baseUrl option and sets it in the model', () => {
+      const baseUrl = 'http://foo';
+      const settings = new Settings({ baseUrl });
+      expect(settings.get('baseUrl')).toBe(baseUrl);
+    });
+    it('baseUrl can be inferred from issuer option', () => {
+      const baseUrl = 'http://foo';
+      const issuer = `${baseUrl}/oauth2/default`;
+      const settings = new Settings({ issuer });
+      expect(settings.get('baseUrl')).toBe(baseUrl);
+    });
+    it('baseUrl can be inferred from authParams.issuer option', () => {
+      const baseUrl = 'http://foo';
+      const issuer = `${baseUrl}/oauth2/default`;
+      const settings = new Settings({ authParams: { issuer } });
+      expect(settings.get('baseUrl')).toBe(baseUrl);
+    });
+    it('baseUrl can be inferred from authClient issuer', () => {
+      const baseUrl = 'http://foo';
+      const authClient = mockAuthClient(baseUrl);
+      const settings = new Settings({ authClient });
+      expect(settings.get('baseUrl')).toBe(baseUrl);
+    });
+  });
+
+  describe('authClient', () => {
+    it('can create settings without an authClient', () => {
+      const { baseUrl } = testContext;
+      const fn = () => {
+        return new Settings({ baseUrl });
+      };
+      expect(fn).not.toThrow();
+    });
+    it('accepts an authClient option and sets it in the model', () => {
+      const { authClient } = testContext;
+      const settings = new Settings({ authClient });
+      expect(settings.get('authClient')).toBe(authClient);
+    });
+    it('exposes authClient on the getAuthClient() method', () => {
+      const { authClient } = testContext;
+      const settings = new Settings({ authClient });
+      expect(settings.getAuthClient()).toBe(authClient);
+    });
+    it('can set authClient using the setAuthClient() method', () => {
+      const { authClient, baseUrl } = testContext;
+      const settings = new Settings({ baseUrl });
+      settings.setAuthClient(authClient);
+      expect(settings.getAuthClient()).toBe(authClient);
+      expect(settings.get('authClient')).toBe(authClient);
+    });
+  });
+
+  describe('oauth2Enabled', () => {
+    it('is false by default', () => {
+      const { baseUrl } = testContext;
+      const settings = new Settings({ baseUrl });
+      expect(settings.get('oauth2Enabled')).toBe(false);
+    });
+    it('is true if clientId option is set', () => {
+      const { baseUrl } = testContext;
+      const settings = new Settings({ baseUrl, clientId: 'abc' });
+      expect(settings.get('oauth2Enabled')).toBe(true);
+    });
+    it('is true if authClient.options.clientId is set', () => {
+      const { baseUrl, authClient } = testContext;
+      authClient.options.clientId = 'ABC';
+      const settings = new Settings({ baseUrl, authClient });
+      expect(settings.get('oauth2Enabled')).toBe(true);
+    });
+  });
 
   describe('languageCode', () => {
     const setup = (mock=[], options) => {

--- a/test/unit/spec/v1/IDPDiscovery_spec.js
+++ b/test/unit/spec/v1/IDPDiscovery_spec.js
@@ -110,6 +110,7 @@ function setupSocial(settings) {
       {
         clientId: 'someClientId',
         redirectUri: 'https://0.0.0.0:9999',
+        useClassicEngine: true,
         authScheme: 'OAUTH2',
         authParams: {
           responseType: 'id_token',

--- a/test/unit/spec/v1/LoginRouter_spec.js
+++ b/test/unit/spec/v1/LoginRouter_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-prototype-builtins */
 /* eslint max-params: [2, 34], max-statements: 0, max-len: [2, 210], camelcase:0 */
 import { _, $, Backbone, Router, internal } from 'okta';
 import getAuthClient from 'widget/getAuthClient';
@@ -67,7 +68,7 @@ Expect.describe('v1/LoginRouter', function() {
   function setup(settings, resp) {
     settings = settings || {};
     const setNextResponse = settings.mockAjax === false ? function() {} : Util.mockAjax();
-    const baseUrl = 'https://foo.com';
+    const baseUrl = settings.hasOwnProperty('baseUrl') ? settings.baseUrl : 'https://foo.com';
     const authParams = { issuer: baseUrl, headers: {} };
     Object.keys(settings).forEach(key => {
       const parts = key.split('.');
@@ -75,7 +76,7 @@ Expect.describe('v1/LoginRouter', function() {
         authParams[parts[1]] = settings[key];
       }
     });
-    const authClient = settings.authClient || getAuthClient({ authParams });
+    const authClient = settings.hasOwnProperty('authClient') ? settings.authClient : getAuthClient({ authParams });
     const eventSpy = jasmine.createSpy('eventSpy');
     const afterRenderHandler = jasmine.createSpy('afterRenderHandler');
     const afterErrorHandler = jasmine.createSpy('afterErrorHandler');
@@ -84,6 +85,7 @@ Expect.describe('v1/LoginRouter', function() {
         {
           el: $sandbox,
           baseUrl: baseUrl,
+          useClassicEngine: true,
           authClient: authClient,
         },
         settings
@@ -94,8 +96,10 @@ Expect.describe('v1/LoginRouter', function() {
     router.on('pageRendered', eventSpy);
     router.on('afterRender', afterRenderHandler);
     router.on('afterError', afterErrorHandler);
-    spyOn(authClient.token, 'getWithoutPrompt').and.callThrough();
-    spyOn(authClient.token.getWithRedirect, '_setLocation');
+    if (authClient) {
+      spyOn(authClient.token, 'getWithoutPrompt').and.callThrough();
+      spyOn(authClient.token.getWithRedirect, '_setLocation');
+    }
     setNextResponse(resp);
 
     return Q({
@@ -679,7 +683,7 @@ Expect.describe('v1/LoginRouter', function() {
     const errorSpy = jasmine.createSpy('errorSpy');
 
     const fn = function() {
-      setup({ globalErrorFn: errorSpy, baseUrl: undefined });
+      setup({ globalErrorFn: errorSpy, baseUrl: undefined, authClient: undefined });
     };
 
     expect(fn).not.toThrow();

--- a/test/unit/spec/v1/PrimaryAuth_spec.js
+++ b/test/unit/spec/v1/PrimaryAuth_spec.js
@@ -113,6 +113,7 @@ async function setup(settings, requests, refreshState) {
       {
         el: $sandbox,
         baseUrl: baseUrl,
+        useClassicEngine: true,
         authClient: authClient,
         globalSuccessFn: successSpy,
       },

--- a/test/unit/spec/v1/RecoveryQuestion_spec.js
+++ b/test/unit/spec/v1/RecoveryQuestion_spec.js
@@ -27,6 +27,7 @@ function setup(settings, res) {
       {
         el: $sandbox,
         baseUrl: baseUrl,
+        useClassicEngine: true,
         features: { securityImage: true },
         authClient: authClient,
       },

--- a/test/unit/spec/v2/BaseLoginRouter_spec.js
+++ b/test/unit/spec/v2/BaseLoginRouter_spec.js
@@ -6,7 +6,6 @@ import Errors from 'util/Errors';
 import $sandbox from 'sandbox';
 import getAuthClient from 'widget/getAuthClient';
 import XHRInteract from '../../../../playground/mocks/data/oauth2/interact.json';
-import XHRWellKnown from '../../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
 import XHRIdentifyWithPassword
   from '../../../../playground/mocks/data/idp/idx/identify-with-password.json';
 import XHRIdentify from '../../../../playground/mocks/data/idp/idx/identify.json';
@@ -54,8 +53,8 @@ describe('v2/BaseLoginRouter', function() {
     const baseUrl = 'http://localhost:3000';
     const authParams = {
       issuer: baseUrl,
-      pkce: settings?.useInteractionCodeFlow || false,
-      clientId: 'somestring',
+      pkce: settings?.pkce || false,
+      clientId: settings?.clientId,
       flow: settings?.flow,
       codeChallenge: settings?.codeChallenge,
       transactionManager: {
@@ -98,7 +97,23 @@ describe('v2/BaseLoginRouter', function() {
           router.render(FormController);
         });
       },
+      ...testContext
     };
+  }
+
+  function setupOAuth(settings = {}) {
+    const clientId = 'someClientId';
+    const codeChallenge = 'someCodeChallenge'; // prevent calculating PKCE values / calling getWellKnown
+    testContext = {
+      clientId,
+      codeChallenge,
+      ...testContext
+    };
+    return setup({
+      clientId,
+      codeChallenge,
+      ...settings
+    });
   }
 
   afterEach(function() {
@@ -110,9 +125,7 @@ describe('v2/BaseLoginRouter', function() {
 
   describe('restartLoginFlow', () => {
     it('re-renders', () => {
-      setup({
-        useInteractionCodeFlow: true
-      });
+      setup();
       const { router } = testContext;
       router.controller = {
         constructor: () => {}
@@ -124,7 +137,7 @@ describe('v2/BaseLoginRouter', function() {
     it('clears the recoveryToken (before render)', () => {
       const recoveryToken = 'abc';
       setup({
-        useInteractionCodeFlow: true,
+        pkce: true,
         recoveryToken
       });
       const { router, authClient } = testContext;
@@ -146,7 +159,7 @@ describe('v2/BaseLoginRouter', function() {
     it('clears the otp (before render)', () => {
       const otp = '123456';
       setup({
-        useInteractionCodeFlow: true,
+        pkce: true,
         otp
       });
       const { router } = testContext;
@@ -192,7 +205,7 @@ describe('v2/BaseLoginRouter', function() {
       const globalErrorFn = jest.fn();
       setup({
         globalErrorFn,
-        useInteractionCodeFlow: true,
+        pkce: true,
         stateToken: 'foo',
         proxyIdxResponse: false,
       });
@@ -220,14 +233,11 @@ describe('v2/BaseLoginRouter', function() {
       jest.spyOn(TestRouter.prototype, 'handleError');
       const globalErrorFn = jest.fn();  // prevents error from being logged to test console as well
 
-      setup({
-        useInteractionCodeFlow: true,
+      setupOAuth({
         globalErrorFn,
-        codeChallenge: 'fake' // avoid calculating PKCE values
       });
 
       Util.mockAjax([
-        mockXhr(XHRWellKnown),
         mockXhr(FakeIdxClientError, 400)
       ]);
 
@@ -247,14 +257,11 @@ describe('v2/BaseLoginRouter', function() {
       jest.spyOn(TestRouter.prototype, 'handleError');
       const globalErrorFn = jest.fn();  // prevents error from being logged to test console as well
 
-      setup({
-        useInteractionCodeFlow: true,
+      setupOAuth({
         globalErrorFn,
-        codeChallenge: 'fake' // avoid calculating PKCE values
       });
 
       Util.mockAjax([
-        mockXhr(XHRWellKnown),
         mockXhr(UnauthorizedClientError, 400)
       ]);
 
@@ -285,10 +292,8 @@ describe('v2/BaseLoginRouter', function() {
         jest.spyOn(mocked.startLoginFlow, 'startLoginFlow').mockResolvedValue(mockIdxState);
         jest.spyOn(TestRouter.prototype, 'handleUpdateAppState');
   
-        setup({
-          useInteractionCodeFlow: true,
+        setupOAuth({
           flow: 'default',
-          codeChallenge: 'fake'
         });
   
         const { router, render, authClient } = testContext;
@@ -314,10 +319,8 @@ describe('v2/BaseLoginRouter', function() {
         jest.spyOn(mocked.startLoginFlow, 'startLoginFlow').mockResolvedValue(mockIdxState);
         jest.spyOn(TestRouter.prototype, 'handleUpdateAppState');
   
-        setup({
-          useInteractionCodeFlow: true,
+        setupOAuth({
           flow: 'default',
-          codeChallenge: 'fake'
         });
   
         const { router, render, authClient } = testContext;
@@ -332,259 +335,222 @@ describe('v2/BaseLoginRouter', function() {
     });
   });
 
-  it('should render without error when flow not provided', async function() {
-    setup({stateToken: 'foo'});
-
-    const { afterErrorHandler, afterRenderHandler, router, render} = testContext;
-    Util.mockAjax([
-      mockXhr(XHRIdentify)
-    ]);
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalledTimes(1);
-    expect(router.appState.getCurrentViewState().name).toBe('identify');
+  describe('stateToken flow', () => {
+    it('should render without error when flow not provided', async function() {
+      setup({stateToken: 'foo'});
+  
+      const { afterErrorHandler, afterRenderHandler, router, render} = testContext;
+      Util.mockAjax([
+        mockXhr(XHRIdentify)
+      ]);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalledTimes(1);
+      expect(router.appState.getCurrentViewState().name).toBe('identify');
+    });
+    it('should render identify page (flow="default")', async function() {
+      setup({
+        flow: 'default',
+        stateToken: 'fake-token'
+      });
+  
+      const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
+      Util.mockAjax([
+        mockXhr(RAW_IDX_RESPONSE)
+      ]);
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('identify');
+    });
   });
 
-  it('should render identify page (stateToken=null, useInteractionCodeFlow=true)', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'default',
-      codeChallenge: 'fake' // avoid calculating PKCE values
+  describe('OAuth', () => {
+    it('should render identify page (flow=default)', async function() {
+      setupOAuth({
+        flow: 'default'
+      });
+      
+      const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(XHRIdentifyWithPassword)
+      ]);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('identify');
     });
-    
-    const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(XHRIdentifyWithPassword)
-    ]);
+    it('should render identify page (flow="login")', async function() {
+      setupOAuth({
+        flow: 'login'
+      });
+      const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+      ]);
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('identify');
+    });
+  
+    it('should result with `enroll-profile` render (flow="signup")', async function() {
+      setupOAuth({
+        flow: 'signup'
+      });
+  
+      const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+        mockXhr(EnrollProfile) // enroll
+      ]);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
+    });
 
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('identify');
+    it('should result with `reset-authenticator` (password) render (flow="resetPassword")', async function() {
+      setupOAuth({
+        flow: 'resetPassword',
+      });
+  
+      const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
+  
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+        mockXhr(ResetPassword) // currentAuthenticator-recover
+      ]);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('reset-authenticator');
+    });
+    it('should result with `select-authenticator-unlock-account` render (flow="unlockAccount")', async function() {
+      setupOAuth({
+        flow: 'unlockAccount',
+      });
+  
+      const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
+  
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+        mockXhr(UserUnlockAccount) // user unlock
+      ]);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('select-authenticator-unlock-account');
+    });
+
+    it('can continue a saved flow', async function() {
+      setupOAuth({
+        flow: 'signup'
+      });
+  
+      const { authClient, afterErrorHandler, afterRenderHandler, router, render, codeChallenge } = testContext;
+      Util.mockAjax([
+        mockXhr(EnrollProfile) // introspect
+      ]);
+
+      const meta = await authClient.idx.createTransactionMeta();
+      meta.interactionHandle = 'fake';
+      meta.codeChallenge = codeChallenge;
+      
+      authClient.idx.saveTransactionMeta(meta);
+      expect(authClient.idx.getSavedTransactionMeta()).toEqual(meta);
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
+    });
+
+    it('should abandon meta flow if it does not match configured flow', async function() {
+      setupOAuth({
+        flow: 'signup'
+      });
+  
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+        mockXhr(EnrollProfile) // enroll
+      ]);
+  
+      const { authClient, afterErrorHandler, afterRenderHandler, router, render, codeChallenge  } = testContext;
+      const meta = await authClient.idx.createTransactionMeta();
+      meta.interactionHandle = 'fake';
+      meta.codeChallenge = codeChallenge;
+      authClient.idx.saveTransactionMeta(meta);
+      expect(authClient.idx.getSavedTransactionMeta()).toEqual(meta);
+      meta.flow = 'login';
+      authClient.idx.saveTransactionMeta(meta);
+      expect(authClient.idx.getSavedTransactionMeta()).toBe(undefined); // fails flow check
+  
+      await render();
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalled();
+      expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
+    });
+
+
+    it('should throw FlowError when there is no transaction on flow=PROCEED', async function() {
+      let globalErr = null;
+      const globalErrorFn = jest.fn(err => {
+        globalErr = err;
+      });
+
+      setupOAuth({
+        flow: 'proceed',
+        globalErrorFn
+      });
+
+      const { authClient, router } = testContext;
+      jest.spyOn(authClient.idx, 'getSavedTransactionMeta').mockResolvedValue(null);
+
+      await router.render(FormController);
+      expect(authClient.idx.getSavedTransactionMeta).toHaveBeenCalled();
+      expect(globalErrorFn).toHaveBeenCalled();
+      expect(globalErr).toBeInstanceOf(Errors.ConfiguredFlowError);
+    });
+
+    it('should throw ConfigError when invalid flow is configured', async function() {
+
+      let globalErr = null;
+      const globalErrorFn = jest.fn(err => {
+        globalErr = err;
+      });
+  
+      setupOAuth({
+        flow: 'notarealflow',
+        globalErrorFn
+      });
+  
+      const { afterErrorHandler, afterRenderHandler, router  } = testContext;
+  
+      Util.mockAjax([
+        mockXhr(XHRInteract), 
+        mockXhr(RAW_IDX_RESPONSE), // introspect
+        mockXhr(EnrollProfile) // enroll
+      ]);
+  
+      await router.render(FormController);
+      expect(afterErrorHandler).toHaveBeenCalledTimes(0);
+      expect(afterRenderHandler).toHaveBeenCalledTimes(1); // generic message is displayed
+      expect(globalErrorFn).toHaveBeenCalled();
+      expect(globalErr).toBeInstanceOf(Errors.ConfigError);
+    });
+
   });
 
-  it('should render identify page (stateToken="fake-token", useInteractionCodeFlow=false)', async function() {
-    setup({
-      flow: 'default',
-      stateToken: 'fake-token'
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
-    Util.mockAjax([
-      mockXhr(RAW_IDX_RESPONSE)
-    ]);
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('identify');
-  });
-
-  it('should render identify page (stateToken="fake-token", useInteractionCodeFlow=true)', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'default',
-      codeChallenge: 'fake',
-      stateToken: 'fake-token' // will ignore stateToken
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-    ]);
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('identify');
-  });
-
-  it('should render identify page (flow="login")', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'login',
-      codeChallenge: 'fake'
-    });
-    const { afterErrorHandler, afterRenderHandler, router, render } = testContext;
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-    ]);
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('identify');
-  });
-
-  it('should result with `enroll-profile` render (flow="signup")', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'signup',
-      codeChallenge: 'fake'
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-      mockXhr(EnrollProfile) // enroll
-    ]);
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
-  });
-
-  it('should result with `reset-authenticator` (password) render (flow="resetPassword")', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'resetPassword',
-      codeChallenge: 'fake'
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
-
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-      mockXhr(ResetPassword) // currentAuthenticator-recover
-    ]);
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('reset-authenticator');
-  });
-
-  it('should result with `select-authenticator-unlock-account` render (flow="unlockAccount")', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'unlockAccount',
-      codeChallenge: 'fake'
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router, render  } = testContext;
-
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-      mockXhr(UserUnlockAccount) // user unlock
-    ]);
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('select-authenticator-unlock-account');
-  });
-
-  it('can continue a saved flow', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'signup',
-      codeChallenge: 'fake'
-    });
-
-    const { authClient, afterErrorHandler, afterRenderHandler, router, render  } = testContext;
-    Util.mockAjax([
-      mockXhr(XHRWellKnown), // validate code challenge method
-      mockXhr(EnrollProfile) // introspect
-    ]);
-    const meta = await authClient.idx.createTransactionMeta();
-    meta.interactionHandle = 'fake';
-    authClient.idx.saveTransactionMeta(meta);
-    expect(authClient.idx.getSavedTransactionMeta()).toEqual(meta);
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
-  });
-
-  it('should abandon meta flow if it does not match configured flow', async function() {
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'signup',
-      codeChallenge: 'fake'
-    });
-
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-      mockXhr(EnrollProfile) // enroll
-    ]);
-
-    const { authClient, afterErrorHandler, afterRenderHandler, router, render  } = testContext;
-    const meta = await authClient.idx.createTransactionMeta();
-    meta.interactionHandle = 'fake';
-    authClient.idx.saveTransactionMeta(meta);
-    expect(authClient.idx.getSavedTransactionMeta()).toEqual(meta);
-    meta.flow = 'login';
-    authClient.idx.saveTransactionMeta(meta);
-    expect(authClient.idx.getSavedTransactionMeta()).toBe(undefined); // fails flow check
-
-    await render();
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalled();
-    expect(router.appState.getCurrentViewState().name).toBe('enroll-profile');
-  });
-
-  it('should throw FlowError when there is no transaction on flow=PROCEED', async function() {
-    let globalErr = null;
-    const globalErrorFn = jest.fn(err => {
-      globalErr = err;
-    });
-
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'proceed',
-      globalErrorFn
-    });
-
-    const { authClient, router } = testContext;
-    jest.spyOn(authClient.idx, 'getSavedTransactionMeta').mockResolvedValue(null);
-
-    await router.render(FormController);
-    expect(authClient.idx.getSavedTransactionMeta).toHaveBeenCalled();
-    expect(globalErrorFn).toHaveBeenCalled();
-    expect(globalErr).toBeInstanceOf(Errors.ConfiguredFlowError);
-  });
-
-  it('should throw ConfigError when invalid flow is configured', async function() {
-
-    let globalErr = null;
-    const globalErrorFn = jest.fn(err => {
-      globalErr = err;
-    });
-
-    setup({
-      useInteractionCodeFlow: true,
-      flow: 'notarealflow',
-      codeChallenge: 'fake',
-      globalErrorFn
-    });
-
-    const { afterErrorHandler, afterRenderHandler, router  } = testContext;
-
-    Util.mockAjax([
-      mockXhr(XHRWellKnown),
-      mockXhr(XHRInteract), 
-      mockXhr(RAW_IDX_RESPONSE), // introspect
-      mockXhr(EnrollProfile) // enroll
-    ]);
-
-    await router.render(FormController);
-    expect(afterErrorHandler).toHaveBeenCalledTimes(0);
-    expect(afterRenderHandler).toHaveBeenCalledTimes(1); // generic message is displayed
-    expect(globalErrorFn).toHaveBeenCalled();
-    expect(globalErr).toBeInstanceOf(Errors.ConfigError);
-  });
 });

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -179,7 +179,7 @@ describe('v2/utils/LinksUtil', function() {
       it('by default, returns `clickHandler` instead of `href`', () => {
         const settings = new Settings({
           baseUrl: 'https://foo',
-          useInteractionCodeFlow: true
+          clientId: 'abc'
         });
         const result = getBackToSignInLink({appState, settings});
         expect(result).toBeInstanceOf(Array);
@@ -195,7 +195,7 @@ describe('v2/utils/LinksUtil', function() {
       it('if `backToSignInLink` is set, returns `href` with value of `backToSignInLink`', () => {
         const settings = new Settings({
           baseUrl: 'https://foo',
-          useInteractionCodeFlow: true,
+          clientId: 'abc',
           backToSignInLink: 'https://okta.com',
         });
         const result = getBackToSignInLink({ appState, settings });
@@ -213,7 +213,7 @@ describe('v2/utils/LinksUtil', function() {
       it('(compat) if `signOutLink` is set, returns `href` with value of `signOutLink`', () => {
         const settings = new Settings({
           baseUrl: 'https://foo',
-          useInteractionCodeFlow: true,
+          clientId: 'abc',
           signOutLink: 'https://okta.com',
         });
         const result = getBackToSignInLink({ appState, settings });


### PR DESCRIPTION
## Description:

Sets OIE on "by default". OIDC flow will use interaction code flow by default. New option "useClassicEngine" can be set to true to enable embedded authn flows.

- removes option "useInteractionCodeFlow"
- adds new option "useClassicEngine" (false by default)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-487653](https://oktainc.atlassian.net/browse/OKTA-487653)


