### PR TITLE
OKTA-488909 :- backport - rolling back fix for bug OKTA-476273

### DIFF
--- a/assets/sass/_container.scss
+++ b/assets/sass/_container.scss
@@ -8,7 +8,7 @@
   background-color: $secondary-bg-color;
   color: $medium-text-color;
   position: relative;
-  overflow: hidden;
+  overflow: auto;
 
   // Auth-container styles
   border-radius: 3px;


### PR DESCRIPTION
## Description:
This PR is a backport of [PR](https://github.com/okta/okta-signin-widget/pull/2566) and it will rollback the fix on [OKTA-476273](https://oktainc.atlassian.net/browse/OKTA-476273). We need to figure out a better way to fix the original problem. The rollback should be enough for now because the original bug is more a "cosmetic" issue.

I wanted to include a testcafe test and make sure we won't have the same issue in the future, however there is a limitation (bug) in testcafe, you can see more details https://github.com/DevExpress/testcafe/issues/1186.
What we are going to do to develop a selenium test to validate this case for MFA in the classic version. I do believe selenium is robust enough and 🤞 it won't have the same limitation than testcafe. This is the [Jira for the selenium test](https://oktainc.atlassian.net/browse/OKTA-505855). 

I created a follow up [jira](https://oktainc.atlassian.net/browse/OKTA-507227) to investigate about how to implement this test in testcafe asserting visible elements on the viewpoint. (🤞 this will work)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)
  YES

### Screenshot/Video:
![image](https://user-images.githubusercontent.com/90656212/173841681-c6f7803d-fe6a-4a34-a0da-f019d6e81964.png)

### Bacon 
https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=VV-OKTA-488909-backport&page=1&pageSize=2&tab=main
![image](https://user-images.githubusercontent.com/90656212/173903271-b1fabc45-44e6-4aa5-a3c7-4ae32963ba0f.png)


### Reviewers:
@justinabrokwah-okta 
@okta/ciamx 

### Issue:
- [OKTA-488909](https://oktainc.atlassian.net/browse/OKTA-488909)


