### PR TITLE
Update Travis CI to use node@14

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,6 @@
 packages/@okta/pseudo-loc/    @nikhilvenkatraman-okta @jmelberg-okta
 packages/@okta/i18n/          @nikhilvenkatraman-okta @jmelberg-okta @mauriciocastillosilva-okta @pradeepdewda-okta
 test/testcafe/spec-en-leaks/  @nikhilvenkatraman-okta @jmelberg-okta
+
+# SIW Next (v3)
+src/v3/                       @glenfannin-okta @leemchale-okta @lesterchoi-okta @shawyu-okta @shuowu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- '12'
+- '14'
 
 install:
 - TMPDIR=/tmp yarn install


### PR DESCRIPTION
- siw-next@cf448b34db7604185d3f1b889e9f985d1a87b9ff
- import siw-next as src/v3 workspace
- add missing dependency @babel/preset-react
- try node v14 in setup
- update expected bundle size of next to 2.1MB
- use prepack script to update package.json in dist before publish
- remove registry url from yarnrc
- fix delay in start:mock-server script
- clean up package.json
- revert changes to responseConfig
- disable skipLibCheck in v3 tsconfig
- move @types to dependencies
- increase timeout of publish task
- fix "src" alias in v3 tsconfig
- remove broken "preview" script
- update supported engines to node>=14.0.0
- re-enable lib checks in tsconfig
- update travis config to use node 14

## Description:



## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


