### PR TITLE
Adds email MFA login test

### DIFF
--- a/test/e2e/cucumber.wdio.conf.ts
+++ b/test/e2e/cucumber.wdio.conf.ts
@@ -82,9 +82,7 @@ export const config: WebdriverIO.Config = {
     path.resolve(__dirname, 'features/**/*.feature')
   ],
   // Patterns to exclude.
-  exclude: [
-      path.resolve(__dirname, 'features/**/webauthn-login.feature')
-  ],
+  exclude: [],
   baseUrl: 'http://localhost:8080',
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,

--- a/test/e2e/features/email-login.feature
+++ b/test/e2e/features/email-login.feature
@@ -1,0 +1,15 @@
+@ignore
+Feature: Email Login
+
+  Background:
+    Given an App configured to use interaction code flow
+    And a User named "testuser" exists in the org and added to "MFA Required" group
+
+    Scenario: User logs in using email MFA
+      Given user opens the login page using "showSignInToGetTokens"
+      When user logs in with username and password
+      Then user is challenged for email code
+      And user clicks send email
+      # And user inputs the correct code from email
+      And user clicks the email magic link
+      Then user sees the tokens on the page

--- a/test/e2e/features/interaction-code-flow.feature
+++ b/test/e2e/features/interaction-code-flow.feature
@@ -10,6 +10,6 @@ Feature: Interaction Code Flow
       Then user sees the tokens on the page
 
     Scenario: User logs in using 3rd party IdP
-      Given user opens the login page using renderEl
+      Given user opens the login page using "renderEl"
       When user logs in using 3rd party IdP
       Then user sees the tokens on the page from 3rd party IdP

--- a/test/e2e/features/webauthn-login.feature
+++ b/test/e2e/features/webauthn-login.feature
@@ -9,7 +9,7 @@ Feature: WebAuthn Login
       When user logs in with username and password
       Then user is challenged for email code
       And user clicks send email
-      And user inputs the correct code from email
+      And user clicks the email magic link
       When user selects biometric authenticator
       And user sets up biometric authenticator
       And user skips enrollment of optional authenticators

--- a/test/e2e/steps/given.ts
+++ b/test/e2e/steps/given.ts
@@ -71,12 +71,29 @@ Given(
 );
 
 Given(
-  /^user opens the login page using renderEl$/,
-  async function() {
-    await TestAppPage.startWithRenderEl.click();
+  /^user opens the login page using "(\w+)"$/,
+  async function(buttonName: string) {
+    switch(buttonName) {
+      case 'renderEl':
+        await TestAppPage.startWithRenderEl.click();
+        break;
+
+      case 'showSignIn':
+        await TestAppPage.showSignInButton.click();
+        break;
+
+      case 'showSignInAndRedirect':
+        await TestAppPage.showSignInAndRedirect.click();
+        break;
+
+      case 'showSignInToGetTokens':
+        await TestAppPage.showSignInToGetTokens.click();
+        break;
+    }
     return await waitForLoad(TestAppPage.widget);
   }
 );
+
 
 Given(
   /^state parameter is set in the widget config$/,

--- a/test/e2e/steps/when.ts
+++ b/test/e2e/steps/when.ts
@@ -86,3 +86,11 @@ When(
 );
 
 
+When(
+  /^user clicks the email magic link$/,
+  async function() {
+    const emailMagicLink = await this.a18nClient.getEmailMagicLink(this.credentials.profileId);
+    await browser.url(emailMagicLink);
+  }
+);
+

--- a/test/e2e/support/a18nClient.ts
+++ b/test/e2e/support/a18nClient.ts
@@ -89,6 +89,24 @@ export default class A18nClient {
     return await this.deleteOnProtectedURL(`${PROFILE_URL}/${profileId}`);
   }
 
+  async getEmailMagicLink(profileId: string) {
+    let retryAttemptsRemaining = 5;
+    let response;
+    while (!response?.content && retryAttemptsRemaining > 0) {
+      await waitForOneSecond();
+      response = await this.getOnURL(LATEST_EMAIL_URL.replace(':profileId', profileId)) as Record<string, string>;
+      --retryAttemptsRemaining;
+    }
+
+    const match = response?.content?.match(/<a id="email-authentication-button" href="(?<url>\S+)"/);
+    const url = match?.groups?.url;
+    if (!url) {
+      throw new Error('Unable to retrieve magic link from email.');
+    }
+
+    return url;
+  }
+
   private async deleteOnProtectedURL(url: string): Promise<string|never>{
     try {
       const response =  await fetch(url, {


### PR DESCRIPTION
## Description:
- Adds email MFA login tests using email magic link
- Enables the disabled webauthn test


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-450197](https://oktainc.atlassian.net/browse/OKTA-450197)


