### PR TITLE
OKTA-519248 : Implementation for global level client side error message

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -18,7 +18,7 @@ import { useCallback, useRef } from 'preact/hooks';
 import { FormContext, useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
 import { ActionOptions, SubmitEvent, UISchemaLayout } from '../../types';
-import { resetMessagesToInputs } from '../../util';
+import { loc, resetMessagesToInputs } from '../../util';
 import Layout from './Layout';
 
 const Form: FunctionComponent<{
@@ -29,12 +29,14 @@ const Form: FunctionComponent<{
     data,
     idxTransaction: currTransaction,
     setIdxTransaction,
+    setMessage,
     dataSchemaRef,
   } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
 
   const handleSubmit = useCallback(async (e: SubmitEvent) => {
     e.preventDefault();
+    setMessage(undefined);
 
     const { actionParams: params, step } = submissionOptionsRef.current!;
 
@@ -60,6 +62,11 @@ const Form: FunctionComponent<{
       if (Object.entries(messages).length) {
         const newTransaction = clone(currTransaction);
         resetMessagesToInputs(newTransaction!.nextStep!.inputs!, messages);
+        setMessage({
+          message: loc('oform.errorbanner.title', 'login'),
+          class: 'ERROR',
+          i18n: { key: 'oform.errorbanner.title' },
+        } as IdxMessage);
         setIdxTransaction(newTransaction);
         return;
       }
@@ -77,6 +84,7 @@ const Form: FunctionComponent<{
     dataSchemaRef,
     setIdxTransaction,
     onSubmitHandler,
+    setMessage,
   ]);
 
   return (

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -283,3 +283,276 @@ exports[`identify-with-password renders the loading state first 1`] = `
   </span>
 </div>
 `;
+
+exports[`identify-with-password sends correct payload fails client side validation with no inputs 1`] = `
+<div>
+  <span>
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
+      id="okta-sign-in"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-1"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-2"
+          />
+        </div>
+        <div
+          class="MuiBox-root emotion-3"
+        >
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-5"
+              role="alert"
+            >
+              <div
+                class="MuiAlert-icon emotion-6"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
+                  data-testid="ErrorOutlineIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiAlert-message emotion-8"
+              >
+                We found some errors. Please review the form and make corrections.
+              </div>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  >
+                    Sign In
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
+                >
+                  <label
+                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                    for="identifier"
+                  >
+                    Username
+                  </label>
+                  <div
+                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-16"
+                  >
+                    <input
+                      aria-invalid="true"
+                      autocomplete="username"
+                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
+                      data-se="identifier"
+                      id="identifier"
+                      name="identifier"
+                      type="text"
+                    />
+                    <fieldset
+                      aria-hidden="true"
+                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    >
+                      <legend
+                        class="emotion-19"
+                      >
+                        <span
+                          class="notranslate"
+                        >
+                          ​
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root Mui-error emotion-20"
+                    data-se="identifier-error"
+                  >
+                    This field cannot be left blank
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
+                >
+                  <div
+                    class="MuiBox-root emotion-14"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                      for="credentials.passcode"
+                    >
+                      Password
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-25"
+                    >
+                      <input
+                        aria-invalid="true"
+                        autocomplete="current-password"
+                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-26"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        name="credentials.passcode"
+                        type="password"
+                      />
+                      <div
+                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-27"
+                      >
+                        <button
+                          aria-label="toggle password visibility"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-28"
+                          data-mui-internal-clone-element="true"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
+                            data-testid="VisibilityIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-18"
+                      >
+                        <legend
+                          class="emotion-19"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root Mui-error emotion-20"
+                    data-se="credentials.passcode-error"
+                  >
+                    This field cannot be left blank
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <label
+                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-34"
+                >
+                  <span
+                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-35"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input emotion-36"
+                      data-se="rememberMe"
+                      data-se-for-name="rememberMe"
+                      id="rememberMe"
+                      name="rememberMe"
+                      type="checkbox"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
+                      data-testid="CheckBoxOutlineBlankIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
+                  >
+                    Keep me signed in
+                  </span>
+                </label>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
+                  data-se="#/properties/submit"
+                  data-type="save"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
+                  data-se="forgot-password"
+                  tabindex="0"
+                  type="button"
+                >
+                  Forgot password?
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
+                  data-se="enroll"
+                  tabindex="0"
+                  type="button"
+                >
+                  Register
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </span>
+</div>
+`;

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -104,7 +104,9 @@ describe('identify-with-password', () => {
       const {
         authClient,
         user,
+        container,
         findByTestId,
+        findByText,
       } = await setup({ mockResponse });
       let identifierError; let
         passwordError;
@@ -115,8 +117,11 @@ describe('identify-with-password', () => {
 
       // empty username & empty password
       await user.click(submitButton);
+      await findByText(/We found some errors./);
       identifierError = await findByTestId('identifier-error');
       expect(identifierError.textContent).toEqual('This field cannot be left blank');
+      expect(container).toMatchSnapshot();
+
       passwordError = await findByTestId('credentials.passcode-error');
       expect(passwordError.textContent).toEqual('This field cannot be left blank');
       expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(


### PR DESCRIPTION
## Description:
Purpose of this ticket is to bring SIW Next into parity with v2 SIW. Client-side form submission field level errors were added recently, however, it was missing the top level error message which exists in v2. This ticket adds the logic to display that error and remove it before submission so it doesnt carry over between views.

Here is a screenshot of what it looks like in v2:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/97472729/181794152-35f9fa93-320b-4a41-b9f2-59675533df24.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/181794360-0ef8fecd-7574-4a4b-9827-3d006164f79b.mov



### Reviewers:


### Issue:

- [OKTA-519248](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)


