### PR TITLE
update configs to run testcafe against v3

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -36,7 +36,7 @@
     "build:i18n": "node src/bin/properties-to-json",
     "clean-svg": "svgo -f src/img/authCoinIcons",
     "predev": "yarn build:i18n",
-    "dev": "preact watch --no-prerender --no-sw",
+    "dev": "preact watch --no-prerender --no-sw --port 3000",
     "prelint": "yarn build:i18n",
     "lint": "eslint .",
     "lint:report": "scripts/buildtools/lint-report.sh",
@@ -128,7 +128,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14 <16"
   },
   "msw": {
     "workerDirectory": "src/static"

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -11,12 +11,9 @@
  */
 
 /* eslint-disable import/no-extraneous-dependencies,no-param-reassign */
-import Buffer from 'buffer';
 import { resolve, join } from 'path';
 import { merge as webpackMerge } from 'webpack-merge';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import envVars from 'preact-cli-plugin-env-vars';
-import { DefinePlugin } from 'webpack';
 import { omit } from 'lodash';
 import playgroundConfig from '../../webpack.playground.config';
 
@@ -65,7 +62,7 @@ export default {
         rule.exclude = /\.svg$/;
       }
 
-      // FIXME remove ts-loader
+      // TODO: OKTA-515335 remove ts-loader
       if (rule.loader === 'babel-loader') {
         const use = [
           {
@@ -144,24 +141,18 @@ export default {
       'index.js',
     );
 
-    // polyfills for jsonforms
-    // https://github.com/APIDevTools/json-schema-ref-parser#browser-support
-    config.plugins.push(new DefinePlugin({ process: { browser: true }, Buffer }));
-
-    // preact-cli-plugin-env-vars
-    envVars(config, env, helpers);
-
-    // override with
-    Object.assign(config, webpackMerge(config, omit(playgroundConfig, [
+    // configs to inherit from webpack.playground.config.js
+    const inherited = omit(playgroundConfig, [
       'devServer.headers.Content-Security-Policy', // merge instead of override
       'devServer.port',
       'entry',
       'module',
       'output',
       'resolve.extensions',
-    ]), {
-      // TODO use built assets instead of relying on dev server
-      // add entry for playground bundle
+    ]);
+
+    // configs to override
+    const overrides = {
       entry: {
         playground: rootResolve('playground', 'main.ts'),
       },
@@ -175,6 +166,9 @@ export default {
           ),
         },
       },
-    }));
+    };
+
+    // TODO: OKTA-516685 use build assets instead of webpack-dev-server
+    Object.assign(config, webpackMerge(config, inherited, overrides));
   },
 };

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -10,54 +10,47 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-import buffer from 'buffer';
+/* eslint-disable import/no-extraneous-dependencies,no-param-reassign */
+import Buffer from 'buffer';
 import { resolve, join } from 'path';
-import { existsSync, copyFileSync } from 'fs';
-
+import { merge as webpackMerge } from 'webpack-merge';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import envVars from 'preact-cli-plugin-env-vars';
 import { DefinePlugin } from 'webpack';
+import { omit } from 'lodash';
+import playgroundConfig from '../../webpack.playground.config';
 
 // util: resolve paths relative to the project root
-const rootResolve = (...segments) => resolve(__dirname, '../../', ...segments);
+const rootResolve = (...parts) => resolve(__dirname, '../../', ...parts);
 
