### PR TITLE
OKTA-520187 add testcafe v3 launch configs

### DIFF
--- a/.testcaferc-parity.js
+++ b/.testcaferc-parity.js
@@ -8,6 +8,6 @@ module.exports = {
   * test/testcafe/spec/Smoke_spec.js
   */
   filter: (testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
-    return fixtureMeta.v3 === true;
+    return fixtureMeta.v3 === true && testMeta.v3 !== false;
   },
 };

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,29 @@
       "type": "node",
       "protocol": "inspector",
       "request": "launch",
+      "name": "Debug v3 Parity with TestCafe",
+      "program": "${workspaceRoot}/node_modules/testcafe/bin/testcafe.js",
+      "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v12.13.0/bin/node",
+      "env": {
+        "OKTA_SIW_V3": "true"
+      },
+      "args": [
+          "chrome",
+          "${relativeFile}",
+          "--browser-init-timeout",
+          "1000000",
+          "--page-load-timeout",
+          "1000000",
+          "--config-file",
+          ".testcaferc-parity.js"
+      ],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceRoot}"
+    },
+    {
+      "type": "node",
+      "protocol": "inspector",
+      "request": "launch",
       "name": "Debug with WebdriverIO",
       "program": "${workspaceRoot}/test/e2e/node_modules/@wdio/cli/bin/wdio.js",
       "runtimeExecutable": "${env:HOME}/.nvm/versions/node/v12.13.0/bin/node",


### PR DESCRIPTION
## Description:

Add VS Code launch configs to debug v3 parity tests in TestCafe

### Steps to run debug task

1. Enable the fixture for parity testing by adding the metadata, e.g., `fixture('name of fixture').meta('v3', true);`
2. Switch to the debug tab in the left navbar (bug with play icon)
![Screen Shot 2022-08-01 at 4 19 01 PM](https://user-images.githubusercontent.com/77294605/182239098-d09f5fe2-68e4-4745-982c-7b9226a68329.png)
3. Select "Debug v3 Parity with TestCafe" from the dropdown"
![Screen Shot 2022-08-01 at 4 18 08 PM](https://user-images.githubusercontent.com/77294605/182238788-03082bb5-228b-4440-a2c8-87d47f3403e1.png)
4. Click the green "play" icon to run. Wait a few seconds for the initialization and a browser should pop up visualizing the test steps.
5. You can set breakpoints to pause the run and see what is happening in browser. You can open Chrome devtools to investigate the DOM, use console, and see the network requests.

NOTE: The new launch config copies the existing TestCafe config; you should have the `NameOfYour_spec.js` file open and focused to run the spec in isolation.

PRO TIP: Use F5 to run from the spec file instead of following steps 4-5.

You _can_ enable live mode by updating the config script but my experience so far has been... iffy.

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-520187](https://oktainc.atlassian.net/browse/OKTA-520187)