### PR TITLE
provide mock responses for interact and wellknown openid endpoints

### DIFF
--- a/test/testcafe/framework/shared/index.js
+++ b/test/testcafe/framework/shared/index.js
@@ -1,4 +1,7 @@
 import { t, ClientFunction } from 'testcafe';
+import { RequestMock as TestCafeRequestMock } from 'testcafe';
+import xhrInteract from '../../../../playground/mocks/data/oauth2/interact.json';
+import xhrWellknownOpenidConfiguration from '../../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
 
 const READY_MESSAGE = '===== playground widget ready event received =====';
 const AFTER_RENDER_MESSAGE = '===== playground widget afterRender event received =====';
@@ -80,3 +83,14 @@ export async function assertRequestMatches(loggedRequest, url, method, body) {
     await t.expect(requestBody).eql(body);
   }
 }
+
+/**
+ * Provides mock responses for common endpoints. Use this export instead of
+ * importing from "testcafe" directly to avoid falling back to dyson mock server
+ * for these requests.
+ */
+export const RequestMock = (...args) => TestCafeRequestMock(...args)
+  .onRequestTo('http://localhost:3000/oauth2/default/v1/interact')
+  .respond(xhrInteract)
+  .onRequestTo('http://localhost:3000/oauth2/default/.well-known/openid-configuration')
+  .respond(xhrWellknownOpenidConfiguration);


### PR DESCRIPTION
## Description:

Provides mock responses for common endpoints to avoid falling back to Dyson mock server.

- `/oauth2/default/v1/interact`
- `/oauth2/default/.well-known/openid-configuration`

### Example usage:

In `test/testcafe/spec/IdentifyWithPassword_spec.js`

```js
import { RequestMock, RequestLogger } from 'testcafe';
```

changes to

```js
import { RequestLogger } from 'testcafe';
import { RequestMock } from '../framework/shared';
```

## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-519068](https://oktainc.atlassian.net/browse/OKTA-519068)


