### PR TITLE
fix: Fixes a UI overlapping when changing the language

### DIFF
--- a/playground/mocks/data/mfa-only/factor-challenge-sms.json
+++ b/playground/mocks/data/mfa-only/factor-challenge-sms.json
@@ -1,0 +1,115 @@
+{
+  "stateToken": "00EPMl_-Vn1hX-3CRz8qjcmdHIIXx89qaNR6d705mU",
+  "type": "CREDENTIAL_VERIFY",
+  "expiresAt": "2022-07-19T16:47:13.000Z",
+  "status": "MFA_REQUIRED",
+  "_embedded": {
+    "user": {
+      "id": "00u1f72JteyclYxWX0g4",
+      "passwordChanged": "2022-01-06T03:31:55.000Z",
+      "profile": {
+        "login": "testuser@okta.com",
+        "firstName": "Test",
+        "lastName": "User",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": [
+      {
+        "id": "clf7aj7Uo0ysppIXK0g4",
+        "factorType": "call",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
+        "profile": {
+          "phoneNumber": "+1 XXX-XXX-4444"
+        },
+        "_links": {
+          "verify": {
+            "href": "http://localhost:3000/api/v1/authn/factors/clf7aj7Uo0ysppIXK0g4/verify",
+            "hints": { "allow": ["POST"] }
+          }
+        }
+      },
+      {
+        "id": "ufs7aj94kVhHKqBgx0g4",
+        "factorType": "question",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
+        "profile": {
+          "question": "name_of_first_plush_toy",
+          "questionText": "What is the name of your first stuffed animal?"
+        },
+        "_links": {
+          "verify": {
+            "href": "http://localhost:3000/api/v1/authn/factors/ufs7aj94kVhHKqBgx0g4/verify",
+            "hints": { "allow": ["POST"] }
+          }
+        }
+      },
+      {
+        "id": "emf7aj8Xy6dQzX9tO0g4",
+        "factorType": "email",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
+        "profile": { "email": "t...@okta.com" },
+        "_links": {
+          "verify": {
+            "href": "http://localhost:3000/api/v1/authn/factors/emf7aj8Xy6dQzX9tO0g4/verify",
+            "hints": { "allow": ["POST"] }
+          }
+        }
+      },
+      {
+        "id": "sms7aj6YStf0WLNgI0g4",
+        "factorType": "sms",
+        "provider": "OKTA",
+        "vendorName": "OKTA",
+        "profile": { "phoneNumber": "+1 XXX-XXX-4444" },
+        "_links": {
+          "verify": {
+            "href": "http://localhost:3000/api/v1/authn/factors/sms7aj6YStf0WLNgI0g4/verify",
+            "hints": { "allow": ["POST"] }
+          }
+        }
+      },
+      {
+        "id": "uft7aiuGxx7SQNvRD0g4",
+        "factorType": "token:software:totp",
+        "provider": "GOOGLE",
+        "vendorName": "GOOGLE",
+        "profile": { "credentialId": "testuser@okta.com" },
+        "_links": {
+          "verify": {
+            "href": "http://localhost:3000/api/v1/authn/factors/uft7aiuGxx7SQNvRD0g4/verify",
+            "hints": { "allow": ["POST"] }
+          }
+        }
+      }
+    ],
+    "policy": {
+      "allowRememberDevice": false,
+      "rememberDeviceLifetimeInMinutes": 0,
+      "rememberDeviceByDefault": false,
+      "factorsPolicyInfo": {}
+    },
+    "target": {
+      "type": "APP",
+      "name": "mfa_adfs",
+      "label": "Microsoft ADFS (MFA)",
+      "_links": {
+        "logo": {
+          "name": "medium",
+          "href": "http://localhost:3000/assets/img/logos/microsoft.f400559a1fa6da092cc039a93f9722fd.png",
+          "type": "image/png"
+        }
+      }
+    }
+  },
+  "_links": {
+    "cancel": {
+      "href": "http://localhost:3000/api/v1/authn/cancel",
+      "hints": { "allow": ["POST"] }
+    }
+  }
+}

--- a/src/v1/views/shared/Header.ts
+++ b/src/v1/views/shared/Header.ts
@@ -39,39 +39,9 @@ function addBeacon(view, NextBeacon, selector, options) {
   view.currentBeacon = view.first();
 }
 
-function typeOfTransition(currentBeacon, NextBeacon, options) {
-  if (!currentBeacon && !NextBeacon) {
-    return 'none';
-  }
-  // Show Loading beacon
-  if (!currentBeacon && options.loading) {
-    return 'load';
-  }
-  // Swap/Hide Loading beacon
-  if (currentBeacon && isLoadingBeacon(currentBeacon)) {
-    return NextBeacon ? 'swap' : 'unload';
-  }
-  if (currentBeacon && currentBeacon.equals(NextBeacon, options)) {
-    return 'same';
-  }
-  if (!currentBeacon && NextBeacon) {
-    return 'add';
-  }
-  if (currentBeacon && !NextBeacon) {
-    return 'remove';
-  }
-  if (currentBeacon instanceof NextBeacon) {
-    return 'fade';
-  }
-  // If none of the above
-  // then we are changing the type of beacon
-  // ex. from SecurityBeacon to FactorBeacon
-  return 'swap';
-}
-
 export default class Header extends View {
   currentBeacon;
-  
+
   preinitialize(...args) {
     this.currentBeacon = null;
     /* eslint-disable @okta/okta/no-unlocalized-text-in-templates */
@@ -104,74 +74,74 @@ export default class Header extends View {
   }
 
   /* eslint complexity: 0 */
-  setBeacon(NextBeacon, options) {
+  private setBeacon(NextBeacon, options): void {
     const selector = '[data-type="beacon-container"]';
     const container = this.$(selector);
-    const transition = typeOfTransition(this.currentBeacon, NextBeacon, options);
+    const transition = this.typeOfTransition(NextBeacon, options);
 
     switch (transition) {
-    case 'none':
-      this.$el.addClass(NO_BEACON_CLS);
-      return;
-    case 'same':
-      return;
-    case 'add':
-      this.$el.removeClass(NO_BEACON_CLS);
-      addBeacon(this, NextBeacon, selector, options);
-      return Animations.explode(container);
-    case 'remove':
-      this.$el.addClass(NO_BEACON_CLS);
-      return Animations.implode(container)
-        .then(() => {
-          removeBeacon(this);
-        })
-        .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
-    case 'fade':
-      // Other transitions are performed on the beacon container,
-      // but this transition is on the content inside the beacon.
-      // For a SecurityBeacon the username change will update the
-      // AppState and trigger an transition to a new Becon
-      // Since there is no url change this method is not called.
-      // For a FactorBeacon a page refresh has occurred
-      // so we execute the beacon's own transition method.
-      if (!this.currentBeacon.fadeOut) {
-        throw new Error('The current beacon is missing the "fadeOut" method');
-      }
-      options.animate = true;
-      return this.currentBeacon
-        .fadeOut()
-        .then(() => {
-          removeBeacon(this);
-          addBeacon(this, NextBeacon, selector, options);
-        })
-        .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
-    case 'swap':
-      return Animations.swapBeacons({
-        $el: container,
-        swap: () => {
-          const isLoading = isLoadingBeacon(this.currentBeacon);
-
-          // Order of these calls is important for -
-          // loader --> security/factor beacon swap.
-          removeBeacon(this);
-          if (isLoading) {
+      case 'none':
+        this.$el.addClass(NO_BEACON_CLS);
+        return;
+      case 'same':
+        return;
+      case 'add':
+        this.$el.removeClass(NO_BEACON_CLS);
+        addBeacon(this, NextBeacon, selector, options);
+        return Animations.explode(container).done();
+      case 'remove':
+        this.$el.addClass(NO_BEACON_CLS);
+        return Animations.implode(container)
+            .then(() => {
+              removeBeacon(this);
+            })
+            .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+      case 'fade':
+        // Other transitions are performed on the beacon container,
+        // but this transition is on the content inside the beacon.
+        // For a SecurityBeacon the username change will update the
+        // AppState and trigger an transition to a new Becon
+        // Since there is no url change this method is not called.
+        // For a FactorBeacon a page refresh has occurred
+        // so we execute the beacon's own transition method.
+        if (!this.currentBeacon.fadeOut) {
+          throw new Error('The current beacon is missing the "fadeOut" method');
+        }
+        options.animate = true;
+        return this.currentBeacon
+            .fadeOut()
+            .then(() => {
+              removeBeacon(this);
+              addBeacon(this, NextBeacon, selector, options);
+            })
+            .done(); // TODO: can this be removed if fadeOut returns standard ES6 Promise?
+      case 'swap':
+        return Animations.swapBeacons({
+          $el: container,
+          swap: () => {
+            // Order of these calls is important for -
+            // loader --> security/factor beacon swap.
+            removeBeacon(this);
             container.removeClass(LOADING_BEACON_CLS);
             this.$el.removeClass(NO_BEACON_CLS);
-          }
-          addBeacon(this, NextBeacon, selector, options);
-        },
-      }).done(); // TODO: can this be removed if Animations.swapBeacons returns standard ES6 Promise?
-    case 'load':
-      // Show the loading beacon. Add a couple of classes
-      // before triggering the add beacon code.
-      container.addClass(LOADING_BEACON_CLS);
-      addBeacon(this, NextBeacon, selector, options);
-      return Animations.explode(container);
-    case 'unload':
-      // Hide the loading beacon.
-      return this.removeLoadingBeacon();
-    default:
-      throw new Error('the "' + transition + '" is not recognized');
+            addBeacon(this, NextBeacon, selector, options);
+          },
+        }).done(); // TODO: can this be removed if Animations.swapBeacons returns standard ES6 Promise?
+      case 'load':
+        // Show the loading beacon. Add a couple of classes
+        // before triggering the add beacon code.
+        container.addClass(LOADING_BEACON_CLS);
+        addBeacon(this, NextBeacon, selector, options);
+        return Animations.explode(container).done();
+      case 'unload':
+        // Hide the loading beacon.
+        return Animations.implode(container)
+            .then(() => {
+              removeBeacon(this);
+              container.removeClass(LOADING_BEACON_CLS);
+            }).done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+      default:
+        throw new Error('the "' + transition + '" is not recognized');
     }
   }
 
@@ -185,14 +155,7 @@ export default class Header extends View {
 
   // Hide the beacon on primary auth failure. On primary auth success, setBeacon does this job.
   removeLoadingBeacon() {
-    const container = this.$('[data-type="beacon-container"]');
-
-    return Animations.implode(container)
-      .then(() => {
-        removeBeacon(this);
-        container.removeClass(LOADING_BEACON_CLS);
-      })
-      .done(); // TODO: can this be removed if Animations.implode returns standard ES6 Promise?
+    this.setBeacon(null, null);
   }
 
   getTemplateData() {
@@ -201,5 +164,35 @@ export default class Header extends View {
 
   getContentEl() {
     return this.$('.auth-content-inner');
+  }
+
+  private typeOfTransition(NextBeacon, options): string {
+    if (!this.currentBeacon && !NextBeacon) {
+      return 'none';
+    }
+    // Show Loading beacon
+    if (!this.currentBeacon && options.loading) {
+      return 'load';
+    }
+    // Swap/Hide Loading beacon
+    if (isLoadingBeacon(this.currentBeacon)) {
+      return NextBeacon ? 'swap' : 'unload';
+    }
+    if (this.currentBeacon && this.currentBeacon.equals(NextBeacon, options)) {
+      return 'same';
+    }
+    if (!this.currentBeacon && NextBeacon) {
+      return 'add';
+    }
+    if (this.currentBeacon && !NextBeacon) {
+      return 'remove';
+    }
+    if (this.currentBeacon instanceof NextBeacon) {
+      return 'fade';
+    }
+    // If none of the above
+    // then we are changing the type of beacon
+    // ex. from SecurityBeacon to FactorBeacon
+    return 'swap';
   }
 }

--- a/test/testcafe/framework/page-objects-v1/MfaChallengePageObject.js
+++ b/test/testcafe/framework/page-objects-v1/MfaChallengePageObject.js
@@ -1,0 +1,20 @@
+import {Selector} from 'testcafe';
+import BasePageObject from '../page-objects/BasePageObject';
+
+export default class MfaChallengePageObject extends BasePageObject {
+  constructor(t) {
+    super(t);
+  }
+
+  getPageTitle() {
+    return this.form.getElement('.okta-form-title').textContent;
+  }
+
+  getBeaconRect() {
+    return Selector('.okta-sign-in-beacon-border').boundingClientRect;
+  }
+
+  getFormRect() {
+    return Selector('.auth-content-inner').boundingClientRect;
+  }
+}

--- a/test/testcafe/spec/v1/MfaOnlySmsChallenge_spec.js
+++ b/test/testcafe/spec/v1/MfaOnlySmsChallenge_spec.js
@@ -1,0 +1,58 @@
+import { ClientFunction, RequestMock } from 'testcafe';
+import MfaChallengePageObject from '../../framework/page-objects-v1/MfaChallengePageObject';
+import mfaChallengeResponse from '../../../../playground/mocks/data/mfa-only/factor-challenge-sms.json';
+
+const mock = RequestMock()
+  .onRequestTo('http://localhost:3000/api/v1/authn/introspect')
+  .respond(mfaChallengeResponse);
+
+
+fixture('Mfa-only SMS challenge');
+
+const renderWidget = ClientFunction((settings) => {
+  window.renderPlaygroundWidget(settings);
+});
+
+async function setup(t, options = {}) {
+  const pageObject = new MfaChallengePageObject(t);
+  await pageObject.navigateToPage({ render: true });
+
+  // Render the widget for interaction code flow
+  await pageObject.mockCrypto();
+  await renderWidget({
+    stateToken: '00EPMl_-Vn1hX-3CRz8qjcmdHIIXx89qaNR6d705mU',
+    status: 'mfa_required',  
+    features: {
+      hideSignOutLinkInMFA: true
+    },
+    ...options
+  });
+
+  return pageObject;
+}
+
+// to reduce the execution time we are testing only 2 transitions
+const supportedLanguages = [
+  'fr',
+  'hu',
+  'id'
+];
+
+supportedLanguages.forEach( (lang) => {
+  test
+    .requestHooks(mock)('Show SMS challenge for MFA only setup "' + lang + '" locale', async t => {
+      const pageObject = await setup(t, {
+        language: lang
+      });
+
+      // wait for all elements to render
+      await t.wait(5000);      
+        
+      const r1 = await pageObject.getBeaconRect();
+      const r2 = await pageObject.getFormRect();
+
+      const overlap = !(r1.top > r2.bottom || r1.left > r2.right ||
+                        r1.bottom < r2.top || r1.right < r2.left);
+      await t.expect(overlap).notOk();
+    });
+});


### PR DESCRIPTION
Fixed the issue when changing the language will result is some cases with overlapped UI elements

Resolves: OKTA-507211

## Description:
The problem was related when the promise to remove the beacon was interleaved with loading event and the parts to remove the beacon was executed after the beacon was set to loading.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:
Before my change:
![Screen Shot 2022-07-22 at 4 51 05 PM](https://user-images.githubusercontent.com/16108120/180566756-d9626aec-f981-4343-993c-c4e4f097be2f.png)
https://okta.enterprise.slack.com/files/U7KV2GCN8/F03QH13UQKG/ui_overlap.mov


Here is a link for the same test after my change:
https://okta.enterprise.slack.com/files/U7KV2GCN8/F03QQ61US2J/after_change.mov
### Reviewers:



### Issue:

- [OKTA-507211](https://oktainc.atlassian.net/browse/OKTA-507211)


