### PR TITLE
change package.json version to 0.0.0 to prevent accidentally blocking…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@okta/okta-signin-widget",
   "description": "The Okta Sign-In Widget",
-  "version": "6.5.0",
+  "version": "0.0.0",
   "homepage": "https://github.com/okta/okta-signin-widget",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description:

Change `package.json` version to `0.0.0` to prevent accidentally blocking the "current' (v2) widget release process.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-514623](https://oktainc.atlassian.net/browse/OKTA-514623)