-const TARGET = rootResolve('target');
-const PLAYGROUND = rootResolve('playground');
-const DEV_SERVER_PORT = 3000;
-const MOCK_SERVER_PORT = 3030;
-const WIDGET_RC_JS = rootResolve('.widgetrc.js');
-const WIDGET_RC = rootResolve('.widgetrc');
-
-// run `OKTA_SIW_HOST=0.0.0.0 yarn start --watch` to override the host
-const HOST = process.env.OKTA_SIW_HOST || 'localhost';
-
-if (!existsSync(WIDGET_RC_JS) && existsSync(WIDGET_RC)) {
-  // eslint-disable-next-line @okta/okta/no-exclusive-language
-  console.error(`============================================
-Please migrate the ${WIDGET_RC} to ${WIDGET_RC_JS}.
-For more information, please see
-https://github.com/okta/okta-signin-widget/blob/master/MIGRATING.md
-============================================`);
-  process.exit(1);
-} else if (!existsSync(WIDGET_RC_JS)) {
-  // create default WIDGET_RC if it doesn't exist to simplifed the build process
-  copyFileSync(rootResolve('.widgetrc.sample.js'), WIDGET_RC_JS);
-}
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+const mergeContentSecurityPolicies = (...policies) => {
+  const toMap = (map, str) => (
+    str.split(/;\W*/)
+      .map((list) => list.split(/[ ]+/))
+      .reduce((m, [k, ...vals]) => {
+        m[k] = m[k] ? m[k].concat(vals) : vals;
+        return m;
+      }, map)
+  );
+  return Object.entries(policies.reduce(toMap, {}))
+    .map(([dir, vals]) => `${dir} ${[...new Set(vals)].join(' ')}`)
+    .join('; ');
+};
 
 export default {
   webpack(config, env, helpers) {
-    /* eslint-disable no-param-reassign */
     config.output.libraryTarget = 'umd';
     config.output.filename = ({ chunk }) => (
-      chunk.name === 'bundle'
-        ? 'okta-sign-in.next.js'
-        : '[name].next.js'
+      chunk.name === 'bundle' ? 'okta-sign-in.next.js' : '[name].next.js'
     );
+
+    // remove MiniCssExtractPlugin
     config.plugins = config.plugins.filter(
       (plugin) => !(plugin instanceof MiniCssExtractPlugin),
     );
 
+    // use odyssey babel configs
     config.module.rules.push({
       test: /\.(js|jsx|ts|tsx)$/,
       exclude: /node_modules/,
@@ -71,15 +64,15 @@ export default {
       if (rule.test && rule.test.test('.svg')) {
         rule.exclude = /\.svg$/;
       }
+
+      // FIXME remove ts-loader
       if (rule.loader === 'babel-loader') {
         const use = [
           {
             loader: 'babel-loader',
             options: rule.options,
           },
-          {
-            loader: 'ts-loader',
-          },
+          { loader: 'ts-loader' },
         ];
         return {
           ...rule,
@@ -128,13 +121,12 @@ export default {
       'index',
     );
 
-    // TODO: integrate with rollup bundling system once migrate to the widget repo
-    // preact-cli still stays with webpack v4, which seems to have issue to understand `exports` field correctly in auth-js' subdeps
-    // using ESM bundle of auth-js is required to enable tree-shaking
+    // TODO: integrate with rollup bundling system once migrate to the widget
+    // repo preact-cli still stays with webpack v4, which seems to have issue to
+    // understand `exports` field correctly in auth-js' subdeps using ESM bundle
+    // of auth-js is required to enable tree-shaking
     // https://github.com/preactjs/preact-cli/issues/1579
-    config.resolve.alias['@okta/okta-auth-js'] = resolve(
-      '..',
-      '..',
+    config.resolve.alias['@okta/okta-auth-js'] = rootResolve(
       'node_modules',
       '@okta',
       'okta-auth-js',
@@ -142,10 +134,9 @@ export default {
       'esm.browser.js',
     );
 
-    // broadcast-channel esnode bundle is loaded by default, browser one should be used
-    config.resolve.alias['broadcast-channel'] = resolve(
-      '..',
-      '..',
+    // broadcast-channel esnode bundle is loaded by default, browser one should
+    // be used
+    config.resolve.alias['broadcast-channel'] = rootResolve(
       'node_modules',
       'broadcast-channel',
       'dist',
@@ -153,51 +144,37 @@ export default {
       'index.js',
     );
 
-    if (env.production) {
-      config.output.libraryTarget = 'umd';
-    }
-
     // polyfills for jsonforms
-    config.plugins.push(
-      new DefinePlugin({
-        // https://github.com/APIDevTools/json-schema-ref-parser#browser-support
-        process: {
-          browser: true,
-        },
-        Buffer: buffer,
-      }),
-    );
-
-    config.devServer = {
-      host: HOST,
-      static: [PLAYGROUND, TARGET, {
-        staticOptions: {
-          watchContentBase: true
-        }
-      }],
-      historyApiFallback: true,
-      // FIXME CSP prevents scripts from loading in dev mode
-      // headers: { 'Content-Security-Policy': `script-src http://${HOST}:${DEV_SERVER_PORT}` },
-      compress: true,
-      port: DEV_SERVER_PORT,
-      proxy: [{
-        context: [
-          '/oauth2/',
-          '/api/v1/',
-          '/idp/idx/',
-          '/login/getimage',
-          '/sso/idps/',
-          '/app/UserHome',
-          '/oauth2/v1/authorize',
-          '/auth/services/',
-          '/.well-known/webfinger'
-        ],
-        target: `http://${HOST}:${MOCK_SERVER_PORT}`
-      }],
-    },
+    // https://github.com/APIDevTools/json-schema-ref-parser#browser-support
+    config.plugins.push(new DefinePlugin({ process: { browser: true }, Buffer }));
 
     // preact-cli-plugin-env-vars
     envVars(config, env, helpers);
-    /* eslint-enable no-param-reassign */
+
+    // override with
+    Object.assign(config, webpackMerge(config, omit(playgroundConfig, [
+      'devServer.headers.Content-Security-Policy', // merge instead of override
+      'devServer.port',
+      'entry',
+      'module',
+      'output',
+      'resolve.extensions',
+    ]), {
+      // TODO use built assets instead of relying on dev server
+      // add entry for playground bundle
+      entry: {
+        playground: rootResolve('playground', 'main.ts'),
+      },
+      devtool: 'cheap-module-source-map',
+      devServer: {
+        headers: {
+          'Content-Security-Policy': mergeContentSecurityPolicies(
+            "object-src 'self'; script-src 'self' 'unsafe-eval'",
+            `script-src ${config.devServer.host}:${config.devServer.port}`,
+            playgroundConfig.devServer.headers['Content-Security-Policy'] || '',
+          ),
+        },
+      },
+    }));
   },
 };

--- a/src/v3/test/e2e/.testcaferc.js
+++ b/src/v3/test/e2e/.testcaferc.js
@@ -4,7 +4,7 @@ module.exports = {
   hooks: {
     fixture: {
       before: async () => {
-         await waitOn({ resources: ['http-get://localhost:8080'] });
+         await waitOn({ resources: ['http-get://localhost:3000'] });
       }
     }
   },

--- a/src/v3/tsconfig.base.json
+++ b/src/v3/tsconfig.base.json
@@ -9,9 +9,15 @@
     "skipLibCheck": false,
     "baseUrl": ".",
     "paths": {
-      "src/*": ["./src/*"],
-      "react": ["node_modules/preact/compat"],
-      "react-dom": ["node_modules/preact/compat"]
+      "src/*": [
+        "./src/*"
+      ],
+      "react": [
+        "node_modules/preact/compat"
+      ],
+      "react-dom": [
+        "node_modules/preact/compat"
+      ]
     }
   }
 }

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -8,8 +8,8 @@ const TARGET = path.resolve(__dirname, 'target');
 const PLAYGROUND = path.resolve(__dirname, 'playground');
 const DEV_SERVER_PORT = 3000;
 const MOCK_SERVER_PORT = 3030;
-const WIDGET_RC_JS = '.widgetrc.js';
-const WIDGET_RC = '.widgetrc';
+const WIDGET_RC_JS = path.resolve(__dirname, '.widgetrc.js');
+const WIDGET_RC = path.resolve(__dirname, '.widgetrc');
 
 // run `OKTA_SIW_HOST=0.0.0.0 yarn start --watch` to override the host
 const HOST = process.env.OKTA_SIW_HOST || 'localhost';
@@ -102,28 +102,14 @@ module.exports = {
       ],
       target: `http://${HOST}:${MOCK_SERVER_PORT}`
     }],
-    onBeforeSetupMiddleware() {
-      const script = path.resolve(
-        __dirname,
-        'playground',
-        'mocks',
-        'server.js'
-      );
-      const watch = [
-        path.resolve(__dirname, 'playground', 'mocks')
-      ];
-      const env = {
-        MOCK_SERVER_PORT,
-        DEV_SERVER_PORT
-      };
+    // https://webpack.js.org/configuration/dev-server/#devserversetupmiddlewares
+    setupMiddlewares(middlewares) {
+      const script = path.resolve(__dirname, 'playground/mocks/server.js');
+      const watch = [path.resolve(__dirname, 'playground/mocks')];
+      const env = { MOCK_SERVER_PORT, DEV_SERVER_PORT };
       nodemon({ script, watch, env, delay: 50 })
-        .on('restart', (filesChanged) => {
-          console.log(
-            'file changed:',
-            filesChanged.join(', ')
-          );
-        })
         .on('crash', console.error);
+      return middlewares;
     },
   },
 };


### PR DESCRIPTION
## Description:

Update webpack and related configs to run existing TestCafe suite against widget v3.

- limit v3 engines node >=14 <16 due to fibers deprecation in 16
- load widgetrc from playground configs using relative path
- replace deprecated onBeforeSetupMiddleware webpack function

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-508218](https://oktainc.atlassian.net/browse/OKTA-508218)


