### PR TITLE
OKTA-516593 - Phone authenticator enrollment show code resend

### DIFF
--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams } from '@okta/okta-auth-js';
+import { IdxActionParams, NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -27,7 +27,7 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({
   formBag,
   widgetProps,
 }) => {
-  const { nextStep: { relatesTo } = {}, availableSteps } = transaction;
+  const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
   const { authClient } = widgetProps;
 
@@ -61,8 +61,9 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({
     },
   };
 
-  const phoneNumber = relatesTo?.value?.profile?.phoneNumber;
-  const methodType = relatesTo?.value?.methods?.[0]?.type;
+  const { methods, profile } = nextStep.relatesTo?.value || {};
+  const { phoneNumber } = profile || {};
+  const methodType = methods?.[0]?.type;
   const sendInfoText = methodType === 'sms'
     ? loc('oie.phone.verify.sms.codeSentText', 'login')
     : loc('mfa.calling', 'login');

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -19,37 +19,37 @@ import {
   IdxStepTransformer,
   ReminderElement,
   TitleElement,
-  Undefinable,
 } from '../../types';
 import { loc } from '../../util';
-  
-export const transformPhoneCodeEnrollment: IdxStepTransformer = (
+
+export const transformPhoneCodeEnrollment: IdxStepTransformer = ({
   transaction,
   formBag,
   widgetProps,
-) => {
-  const { nextStep: { relatesTo } = {}, nextStep, availableSteps } = transaction;
+}) => {
+  const { nextStep: { relatesTo } = {}, availableSteps } = transaction;
   const { uischema } = formBag;
   const { authClient } = widgetProps;
 
-  let reminderElement: Undefinable<ReminderElement>;
+  let reminderElement: ReminderElement | undefined;
 
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
-  if (nextStep.canResend && resendStep) {
-    const { name } = resendStep;
+  if (resendStep) {
+    const { name, action } = resendStep;
     reminderElement = {
       type: 'Reminder',
       options: {
-        ctaText: 'oie.phone.verify.sms.resendText',
+        ctaText: loc('oie.phone.verify.sms.resendText', 'login'),
+        linkLabel: loc('email.button.resend', 'login'),
         // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-        action: (params?: IdxActionParams) => {
+        action: action && ((params?: IdxActionParams) => {
           const { stateHandle, ...rest } = params ?? {};
           return authClient?.idx.proceed({
             // @ts-ignore stateHandle can be undefined
             stateHandle,
             actions: [{ name, params: rest }],
           });
-        },
+        }),
       },
     };
   }

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
+<<<<<<< HEAD
                 class="MuiBox-root emotion-10"
               >
                 <div
@@ -73,6 +74,18 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 >
                   <h2
                     class="MuiTypography-root MuiTypography-h3 emotion-12"
+=======
+                class="MuiBox-root emotion-7"
+              />
+              <div
+                class="MuiBox-root emotion-7"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h3 emotion-10"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     Set up phone authentication
                   </h2>
@@ -111,18 +124,31 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
+<<<<<<< HEAD
                     class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                     for="credentials.passcode"
+=======
+                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                    for="generated"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     Enter Code
                   </label>
                   <div
+<<<<<<< HEAD
                     class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+=======
+                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
+<<<<<<< HEAD
                       class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
+=======
+                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
+>>>>>>> fd20864ab (update snapshots)
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -130,10 +156,17 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
+<<<<<<< HEAD
                       class="MuiOutlinedInput-notchedOutline emotion-22"
                     >
                       <legend
                         class="emotion-23"
+=======
+                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    >
+                      <legend
+                        class="emotion-19"
+>>>>>>> fd20864ab (update snapshots)
                       >
                         <span
                           class="notranslate"
@@ -149,7 +182,11 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+=======
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -161,7 +198,11 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+=======
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -173,7 +214,11 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+=======
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="cancel"
                   tabindex="0"
                   type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -66,15 +66,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
-<<<<<<< HEAD
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-=======
                 class="MuiBox-root emotion-7"
               />
               <div
@@ -85,7 +76,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 >
                   <h2
                     class="MuiTypography-root MuiTypography-h3 emotion-10"
->>>>>>> fd20864ab (update snapshots)
                   >
                     Set up phone authentication
                   </h2>
@@ -124,31 +114,18 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
-<<<<<<< HEAD
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
-                    for="credentials.passcode"
-=======
                     class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
                     for="generated"
->>>>>>> fd20864ab (update snapshots)
                   >
                     Enter Code
                   </label>
                   <div
-<<<<<<< HEAD
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
-=======
                     class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
->>>>>>> fd20864ab (update snapshots)
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
-<<<<<<< HEAD
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
-=======
                       class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
->>>>>>> fd20864ab (update snapshots)
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -156,17 +133,10 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-<<<<<<< HEAD
-                      class="MuiOutlinedInput-notchedOutline emotion-22"
-                    >
-                      <legend
-                        class="emotion-23"
-=======
                       class="MuiOutlinedInput-notchedOutline emotion-18"
                     >
                       <legend
                         class="emotion-19"
->>>>>>> fd20864ab (update snapshots)
                       >
                         <span
                           class="notranslate"
@@ -182,11 +152,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-=======
                   class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
->>>>>>> fd20864ab (update snapshots)
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -198,11 +164,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-=======
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
->>>>>>> fd20864ab (update snapshots)
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -214,11 +176,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-=======
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
->>>>>>> fd20864ab (update snapshots)
                   data-se="cancel"
                   tabindex="0"
                   type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -66,16 +66,16 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
-                class="MuiBox-root emotion-7"
+                class="MuiBox-root emotion-10"
               />
               <div
-                class="MuiBox-root emotion-7"
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-12"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-10"
+                    class="MuiTypography-root MuiTypography-h3 emotion-13"
                   >
                     Set up phone authentication
                   </h2>
@@ -85,7 +85,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <p
                     class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
@@ -98,7 +98,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <p
                     class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
@@ -114,18 +114,18 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="generated"
+                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                    for="credentials.passcode"
                   >
                     Enter Code
                   </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
+                      class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -133,10 +133,10 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                      class="MuiOutlinedInput-notchedOutline emotion-23"
                     >
                       <legend
-                        class="emotion-19"
+                        class="emotion-24"
                       >
                         <span
                           class="notranslate"
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -164,7 +164,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -176,7 +176,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
                   data-se="cancel"
                   tabindex="0"
                   type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
+<<<<<<< HEAD
                 class="MuiBox-root emotion-10"
               >
                 <div
@@ -73,6 +74,18 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 >
                   <h2
                     class="MuiTypography-root MuiTypography-h3 emotion-12"
+=======
+                class="MuiBox-root emotion-7"
+              />
+              <div
+                class="MuiBox-root emotion-7"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h3 emotion-10"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     Set up phone authentication
                   </h2>
@@ -111,18 +124,31 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
+<<<<<<< HEAD
                     class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                     for="credentials.passcode"
+=======
+                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                    for="generated"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     Enter Code
                   </label>
                   <div
+<<<<<<< HEAD
                     class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+=======
+                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+>>>>>>> fd20864ab (update snapshots)
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
+<<<<<<< HEAD
                       class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
+=======
+                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
+>>>>>>> fd20864ab (update snapshots)
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -130,10 +156,17 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
+<<<<<<< HEAD
                       class="MuiOutlinedInput-notchedOutline emotion-22"
                     >
                       <legend
                         class="emotion-23"
+=======
+                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    >
+                      <legend
+                        class="emotion-19"
+>>>>>>> fd20864ab (update snapshots)
                       >
                         <span
                           class="notranslate"
@@ -149,7 +182,11 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+=======
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -161,7 +198,11 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+=======
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -173,7 +214,11 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
+<<<<<<< HEAD
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+=======
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+>>>>>>> fd20864ab (update snapshots)
                   data-se="cancel"
                   tabindex="0"
                   type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -66,16 +66,16 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
-                class="MuiBox-root emotion-7"
+                class="MuiBox-root emotion-10"
               />
               <div
-                class="MuiBox-root emotion-7"
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-12"
                 >
                   <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-10"
+                    class="MuiTypography-root MuiTypography-h3 emotion-13"
                   >
                     Set up phone authentication
                   </h2>
@@ -85,7 +85,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <p
                     class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
@@ -98,7 +98,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <p
                     class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
@@ -114,18 +114,18 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="generated"
+                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                    for="credentials.passcode"
                   >
                     Enter Code
                   </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
+                      class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -133,10 +133,10 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                      class="MuiOutlinedInput-notchedOutline emotion-23"
                     >
                       <legend
-                        class="emotion-19"
+                        class="emotion-24"
                       >
                         <span
                           class="notranslate"
@@ -152,7 +152,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -164,7 +164,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -176,7 +176,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
                   data-se="cancel"
                   tabindex="0"
                   type="button"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -66,15 +66,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="MuiBox-root emotion-9"
             >
               <div
-<<<<<<< HEAD
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-=======
                 class="MuiBox-root emotion-7"
               />
               <div
@@ -85,7 +76,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 >
                   <h2
                     class="MuiTypography-root MuiTypography-h3 emotion-10"
->>>>>>> fd20864ab (update snapshots)
                   >
                     Set up phone authentication
                   </h2>
@@ -124,31 +114,18 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   class="MuiBox-root emotion-3"
                 >
                   <label
-<<<<<<< HEAD
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
-                    for="credentials.passcode"
-=======
                     class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
                     for="generated"
->>>>>>> fd20864ab (update snapshots)
                   >
                     Enter Code
                   </label>
                   <div
-<<<<<<< HEAD
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
-=======
                     class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
->>>>>>> fd20864ab (update snapshots)
                   >
                     <input
                       aria-invalid="false"
                       autocomplete="one-time-code"
-<<<<<<< HEAD
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
-=======
                       class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
->>>>>>> fd20864ab (update snapshots)
                       data-se="credentials.passcode"
                       id="credentials.passcode"
                       name="credentials.passcode"
@@ -156,17 +133,10 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     />
                     <fieldset
                       aria-hidden="true"
-<<<<<<< HEAD
-                      class="MuiOutlinedInput-notchedOutline emotion-22"
-                    >
-                      <legend
-                        class="emotion-23"
-=======
                       class="MuiOutlinedInput-notchedOutline emotion-18"
                     >
                       <legend
                         class="emotion-19"
->>>>>>> fd20864ab (update snapshots)
                       >
                         <span
                           class="notranslate"
@@ -182,11 +152,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-=======
                   class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
->>>>>>> fd20864ab (update snapshots)
                   data-se="#/properties/submit"
                   tabindex="0"
                   type="submit"
@@ -198,11 +164,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-=======
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
->>>>>>> fd20864ab (update snapshots)
                   data-se="switchAuthenticator"
                   tabindex="0"
                   type="button"
@@ -214,11 +176,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <button
-<<<<<<< HEAD
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-=======
                   class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
->>>>>>> fd20864ab (update snapshots)
                   data-se="cancel"
                   tabindex="0"
                   type="button"


### PR DESCRIPTION
## Description:

Fixes the issue where the sms code resend reminder was not showing in phone authenticator enrollment.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-516593](https://oktainc.atlassian.net/browse/OKTA-516593)


