### PR TITLE
OKTA-488909 :- rolling back fix for bug OKTA-476273

### DIFF
--- a/assets/sass/_container.scss
+++ b/assets/sass/_container.scss
@@ -8,7 +8,7 @@
   background-color: $secondary-bg-color;
   color: $medium-text-color;
   position: relative;
-  overflow: hidden;
+  overflow: auto;
 
   // Auth-container styles
   border-radius: 3px;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "6.4.2",
+  "version": "6.4.1",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description:
This PR will rollback the fix on [OKTA-476273](https://oktainc.atlassian.net/browse/OKTA-476273). We need to figure out a better way to fix the original problem. The rollback should be enough for now because the original bug is more a "cosmetic" issue.

I wanted to include a testcafe test and make sure we won't have the same issue in the future, however there is a limitation (bug) in testcafe, you can see more details [here](https://github.com/DevExpress/testcafe/issues/1186).
What we are going to do to develop a selenium test to validate this case for MFA in the classic version. I do believe selenium is robust enough and 🤞 it won't have the same limitation than testcafe. This is the [Jira for the selenium test](https://oktainc.atlassian.net/browse/OKTA-505855)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)
   YES, you can see [bacon here](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=VV-OKTA-488909-SIW-testing&page=1&pageSize=1)

### Screenshot/Video:
![aa](https://user-images.githubusercontent.com/90656212/173612309-0875a0e2-d1b0-4d9b-8177-2a037de1a70c.png)

### Reviewers:
@justinabrokwah-okta 

@okta/ciamx 

### Issue:
- [OKTA-488909](https://oktainc.atlassian.net/browse/OKTA-488909)


### Bacon
https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=VV-OKTA-488909&page=1&pageSize=1

![image](https://user-images.githubusercontent.com/90656212/173674635-7b3a7e37-dde8-4fb5-bf30-78cc66b20b2e.png)
