### PR TITLE
feat(IdentifierView): show custom access denied error message

### DIFF
--- a/assets/sass/v2/_all.scss
+++ b/assets/sass/v2/_all.scss
@@ -23,3 +23,4 @@
 @import "./success-redirect";
 @import "./captcha";
 @import "./yubikey";
+@import "./custom-access-denied-error-message";

--- a/assets/sass/v2/_custom-access-denied-error-message.scss
+++ b/assets/sass/v2/_custom-access-denied-error-message.scss
@@ -1,0 +1,6 @@
+.custom-access-denied-error-message {
+    .custom-links {
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/assets/sass/v2/_custom-access-denied-error-message.scss
+++ b/assets/sass/v2/_custom-access-denied-error-message.scss
@@ -2,5 +2,6 @@
     .custom-links {
         display: flex;
         flex-direction: column;
+        margin-left: 0; // unset ul style
     }
 }

--- a/assets/sass/v2/_custom-access-denied-error-message.scss
+++ b/assets/sass/v2/_custom-access-denied-error-message.scss
@@ -1,7 +1,7 @@
 .custom-access-denied-error-message {
-    .custom-links {
-        display: flex;
-        flex-direction: column;
-        margin-left: 0; // unset ul style
-    }
+  .custom-links {
+    display: flex;
+    flex-direction: column;
+    margin-left: 0; // unset ul style
+  }
 }

--- a/packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-api-keys.js
+++ b/packages/@okta/eslint-plugin-okta-ui/lib/rules/no-missing-api-keys.js
@@ -29,6 +29,7 @@ module.exports = {
       'api.factors.error.sms.invalid_phone', // mapped to oie.phone.invalid in i18nTransformer
       'E0000009', // mapped to errors.E0000009 in i18nTransformer
       'oie.selfservice.unlock_user.challenge.failed.permissions', // mapped to errors.E0000006 in i18nTransformer
+      'security.access_denied_custom_message', // user-provided string
     ];
     return {
       'Program': function (node) {

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -125,6 +125,7 @@ const idx = {
     // 'authenticator-verification-email-without-emailmagiclink',
     // 'identify-with-only-one-third-party-idp',
     // 'error-identify-access-denied',
+    // 'error-identify-access-denied-custom-message',
     // 'error-identify-user-locked-unable-challenge',
     // 'error-unable-to-authenticate-user',
     // 'terminal-device-activated',

--- a/playground/mocks/data/idp/idx/error-identify-access-denied-custom-message.json
+++ b/playground/mocks/data/idp/idx/error-identify-access-denied-custom-message.json
@@ -1,0 +1,19 @@
+{
+  "stateHandle": "01OCl7uyAUC4CUqHsObI9bvFiq01cRFgbnpJQ1bz82",
+  "version": "1.0.0",
+  "expiresAt": "2020-05-18T20:42:23.000Z",
+
+  "intent": "LOGIN",
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "You do not have <a href='#'>permission</a> to perform the requested action.",
+        "i18n": {
+          "key": "security.access_denied_custom_message"
+        },
+        "class": "ERROR"
+      }
+    ]
+  }
+}

--- a/playground/mocks/data/idp/idx/error-identify-access-denied-custom-message.json
+++ b/playground/mocks/data/idp/idx/error-identify-access-denied-custom-message.json
@@ -8,7 +8,11 @@
     "type": "array",
     "value": [
       {
-        "message": "You do not have <a href='#'>permission</a> to perform the requested action.",
+        "message": "You do not have permission to perform the requested action.",
+        "links": [
+          {"label": "Help link 1", "url": "https://www.okta.com/"},
+          {"label": "Help link 2", "url": "https://www.okta.com/help?page=1"}
+        ],
         "i18n": {
           "key": "security.access_denied_custom_message"
         },

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -350,10 +350,8 @@ export default Controller.extend({
       errorObj = { responseJSON: { errorSummary: loc('error.unsupported.response', 'login')}};
     }
 
-    this.options.appState.set('messages', idxStateError.messages)
-
     if(_.isFunction(form?.showCustomFormErrorCallout)) {
-      showErrorBanner = !form.showCustomFormErrorCallout(errorObj);
+      showErrorBanner = !form.showCustomFormErrorCallout(errorObj, idxStateError.messages);
     }
 
     // show error before updating app state.

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -350,6 +350,8 @@ export default Controller.extend({
       errorObj = { responseJSON: { errorSummary: loc('error.unsupported.response', 'login')}};
     }
 
+    this.options.appState.set('messages', idxStateError.messages)
+
     if(_.isFunction(form?.showCustomFormErrorCallout)) {
       showErrorBanner = !form.showCustomFormErrorCallout(errorObj);
     }

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -10,7 +10,7 @@ import signInWithDeviceOption from './signin/SignInWithDeviceOption';
 import { isCustomizedI18nKey } from '../../ion/i18nTransformer';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 import CookieUtil from 'util/CookieUtil';
-import HtmlView from './shared/HtmlView';
+import CustomAccessDeniedErrorMessage from './shared/CustomAccessDeniedErrorMessage';
 
 const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 
@@ -170,9 +170,13 @@ const Body = BaseForm.extend({
     }
 
     const { errorSummary } = error.responseJSON;
+
     const options = {
       type: 'error',
-      content: new HtmlView({ message: errorSummary }),
+      content: new CustomAccessDeniedErrorMessage({
+        message: errorSummary,
+        links: this.options.appState.get('messages')[0]?.links || [],
+      }),
     };
 
     this.showMessages(createCallout(options));

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -164,7 +164,7 @@ const Body = BaseForm.extend({
     return newSchemas;
   },
 
-  showCustomFormErrorCallout(error) {
+  showCustomFormErrorCallout(error, messages) {
     if (!error?.responseJSON?.errorSummaryKeys?.includes(CUSTOM_ACCESS_DENIED_KEY)) {
       return false;
     }
@@ -175,7 +175,7 @@ const Body = BaseForm.extend({
       type: 'error',
       content: new CustomAccessDeniedErrorMessage({
         message: errorSummary,
-        links: this.options.appState.get('messages')[0]?.links || [],
+        links: messages[0]?.links,
       }),
     };
 

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -169,13 +169,18 @@ const Body = BaseForm.extend({
       return false;
     }
 
+    const message = messages.find(message => message.i18n.key === CUSTOM_ACCESS_DENIED_KEY);
+    if (!message) {
+      return false;
+    }
+
     const { errorSummary } = error.responseJSON;
 
     const options = {
       type: 'error',
       content: new CustomAccessDeniedErrorMessage({
         message: errorSummary,
-        links: messages[0]?.links,
+        links: message.links,
       }),
     };
 

--- a/src/v2/view-builder/views/IdentifierView.js
+++ b/src/v2/view-builder/views/IdentifierView.js
@@ -1,4 +1,4 @@
-import { loc } from 'okta';
+import { loc, createCallout } from 'okta';
 import { FORMS as RemediationForms } from '../../ion/RemediationConstants';
 import { BaseForm, BaseView, createIdpButtons, createCustomButtons } from '../internals';
 import DeviceFingerprinting from '../utils/DeviceFingerprinting';
@@ -10,6 +10,10 @@ import signInWithDeviceOption from './signin/SignInWithDeviceOption';
 import { isCustomizedI18nKey } from '../../ion/i18nTransformer';
 import { getForgotPasswordLink } from '../utils/LinksUtil';
 import CookieUtil from 'util/CookieUtil';
+import HtmlView from './shared/HtmlView';
+
+const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
+
 
 const Body = BaseForm.extend({
 
@@ -158,6 +162,21 @@ const Body = BaseForm.extend({
     }
 
     return newSchemas;
+  },
+
+  showCustomFormErrorCallout(error) {
+    if (!error?.responseJSON?.errorSummaryKeys?.includes(CUSTOM_ACCESS_DENIED_KEY)) {
+      return false;
+    }
+
+    const { errorSummary } = error.responseJSON;
+    const options = {
+      type: 'error',
+      content: new HtmlView({ message: errorSummary }),
+    };
+
+    this.showMessages(createCallout(options));
+    return true;
   },
 
   _addForgotPasswordView() {

--- a/src/v2/view-builder/views/TerminalView.js
+++ b/src/v2/view-builder/views/TerminalView.js
@@ -1,8 +1,9 @@
-import { loc } from 'okta';
+import { loc, createCallout } from 'okta';
 import { BaseForm, BaseFooter, BaseView } from '../internals';
 import { getBackToSignInLink, getSkipSetupLink, getReloadPageButtonLink } from '../utils/LinksUtil';
 import EmailAuthenticatorHeader from '../components/EmailAuthenticatorHeader';
 import { OTPInformationTerminalView } from './consent/EmailMagicLinkOTPTerminalView';
+import CustomAccessDeniedErrorMessage from './shared/CustomAccessDeniedErrorMessage';
 
 const RETURN_LINK_EXPIRED_KEY = 'idx.return.link.expired';
 const IDX_RETURN_LINK_OTP_ONLY = 'idx.enter.otp.in.original.tab';
@@ -25,7 +26,8 @@ const EMAIL_ACTIVATION_EMAIL_EXPIRE = 'idx.expired.activation.token';
 const EMAIL_ACTIVATION_EMAIL_INVALID = 'idx.missing.activation.token';
 const EMAIL_ACTIVATION_EMAIL_SUBMITTED = 'idx.request.activation.email';
 const EMAIL_ACTIVATION_EMAIL_SUSPENDED = 'idx.activating.inactive.user';
- 
+
+const CUSTOM_ACCESS_DENIED_KEY = 'security.access_denied_custom_message';
 
 export const REGISTRATION_NOT_ENABLED = 'oie.registration.is.not.enabled';
 export const FORGOT_PASSWORD_NOT_ENABLED = 'oie.forgot.password.is.not.enabled';
@@ -131,6 +133,13 @@ const Body = BaseForm.extend({
       messagesObjs.value[0].class = 'ERROR';
     } else if (this.options.appState.containsMessageWithI18nKey(IDX_RETURN_LINK_OTP_ONLY)) {
       this.add(OTPInformationTerminalView);
+      hasCustomView = true;
+    } else if (this.options.appState.containsMessageStartingWithI18nKey(CUSTOM_ACCESS_DENIED_KEY)) {
+      this.add(createCallout({
+        type: 'error',
+        content: new CustomAccessDeniedErrorMessage(
+          { message: messagesObjs.value[0].message, links: messagesObjs.value[0].links })
+      }));
       hasCustomView = true;
     }
 

--- a/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
+++ b/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
@@ -1,0 +1,24 @@
+import { View } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+
+export default View.extend({
+  className: 'custom-access-denied-error-message',
+  template: hbs`
+    <p>{{message}}</p>
+    {{#if links}}
+      <div class="custom-links">
+        {{#each links}}
+        <a href={{url}} target="_blank" rel="noopener noreferrer">
+          {{label}}
+        </a>
+        {{/each}}
+      </div>
+    {{/if}}
+  `,
+  getTemplateData() {
+    return {
+      message: this.options.message,
+      links: this.options.links,
+    };
+  },
+});

--- a/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
+++ b/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
@@ -8,13 +8,15 @@ export default View.extend({
       <p>{{message}}</p>
     {{/if}}
     {{#if links}}
-      <div class="custom-links">
+      <ul class="custom-links">
         {{#each links}}
-        <a href={{url}} target="_blank" rel="noopener noreferrer">
-          {{label}}
-        </a>
+        <li>
+          <a href={{url}} target="_blank" rel="noopener noreferrer">
+            {{label}}
+          </a>
+        </li>
         {{/each}}
-      </div>
+      </ul>
     {{/if}}
   `,
   getTemplateData() {

--- a/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
+++ b/src/v2/view-builder/views/shared/CustomAccessDeniedErrorMessage.js
@@ -4,7 +4,9 @@ import hbs from 'handlebars-inline-precompile';
 export default View.extend({
   className: 'custom-access-denied-error-message',
   template: hbs`
-    <p>{{message}}</p>
+    {{#if message}}
+      <p>{{message}}</p>
+    {{/if}}
     {{#if links}}
       <div class="custom-links">
         {{#each links}}

--- a/src/v2/view-builder/views/shared/HtmlView.js
+++ b/src/v2/view-builder/views/shared/HtmlView.js
@@ -1,0 +1,9 @@
+import { View } from 'okta';
+import hbs from 'handlebars-inline-precompile';
+
+export default View.extend({
+  template: hbs`{{{message}}}`,
+  getTemplateData() {
+    return { message: this.options.message };
+  }
+});

--- a/src/v2/view-builder/views/shared/HtmlView.js
+++ b/src/v2/view-builder/views/shared/HtmlView.js
@@ -1,9 +1,0 @@
-import { View } from 'okta';
-import hbs from 'handlebars-inline-precompile';
-
-export default View.extend({
-  template: hbs`{{{message}}}`,
-  getTemplateData() {
-    return { message: this.options.message };
-  }
-});

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -119,6 +119,10 @@ export default class BaseFormObject {
     return this.el.find(FORM_INFOBOX_ERROR).innerText;
   }
 
+  getErrorBoxHtml() {
+    return this.getCallout(FORM_INFOBOX_ERROR).innerHTML;
+  }
+
   getAllErrorBoxTexts() {
     return this.getInnerTexts(FORM_INFOBOX_ERROR);
   }
@@ -230,7 +234,9 @@ export default class BaseFormObject {
   // =====================================
 
   getCallout(selector) {
-    return Selector(selector);
+    return Selector(selector).addCustomDOMProperties({
+      innerHTML: el => el.innerHTML,
+    });
   }
 
   async clickElement(selector) {

--- a/test/testcafe/framework/page-objects/components/BaseFormObject.js
+++ b/test/testcafe/framework/page-objects/components/BaseFormObject.js
@@ -2,6 +2,7 @@ import { Selector, ClientFunction } from 'testcafe';
 
 const TERMINAL_CONTENT = '.o-form-error-container .ion-messages-container';
 const FORM_INFOBOX_ERROR = '[data-se="o-form-error-container"] .infobox-error';
+const CALLOUT = '[data-se="callout"]';
 
 const SUBMIT_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="save"]';
 const CANCEL_BUTTON_SELECTOR = '.o-form-button-bar input[data-type="cancel"]';
@@ -120,7 +121,7 @@ export default class BaseFormObject {
   }
 
   getErrorBoxHtml() {
-    return this.getCallout(FORM_INFOBOX_ERROR).innerHTML;
+    return this.getCallout(CALLOUT).innerHTML;
   }
 
   getAllErrorBoxTexts() {

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -4,6 +4,8 @@ import { checkConsoleMessages, renderWidget } from '../framework/shared';
 import xhrIdentifyWithPassword from '../../../playground/mocks/data/idp/idx/identify-with-password';
 import xhrIdentifyRecover from '../../../playground/mocks/data/idp/idx/identify-recovery';
 import xhrErrorIdentify from '../../../playground/mocks/data/idp/idx/error-identify-access-denied';
+import xhrErrorIdentifyAccessDeniedCustomMessage
+  from '../../../playground/mocks/data/idp/idx/error-identify-access-denied-custom-message';
 
 const identifyWithPasswordMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -12,6 +14,12 @@ const identifyWithPasswordMock = RequestMock()
   .respond(xhrErrorIdentify, 403)
   .onRequestTo('http://localhost:3000/idp/idx/recover')
   .respond(xhrIdentifyRecover);
+
+const identifyWithPasswordErrorMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(xhrIdentifyWithPassword)
+  .onRequestTo('http://localhost:3000/idp/idx/identify')
+  .respond(xhrErrorIdentifyAccessDeniedCustomMessage, 403);
 
 const identifyRequestLogger = RequestLogger(
   /idx\/identify/,
@@ -148,3 +156,12 @@ test.requestHooks(identifyWithPasswordMock)('should add sub labels for Username 
   await t.expect(identityPage.getPasswordSubLabelValue()).eql('Your password goes here');
 });
 
+test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message\'s html', async t => {
+  const identityPage = await setup(t);
+
+  await identityPage.fillIdentifierField('Test Identifier');
+  await identityPage.fillPasswordField('adasdas');
+  await identityPage.clickNextButton();
+  await identityPage.waitForErrorBox();
+  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div>You do not have <a href="#">permission</a> to perform the requested action.</div>');
+});

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -156,12 +156,12 @@ test.requestHooks(identifyWithPasswordMock)('should add sub labels for Username 
   await t.expect(identityPage.getPasswordSubLabelValue()).eql('Your password goes here');
 });
 
-test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message\'s links', async t => {
+test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('adasdas');
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
-  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><div class="custom-links"><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></div></div>');
+  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
 });

--- a/test/testcafe/spec/IdentifyWithPassword_spec.js
+++ b/test/testcafe/spec/IdentifyWithPassword_spec.js
@@ -156,12 +156,12 @@ test.requestHooks(identifyWithPasswordMock)('should add sub labels for Username 
   await t.expect(identityPage.getPasswordSubLabelValue()).eql('Your password goes here');
 });
 
-test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message\'s html', async t => {
+test.requestHooks(identifyWithPasswordErrorMock)('should show custom access denied error message\'s links', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('adasdas');
   await identityPage.clickNextButton();
   await identityPage.waitForErrorBox();
-  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div>You do not have <a href="#">permission</a> to perform the requested action.</div>');
+  await t.expect(identityPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><div class="custom-links"><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></div></div>');
 });

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -12,6 +12,7 @@ import unlockFailed from '../../../playground/mocks/data/idp/idx/error-unlock-ac
 import accessDeniedOnOtherDeivce from '../../../playground/mocks/data/idp/idx/terminal-return-email-consent-denied';
 import terminalUnlockAccountFailedPermissions from '../../../playground/mocks/data/idp/idx/error-unlock-account-failed-permissions';
 import errorTerminalMultipleErrors from '../../../playground/mocks/data/idp/idx/error-terminal-multiple-errors';
+import customAccessDeniedErrorMessage from '../../../playground/mocks/data/idp/idx/error-identify-access-denied-custom-message.json';
 
 const terminalTransferredEmailMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
@@ -60,6 +61,10 @@ const accessDeniedOnOtherDeivceMock = RequestMock()
 const terminalUnlockAccountFailedPermissionsMock = RequestMock()
   .onRequestTo('http://localhost:3000/idp/idx/introspect')
   .respond(terminalUnlockAccountFailedPermissions);
+
+const terminalCustomAccessDeniedErrorMessageMock = RequestMock()
+  .onRequestTo('http://localhost:3000/idp/idx/introspect')
+  .respond(customAccessDeniedErrorMessage);
 
 fixture('Terminal view');
 
@@ -154,4 +159,10 @@ test.requestHooks(terminalMultipleErrorsMock)('should render each error message 
     'Please enter a password',
     'Your session has expired. Please try to sign in again.'
   ]);
+});
+
+test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
+  const terminalViewPage = await setup(t);
+
+  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><div class="custom-links"><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></div></div>');
 });

--- a/test/testcafe/spec/TerminalView_spec.js
+++ b/test/testcafe/spec/TerminalView_spec.js
@@ -164,5 +164,5 @@ test.requestHooks(terminalMultipleErrorsMock)('should render each error message 
 test.requestHooks(terminalCustomAccessDeniedErrorMessageMock)('should render custom access denied error message', async t => {
   const terminalViewPage = await setup(t);
 
-  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><div class="custom-links"><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></div></div>');
+  await t.expect(terminalViewPage.form.getErrorBoxHtml()).eql('<span data-se="icon" class="icon error-16"></span><div class="custom-access-denied-error-message"><p>You do not have permission to perform the requested action.</p><ul class="custom-links"><li><a href="https://www.okta.com/" target="_blank" rel="noopener noreferrer">Help link 1</a></li><li><a href="https://www.okta.com/help?page=1" target="_blank" rel="noopener noreferrer">Help link 2</a></li></ul></div>');
 });


### PR DESCRIPTION
## Description:
- new i18n key is gated on backend by ff
- renders custom error message callout:
1. identify view
<img width="424" alt="Screen Shot 2022-07-25 at 9 39 18 AM" src="https://user-images.githubusercontent.com/71431120/180830369-3b67d8f1-be60-497a-83c5-b4652841e20a.png">

2. terminal view
<img width="443" alt="Screen Shot 2022-07-25 at 9 38 50 AM" src="https://user-images.githubusercontent.com/71431120/180830357-e3a3b21e-f3bf-4ba5-b13e-770be1a4ed05.png">


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [x] Added e2e tests

- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- [x] Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-514055](https://oktainc.atlassian.net/browse/OKTA-514055)


