### PR TITLE
Hide autopush checkbox for custom push

### DIFF
--- a/src/v2/view-builder/views/shared/ChallengePushView.js
+++ b/src/v2/view-builder/views/shared/ChallengePushView.js
@@ -28,7 +28,7 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       // 'hasSavingState' would be true by default.
       // Setting it to false when auth key is okta_verify or custom_app with autochallenge schema
       // So that 'o-form-saving' css class is not added while polling and checkbox remains enabled.
-      if (this.isOVWithAutoChallenge() || this.isCustomAppWithAutoChallenge()) {
+      if ((this.isOV() || this.isCustomApp()) && this.isAutoChallengeSupported()) {
         this.hasSavingState = false;
       }
       this.listenTo(this.model, 'error', this.stopPoll);
@@ -51,11 +51,15 @@ const Body = BaseFormWithPolling.extend(Object.assign(
 
     render() {
       BaseFormWithPolling.prototype.render.apply(this, arguments);
-      // Move checkbox below the button
-      // Checkbox is rendered by BaseForm using remediation response and
-      // hence by default always gets added above buttons.
-      if (this.isOVWithAutoChallenge() || this.isCustomAppWithAutoChallenge()) {
-        const checkbox = this.$el.find('[data-se="o-form-fieldset-autoChallenge"]');
+
+      const checkbox = this.$el.find('[data-se="o-form-fieldset-autoChallenge"]');
+
+      if (!this.isAutoChallengeSupported()) {
+        checkbox.length && checkbox.hide();
+      } else if (this.isOV() || this.isCustomApp()) {
+        // Move checkbox below the button
+        // Checkbox is rendered by BaseForm using remediation response and
+        // hence by default always gets added above buttons.
         checkbox.length && this.$el.find('.o-form-fieldset-container').append(checkbox);
       }
     },
@@ -108,12 +112,9 @@ const Body = BaseFormWithPolling.extend(Object.assign(
       return this.options.appState.get('authenticatorKey') === AUTHENTICATOR_KEY.CUSTOM_APP;
     },
 
-    isOVWithAutoChallenge() {
-      return this.isOV() && this.options.appState.getSchemaByName('autoChallenge');
-    },
-
-    isCustomAppWithAutoChallenge(){
-      return this.isCustomApp() && this.options.appState.getSchemaByName('autoChallenge');
+    isAutoChallengeSupported() {
+      return (this.options.appState.getSchemaByName('autoChallenge') !== null &&
+        this.options.appState.getSchemaByName('autoChallenge') !== undefined);
     }
   },
 

--- a/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeCustomAppPushPageObject.js
@@ -50,6 +50,10 @@ export default class ChallengeCustomAppPushPageObject extends ChallengeFactorPag
     return this.form.elementExist(AUTO_CHALLENGE_CHECKBOX_SELECTOR);
   }
 
+  async autoChallengeInputIsVisible() {
+    return this.form.getElement(AUTO_CHALLENGE_CHECKBOX_SELECTOR).visible;
+  }
+
   getAutoChallengeCheckboxLabel() {
     return this.form.getElement(AUTO_CHALLENGE_CHECKBOX_LABEL_SELECTOR);
   }

--- a/test/testcafe/spec/ChallengeCustomAppPush_spec.js
+++ b/test/testcafe/spec/ChallengeCustomAppPush_spec.js
@@ -35,6 +35,10 @@ const pushWaitMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/challenge/poll')
   .respond(pushPoll);
 
+const pushNoAutoChallengeMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(pushPoll);
+
 const pushAutoChallengeMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(pushPollAutoChallenge);
@@ -107,6 +111,9 @@ test
     await t.expect(checkboxLabel.hasClass('checked')).ok();
     await t.expect(checkboxLabel.textContent).eql('Send push automatically');
 
+    // make sure checkbox is visible
+    await t.expect(await challengeCustomAppPushPageObject.autoChallengeInputIsVisible()).ok();
+
     // unselect checkbox on click
     await challengeCustomAppPushPageObject.clickAutoChallengeCheckbox();
     await t.expect(checkboxLabel.hasClass('checked')).notOk();
@@ -117,6 +124,33 @@ test
     await t.expect(await challengeCustomAppPushPageObject.signoutLinkExists()).ok();
     await t.expect(challengeCustomAppPushPageObject.getSignoutLinkText()).eql('Back to sign in');
     
+  });
+
+test
+  .requestHooks(pushNoAutoChallengeMock)(`challenge custom app push screen does not have checkbox
+    when autoChallenge object is missing from IDX remediation response`, async t => {
+    
+    const challengeCustomAppPushPageObject = await setup(t);
+    
+    // all UI elements should be present except the checkbox
+    const pageTitle = challengeCustomAppPushPageObject.getPageTitle();
+    const pushBtn = challengeCustomAppPushPageObject.getPushButton();
+    const a11ySpan = challengeCustomAppPushPageObject.getA11ySpan();
+    const logoClass = challengeCustomAppPushPageObject.getBeaconClass();
+    await t.expect(pushBtn.textContent).contains('Push notification sent');
+    await t.expect(a11ySpan.textContent).contains('Push notification sent');
+    await t.expect(pushBtn.hasClass('link-button-disabled')).ok();
+    await t.expect(logoClass).contains('custom-app-logo');
+    await t.expect(pageTitle).contains('Verify with Custom Push');
+
+    // Verify links
+    await t.expect(await challengeCustomAppPushPageObject.switchAuthenticatorLinkExists()).ok();
+    await t.expect(challengeCustomAppPushPageObject.getSwitchAuthenticatorLinkText()).eql('Verify with something else');
+    await t.expect(await challengeCustomAppPushPageObject.signoutLinkExists()).ok();
+    await t.expect(challengeCustomAppPushPageObject.getSignoutLinkText()).eql('Back to sign in');
+
+    // assert checkbox not visible
+    await t.expect(await challengeCustomAppPushPageObject.autoChallengeInputIsVisible()).notOk();
   });
 
 test


### PR DESCRIPTION
## Description:

For Custom Push EA, we are not going to support auto-push for it, so the ask is to hide the "Send push automatically" checkbox. After we EA, then we will update the backend code to support the autopush cookie and then revert this SIW PR.

Accompanying backend change: https://github.com/okta/okta-core/pull/67379

## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [X] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? YES - tested topic version `yarn install-signin-widget 6.5.0-g91362c1` on my local rain and things looked good

### Screenshot/Video:

#### Before
![image](https://user-images.githubusercontent.com/19472516/173460991-4298c298-cb72-456c-955e-27e1d9af2790.png)


#### After
![image](https://user-images.githubusercontent.com/19472516/173461003-ceac38a5-dcce-42b5-8fa4-933d8be2ff18.png)


(Checkbox still shows for OV)
![image](https://user-images.githubusercontent.com/19472516/173461028-728d7b74-3a48-47a5-a514-71bbb012638d.png)


### Reviewers:

@mauriciocastillosilva-okta @indirathirumalaimurugan-okta @praveendurai-okta 

### Issue:

- [OKTA-506495](https://oktainc.atlassian.net/browse/OKTA-506495)


