### PR TITLE
Fixes race condition when re-rendering

### DIFF
--- a/playground/mocks/config/test-configs/IdentifyWithRememberUsername.js
+++ b/playground/mocks/config/test-configs/IdentifyWithRememberUsername.js
@@ -13,6 +13,19 @@ const identifyWithEmailAuthenticator = {
   ],
 };
 
+const identifyMock = {
+  '/idp/idx/introspect': [
+    'identify'
+  ],
+  '/idp/idx/identify': [
+    'authenticator-verification-password'
+  ],
+  '/idp/idx/challenge/answer': [
+    'success'
+  ],
+};
+
 module.exports = {
-  identifyWithEmailAuthenticator
+  identifyWithEmailAuthenticator,
+  identifyMock
 };

--- a/playground/mocks/config/test-configs/SessionStorage.js
+++ b/playground/mocks/config/test-configs/SessionStorage.js
@@ -1,4 +1,4 @@
-const identifyChallengeMockWithError = {
+const identifyChallengeMock = {
   '/idp/idx/introspect': [
     'identify'
   ],
@@ -8,16 +8,20 @@ const identifyChallengeMockWithError = {
   '/idp/idx/challenge/poll': [
     'authenticator-verification-email'
   ],
-  '/idp/idx/challenge/answer': [
-    'error-401-invalid-otp-passcode'
-  ],
   '/idp/idx/cancel': [
     'identify'
   ]
 };
 
+const identifyChallengeMockWithError = {
+  ...identifyChallengeMock,
+  '/idp/idx/challenge/answer': [
+    'error-401-invalid-otp-passcode'
+  ]
+};
+
 const challengeSuccessMock = {
-  ...identifyChallengeMockWithError,
+  ...identifyChallengeMock,
   '/oauth2/default/.well-known/openid-configuration': [
     'well-known-openid-configuration'
   ],

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -259,6 +259,9 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     // clear otp (email magic link), if any
     this.settings.unset('otp');
 
+    // remove all event listeners from current controller instance. A new instance will be created in render().
+    this.controller.stopListening();
+
     // Re-render the widget
     this.render(this.controller.constructor);
   }

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -29,12 +29,10 @@ import AppState from './models/AppState';
 import sessionStorageHelper from './client/sessionStorageHelper';
 import {
   startLoginFlow,
-  interactionCodeFlow,
   handleConfiguredFlow,
+  updateAppState
 } from './client';
 
-import transformIdxResponse from './ion/transformIdxResponse';
-import { FORMS } from './ion/RemediationConstants';
 import CookieUtil from 'util/CookieUtil';
 import { formatError, LegacyIdxError, StandardApiError } from './client/formatError';
 import { RenderError, RenderResult } from 'types';
@@ -87,7 +85,10 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     });
 
     this.hooks = options.hooks;
-    this.appState = new AppState();
+    this.appState = new AppState({}, {
+      settings: this.settings,
+      hooks: this.hooks
+    });
 
     const wrapper = new AuthContainer({ appState: this.appState });
 
@@ -103,9 +104,9 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     this.hide();
 
     this.listenTo(this.appState, 'change:deviceFingerprint', this.updateDeviceFingerprint);
-    this.listenTo(this.appState, 'error', this.handleError);
-    this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);
-    this.listenTo(this.appState, 'remediationError', this.handleIdxResponseFailure);
+    // this.listenTo(this.appState, 'error', this.handleError);
+    // this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);
+    // this.listenTo(this.appState, 'remediationError', this.handleIdxResponseFailure);
     this.listenTo(this.appState, 'restartLoginFlow', this.restartLoginFlow);
   }
 
@@ -117,76 +118,19 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     }
   }
 
