### PR TITLE
fix: remove invalid values from self service registration request

### DIFF
--- a/src/v1/controllers/RegistrationController.js
+++ b/src/v1/controllers/RegistrationController.js
@@ -94,6 +94,8 @@ export default BaseLoginController.extend({
   registerUser: function(postData) {
     const self = this;
 
+    Object.keys(postData).forEach((k) =>
+      (_.isNull(postData[k]) || _.isUndefined(postData[k]) || postData[k] === '') && delete postData[k]);
     this.model.attributes = postData;
     // Model.save returns a jqXHR
     Backbone.Model.prototype.save

--- a/test/unit/spec/v1/Registration_spec.js
+++ b/test/unit/spec/v1/Registration_spec.js
@@ -1037,4 +1037,100 @@ Expect.describe('Registration', function() {
         });
     });
   });
+
+  const sanitizeSetting = function() {
+    const preSubmitSpy = jasmine.createSpy('preSubmitSpy');
+    return {
+      registration: {
+        preSubmit: function(postData, onSuccess, onFailure) {
+          preSubmitSpy(postData, onSuccess, onFailure);
+          onSuccess(postData);
+        },
+        postSubmit: jasmine.createSpy('postSubmitSpy'),
+      },
+    };
+  };
+
+  Expect.describe('sanitizes invalid request values', function() {
+    itp('null value', function() {
+      const setting = sanitizeSetting();
+      return setup(setting).then(function(test) {
+        Util.resetAjaxRequests();
+        test.form.setUserName('test@example.com');
+        test.form.setPassword('Abcd1234');
+        test.form.setFirstname('firstName');
+        test.form.setLastname(null);
+        test.form.submit();
+        const model = test.router.controller.model;
+
+        spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
+        model.save();
+        Util.callAllTimeouts();
+        expect(test.router.controller.model.get('userName')).toBe('test@example.com');
+        expect(test.router.controller.model.get('firstName')).toBe('firstName');
+        expect(test.router.controller.model.has('lastName')).toBe(false);
+        expect(setting.registration.postSubmit).toHaveBeenCalled();
+      });
+    });
+    itp('undefined value', function() {
+      const setting = sanitizeSetting();
+      return setup(setting).then(function(test) {
+        Util.resetAjaxRequests();
+        test.form.setUserName('test@example.com');
+        test.form.setPassword('Abcd1234');
+        test.form.setFirstname('firstName');
+        test.form.setLastname(undefined);
+        test.form.submit();
+        const model = test.router.controller.model;
+
+        spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
+        model.save();
+        Util.callAllTimeouts();
+        expect(test.router.controller.model.get('userName')).toBe('test@example.com');
+        expect(test.router.controller.model.get('firstName')).toBe('firstName');
+        expect(test.router.controller.model.has('lastName')).toBe(false);
+        expect(setting.registration.postSubmit).toHaveBeenCalled();
+      });
+    });
+    itp('empty string', function() {
+      const setting = sanitizeSetting();
+      return setup(setting).then(function(test) {
+        Util.resetAjaxRequests();
+        test.form.setUserName('test@example.com');
+        test.form.setPassword('Abcd1234');
+        test.form.setFirstname('firstName');
+        test.form.setLastname('');
+        test.form.submit();
+        const model = test.router.controller.model;
+
+        spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
+        model.save();
+        Util.callAllTimeouts();
+        expect(test.router.controller.model.get('userName')).toBe('test@example.com');
+        expect(test.router.controller.model.get('firstName')).toBe('firstName');
+        expect(test.router.controller.model.has('lastName')).toBe(false);
+        expect(setting.registration.postSubmit).toHaveBeenCalled();
+      });
+    });
+    itp('no sanitize', function() {
+      const setting = sanitizeSetting();
+      return setup(setting).then(function(test) {
+        Util.resetAjaxRequests();
+        test.form.setUserName('test@example.com');
+        test.form.setPassword('Abcd1234');
+        test.form.setFirstname('firstName');
+        test.form.setLastname('lastName');
+        test.form.submit();
+        const model = test.router.controller.model;
+
+        spyOn(Backbone.Model.prototype, 'save').and.returnValue($.Deferred().resolve());
+        model.save();
+        Util.callAllTimeouts();
+        expect(test.router.controller.model.get('userName')).toBe('test@example.com');
+        expect(test.router.controller.model.get('firstName')).toBe('firstName');
+        expect(test.router.controller.model.get('lastName')).toBe('lastName');
+        expect(setting.registration.postSubmit).toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description:
- Self-Service Registration (classic) is using null values in the registration request for some optional fields that are not populated in the registration form. This causes a NPE in okta-core
   - Add logic which removes any null, undefined, or empty string fields from the request

- [Green Monolith Bacon](https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=OKTA-495844-inline-hook-bug&page=1&pageSize=6&sha=b27a53cadd5382af8b7657b71d17a7eef5f497e7&tab=main)

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (**YES**)

### Screenshot/Video:
* [Video - Before](https://okta.app.box.com/file/972244347977)
* [Video - After](https://okta.app.box.com/file/972244442523)

### Reviewers:
@vicentevillegas-okta @justinabrokwah-okta @okta/ciamx 

### Issue:

- [OKTA-495844](https://oktainc.atlassian.net/browse/OKTA-495844)