### PR TITLE
on-perm mfa pin value should be masked.

### DIFF
--- a/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/ChallengeAuthenticatorOnPremView.js
@@ -3,6 +3,7 @@ import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const ON_PREM_TOKEN_CHANGE_KEY = 'errors.E0000113';
+const PASSCODE_INPUT_NAME = 'credentials.passcode';
 
 const Body = BaseForm.extend({
 
@@ -17,6 +18,17 @@ const Body = BaseForm.extend({
       this.options.appState.getAuthenticatorDisplayName() ||
       loc('oie.on_prem.authenticator.default.vendorName', 'login');
     return loc('oie.on_prem.verify.title', 'login', [vendorName]);
+  },
+
+  getUISchema() {
+    const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
+    const passcodeSchema = uiSchemas.find(({name}) => name === PASSCODE_INPUT_NAME);
+
+    if (passcodeSchema) {
+      passcodeSchema.type = 'password';
+    }
+
+    return uiSchemas;
   },
 
   _checkTokenChange(model, convertedErrors) {

--- a/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
+++ b/src/v2/view-builder/views/on-prem/EnrollAuthenticatorOnPremView.js
@@ -3,6 +3,7 @@ import { BaseForm } from '../../internals';
 import BaseAuthenticatorView from '../../components/BaseAuthenticatorView';
 
 const ON_PREM_TOKEN_CHANGE_KEY = 'errors.E0000113';
+const PASSCODE_INPUT_NAME = 'credentials.passcode';
 
 const Body = BaseForm.extend({
 
@@ -17,6 +18,17 @@ const Body = BaseForm.extend({
       this.options.appState.getAuthenticatorDisplayName() ||
       loc('oie.on_prem.authenticator.default.vendorName', 'login');
     return loc('oie.on_prem.enroll.title', 'login', [vendorName]);
+  },
+
+  getUISchema() {
+    const uiSchemas = BaseForm.prototype.getUISchema.apply(this, arguments);
+    const passcodeSchema = uiSchemas.find(({name}) => name === PASSCODE_INPUT_NAME);
+
+    if (passcodeSchema) {
+      passcodeSchema.type = 'password';
+    }
+
+    return uiSchemas;
   },
 
   _checkTokenChange(model, convertedErrors) {

--- a/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
@@ -15,4 +15,8 @@ export default class ChallengeOnPremPageObject extends ChallengeFactorPageObject
     return this.form.getTextBoxErrorMessage(PASSCODE_FIELD_NAME);
   }
 
+  passcodeFieldType() {
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).type;
+  }
+
 }

--- a/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
@@ -16,7 +16,7 @@ export default class ChallengeOnPremPageObject extends ChallengeFactorPageObject
   }
 
   passcodeFieldType() {
-    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).type;
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).attr('type');
   }
 
 }

--- a/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/ChallengeOnPremPageObject.js
@@ -16,7 +16,7 @@ export default class ChallengeOnPremPageObject extends ChallengeFactorPageObject
   }
 
   passcodeFieldType() {
-    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).attr('type');
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).getAttribute('type');
   }
 
 }

--- a/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
@@ -14,7 +14,7 @@ export default class EnrollOnPremPageObject extends BasePageObject {
   }
 
   passcodeFieldType() {
-    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).attr('type');
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).getAttribute('type');
   }
 
   userNameFieldExists() {

--- a/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
@@ -13,6 +13,10 @@ export default class EnrollOnPremPageObject extends BasePageObject {
     return this.form.elementExist(`input[name="${PASSCODE_FIELD_NAME}"]`);
   }
 
+  passcodeFieldType() {
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).type;
+  }
+
   userNameFieldExists() {
     return this.form.elementExist(`input[name="${USER_NAME_FIELD_NAME}"]`);
   }

--- a/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
+++ b/test/testcafe/framework/page-objects/EnrollOnPremPageObject.js
@@ -14,7 +14,7 @@ export default class EnrollOnPremPageObject extends BasePageObject {
   }
 
   passcodeFieldType() {
-    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).type;
+    return this.form.getElement(`input[name="${PASSCODE_FIELD_NAME}"]`).attr('type');
   }
 
   userNameFieldExists() {

--- a/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
+++ b/test/testcafe/spec/ChallengeAuthenticatorOnPrem_spec.js
@@ -54,6 +54,7 @@ test.requestHooks(mockChallengeAuthenticatorOnPrem)('challenge on prem authentic
 
   // verify passcode
   await challengeOnPremPage.verifyFactor('credentials.passcode', 'test');
+  await t.expect(challengeOnPremPage.passcodeFieldType()).eql('password');
   await challengeOnPremPage.clickNextButton();
   const successPage = new SuccessPageObject(t);
   const pageUrl = await successPage.getPageUrl();

--- a/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
+++ b/test/testcafe/spec/EnrollAuthenticatorOnPremMfaView_spec.js
@@ -42,6 +42,7 @@ test
     await t.expect(enrollOnPremPage.getSaveButtonLabel()).eql('Verify');
     await t.expect(enrollOnPremPage.userNameFieldExists()).eql(true);
     await t.expect(enrollOnPremPage.passcodeFieldExists()).eql(true);
+    await t.expect(enrollOnPremPage.passcodeFieldType()).eql('password');
 
     // Verify links (switch authenticator link is present even if there is just one authenticator available)
     await t.expect(await enrollOnPremPage.switchAuthenticatorLinkExists()).ok();


### PR DESCRIPTION
## Description:
As of today, we are displaying on-perm mfa passcode in clear text and customer wants to mask this value.

Bacon: https://bacon-go.aue1e.saasure.net/commits?artifact=okta-signin-widget&branch=CA-OKTA-500843&page=1&pageSize=6&sha=feea2bfacc8e672b8a2da8435649fd25ce6bd5cb&tab=main


## PR Checklist

- [X] Have you verified the basic functionality for this change?

- [X] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
Enroll Screenshot
![EnrollScreen](https://user-images.githubusercontent.com/100623681/178885520-3dd87afd-b632-40af-8e3f-940ad99b17b4.png)

Challenge Screenshot
![ChallengeScreen](https://user-images.githubusercontent.com/100623681/178885527-df119026-2355-440f-98a0-a2d2d98851d0.png)


### Reviewers:
@praveendurai-okta @abdullahchougle-okta @okta/hybridaccess-team 

### Issue:

- [OKTA-500843](https://oktainc.atlassian.net/browse/OKTA-500843)