-  async handleUpdateAppState(idxResponse: IdxResponse): Promise<IdxResponse> {
-    // Only update the cookie when the user has successfully authenticated themselves 
-    // to avoid incorrect/unnecessary updates.
-    if (this.hasAuthenticationSucceeded(idxResponse) 
-      && this.settings.get('features.rememberMyUsernameOnOIE')) {
-      this.updateIdentifierCookie(idxResponse);
-    }    
-
-    const lastResponse = this.appState.get('idx');
-    const useInteractionCodeFlow = this.settings.get('useInteractionCodeFlow');
-    if (useInteractionCodeFlow) {
-      if (idxResponse.interactionCode) {
-        // Although session.stateHandle isn't used by interation flow,
-        // it's better to clean up at the end of the flow.
-        sessionStorageHelper.removeStateHandle();
-        // This is the end of the IDX flow, now entering OAuth
-        return interactionCodeFlow(this.settings, idxResponse);
-      }  
-    } else {
-      // Do not save state handle for the first page loads.
-      // Because there shall be no difference between following behavior
-      // 1. bootstrap widget
-      //    -> save state handle to session storage
-      //    -> refresh page
-      //    -> introspect using sessionStorage.stateHandle
-      // 2. bootstrap widget
-      //    -> do not save state handle to session storage
-      //    -> refresh page
-      //    -> introspect using options.stateHandle
-      if (lastResponse) {
-        sessionStorageHelper.setStateHandle(idxResponse?.context?.stateHandle);
-      }
-      // Login flows that mimic step up (moving forward in login pipeline) via internal api calls,
-      // need to clear stored stateHandles.
-      // This way the flow can maintain the latest state handle. For eg. Device probe calls
-      if (this.appState.get('currentFormName') === FORMS.CANCEL_TRANSACTION) {
-        sessionStorageHelper.removeStateHandle();
-      }
-    }
-
-    // transform response
-    const ionResponse = transformIdxResponse(this.settings, idxResponse, lastResponse);
-
-    await this.appState.setIonResponse(ionResponse, this.hooks);
-  }
-
-  handleIdxResponseFailure(error: LegacyIdxError = { error: 'unknown', details: undefined }) {
+  async handleIdxResponseFailure(error: LegacyIdxError = { error: 'unknown', details: undefined }) {
     // IDX errors will not call the global error handler
     error = formatError(error);
-    this.handleUpdateAppState(error.details);
+    await updateAppState(this.appState, error.details);
   }
 
   // Generic error handler for all exceptions
-  handleError(error: LegacyIdxError | StandardApiError | Error = { error: 'unknown', details: undefined }) {
-    // Show error message and notify listeners
-    const originalError = error;
+  async handleError(error: LegacyIdxError | StandardApiError | Error = { error: 'unknown', details: undefined }) {
     const formattedError = formatError({...error}); // format the error to resemble an IDX response
-    this.handleUpdateAppState(formattedError.details);
-    this.settings.callGlobalError(originalError);
-
-    // -- TODO: OKTA-244631 How to surface up the CORS error in IDX?
-    // -- The `err` object from idx.js doesn't have XHR object
-    // Global error handling for CORS enabled errors
-    // if (err.xhr && BrowserFeatures.corsIsNotEnabled(err.xhr)) {
-    //   this.settings.callGlobalError(new Errors.UnsupportedBrowserError(loc('error.enabled.cors')));
-    //   return;
-    // }
+    await updateAppState(this.appState, formattedError.details);
   }
 
-  /* eslint max-statements: [2, 30], complexity: [2, 13] */
+  /* eslint max-statements: [2, 34], complexity: [2, 14] */
   async render(Controller, options = {}) {
     // If url changes then widget assumes that user's intention was to initiate a new login flow,
     // so clear stored token to use the latest token.
@@ -209,11 +153,12 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     // introspect stateToken when widget is bootstrap with state token
     // and remove it from `settings` afterwards as IDX response always has
     // state token (which will be set into AppState)
+    let error;
     if (this.settings.get('oieEnabled')) {
       try {
         let idxResp = await startLoginFlow(this.settings);
         if (idxResp.error) {
-          this.appState.trigger('remediationError', idxResp.error);
+          await this.handleIdxResponseFailure(idxResp.error);
         } else {
           if (this.settings.get('flow') && !this.hasControllerRendered) {
             idxResp = await handleConfiguredFlow(idxResp, this.settings);
@@ -226,10 +171,11 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
             authClient.transactionManager.clear();
           }
 
-          this.appState.trigger('updateAppState', idxResp);
+          await updateAppState(this.appState, idxResp);
         }
       } catch (exception) {
-        this.appState.trigger('error', exception);
+        error = exception;
+        await this.handleError(exception);
       } finally {
         // These settings should only be used one time, for initial render
         this.settings.unset('stateToken');
@@ -264,6 +210,19 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     this.controller.render();
 
     this.hasControllerRendered = true;
+
+    // This will reject the promise returned from renderEl
+    if (error) {
+      this.settings.callGlobalError(error);
+    }
+
+    // -- TODO: OKTA-244631 How to surface up the CORS error in IDX?
+    // -- The `err` object from idx.js doesn't have XHR object
+    // Global error handling for CORS enabled errors
+    // if (err.xhr && BrowserFeatures.corsIsNotEnabled(err.xhr)) {
+    //   this.settings.callGlobalError(new Errors.UnsupportedBrowserError(loc('error.enabled.cors')));
+    //   return;
+    // }
   }
 
   /**

--- a/src/v2/BaseLoginRouter.ts
+++ b/src/v2/BaseLoginRouter.ts
@@ -104,9 +104,6 @@ class BaseLoginRouter extends Router<Settings, BaseLoginRouterOptions> {
     this.hide();
 
     this.listenTo(this.appState, 'change:deviceFingerprint', this.updateDeviceFingerprint);
-    // this.listenTo(this.appState, 'error', this.handleError);
-    // this.listenTo(this.appState, 'updateAppState', this.handleUpdateAppState);
-    // this.listenTo(this.appState, 'remediationError', this.handleIdxResponseFailure);
     this.listenTo(this.appState, 'restartLoginFlow', this.restartLoginFlow);
   }
 

--- a/src/v2/client/index.js
+++ b/src/v2/client/index.js
@@ -14,3 +14,4 @@ export * from './interactionCodeFlow';
 export * from './startLoginFlow';
 export * from './handleConfiguredFlow';
 export * from './constants';
+export * from './updateAppState';

--- a/src/v2/client/updateAppState.ts
+++ b/src/v2/client/updateAppState.ts
@@ -1,0 +1,80 @@
+import { IdxResponse } from "@okta/okta-auth-js";
+import CookieUtil from '../../util/CookieUtil';
+import AppState from '../models/AppState';
+import Settings from '../../models/Settings';
+import sessionStorageHelper from './sessionStorageHelper';
+import { interactionCodeFlow } from './interactionCodeFlow';
+import { FORMS } from "../ion/RemediationConstants";
+import transformIdxResponse from '../ion/transformIdxResponse';
+
+function hasAuthenticationSucceeded(idxResponse: IdxResponse) {
+  // Check whether authentication has succeeded. This is done by checking the server response
+  // and seeing if either the 'success' or 'successWithInteractionCode' objects are present.
+  return idxResponse?.rawIdxState?.success || idxResponse?.rawIdxState?.successWithInteractionCode;
+}
+
+/**
+  * When "Remember My Username" is enabled, we save the identifier in a cookie
+  * so that the next time the user visits the SIW, the identifier field can be 
+  * pre-filled with this value.
+  */
+function updateIdentifierCookie(idxResponse: IdxResponse) {
+  if (this.settings.get('features.rememberMe')) {
+    // Update the cookie with the identifier
+    const user = idxResponse?.context?.user;
+    const { identifier } = user?.value || {};
+    if (identifier) {
+      CookieUtil.setUsernameCookie(identifier);
+    }
+  } else {
+    // We remove the cookie explicitly if this feature is disabled.
+    CookieUtil.removeUsernameCookie();
+  }    
+}
+
+export async function updateAppState(appState: AppState, idxResponse: IdxResponse): Promise<void> {
+  const settings = appState.settings;
+
+  // Only update the cookie when the user has successfully authenticated themselves 
+  // to avoid incorrect/unnecessary updates.
+  if (hasAuthenticationSucceeded(idxResponse) && settings.get('features.rememberMyUsernameOnOIE')) {
+      updateIdentifierCookie(idxResponse);
+  }    
+
+  const lastResponse = appState.get('idx');
+  const useInteractionCodeFlow = settings.get('useInteractionCodeFlow');
+  if (useInteractionCodeFlow) {
+    if (idxResponse.interactionCode) {
+      // Although session.stateHandle isn't used by interation flow,
+      // it's better to clean up at the end of the flow.
+      sessionStorageHelper.removeStateHandle();
+      // This is the end of the IDX flow, now entering OAuth
+      return interactionCodeFlow(settings, idxResponse);
+    }  
+  } else {
+    // Do not save state handle for the first page loads.
+    // Because there shall be no difference between following behavior
+    // 1. bootstrap widget
+    //    -> save state handle to session storage
+    //    -> refresh page
+    //    -> introspect using sessionStorage.stateHandle
+    // 2. bootstrap widget
+    //    -> do not save state handle to session storage
+    //    -> refresh page
+    //    -> introspect using options.stateHandle
+    if (lastResponse) {
+      sessionStorageHelper.setStateHandle(idxResponse?.context?.stateHandle);
+    }
+    // Login flows that mimic step up (moving forward in login pipeline) via internal api calls,
+    // need to clear stored stateHandles.
+    // This way the flow can maintain the latest state handle. For eg. Device probe calls
+    if (appState.get('currentFormName') === FORMS.CANCEL_TRANSACTION) {
+      sessionStorageHelper.removeStateHandle();
+    }
+  }
+
+  // transform response
+  const ionResponse = transformIdxResponse(settings, idxResponse, lastResponse);
+
+  await appState.setIonResponse(ionResponse);
+}

--- a/src/v2/client/updateAppState.ts
+++ b/src/v2/client/updateAppState.ts
@@ -1,7 +1,6 @@
 import { IdxResponse } from "@okta/okta-auth-js";
 import CookieUtil from '../../util/CookieUtil';
 import AppState from '../models/AppState';
-import Settings from '../../models/Settings';
 import sessionStorageHelper from './sessionStorageHelper';
 import { interactionCodeFlow } from './interactionCodeFlow';
 import { FORMS } from "../ion/RemediationConstants";
@@ -18,8 +17,9 @@ function hasAuthenticationSucceeded(idxResponse: IdxResponse) {
   * so that the next time the user visits the SIW, the identifier field can be 
   * pre-filled with this value.
   */
-function updateIdentifierCookie(idxResponse: IdxResponse) {
-  if (this.settings.get('features.rememberMe')) {
+function updateIdentifierCookie(appState: AppState, idxResponse: IdxResponse) {
+  const settings = appState.settings;
+  if (settings.get('features.rememberMe')) {
     // Update the cookie with the identifier
     const user = idxResponse?.context?.user;
     const { identifier } = user?.value || {};
@@ -38,7 +38,7 @@ export async function updateAppState(appState: AppState, idxResponse: IdxRespons
   // Only update the cookie when the user has successfully authenticated themselves 
   // to avoid incorrect/unnecessary updates.
   if (hasAuthenticationSucceeded(idxResponse) && settings.get('features.rememberMyUsernameOnOIE')) {
-      updateIdentifierCookie(idxResponse);
+      updateIdentifierCookie(appState, idxResponse);
   }    
 
   const lastResponse = appState.get('idx');

--- a/src/v2/models/AppState.ts
+++ b/src/v2/models/AppState.ts
@@ -21,6 +21,8 @@ import {
 import { createOVOptions } from '../ion/ui-schema/ion-object-handler';
 import { _ } from '../mixins/mixins';
 import { executeHooksBefore, executeHooksAfter } from 'util/Hooks';
+import Settings from 'models/Settings';
+import Hooks from 'models/Hooks';
 
 /**
  * Keep track of stateMachine with this special model. Similar to `src/models/AppState.js`
@@ -72,6 +74,14 @@ const derived: Record<string, ModelProperty> = {
 export type AppStateProps = typeof local & typeof derived;
 
 export default class AppState extends Model {
+  settings: Settings;
+  hooks: Hooks;
+  
+  constructor(attributes, options) {
+    super(attributes, options);
+    this.settings = options.settings;
+    this.hooks = options.hooks;
+  }
 
   get<A extends Backbone._StringKey<AppStateProps>>(attributeName: A): any {
     return Model.prototype.get.call(this, attributeName);
@@ -252,7 +262,7 @@ export default class AppState extends Model {
     this.trigger('cache:clear');
   }
 
-  async setIonResponse(transformedResponse, hooks) {
+  async setIonResponse(transformedResponse) {
     const doRerender = this.shouldReRenderView(transformedResponse);
     this.clearAppStateCache();
     // set new app state properties
@@ -270,7 +280,7 @@ export default class AppState extends Model {
         Logger.error(JSON.stringify(transformedResponse, null, 2));
       }
 
-      const hook = hooks?.getHook(currentFormName); // may be undefined
+      const hook = this.hooks?.getHook(currentFormName); // may be undefined
       await executeHooksBefore(hook);
   
       this.unset('currentFormName', { silent: true });

--- a/test/unit/spec/v2/BaseLoginRouter_spec.js
+++ b/test/unit/spec/v2/BaseLoginRouter_spec.js
@@ -132,9 +132,7 @@ describe('v2/BaseLoginRouter', function() {
         useInteractionCodeFlow: true
       });
       const { router } = testContext;
-      router.controller = {
-        constructor: () => {}
-      };
+      router.controller = new FakeController();
       jest.spyOn(router, 'render').mockImplementation();
       router.appState.trigger('restartLoginFlow');
       expect(router.render).toHaveBeenCalledWith(router.controller.constructor);
@@ -150,7 +148,7 @@ describe('v2/BaseLoginRouter', function() {
       expect(settings.get('recoveryToken')).toBe(recoveryToken);
       expect(authClient.options.recoveryToken).toBe(recoveryToken);
 
-      router.controller = {};
+      router.controller = new FakeController();
       let clearInsideRender = false;
       jest.spyOn(router, 'render').mockImplementation(() => {
         expect(authClient.options.recoveryToken).toBe(undefined);
@@ -171,7 +169,7 @@ describe('v2/BaseLoginRouter', function() {
       const { settings } = router;
       expect(settings.get('otp')).toBe(otp);
 
-      router.controller = {};
+      router.controller = new FakeController();
       let clearInsideRender = false;
       jest.spyOn(router, 'render').mockImplementation(() => {
         expect(settings.get('otp')).toBe(undefined);

--- a/test/unit/spec/v2/BaseLoginRouter_spec.js
+++ b/test/unit/spec/v2/BaseLoginRouter_spec.js
@@ -199,15 +199,13 @@ describe('v2/BaseLoginRouter', function() {
       const { router, render, authClient } = testContext;
 
 
-      const { settings, appState } = router;
+      const { settings } = router;
       const error = new Error('test error');
       jest.spyOn(authClient.idx, 'start').mockRejectedValue(error);
-      jest.spyOn(appState, 'trigger');
       expect(settings.get('stateToken')).toBe('foo');
       expect(settings.get('proxyIdxResponse')).toBe(false);
   
       await render();
-      expect(appState.trigger).toHaveBeenCalledWith('error', error);
       expect(globalErrorFn).toHaveBeenCalledWith(error);
       expect(settings.get('stateToken')).toBe(undefined);
       expect(settings.get('proxyIdxResponse')).toBe(undefined);

--- a/test/unit/spec/v2/models/AppState_spec.js
+++ b/test/unit/spec/v2/models/AppState_spec.js
@@ -13,7 +13,7 @@ describe('v2/models/AppState', function() {
       if (currentFormName) {
         appStateData.currentFormName = currentFormName;
       }
-      this.appState = new AppState(appStateData);
+      this.appState = new AppState(appStateData, {});
     };
   });
 

--- a/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
+++ b/test/unit/spec/v2/view-builder/internals/BaseFooter_spec.js
@@ -25,7 +25,7 @@ describe('v2/view-builder/internals/BaseFooter', function() {
 
   beforeEach(() => {
     testContext = {
-      appState: new AppState(),
+      appState: new AppState({}, {}),
       settings: new Settings({ baseUrl: 'http://localhost:3000' }),
     };
   });

--- a/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
+++ b/test/unit/spec/v2/view-builder/utils/LinksUtil_spec.js
@@ -5,7 +5,7 @@ import Settings from '../../../../../../src/models/Settings';
 
 describe('v2/utils/LinksUtil', function() {
   const mockAppState = ({ remediationFormName, authenticatorCount, isPasswordRecovery }) => {
-    const appState = new AppState();
+    const appState = new AppState({}, {});
     jest.spyOn(appState, 'getRemediationAuthenticationOptions').mockImplementation(formName => {
       if (formName === remediationFormName) {
         if (authenticatorCount === 'many') {

--- a/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/AutoRedirectView_spec.js
@@ -15,7 +15,7 @@ describe('v2/view-builder/views/AutoRedirectView', function() {
   beforeEach(function() { 
     testContext = {};
     testContext.init = (user = SuccessWithAppUser.user.value, app = SuccessWithAppUser.app.value) => {
-      const appState = new AppState();
+      const appState = new AppState({}, {});
       appState.set('user', user);
       appState.set('app', app);
 

--- a/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/CaptchaView_spec.js
@@ -14,7 +14,7 @@ describe('v2/view-builder/views/CaptchaView', function() {
     testContext.init = (captcha = enrollProfileWithReCaptcha.captcha.value) => {
       const appState = new AppState({
         captcha
-      });
+      }, {});
       const settings = new Settings({ baseUrl: 'http://localhost:3000', language });
       testContext.view = new CaptchaView({
         appState,

--- a/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/ChallengeWebauthnView_spec.js
@@ -22,7 +22,7 @@ describe('v2/view-builder/views/webauthn/ChallengeWebauthnView', function() {
         currentAuthenticator,
         authenticatorEnrollments,
         app,
-      });
+      }, {});
       jest.spyOn(appState, 'getRemediationAuthenticationOptions').mockReturnValue(formName => {
         if (formName === 'select-authenticator-authenticate') {
           return [ { label: 'some authenticator '} ];

--- a/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollPollOktaVerifyView_spec.js
@@ -21,7 +21,7 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
       };
       const appState = new AppState({
         currentAuthenticator
-      });
+      }, {});
       spyOn(appState, 'hasRemediationObject').and.callFake((formName) => formName === 'select-enrollment-channel');
       spyOn(appState, 'trigger');
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
@@ -68,7 +68,7 @@ describe('v2/view-builder/views/ov/EnrollPollOktaVerifyView', function() {
 
   it('switches to select enroll method form when on mobile', function(done) {
     MockUtil.mockIntrospect(done, xhrAuthenticatorEnrollOktaVerifyQr, async (idxResp) => {
-      const appState = new AppState();
+      const appState = new AppState({}, {});
       const settings = new Settings({ baseUrl: 'http://localhost:3000' });
       const ionResponse = transformIdxResponse(settings, idxResp);
       await appState.setIonResponse(ionResponse);

--- a/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/EnrollWebauthnView_spec.js
@@ -26,7 +26,7 @@ describe('v2/view-builder/views/webauthn/EnrollWebauthnView', function() {
       const appState = new AppState({
         currentAuthenticator,
         authenticatorEnrollments,
-      });
+      }, {});
       spyOn(appState, 'getRemediationAuthenticationOptions').and.callFake(formName => {
         if (formName === 'select-authenticator-enroll') {
           return [ { label: 'some authenticator '} ];

--- a/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
+++ b/test/unit/spec/v2/view-builder/views/IdentifierView_spec.js
@@ -28,7 +28,7 @@ describe('v2/view-builder/views/IdentifierView', function() {
   beforeEach(function() { 
     testContext = {};
     testContext.init = (remediations = XHRIdentifyWithThirdPartyIdps.remediation.value) => {
-      const appState = new AppState();
+      const appState = new AppState({}, {});
       appState.set('remediations', remediations);
       testContext.view = new IdentifierView({
         appState,

--- a/test/unit/spec/v2/view-builder/views/shared/polling_spec.js
+++ b/test/unit/spec/v2/view-builder/views/shared/polling_spec.js
@@ -10,7 +10,7 @@ describe('v2/view-builder/views/polling', function() {
     Object.assign(testContext.pollingTestObj, polling);
 
     testContext.pollingTestObj.options = {};
-    testContext.pollingTestObj.options.appState = new AppState();
+    testContext.pollingTestObj.options.appState = new AppState({}, {});
     testContext.appState = testContext.pollingTestObj.options.appState;
     testContext.pollingTestObj.model = {};
   };


### PR DESCRIPTION
## Description:
There is a race condition on rendering caused by using synchronous event dispatch pattern with asynchronous handlers. When pressing "Back to Signin" the following message may appear in the console:

```
Panic!!
Cannot find view state for form identify-recovery.
All available form names: identify,select-enroll-profile,unlock-account,redirect-idp,redirect-idp,redirect-idp
```

See related GH issue: https://github.com/okta/okta-signin-widget/issues/2452

This PR fixes the issue by replacing the event dispatch pattern with a direct function call with "await" keyword to block further execution until the async handler has completed.


## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [x] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES)

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&branch=d16t-okta-signin-widget-3ea787f-62d06279&page=1&pageSize=6&tab=main

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-490220](https://oktainc.atlassian.net/browse/OKTA-490220)


