### PR TITLE
Okta 485079 fix issue with secondary authenticator recovery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1436,6 +1436,7 @@ In `okta-signin-widget` directory:
 
 ```bash
 yarn build:release
+cd dist
 yarn link
 yarn build:webpack-dev --output-path ./dist/js --output-filename okta-sign-in.entry.js --watch
 ```

--- a/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
+++ b/src/v2/view-builder/views/phone/ChallengeAuthenticatorDataPhoneView.js
@@ -19,7 +19,8 @@ const Body = BaseForm.extend(
         : loc('oie.phone.call.primaryButton', 'login');
     },
 
-    handleSecondaryLinkClick() {
+    handleSecondaryLinkClick(e) {
+      e.preventDefault();
       // Call the API to send a code via secondary mode
       const secondaryMode = this.model.get('secondaryMode');
       this.model.set('authenticator.methodType', secondaryMode);

--- a/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorPhone_spec.js
@@ -134,6 +134,10 @@ async function setupInteractionCodeFlow(t) {
     clientId: 'fake',
     redirectUri: 'http://doesnot-matter',
     useInteractionCodeFlow: true,
+    authParams: {
+      pkce: true,
+      state: 'mock-state'
+    }
   });
   return challengePhonePageObject;
 }
@@ -193,7 +197,7 @@ test
   });
 
 test
-  .requestHooks(logger, voiceSecondaryMock)('lazar', async t => {
+  .requestHooks(logger, voiceSecondaryMock)('Voice secondary mode - Secondary button click (interaction code flow)', async t => {
     const challengePhonePageObject = await setupInteractionCodeFlow(t);
     await challengePhonePageObject.clickSecondaryLink();
     await t.expect(logger.count(() => true)).eql(1);


### PR DESCRIPTION
## Description:

- Fixes issue with the secondary authenticator recovery link navigating away from the page instead of displaying the verification code input
- Updates the steps for local development workflow using `yarn link` in README.md

[Bacon build](https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=OKTA-485079-fix-issue-with-secondary-authenticator-recovery-link&page=1&pageSize=6&sha=db6071181cd4b1783fc08e384cb2765263aa975c&tab=main)


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? UNSURE

### Video:

https://okta.box.com/s/u9jg0sm8g9odux3ubd5ny7eqh1ryr223

### Reviewers:

@jaredperreault-okta 

### Issue:

https://oktainc.atlassian.net/browse/OKTA-485079


