### PR TITLE
Add MUI `ScopedCssBaseline` to hoist common styles to entire application

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -10,8 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { ScopedCssBaseline } from '@mui/material';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import { ThemeProvider } from '@okta/odyssey-react-theme';
 import {
   AuthApiError,

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -11,6 +11,7 @@
  */
 
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { ScopedCssBaseline } from '@mui/material';
 import { ThemeProvider } from '@okta/odyssey-react-theme';
 import {
   AuthApiError,
@@ -257,25 +258,27 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     >
       {/* Note that we need two theme providers until we fully migrate to odyssey-mui */}
       <MuiThemeProvider theme={mapMuiThemeFromBrand(brandColors)}>
-        <ThemeProvider theme={mapThemeFromBrand(brandColors)}>
-          <AuthContainer>
-            <AuthHeader
-              logo={logo}
-              logoText={logoText}
-              brandName={brandName}
-              authCoinProps={buildAuthCoinProps(idxTransaction)}
-            />
-            <AuthContent>
-              <IdentifierContainer />
-              <InfoSection message={message} />
-              {
-                formBag.uischema.elements.length > 0
-                  ? <Form uischema={formBag.uischema as UISchemaLayout} />
-                  : <Spinner />
-              }
-            </AuthContent>
-          </AuthContainer>
-        </ThemeProvider>
+        <ScopedCssBaseline>
+          <ThemeProvider theme={mapThemeFromBrand(brandColors)}>
+            <AuthContainer>
+              <AuthHeader
+                logo={logo}
+                logoText={logoText}
+                brandName={brandName}
+                authCoinProps={buildAuthCoinProps(idxTransaction)}
+              />
+              <AuthContent>
+                <IdentifierContainer />
+                <InfoSection message={message} />
+                {
+                  formBag.uischema.elements.length > 0
+                    ? <Form uischema={formBag.uischema as UISchemaLayout} />
+                    : <Spinner />
+                }
+              </AuthContent>
+            </AuthContainer>
+          </ThemeProvider>
+        </ScopedCssBaseline>
       </MuiThemeProvider>
     </WidgetContextProvider>
   );

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-email-verification-data should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                shaw.yu@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  shaw.yu@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,55 +71,59 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Verify with your email
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Verify with your email
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Verify with an email link or enter a code sent to your email.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Verify with an email link or enter a code sent to your email.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-17"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send me an email
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-19"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-16"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me an email
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-18"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-enroll-data-phone should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester13@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester13@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,1469 +71,1473 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up phone authentication
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up phone authentication
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-11"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Enter your phone number to receive a verification code via SMS.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <fieldset
-                    class="MuiFormControl-root emotion-17"
-                  >
                     <div
-                      class="MuiFormGroup-root emotion-18"
-                      id="authenticator.methodType"
-                      role="radiogroup"
+                      class="MuiBox-root emotion-12"
                     >
-                      <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-19"
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <span
-                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-20"
-                        >
-                          <input
-                            class="PrivateSwitchBase-input emotion-21"
-                            name="authenticator.methodType"
-                            type="radio"
-                            value="sms"
-                          />
-                          <span
-                            class="emotion-22"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
-                              data-testid="RadioButtonUncheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                              />
-                            </svg>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
-                              data-testid="RadioButtonCheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-25"
-                        >
-                          SMS
-                        </span>
-                      </label>
-                      <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-19"
-                      >
-                        <span
-                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-20"
-                        >
-                          <input
-                            class="PrivateSwitchBase-input emotion-21"
-                            name="authenticator.methodType"
-                            type="radio"
-                            value="voice"
-                          />
-                          <span
-                            class="emotion-22"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
-                              data-testid="RadioButtonUncheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                              />
-                            </svg>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-31"
-                              data-testid="RadioButtonCheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-25"
-                        >
-                          Voice call
-                        </span>
-                      </label>
+                        Enter your phone number to receive a verification code via SMS.
+                      </p>
                     </div>
-                  </fieldset>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
+                  </div>
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-11"
                   >
-                    <div
-                      class="MuiBox-root emotion-10"
+                    <fieldset
+                      class="MuiFormControl-root emotion-18"
                     >
                       <div
-                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                        class="MuiFormGroup-root emotion-19"
+                        id="authenticator.methodType"
+                        role="radiogroup"
                       >
                         <label
-                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="countryList"
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
                         >
                           <span
-                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-21"
                           >
-                            Country
+                            <input
+                              class="PrivateSwitchBase-input emotion-22"
+                              name="authenticator.methodType"
+                              type="radio"
+                              value="sms"
+                            />
+                            <span
+                              class="emotion-23"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                          >
+                            SMS
                           </span>
                         </label>
-                        <div
-                          class="ods-mUkyrD"
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-20"
                         >
-                          <select
-                            autocomplete="tel-country-code"
-                            class="ods-1B2Zfy"
-                            data-se="countryList"
-                            id="countryList"
-                          >
-                            <option
-                              value="AF"
-                            >
-                              Afghanistan
-                            </option>
-                            <option
-                              value="AL"
-                            >
-                              Albania
-                            </option>
-                            <option
-                              value="DZ"
-                            >
-                              Algeria
-                            </option>
-                            <option
-                              value="AS"
-                            >
-                              American Samoa
-                            </option>
-                            <option
-                              value="AD"
-                            >
-                              Andorra
-                            </option>
-                            <option
-                              value="AO"
-                            >
-                              Angola
-                            </option>
-                            <option
-                              value="AI"
-                            >
-                              Anguilla
-                            </option>
-                            <option
-                              value="AQ"
-                            >
-                              Antarctica
-                            </option>
-                            <option
-                              value="AG"
-                            >
-                              Antigua and Barbuda
-                            </option>
-                            <option
-                              value="AR"
-                            >
-                              Argentina
-                            </option>
-                            <option
-                              value="AM"
-                            >
-                              Armenia
-                            </option>
-                            <option
-                              value="AW"
-                            >
-                              Aruba
-                            </option>
-                            <option
-                              value="AU"
-                            >
-                              Australia
-                            </option>
-                            <option
-                              value="AT"
-                            >
-                              Austria
-                            </option>
-                            <option
-                              value="AZ"
-                            >
-                              Azerbaijan
-                            </option>
-                            <option
-                              value="BS"
-                            >
-                              Bahamas
-                            </option>
-                            <option
-                              value="BH"
-                            >
-                              Bahrain
-                            </option>
-                            <option
-                              value="BD"
-                            >
-                              Bangladesh
-                            </option>
-                            <option
-                              value="BB"
-                            >
-                              Barbados
-                            </option>
-                            <option
-                              value="BY"
-                            >
-                              Belarus
-                            </option>
-                            <option
-                              value="BE"
-                            >
-                              Belgium
-                            </option>
-                            <option
-                              value="BZ"
-                            >
-                              Belize
-                            </option>
-                            <option
-                              value="BJ"
-                            >
-                              Benin
-                            </option>
-                            <option
-                              value="BM"
-                            >
-                              Bermuda
-                            </option>
-                            <option
-                              value="BT"
-                            >
-                              Bhutan
-                            </option>
-                            <option
-                              value="BO"
-                            >
-                              Bolivia, Plurinational State of
-                            </option>
-                            <option
-                              value="BA"
-                            >
-                              Bosnia and Herzegovina
-                            </option>
-                            <option
-                              value="BW"
-                            >
-                              Botswana
-                            </option>
-                            <option
-                              value="BR"
-                            >
-                              Brazil
-                            </option>
-                            <option
-                              value="IO"
-                            >
-                              British Indian Ocean Territory
-                            </option>
-                            <option
-                              value="BN"
-                            >
-                              Brunei Darussalam
-                            </option>
-                            <option
-                              value="BG"
-                            >
-                              Bulgaria
-                            </option>
-                            <option
-                              value="BF"
-                            >
-                              Burkina Faso
-                            </option>
-                            <option
-                              value="BI"
-                            >
-                              Burundi
-                            </option>
-                            <option
-                              value="KH"
-                            >
-                              Cambodia
-                            </option>
-                            <option
-                              value="CM"
-                            >
-                              Cameroon
-                            </option>
-                            <option
-                              value="CA"
-                            >
-                              Canada
-                            </option>
-                            <option
-                              value="CV"
-                            >
-                              Cape Verde
-                            </option>
-                            <option
-                              value="KY"
-                            >
-                              Cayman Islands
-                            </option>
-                            <option
-                              value="CF"
-                            >
-                              Central African Republic
-                            </option>
-                            <option
-                              value="TD"
-                            >
-                              Chad
-                            </option>
-                            <option
-                              value="CL"
-                            >
-                              Chile
-                            </option>
-                            <option
-                              value="CN"
-                            >
-                              China
-                            </option>
-                            <option
-                              value="CX"
-                            >
-                              Christmas Island
-                            </option>
-                            <option
-                              value="CO"
-                            >
-                              Colombia
-                            </option>
-                            <option
-                              value="KM"
-                            >
-                              Comoros
-                            </option>
-                            <option
-                              value="CG"
-                            >
-                              Congo
-                            </option>
-                            <option
-                              value="CD"
-                            >
-                              Congo, the Democratic Republic of the
-                            </option>
-                            <option
-                              value="CK"
-                            >
-                              Cook Islands
-                            </option>
-                            <option
-                              value="CR"
-                            >
-                              Costa Rica
-                            </option>
-                            <option
-                              value="HR"
-                            >
-                              Croatia
-                            </option>
-                            <option
-                              value="CU"
-                            >
-                              Cuba
-                            </option>
-                            <option
-                              value="CY"
-                            >
-                              Cyprus
-                            </option>
-                            <option
-                              value="CZ"
-                            >
-                              Czech Republic
-                            </option>
-                            <option
-                              value="CI"
-                            >
-                              Côte d'Ivoire
-                            </option>
-                            <option
-                              value="DK"
-                            >
-                              Denmark
-                            </option>
-                            <option
-                              value="DJ"
-                            >
-                              Djibouti
-                            </option>
-                            <option
-                              value="DM"
-                            >
-                              Dominica
-                            </option>
-                            <option
-                              value="DO"
-                            >
-                              Dominican Republic
-                            </option>
-                            <option
-                              value="EC"
-                            >
-                              Ecuador
-                            </option>
-                            <option
-                              value="EG"
-                            >
-                              Egypt
-                            </option>
-                            <option
-                              value="SV"
-                            >
-                              El Salvador
-                            </option>
-                            <option
-                              value="GQ"
-                            >
-                              Equatorial Guinea
-                            </option>
-                            <option
-                              value="ER"
-                            >
-                              Eritrea
-                            </option>
-                            <option
-                              value="EE"
-                            >
-                              Estonia
-                            </option>
-                            <option
-                              value="ET"
-                            >
-                              Ethiopia
-                            </option>
-                            <option
-                              value="FK"
-                            >
-                              Falkland Islands (Malvinas)
-                            </option>
-                            <option
-                              value="FO"
-                            >
-                              Faroe Islands
-                            </option>
-                            <option
-                              value="FJ"
-                            >
-                              Fiji
-                            </option>
-                            <option
-                              value="FI"
-                            >
-                              Finland
-                            </option>
-                            <option
-                              value="FR"
-                            >
-                              France
-                            </option>
-                            <option
-                              value="GF"
-                            >
-                              French Guiana
-                            </option>
-                            <option
-                              value="PF"
-                            >
-                              French Polynesia
-                            </option>
-                            <option
-                              value="GA"
-                            >
-                              Gabon
-                            </option>
-                            <option
-                              value="GM"
-                            >
-                              Gambia
-                            </option>
-                            <option
-                              value="GE"
-                            >
-                              Georgia
-                            </option>
-                            <option
-                              value="DE"
-                            >
-                              Germany
-                            </option>
-                            <option
-                              value="GH"
-                            >
-                              Ghana
-                            </option>
-                            <option
-                              value="GI"
-                            >
-                              Gibraltar
-                            </option>
-                            <option
-                              value="GR"
-                            >
-                              Greece
-                            </option>
-                            <option
-                              value="GL"
-                            >
-                              Greenland
-                            </option>
-                            <option
-                              value="GD"
-                            >
-                              Grenada
-                            </option>
-                            <option
-                              value="GP"
-                            >
-                              Guadeloupe
-                            </option>
-                            <option
-                              value="GU"
-                            >
-                              Guam
-                            </option>
-                            <option
-                              value="GT"
-                            >
-                              Guatemala
-                            </option>
-                            <option
-                              value="GG"
-                            >
-                              Guernsey
-                            </option>
-                            <option
-                              value="GN"
-                            >
-                              Guinea
-                            </option>
-                            <option
-                              value="GW"
-                            >
-                              Guinea-Bissau
-                            </option>
-                            <option
-                              value="GY"
-                            >
-                              Guyana
-                            </option>
-                            <option
-                              value="HT"
-                            >
-                              Haiti
-                            </option>
-                            <option
-                              value="VA"
-                            >
-                              Holy See (Vatican City State)
-                            </option>
-                            <option
-                              value="HN"
-                            >
-                              Honduras
-                            </option>
-                            <option
-                              value="HK"
-                            >
-                              Hong Kong
-                            </option>
-                            <option
-                              value="HU"
-                            >
-                              Hungary
-                            </option>
-                            <option
-                              value="IS"
-                            >
-                              Iceland
-                            </option>
-                            <option
-                              value="IN"
-                            >
-                              India
-                            </option>
-                            <option
-                              value="ID"
-                            >
-                              Indonesia
-                            </option>
-                            <option
-                              value="IR"
-                            >
-                              Iran, Islamic Republic of
-                            </option>
-                            <option
-                              value="IQ"
-                            >
-                              Iraq
-                            </option>
-                            <option
-                              value="IE"
-                            >
-                              Ireland
-                            </option>
-                            <option
-                              value="IL"
-                            >
-                              Israel
-                            </option>
-                            <option
-                              value="IT"
-                            >
-                              Italy
-                            </option>
-                            <option
-                              value="JM"
-                            >
-                              Jamaica
-                            </option>
-                            <option
-                              value="JP"
-                            >
-                              Japan
-                            </option>
-                            <option
-                              value="JE"
-                            >
-                              Jersey
-                            </option>
-                            <option
-                              value="JO"
-                            >
-                              Jordan
-                            </option>
-                            <option
-                              value="KZ"
-                            >
-                              Kazakhstan
-                            </option>
-                            <option
-                              value="KE"
-                            >
-                              Kenya
-                            </option>
-                            <option
-                              value="KI"
-                            >
-                              Kiribati
-                            </option>
-                            <option
-                              value="KP"
-                            >
-                              Korea, Democratic People's Republic of
-                            </option>
-                            <option
-                              value="KR"
-                            >
-                              Korea, Republic of
-                            </option>
-                            <option
-                              value="XK"
-                            >
-                              Kosovo, Republic of
-                            </option>
-                            <option
-                              value="KW"
-                            >
-                              Kuwait
-                            </option>
-                            <option
-                              value="KG"
-                            >
-                              Kyrgyzstan
-                            </option>
-                            <option
-                              value="LA"
-                            >
-                              Lao People's Democratic Republic
-                            </option>
-                            <option
-                              value="LV"
-                            >
-                              Latvia
-                            </option>
-                            <option
-                              value="LB"
-                            >
-                              Lebanon
-                            </option>
-                            <option
-                              value="LS"
-                            >
-                              Lesotho
-                            </option>
-                            <option
-                              value="LR"
-                            >
-                              Liberia
-                            </option>
-                            <option
-                              value="LY"
-                            >
-                              Libya
-                            </option>
-                            <option
-                              value="LI"
-                            >
-                              Liechtenstein
-                            </option>
-                            <option
-                              value="LT"
-                            >
-                              Lithuania
-                            </option>
-                            <option
-                              value="LU"
-                            >
-                              Luxembourg
-                            </option>
-                            <option
-                              value="MO"
-                            >
-                              Macao
-                            </option>
-                            <option
-                              value="MK"
-                            >
-                              Macedonia, the former Yugoslav Republic of
-                            </option>
-                            <option
-                              value="MG"
-                            >
-                              Madagascar
-                            </option>
-                            <option
-                              value="MW"
-                            >
-                              Malawi
-                            </option>
-                            <option
-                              value="MY"
-                            >
-                              Malaysia
-                            </option>
-                            <option
-                              value="MV"
-                            >
-                              Maldives
-                            </option>
-                            <option
-                              value="ML"
-                            >
-                              Mali
-                            </option>
-                            <option
-                              value="MT"
-                            >
-                              Malta
-                            </option>
-                            <option
-                              value="MH"
-                            >
-                              Marshall Islands
-                            </option>
-                            <option
-                              value="MQ"
-                            >
-                              Martinique
-                            </option>
-                            <option
-                              value="MR"
-                            >
-                              Mauritania
-                            </option>
-                            <option
-                              value="MU"
-                            >
-                              Mauritius
-                            </option>
-                            <option
-                              value="YT"
-                            >
-                              Mayotte
-                            </option>
-                            <option
-                              value="MX"
-                            >
-                              Mexico
-                            </option>
-                            <option
-                              value="FM"
-                            >
-                              Micronesia, Federated States of
-                            </option>
-                            <option
-                              value="MD"
-                            >
-                              Moldova, Republic of
-                            </option>
-                            <option
-                              value="MC"
-                            >
-                              Monaco
-                            </option>
-                            <option
-                              value="MN"
-                            >
-                              Mongolia
-                            </option>
-                            <option
-                              value="ME"
-                            >
-                              Montenegro
-                            </option>
-                            <option
-                              value="MS"
-                            >
-                              Montserrat
-                            </option>
-                            <option
-                              value="MA"
-                            >
-                              Morocco
-                            </option>
-                            <option
-                              value="MZ"
-                            >
-                              Mozambique
-                            </option>
-                            <option
-                              value="MM"
-                            >
-                              Myanmar
-                            </option>
-                            <option
-                              value="NA"
-                            >
-                              Namibia
-                            </option>
-                            <option
-                              value="NR"
-                            >
-                              Nauru
-                            </option>
-                            <option
-                              value="NP"
-                            >
-                              Nepal
-                            </option>
-                            <option
-                              value="NL"
-                            >
-                              Netherlands
-                            </option>
-                            <option
-                              value="AN"
-                            >
-                              Netherlands Antilles
-                            </option>
-                            <option
-                              value="NC"
-                            >
-                              New Caledonia
-                            </option>
-                            <option
-                              value="NZ"
-                            >
-                              New Zealand
-                            </option>
-                            <option
-                              value="NI"
-                            >
-                              Nicaragua
-                            </option>
-                            <option
-                              value="NE"
-                            >
-                              Niger
-                            </option>
-                            <option
-                              value="NG"
-                            >
-                              Nigeria
-                            </option>
-                            <option
-                              value="NU"
-                            >
-                              Niue
-                            </option>
-                            <option
-                              value="NF"
-                            >
-                              Norfolk Island
-                            </option>
-                            <option
-                              value="MP"
-                            >
-                              Northern Mariana Islands
-                            </option>
-                            <option
-                              value="NO"
-                            >
-                              Norway
-                            </option>
-                            <option
-                              value="OM"
-                            >
-                              Oman
-                            </option>
-                            <option
-                              value="PK"
-                            >
-                              Pakistan
-                            </option>
-                            <option
-                              value="PW"
-                            >
-                              Palau
-                            </option>
-                            <option
-                              value="PS"
-                            >
-                              Palestine, State of
-                            </option>
-                            <option
-                              value="PA"
-                            >
-                              Panama
-                            </option>
-                            <option
-                              value="PG"
-                            >
-                              Papua New Guinea
-                            </option>
-                            <option
-                              value="PY"
-                            >
-                              Paraguay
-                            </option>
-                            <option
-                              value="PE"
-                            >
-                              Peru
-                            </option>
-                            <option
-                              value="PH"
-                            >
-                              Philippines
-                            </option>
-                            <option
-                              value="PN"
-                            >
-                              Pitcairn
-                            </option>
-                            <option
-                              value="PL"
-                            >
-                              Poland
-                            </option>
-                            <option
-                              value="PT"
-                            >
-                              Portugal
-                            </option>
-                            <option
-                              value="PR"
-                            >
-                              Puerto Rico
-                            </option>
-                            <option
-                              value="QA"
-                            >
-                              Qatar
-                            </option>
-                            <option
-                              value="RO"
-                            >
-                              Romania
-                            </option>
-                            <option
-                              value="RU"
-                            >
-                              Russian Federation
-                            </option>
-                            <option
-                              value="RW"
-                            >
-                              Rwanda
-                            </option>
-                            <option
-                              value="RE"
-                            >
-                              Réunion
-                            </option>
-                            <option
-                              value="SH"
-                            >
-                              Saint Helena, Ascension and Tristan da Cunha
-                            </option>
-                            <option
-                              value="KN"
-                            >
-                              Saint Kitts and Nevis
-                            </option>
-                            <option
-                              value="LC"
-                            >
-                              Saint Lucia
-                            </option>
-                            <option
-                              value="PM"
-                            >
-                              Saint Pierre and Miquelon
-                            </option>
-                            <option
-                              value="VC"
-                            >
-                              Saint Vincent and the Grenadines
-                            </option>
-                            <option
-                              value="WS"
-                            >
-                              Samoa
-                            </option>
-                            <option
-                              value="SM"
-                            >
-                              San Marino
-                            </option>
-                            <option
-                              value="SA"
-                            >
-                              Saudi Arabia
-                            </option>
-                            <option
-                              value="SN"
-                            >
-                              Senegal
-                            </option>
-                            <option
-                              value="RS"
-                            >
-                              Serbia
-                            </option>
-                            <option
-                              value="SC"
-                            >
-                              Seychelles
-                            </option>
-                            <option
-                              value="SL"
-                            >
-                              Sierra Leone
-                            </option>
-                            <option
-                              value="SG"
-                            >
-                              Singapore
-                            </option>
-                            <option
-                              value="SK"
-                            >
-                              Slovakia
-                            </option>
-                            <option
-                              value="SI"
-                            >
-                              Slovenia
-                            </option>
-                            <option
-                              value="SB"
-                            >
-                              Solomon Islands
-                            </option>
-                            <option
-                              value="SO"
-                            >
-                              Somalia
-                            </option>
-                            <option
-                              value="ZA"
-                            >
-                              South Africa
-                            </option>
-                            <option
-                              value="GS"
-                            >
-                              South Georgia and the South Sandwich Islands
-                            </option>
-                            <option
-                              value="SS"
-                            >
-                              South Sudan
-                            </option>
-                            <option
-                              value="ES"
-                            >
-                              Spain
-                            </option>
-                            <option
-                              value="LK"
-                            >
-                              Sri Lanka
-                            </option>
-                            <option
-                              value="SD"
-                            >
-                              Sudan
-                            </option>
-                            <option
-                              value="SR"
-                            >
-                              Suriname
-                            </option>
-                            <option
-                              value="SJ"
-                            >
-                              Svalbard and Jan Mayen
-                            </option>
-                            <option
-                              value="SZ"
-                            >
-                              Swaziland
-                            </option>
-                            <option
-                              value="SE"
-                            >
-                              Sweden
-                            </option>
-                            <option
-                              value="CH"
-                            >
-                              Switzerland
-                            </option>
-                            <option
-                              value="SY"
-                            >
-                              Syrian Arab Republic
-                            </option>
-                            <option
-                              value="ST"
-                            >
-                              São Tomé and Príncipe
-                            </option>
-                            <option
-                              value="TW"
-                            >
-                              Taiwan
-                            </option>
-                            <option
-                              value="TJ"
-                            >
-                              Tajikistan
-                            </option>
-                            <option
-                              value="TZ"
-                            >
-                              Tanzania, United Republic of
-                            </option>
-                            <option
-                              value="TH"
-                            >
-                              Thailand
-                            </option>
-                            <option
-                              value="TL"
-                            >
-                              Timor-Leste
-                            </option>
-                            <option
-                              value="TG"
-                            >
-                              Togo
-                            </option>
-                            <option
-                              value="TK"
-                            >
-                              Tokelau
-                            </option>
-                            <option
-                              value="TO"
-                            >
-                              Tonga
-                            </option>
-                            <option
-                              value="TT"
-                            >
-                              Trinidad and Tobago
-                            </option>
-                            <option
-                              value="TN"
-                            >
-                              Tunisia
-                            </option>
-                            <option
-                              value="TR"
-                            >
-                              Turkey
-                            </option>
-                            <option
-                              value="TM"
-                            >
-                              Turkmenistan
-                            </option>
-                            <option
-                              value="TC"
-                            >
-                              Turks and Caicos Islands
-                            </option>
-                            <option
-                              value="TV"
-                            >
-                              Tuvalu
-                            </option>
-                            <option
-                              value="UG"
-                            >
-                              Uganda
-                            </option>
-                            <option
-                              value="UA"
-                            >
-                              Ukraine
-                            </option>
-                            <option
-                              value="AE"
-                            >
-                              United Arab Emirates
-                            </option>
-                            <option
-                              value="GB"
-                            >
-                              United Kingdom
-                            </option>
-                            <option
-                              value="US"
-                            >
-                              United States
-                            </option>
-                            <option
-                              value="UM"
-                            >
-                              United States Minor Outlying Islands
-                            </option>
-                            <option
-                              value="UY"
-                            >
-                              Uruguay
-                            </option>
-                            <option
-                              value="UZ"
-                            >
-                              Uzbekistan
-                            </option>
-                            <option
-                              value="VU"
-                            >
-                              Vanuatu
-                            </option>
-                            <option
-                              value="VE"
-                            >
-                              Venezuela, Bolivarian Republic of
-                            </option>
-                            <option
-                              value="VN"
-                            >
-                              Viet Nam
-                            </option>
-                            <option
-                              value="VG"
-                            >
-                              Virgin Islands, British
-                            </option>
-                            <option
-                              value="VI"
-                            >
-                              Virgin Islands, U.S.
-                            </option>
-                            <option
-                              value="WF"
-                            >
-                              Wallis and Futuna
-                            </option>
-                            <option
-                              value="EH"
-                            >
-                              Western Sahara
-                            </option>
-                            <option
-                              value="YE"
-                            >
-                              Yemen
-                            </option>
-                            <option
-                              value="ZM"
-                            >
-                              Zambia
-                            </option>
-                            <option
-                              value="ZW"
-                            >
-                              Zimbabwe
-                            </option>
-                            <option
-                              value="AX"
-                            >
-                              Åland Islands
-                            </option>
-                          </select>
                           <span
-                            class="ods-7mdg51"
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-21"
                           >
-                            <svg
-                              class="ods-2icygl"
-                              fill="none"
-                              role="presentation"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
+                            <input
+                              class="PrivateSwitchBase-input emotion-22"
+                              name="authenticator.methodType"
+                              type="radio"
+                              value="voice"
+                            />
+                            <span
+                              class="emotion-23"
                             >
-                              <path
-                                clip-rule="evenodd"
-                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-32"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </div>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-26"
+                          >
+                            Voice call
+                          </span>
+                        </label>
                       </div>
-                    </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
                     <div
-                      class="MuiBox-root emotion-36"
+                      class="MuiBox-root emotion-4"
                     >
                       <div
-                        class="MuiBox-root emotion-37"
+                        class="MuiBox-root emotion-11"
                       >
                         <div
                           class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
                         >
                           <label
                             class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                            for="authenticator.phoneNumber"
+                            for="countryList"
                           >
                             <span
                               class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                             >
-                              Phone number
+                              Country
                             </span>
                           </label>
                           <div
-                            class="ods-10aW0m"
+                            class="ods-mUkyrD"
                           >
-                            <input
-                              autocomplete="tel-national"
-                              class="ods-7qBw9I"
-                              data-se="authenticator.phoneNumber"
-                              id="authenticator.phoneNumber"
-                              name="authenticator.phoneNumber"
-                              type="tel"
-                            />
+                            <select
+                              autocomplete="tel-country-code"
+                              class="ods-1B2Zfy"
+                              data-se="countryList"
+                              id="countryList"
+                            >
+                              <option
+                                value="AF"
+                              >
+                                Afghanistan
+                              </option>
+                              <option
+                                value="AL"
+                              >
+                                Albania
+                              </option>
+                              <option
+                                value="DZ"
+                              >
+                                Algeria
+                              </option>
+                              <option
+                                value="AS"
+                              >
+                                American Samoa
+                              </option>
+                              <option
+                                value="AD"
+                              >
+                                Andorra
+                              </option>
+                              <option
+                                value="AO"
+                              >
+                                Angola
+                              </option>
+                              <option
+                                value="AI"
+                              >
+                                Anguilla
+                              </option>
+                              <option
+                                value="AQ"
+                              >
+                                Antarctica
+                              </option>
+                              <option
+                                value="AG"
+                              >
+                                Antigua and Barbuda
+                              </option>
+                              <option
+                                value="AR"
+                              >
+                                Argentina
+                              </option>
+                              <option
+                                value="AM"
+                              >
+                                Armenia
+                              </option>
+                              <option
+                                value="AW"
+                              >
+                                Aruba
+                              </option>
+                              <option
+                                value="AU"
+                              >
+                                Australia
+                              </option>
+                              <option
+                                value="AT"
+                              >
+                                Austria
+                              </option>
+                              <option
+                                value="AZ"
+                              >
+                                Azerbaijan
+                              </option>
+                              <option
+                                value="BS"
+                              >
+                                Bahamas
+                              </option>
+                              <option
+                                value="BH"
+                              >
+                                Bahrain
+                              </option>
+                              <option
+                                value="BD"
+                              >
+                                Bangladesh
+                              </option>
+                              <option
+                                value="BB"
+                              >
+                                Barbados
+                              </option>
+                              <option
+                                value="BY"
+                              >
+                                Belarus
+                              </option>
+                              <option
+                                value="BE"
+                              >
+                                Belgium
+                              </option>
+                              <option
+                                value="BZ"
+                              >
+                                Belize
+                              </option>
+                              <option
+                                value="BJ"
+                              >
+                                Benin
+                              </option>
+                              <option
+                                value="BM"
+                              >
+                                Bermuda
+                              </option>
+                              <option
+                                value="BT"
+                              >
+                                Bhutan
+                              </option>
+                              <option
+                                value="BO"
+                              >
+                                Bolivia, Plurinational State of
+                              </option>
+                              <option
+                                value="BA"
+                              >
+                                Bosnia and Herzegovina
+                              </option>
+                              <option
+                                value="BW"
+                              >
+                                Botswana
+                              </option>
+                              <option
+                                value="BR"
+                              >
+                                Brazil
+                              </option>
+                              <option
+                                value="IO"
+                              >
+                                British Indian Ocean Territory
+                              </option>
+                              <option
+                                value="BN"
+                              >
+                                Brunei Darussalam
+                              </option>
+                              <option
+                                value="BG"
+                              >
+                                Bulgaria
+                              </option>
+                              <option
+                                value="BF"
+                              >
+                                Burkina Faso
+                              </option>
+                              <option
+                                value="BI"
+                              >
+                                Burundi
+                              </option>
+                              <option
+                                value="KH"
+                              >
+                                Cambodia
+                              </option>
+                              <option
+                                value="CM"
+                              >
+                                Cameroon
+                              </option>
+                              <option
+                                value="CA"
+                              >
+                                Canada
+                              </option>
+                              <option
+                                value="CV"
+                              >
+                                Cape Verde
+                              </option>
+                              <option
+                                value="KY"
+                              >
+                                Cayman Islands
+                              </option>
+                              <option
+                                value="CF"
+                              >
+                                Central African Republic
+                              </option>
+                              <option
+                                value="TD"
+                              >
+                                Chad
+                              </option>
+                              <option
+                                value="CL"
+                              >
+                                Chile
+                              </option>
+                              <option
+                                value="CN"
+                              >
+                                China
+                              </option>
+                              <option
+                                value="CX"
+                              >
+                                Christmas Island
+                              </option>
+                              <option
+                                value="CO"
+                              >
+                                Colombia
+                              </option>
+                              <option
+                                value="KM"
+                              >
+                                Comoros
+                              </option>
+                              <option
+                                value="CG"
+                              >
+                                Congo
+                              </option>
+                              <option
+                                value="CD"
+                              >
+                                Congo, the Democratic Republic of the
+                              </option>
+                              <option
+                                value="CK"
+                              >
+                                Cook Islands
+                              </option>
+                              <option
+                                value="CR"
+                              >
+                                Costa Rica
+                              </option>
+                              <option
+                                value="HR"
+                              >
+                                Croatia
+                              </option>
+                              <option
+                                value="CU"
+                              >
+                                Cuba
+                              </option>
+                              <option
+                                value="CY"
+                              >
+                                Cyprus
+                              </option>
+                              <option
+                                value="CZ"
+                              >
+                                Czech Republic
+                              </option>
+                              <option
+                                value="CI"
+                              >
+                                Côte d'Ivoire
+                              </option>
+                              <option
+                                value="DK"
+                              >
+                                Denmark
+                              </option>
+                              <option
+                                value="DJ"
+                              >
+                                Djibouti
+                              </option>
+                              <option
+                                value="DM"
+                              >
+                                Dominica
+                              </option>
+                              <option
+                                value="DO"
+                              >
+                                Dominican Republic
+                              </option>
+                              <option
+                                value="EC"
+                              >
+                                Ecuador
+                              </option>
+                              <option
+                                value="EG"
+                              >
+                                Egypt
+                              </option>
+                              <option
+                                value="SV"
+                              >
+                                El Salvador
+                              </option>
+                              <option
+                                value="GQ"
+                              >
+                                Equatorial Guinea
+                              </option>
+                              <option
+                                value="ER"
+                              >
+                                Eritrea
+                              </option>
+                              <option
+                                value="EE"
+                              >
+                                Estonia
+                              </option>
+                              <option
+                                value="ET"
+                              >
+                                Ethiopia
+                              </option>
+                              <option
+                                value="FK"
+                              >
+                                Falkland Islands (Malvinas)
+                              </option>
+                              <option
+                                value="FO"
+                              >
+                                Faroe Islands
+                              </option>
+                              <option
+                                value="FJ"
+                              >
+                                Fiji
+                              </option>
+                              <option
+                                value="FI"
+                              >
+                                Finland
+                              </option>
+                              <option
+                                value="FR"
+                              >
+                                France
+                              </option>
+                              <option
+                                value="GF"
+                              >
+                                French Guiana
+                              </option>
+                              <option
+                                value="PF"
+                              >
+                                French Polynesia
+                              </option>
+                              <option
+                                value="GA"
+                              >
+                                Gabon
+                              </option>
+                              <option
+                                value="GM"
+                              >
+                                Gambia
+                              </option>
+                              <option
+                                value="GE"
+                              >
+                                Georgia
+                              </option>
+                              <option
+                                value="DE"
+                              >
+                                Germany
+                              </option>
+                              <option
+                                value="GH"
+                              >
+                                Ghana
+                              </option>
+                              <option
+                                value="GI"
+                              >
+                                Gibraltar
+                              </option>
+                              <option
+                                value="GR"
+                              >
+                                Greece
+                              </option>
+                              <option
+                                value="GL"
+                              >
+                                Greenland
+                              </option>
+                              <option
+                                value="GD"
+                              >
+                                Grenada
+                              </option>
+                              <option
+                                value="GP"
+                              >
+                                Guadeloupe
+                              </option>
+                              <option
+                                value="GU"
+                              >
+                                Guam
+                              </option>
+                              <option
+                                value="GT"
+                              >
+                                Guatemala
+                              </option>
+                              <option
+                                value="GG"
+                              >
+                                Guernsey
+                              </option>
+                              <option
+                                value="GN"
+                              >
+                                Guinea
+                              </option>
+                              <option
+                                value="GW"
+                              >
+                                Guinea-Bissau
+                              </option>
+                              <option
+                                value="GY"
+                              >
+                                Guyana
+                              </option>
+                              <option
+                                value="HT"
+                              >
+                                Haiti
+                              </option>
+                              <option
+                                value="VA"
+                              >
+                                Holy See (Vatican City State)
+                              </option>
+                              <option
+                                value="HN"
+                              >
+                                Honduras
+                              </option>
+                              <option
+                                value="HK"
+                              >
+                                Hong Kong
+                              </option>
+                              <option
+                                value="HU"
+                              >
+                                Hungary
+                              </option>
+                              <option
+                                value="IS"
+                              >
+                                Iceland
+                              </option>
+                              <option
+                                value="IN"
+                              >
+                                India
+                              </option>
+                              <option
+                                value="ID"
+                              >
+                                Indonesia
+                              </option>
+                              <option
+                                value="IR"
+                              >
+                                Iran, Islamic Republic of
+                              </option>
+                              <option
+                                value="IQ"
+                              >
+                                Iraq
+                              </option>
+                              <option
+                                value="IE"
+                              >
+                                Ireland
+                              </option>
+                              <option
+                                value="IL"
+                              >
+                                Israel
+                              </option>
+                              <option
+                                value="IT"
+                              >
+                                Italy
+                              </option>
+                              <option
+                                value="JM"
+                              >
+                                Jamaica
+                              </option>
+                              <option
+                                value="JP"
+                              >
+                                Japan
+                              </option>
+                              <option
+                                value="JE"
+                              >
+                                Jersey
+                              </option>
+                              <option
+                                value="JO"
+                              >
+                                Jordan
+                              </option>
+                              <option
+                                value="KZ"
+                              >
+                                Kazakhstan
+                              </option>
+                              <option
+                                value="KE"
+                              >
+                                Kenya
+                              </option>
+                              <option
+                                value="KI"
+                              >
+                                Kiribati
+                              </option>
+                              <option
+                                value="KP"
+                              >
+                                Korea, Democratic People's Republic of
+                              </option>
+                              <option
+                                value="KR"
+                              >
+                                Korea, Republic of
+                              </option>
+                              <option
+                                value="XK"
+                              >
+                                Kosovo, Republic of
+                              </option>
+                              <option
+                                value="KW"
+                              >
+                                Kuwait
+                              </option>
+                              <option
+                                value="KG"
+                              >
+                                Kyrgyzstan
+                              </option>
+                              <option
+                                value="LA"
+                              >
+                                Lao People's Democratic Republic
+                              </option>
+                              <option
+                                value="LV"
+                              >
+                                Latvia
+                              </option>
+                              <option
+                                value="LB"
+                              >
+                                Lebanon
+                              </option>
+                              <option
+                                value="LS"
+                              >
+                                Lesotho
+                              </option>
+                              <option
+                                value="LR"
+                              >
+                                Liberia
+                              </option>
+                              <option
+                                value="LY"
+                              >
+                                Libya
+                              </option>
+                              <option
+                                value="LI"
+                              >
+                                Liechtenstein
+                              </option>
+                              <option
+                                value="LT"
+                              >
+                                Lithuania
+                              </option>
+                              <option
+                                value="LU"
+                              >
+                                Luxembourg
+                              </option>
+                              <option
+                                value="MO"
+                              >
+                                Macao
+                              </option>
+                              <option
+                                value="MK"
+                              >
+                                Macedonia, the former Yugoslav Republic of
+                              </option>
+                              <option
+                                value="MG"
+                              >
+                                Madagascar
+                              </option>
+                              <option
+                                value="MW"
+                              >
+                                Malawi
+                              </option>
+                              <option
+                                value="MY"
+                              >
+                                Malaysia
+                              </option>
+                              <option
+                                value="MV"
+                              >
+                                Maldives
+                              </option>
+                              <option
+                                value="ML"
+                              >
+                                Mali
+                              </option>
+                              <option
+                                value="MT"
+                              >
+                                Malta
+                              </option>
+                              <option
+                                value="MH"
+                              >
+                                Marshall Islands
+                              </option>
+                              <option
+                                value="MQ"
+                              >
+                                Martinique
+                              </option>
+                              <option
+                                value="MR"
+                              >
+                                Mauritania
+                              </option>
+                              <option
+                                value="MU"
+                              >
+                                Mauritius
+                              </option>
+                              <option
+                                value="YT"
+                              >
+                                Mayotte
+                              </option>
+                              <option
+                                value="MX"
+                              >
+                                Mexico
+                              </option>
+                              <option
+                                value="FM"
+                              >
+                                Micronesia, Federated States of
+                              </option>
+                              <option
+                                value="MD"
+                              >
+                                Moldova, Republic of
+                              </option>
+                              <option
+                                value="MC"
+                              >
+                                Monaco
+                              </option>
+                              <option
+                                value="MN"
+                              >
+                                Mongolia
+                              </option>
+                              <option
+                                value="ME"
+                              >
+                                Montenegro
+                              </option>
+                              <option
+                                value="MS"
+                              >
+                                Montserrat
+                              </option>
+                              <option
+                                value="MA"
+                              >
+                                Morocco
+                              </option>
+                              <option
+                                value="MZ"
+                              >
+                                Mozambique
+                              </option>
+                              <option
+                                value="MM"
+                              >
+                                Myanmar
+                              </option>
+                              <option
+                                value="NA"
+                              >
+                                Namibia
+                              </option>
+                              <option
+                                value="NR"
+                              >
+                                Nauru
+                              </option>
+                              <option
+                                value="NP"
+                              >
+                                Nepal
+                              </option>
+                              <option
+                                value="NL"
+                              >
+                                Netherlands
+                              </option>
+                              <option
+                                value="AN"
+                              >
+                                Netherlands Antilles
+                              </option>
+                              <option
+                                value="NC"
+                              >
+                                New Caledonia
+                              </option>
+                              <option
+                                value="NZ"
+                              >
+                                New Zealand
+                              </option>
+                              <option
+                                value="NI"
+                              >
+                                Nicaragua
+                              </option>
+                              <option
+                                value="NE"
+                              >
+                                Niger
+                              </option>
+                              <option
+                                value="NG"
+                              >
+                                Nigeria
+                              </option>
+                              <option
+                                value="NU"
+                              >
+                                Niue
+                              </option>
+                              <option
+                                value="NF"
+                              >
+                                Norfolk Island
+                              </option>
+                              <option
+                                value="MP"
+                              >
+                                Northern Mariana Islands
+                              </option>
+                              <option
+                                value="NO"
+                              >
+                                Norway
+                              </option>
+                              <option
+                                value="OM"
+                              >
+                                Oman
+                              </option>
+                              <option
+                                value="PK"
+                              >
+                                Pakistan
+                              </option>
+                              <option
+                                value="PW"
+                              >
+                                Palau
+                              </option>
+                              <option
+                                value="PS"
+                              >
+                                Palestine, State of
+                              </option>
+                              <option
+                                value="PA"
+                              >
+                                Panama
+                              </option>
+                              <option
+                                value="PG"
+                              >
+                                Papua New Guinea
+                              </option>
+                              <option
+                                value="PY"
+                              >
+                                Paraguay
+                              </option>
+                              <option
+                                value="PE"
+                              >
+                                Peru
+                              </option>
+                              <option
+                                value="PH"
+                              >
+                                Philippines
+                              </option>
+                              <option
+                                value="PN"
+                              >
+                                Pitcairn
+                              </option>
+                              <option
+                                value="PL"
+                              >
+                                Poland
+                              </option>
+                              <option
+                                value="PT"
+                              >
+                                Portugal
+                              </option>
+                              <option
+                                value="PR"
+                              >
+                                Puerto Rico
+                              </option>
+                              <option
+                                value="QA"
+                              >
+                                Qatar
+                              </option>
+                              <option
+                                value="RO"
+                              >
+                                Romania
+                              </option>
+                              <option
+                                value="RU"
+                              >
+                                Russian Federation
+                              </option>
+                              <option
+                                value="RW"
+                              >
+                                Rwanda
+                              </option>
+                              <option
+                                value="RE"
+                              >
+                                Réunion
+                              </option>
+                              <option
+                                value="SH"
+                              >
+                                Saint Helena, Ascension and Tristan da Cunha
+                              </option>
+                              <option
+                                value="KN"
+                              >
+                                Saint Kitts and Nevis
+                              </option>
+                              <option
+                                value="LC"
+                              >
+                                Saint Lucia
+                              </option>
+                              <option
+                                value="PM"
+                              >
+                                Saint Pierre and Miquelon
+                              </option>
+                              <option
+                                value="VC"
+                              >
+                                Saint Vincent and the Grenadines
+                              </option>
+                              <option
+                                value="WS"
+                              >
+                                Samoa
+                              </option>
+                              <option
+                                value="SM"
+                              >
+                                San Marino
+                              </option>
+                              <option
+                                value="SA"
+                              >
+                                Saudi Arabia
+                              </option>
+                              <option
+                                value="SN"
+                              >
+                                Senegal
+                              </option>
+                              <option
+                                value="RS"
+                              >
+                                Serbia
+                              </option>
+                              <option
+                                value="SC"
+                              >
+                                Seychelles
+                              </option>
+                              <option
+                                value="SL"
+                              >
+                                Sierra Leone
+                              </option>
+                              <option
+                                value="SG"
+                              >
+                                Singapore
+                              </option>
+                              <option
+                                value="SK"
+                              >
+                                Slovakia
+                              </option>
+                              <option
+                                value="SI"
+                              >
+                                Slovenia
+                              </option>
+                              <option
+                                value="SB"
+                              >
+                                Solomon Islands
+                              </option>
+                              <option
+                                value="SO"
+                              >
+                                Somalia
+                              </option>
+                              <option
+                                value="ZA"
+                              >
+                                South Africa
+                              </option>
+                              <option
+                                value="GS"
+                              >
+                                South Georgia and the South Sandwich Islands
+                              </option>
+                              <option
+                                value="SS"
+                              >
+                                South Sudan
+                              </option>
+                              <option
+                                value="ES"
+                              >
+                                Spain
+                              </option>
+                              <option
+                                value="LK"
+                              >
+                                Sri Lanka
+                              </option>
+                              <option
+                                value="SD"
+                              >
+                                Sudan
+                              </option>
+                              <option
+                                value="SR"
+                              >
+                                Suriname
+                              </option>
+                              <option
+                                value="SJ"
+                              >
+                                Svalbard and Jan Mayen
+                              </option>
+                              <option
+                                value="SZ"
+                              >
+                                Swaziland
+                              </option>
+                              <option
+                                value="SE"
+                              >
+                                Sweden
+                              </option>
+                              <option
+                                value="CH"
+                              >
+                                Switzerland
+                              </option>
+                              <option
+                                value="SY"
+                              >
+                                Syrian Arab Republic
+                              </option>
+                              <option
+                                value="ST"
+                              >
+                                São Tomé and Príncipe
+                              </option>
+                              <option
+                                value="TW"
+                              >
+                                Taiwan
+                              </option>
+                              <option
+                                value="TJ"
+                              >
+                                Tajikistan
+                              </option>
+                              <option
+                                value="TZ"
+                              >
+                                Tanzania, United Republic of
+                              </option>
+                              <option
+                                value="TH"
+                              >
+                                Thailand
+                              </option>
+                              <option
+                                value="TL"
+                              >
+                                Timor-Leste
+                              </option>
+                              <option
+                                value="TG"
+                              >
+                                Togo
+                              </option>
+                              <option
+                                value="TK"
+                              >
+                                Tokelau
+                              </option>
+                              <option
+                                value="TO"
+                              >
+                                Tonga
+                              </option>
+                              <option
+                                value="TT"
+                              >
+                                Trinidad and Tobago
+                              </option>
+                              <option
+                                value="TN"
+                              >
+                                Tunisia
+                              </option>
+                              <option
+                                value="TR"
+                              >
+                                Turkey
+                              </option>
+                              <option
+                                value="TM"
+                              >
+                                Turkmenistan
+                              </option>
+                              <option
+                                value="TC"
+                              >
+                                Turks and Caicos Islands
+                              </option>
+                              <option
+                                value="TV"
+                              >
+                                Tuvalu
+                              </option>
+                              <option
+                                value="UG"
+                              >
+                                Uganda
+                              </option>
+                              <option
+                                value="UA"
+                              >
+                                Ukraine
+                              </option>
+                              <option
+                                value="AE"
+                              >
+                                United Arab Emirates
+                              </option>
+                              <option
+                                value="GB"
+                              >
+                                United Kingdom
+                              </option>
+                              <option
+                                value="US"
+                              >
+                                United States
+                              </option>
+                              <option
+                                value="UM"
+                              >
+                                United States Minor Outlying Islands
+                              </option>
+                              <option
+                                value="UY"
+                              >
+                                Uruguay
+                              </option>
+                              <option
+                                value="UZ"
+                              >
+                                Uzbekistan
+                              </option>
+                              <option
+                                value="VU"
+                              >
+                                Vanuatu
+                              </option>
+                              <option
+                                value="VE"
+                              >
+                                Venezuela, Bolivarian Republic of
+                              </option>
+                              <option
+                                value="VN"
+                              >
+                                Viet Nam
+                              </option>
+                              <option
+                                value="VG"
+                              >
+                                Virgin Islands, British
+                              </option>
+                              <option
+                                value="VI"
+                              >
+                                Virgin Islands, U.S.
+                              </option>
+                              <option
+                                value="WF"
+                              >
+                                Wallis and Futuna
+                              </option>
+                              <option
+                                value="EH"
+                              >
+                                Western Sahara
+                              </option>
+                              <option
+                                value="YE"
+                              >
+                                Yemen
+                              </option>
+                              <option
+                                value="ZM"
+                              >
+                                Zambia
+                              </option>
+                              <option
+                                value="ZW"
+                              >
+                                Zimbabwe
+                              </option>
+                              <option
+                                value="AX"
+                              >
+                                Åland Islands
+                              </option>
+                            </select>
+                            <span
+                              class="ods-7mdg51"
+                            >
+                              <svg
+                                class="ods-2icygl"
+                                fill="none"
+                                role="presentation"
+                                viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  clip-rule="evenodd"
+                                  d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                  fill="currentColor"
+                                  fill-rule="evenodd"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="MuiBox-root emotion-37"
+                      >
+                        <div
+                          class="MuiBox-root emotion-38"
+                        >
+                          <div
+                            class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                          >
+                            <label
+                              class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                              for="authenticator.phoneNumber"
+                            >
+                              <span
+                                class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                              >
+                                Phone number
+                              </span>
+                            </label>
+                            <div
+                              class="ods-10aW0m"
+                            >
+                              <input
+                                autocomplete="tel-national"
+                                class="ods-7qBw9I"
+                                data-se="authenticator.phoneNumber"
+                                id="authenticator.phoneNumber"
+                                name="authenticator.phoneNumber"
+                                type="tel"
+                              />
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Receive a code via SMS
+                    </button>
+                  </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-39"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
+                    data-se="switchAuthenticator"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Receive a code via SMS
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-41"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-41"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-enroll-google-authenticator renders form renders QR code view 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester19@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester19@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,162 +71,166 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up Google Authenticator
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up Google Authenticator
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-11"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <div
+                      class="MuiBox-root emotion-12"
                     >
-                      Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".
-                    </p>
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Launch Google Authenticator, tap the "+" icon, then select "Scan barcode".
+                      </p>
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
                   <div
-                    class="qrContainer MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-11"
                   >
-                    <img
-                      alt="Google Authenticator"
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAE7ElEQVR42u3dwWrsMAwF0Pz/T7/uC29RYklXzrnQ1ZQh4/gEFDvK809E/pvHEIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIIL+/6Hla/04f718/rx6v0+Ndff5umx+AAAIIIIAAAggggOwDUj2h3k64r4N9O17pFxxAAAEEEEAAAQQQQAB5O+HSiubTYKrHo3p8TwNKmR+AAAIIIIAAAggggABS9f1vJ3BaEV+9sAcIIIAAAggggAACCCCK9FmQ1UX5NAhAAAEEEEAAAQQQQADZBqQbYPUJOl20Vx9/90Jn2vwABBBAAAEEEEAAAeR+INsnmM/vugAB4nNAADHBAAEEEEDuA5KW6QeQqv8/feHzmnkECCCAAAIIIIAAAkgskO4ivPsBpemisvqBp9Pjvb0RHSCAAAIIIIAAAggg+4CcPmGpA5gygbvHa/oCBwgggAACCCCAAAIIIGnNnKebXXc3jqsez+nvnwoggAACCCCAAAIIILlA0ovW9KKwu/n29E2PLYAAAQQQQAABBBBAANkDpLvIvA3k6QtO+gRO3bwICCCAAAIIIIAAAsgeILe9VLP7ga9tmz+rjx8QQAABBBBAAAEEEEC6i/juE5S22bD6psH0wlzq8QECCCCAAAIIIIAAkgvk600SqhuzpT+QdmtTDkAAAQQQQAABBBBA9hTp3UVz2kLWdLPn6c2ctwQQQAABBBBAAAEEkL1AtoPqPv7pInZ682XKTSJAAAEEEEAAAQQQQO4FUg3u9E2GbS+EmW5SseUBKUAAAQQQQAABBBBAvrNZcfoFL9MLidXjUX3BuqVJAyCAAAIIIIAAAggge4v00z94+qH+6SK9e/Nm98Le57uaAAIIIIAAAggggAASV7RPT5i0hbPuCT1dtFfPN0AAAQQQQAABBBBA9gNJW1iaLiKnP0/7vvRm2oAAAggggAACCCCA5ANJWzibLuKnx2/6pkk1uHVFOiCAAAIIIIAAAggg5UCqP59eiEt7QOj0+GxrXg0IIIAAAggggAACCCDbiuDu39+9+TCtacPp8wMIIIAAAggggAACCCDpRf40iNMLhbc1rrt+syIggAACCCCAAAIIIOVFW9qE6v593UVv9QVu200FQAABBBBAAAEEEEC+17RhWxFbfVOhewJ3j2faBQgQQAABBBBAAAEEkPuAfL2JQvdNhfTNgt1Ar+tqAggggAACCCCAAAJIeVHYXRSnvYAm7QJw++8HxATx+wEBBBBAAAHkfiDdAzLdTHv6gpIGcAsIQAABBBBAAAEEEEDuBTLdPLl74S6tyE1r/v35hUJAAAEEEEAAAQQQQNYlrXHa9AuBTt9ESbtJAwgggAACCCCAAAIIINMvkUwruqubeXcff1rTjPULhYAAAggggAACCCCAjBdp1QuRaQCmFxqrN4cq0gEBBBBAAAEEEEAAmQYy3Ugu/QU3ad/Xvfk0BQQggAACCCCAAAIIIIB0nfBuANtfINQ9X6ZuEgECCCCAAAIIIIAAAsiWonM6aUXv9E0WQAABBBBAAAEEEEC8H2S6qEsDPv3/08eX+kIfQAABBBBAAAEEEED2ANnezDh9IS/tb2oCry3SAQEEEEAAAQQQQAAREUBEABEBRAQQEUBEABEBRAQQEUBEBBARQEQAEQFEBBARQEQAEQFE5Ob8AIHb9L3GGLlfAAAAAElFTkSuQmCC"
-                    />
+                    <div
+                      class="qrContainer MuiBox-root emotion-4"
+                    >
+                      <img
+                        alt="Google Authenticator"
+                        class="qrImg"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAE7ElEQVR42u3dwWrsMAwF0Pz/T7/uC29RYklXzrnQ1ZQh4/gEFDvK809E/pvHEIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIIL+/6Hla/04f718/rx6v0+Ndff5umx+AAAIIIIAAAggggOwDUj2h3k64r4N9O17pFxxAAAEEEEAAAQQQQAB5O+HSiubTYKrHo3p8TwNKmR+AAAIIIIAAAggggABS9f1vJ3BaEV+9sAcIIIAAAggggAACCCCK9FmQ1UX5NAhAAAEEEEAAAQQQQADZBqQbYPUJOl20Vx9/90Jn2vwABBBAAAEEEEAAAeR+INsnmM/vugAB4nNAADHBAAEEEEDuA5KW6QeQqv8/feHzmnkECCCAAAIIIIAAAkgskO4ivPsBpemisvqBp9Pjvb0RHSCAAAIIIIAAAggg+4CcPmGpA5gygbvHa/oCBwgggAACCCCAAAIIIGnNnKebXXc3jqsez+nvnwoggAACCCCAAAIIILlA0ovW9KKwu/n29E2PLYAAAQQQQAABBBBAANkDpLvIvA3k6QtO+gRO3bwICCCAAAIIIIAAAsgeILe9VLP7ga9tmz+rjx8QQAABBBBAAAEEEEC6i/juE5S22bD6psH0wlzq8QECCCCAAAIIIIAAkgvk600SqhuzpT+QdmtTDkAAAQQQQAABBBBA9hTp3UVz2kLWdLPn6c2ctwQQQAABBBBAAAEEkL1AtoPqPv7pInZ682XKTSJAAAEEEEAAAQQQQO4FUg3u9E2GbS+EmW5SseUBKUAAAQQQQAABBBBAvrNZcfoFL9MLidXjUX3BuqVJAyCAAAIIIIAAAggge4v00z94+qH+6SK9e/Nm98Le57uaAAIIIIAAAggggAASV7RPT5i0hbPuCT1dtFfPN0AAAQQQQAABBBBA9gNJW1iaLiKnP0/7vvRm2oAAAggggAACCCCA5ANJWzibLuKnx2/6pkk1uHVFOiCAAAIIIIAAAggg5UCqP59eiEt7QOj0+GxrXg0IIIAAAggggAACCCDbiuDu39+9+TCtacPp8wMIIIAAAggggAACCCDpRf40iNMLhbc1rrt+syIggAACCCCAAAIIIOVFW9qE6v593UVv9QVu200FQAABBBBAAAEEEEC+17RhWxFbfVOhewJ3j2faBQgQQAABBBBAAAEEkPuAfL2JQvdNhfTNgt1Ar+tqAggggAACCCCAAAJIeVHYXRSnvYAm7QJw++8HxATx+wEBBBBAAAHkfiDdAzLdTHv6gpIGcAsIQAABBBBAAAEEEEDuBTLdPLl74S6tyE1r/v35hUJAAAEEEEAAAQQQQNYlrXHa9AuBTt9ESbtJAwgggAACCCCAAAIIINMvkUwruqubeXcff1rTjPULhYAAAggggAACCCCAjBdp1QuRaQCmFxqrN4cq0gEBBBBAAAEEEEAAmQYy3Ugu/QU3ad/Xvfk0BQQggAACCCCAAAIIIIB0nfBuANtfINQ9X6ZuEgECCCCAAAIIIIAAAsiWonM6aUXv9E0WQAABBBBAAAEEEEC8H2S6qEsDPv3/08eX+kIfQAABBBBAAAEEEED2ANnezDh9IS/tb2oCry3SAQEEEEAAAQQQQAAREUBEABEBRAQQEUBEABEBRAQQEUBEBBARQEQAEQFEBBARQEQAEQFE5Ob8AIHb9L3GGLlfAAAAAElFTkSuQmCC"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Can't scan barcode?
+                    </button>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Next
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-24"
+                    data-se="switchAuthenticator"
                     tabindex="0"
                     type="button"
                   >
-                    Can't scan barcode?
+                    Return to authenticator list
                   </button>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-24"
+                    data-se="cancel"
                     tabindex="0"
                     type="button"
                   >
-                    Next
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-enroll-google-authenticator renders form renders challenge view 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester19@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester19@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -234,180 +238,184 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up Google Authenticator
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up Google Authenticator
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-11"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Enter code displayed from application
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
-                      for="credentials.passcode"
-                    >
-                      Enter code
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                      class="MuiBox-root emotion-12"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="one-time-code"
-                        class="MuiOutlinedInput-input MuiInputBase-input emotion-20"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="text"
-                      />
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-21"
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <legend
-                          class="emotion-22"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
+                        Enter code displayed from application
+                      </p>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        for="credentials.passcode"
+                      >
+                        Enter code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-22"
+                        >
+                          <legend
+                            class="emotion-23"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="switchAuthenticator"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Verify
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-enroll-google-authenticator renders form renders secret key view 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester19@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester19@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -415,27 +423,14 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Set up Google Authenticator
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-10"
-                >
                   <div
-                    class="MuiBox-root emotion-11"
+                    class="MuiBox-root emotion-12"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      To set up manually enter your Okta Account username and then input the following in the Secret Key Field
-                    </p>
+                      Set up Google Authenticator
+                    </h2>
                   </div>
                 </div>
                 <div
@@ -444,122 +439,139 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   <div
                     class="MuiBox-root emotion-11"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <div
+                      class="MuiBox-root emotion-12"
                     >
-                      K A G W B I X A K O L P E F M Y
-                    </p>
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        To set up manually enter your Okta Account username and then input the following in the Secret Key Field
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        K A G W B I X A K O L P E F M Y
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Next
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
                     tabindex="0"
                     type="button"
                   >
-                    Next
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-enroll-google-authenticator renders form renders secret key view 2`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester19@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester19@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -567,112 +579,116 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up Google Authenticator
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up Google Authenticator
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-11"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Enter code displayed from application
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
-                      for="credentials.passcode"
-                    >
-                      Enter code
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                      class="MuiBox-root emotion-12"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="one-time-code"
-                        class="MuiOutlinedInput-input MuiInputBase-input emotion-20"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="text"
-                      />
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-21"
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <legend
-                          class="emotion-22"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
+                        Enter code displayed from application
+                      </p>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        for="credentials.passcode"
+                      >
+                        Enter code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-22"
+                        >
+                          <legend
+                            class="emotion-23"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="switchAuthenticator"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Verify
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -2,193 +2,197 @@
 
 exports[`authenticator-enroll-phone-sms should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester13@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester13@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-13"
-                  >
-                    Set up phone authentication
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
+                  class="MuiBox-root emotion-11"
+                />
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    A code was sent to your phone. Enter the code below to verify.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Carrier messaging charges may apply
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
-                    for="credentials.passcode"
-                  >
-                    Enter Code
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
+                    class="MuiBox-root emotion-13"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
-                      data-se="credentials.passcode"
-                      id="credentials.passcode"
-                      name="credentials.passcode"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-23"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-14"
                     >
-                      <legend
-                        class="emotion-24"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Set up phone authentication
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      A code was sent to your phone. Enter the code below to verify.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Carrier messaging charges may apply
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      for="credentials.passcode"
+                    >
+                      Enter Code
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        name="credentials.passcode"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-24"
+                      >
+                        <legend
+                          class="emotion-25"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -2,193 +2,197 @@
 
 exports[`authenticator-enroll-phone-voice should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester3@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester3@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-13"
-                  >
-                    Set up phone authentication
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
+                  class="MuiBox-root emotion-11"
+                />
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Calling your phone. Enter the code below to verify.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Carrier messaging charges may apply
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
-                    for="credentials.passcode"
-                  >
-                    Enter Code
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
+                    class="MuiBox-root emotion-13"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
-                      data-se="credentials.passcode"
-                      id="credentials.passcode"
-                      name="credentials.passcode"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-23"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-14"
                     >
-                      <legend
-                        class="emotion-24"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Set up phone authentication
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Calling your phone. Enter the code below to verify.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Carrier messaging charges may apply
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      for="credentials.passcode"
+                    >
+                      Enter Code
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        name="credentials.passcode"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-24"
+                      >
+                        <legend
+                          class="emotion-25"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -2,446 +2,450 @@
 
 exports[`authenticator-enroll-security-question should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester14@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester14@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-12"
                   >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-13"
-                    >
-                      Set up security question
-                    </h2>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <fieldset
-                    class="MuiFormControl-root emotion-15"
-                  >
-                    
                     <div
-                      class="MuiFormGroup-root emotion-16"
-                      role="radiogroup"
+                      class="MuiBox-root emotion-13"
                     >
-                      <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
                       >
-                        <span
-                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                        >
-                          <input
-                            class="PrivateSwitchBase-input emotion-19"
-                            name="questionType"
-                            type="radio"
-                            value="predefined"
-                          />
-                          <span
-                            class="emotion-20"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                              data-testid="RadioButtonUncheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                              />
-                            </svg>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                              data-testid="RadioButtonCheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                        >
-                          Choose a security question
-                        </span>
-                      </label>
-                      <label
-                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                      >
-                        <span
-                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                        >
-                          <input
-                            class="PrivateSwitchBase-input emotion-19"
-                            name="questionType"
-                            type="radio"
-                            value="custom"
-                          />
-                          <span
-                            class="emotion-20"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                              data-testid="RadioButtonUncheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                              />
-                            </svg>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                              data-testid="RadioButtonCheckedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                        <span
-                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                        >
-                          Create my own security question
-                        </span>
-                      </label>
+                        Set up security question
+                      </h2>
                     </div>
-                  </fieldset>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
+                  </div>
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-12"
                   >
-                    <div
-                      class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                    <fieldset
+                      class="MuiFormControl-root emotion-16"
                     >
-                      <label
-                        class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                        for="credentials.questionKey"
-                      >
-                        <span
-                          class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                        >
-                          Choose a security question
-                        </span>
-                      </label>
+                      
                       <div
-                        class="ods-mUkyrD"
+                        class="MuiFormGroup-root emotion-17"
+                        role="radiogroup"
                       >
-                        <select
-                          class="ods-1B2Zfy"
-                          id="credentials.questionKey"
-                          name="credentials.questionKey"
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
                         >
-                          <option
-                            value=""
-                          />
-                          <option
-                            value="disliked_food"
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
                           >
-                            What is the food you least liked as a child?
-                          </option>
-                          <option
-                            value="name_of_first_plush_toy"
-                          >
-                            What is the name of your first stuffed animal?
-                          </option>
-                          <option
-                            value="first_award"
-                          >
-                            What did you earn your first medal or award for?
-                          </option>
-                          <option
-                            value="favorite_security_question"
-                          >
-                            What is your favorite security question?
-                          </option>
-                          <option
-                            value="favorite_toy"
-                          >
-                            What is the toy/stuffed animal you liked the most as a kid?
-                          </option>
-                          <option
-                            value="first_computer_game"
-                          >
-                            What was the first computer game you played?
-                          </option>
-                          <option
-                            value="favorite_movie_quote"
-                          >
-                            What is your favorite movie quote?
-                          </option>
-                          <option
-                            value="first_sports_team_mascot"
-                          >
-                            What was the mascot of the first sports team you played on?
-                          </option>
-                          <option
-                            value="first_music_purchase"
-                          >
-                            What music album or song did you first purchase?
-                          </option>
-                          <option
-                            value="favorite_art_piece"
-                          >
-                            What is your favorite piece of art?
-                          </option>
-                          <option
-                            value="grandmother_favorite_desert"
-                          >
-                            What was your grandmother's favorite dessert?
-                          </option>
-                          <option
-                            value="first_thing_cooked"
-                          >
-                            What was the first thing you learned to cook?
-                          </option>
-                          <option
-                            value="childhood_dream_job"
-                          >
-                            What was your dream job as a child?
-                          </option>
-                          <option
-                            value="place_where_significant_other_was_met"
-                          >
-                            Where did you meet your spouse/significant other?
-                          </option>
-                          <option
-                            value="favorite_vacation_location"
-                          >
-                            Where did you go for your favorite vacation?
-                          </option>
-                          <option
-                            value="new_years_two_thousand"
-                          >
-                            Where were you on New Year's Eve in the year 2000?
-                          </option>
-                          <option
-                            value="favorite_speaker_actor"
-                          >
-                            Who is your favorite speaker/orator?
-                          </option>
-                          <option
-                            value="favorite_book_movie_character"
-                          >
-                            Who is your favorite book/movie character?
-                          </option>
-                          <option
-                            value="favorite_sports_player"
-                          >
-                            Who is your favorite sports player?
-                          </option>
-                        </select>
-                        <span
-                          class="ods-7mdg51"
-                        >
-                          <svg
-                            class="ods-2icygl"
-                            fill="none"
-                            role="presentation"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
                             />
-                          </svg>
-                        </span>
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
                       </div>
-                    </div>
+                    </fieldset>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiBox-root emotion-3"
+                      class="MuiBox-root emotion-4"
                     >
-                      <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-36"
-                        for="credentials.answer"
-                      >
-                        Answer
-                      </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-37"
+                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
                       >
-                        <input
-                          aria-invalid="false"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-38"
-                          data-se="credentials.answer"
-                          id="credentials.answer"
-                          name="credentials.answer"
-                          type="password"
-                        />
-                        <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-39"
+                        <label
+                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                          for="credentials.questionKey"
                         >
-                          <button
-                            aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-40"
-                            data-mui-internal-clone-element="true"
-                            tabindex="0"
-                            type="button"
+                          <span
+                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <div
+                          class="ods-mUkyrD"
+                        >
+                          <select
+                            class="ods-1B2Zfy"
+                            id="credentials.questionKey"
+                            name="credentials.questionKey"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              value="disliked_food"
+                            >
+                              What is the food you least liked as a child?
+                            </option>
+                            <option
+                              value="name_of_first_plush_toy"
+                            >
+                              What is the name of your first stuffed animal?
+                            </option>
+                            <option
+                              value="first_award"
+                            >
+                              What did you earn your first medal or award for?
+                            </option>
+                            <option
+                              value="favorite_security_question"
+                            >
+                              What is your favorite security question?
+                            </option>
+                            <option
+                              value="favorite_toy"
+                            >
+                              What is the toy/stuffed animal you liked the most as a kid?
+                            </option>
+                            <option
+                              value="first_computer_game"
+                            >
+                              What was the first computer game you played?
+                            </option>
+                            <option
+                              value="favorite_movie_quote"
+                            >
+                              What is your favorite movie quote?
+                            </option>
+                            <option
+                              value="first_sports_team_mascot"
+                            >
+                              What was the mascot of the first sports team you played on?
+                            </option>
+                            <option
+                              value="first_music_purchase"
+                            >
+                              What music album or song did you first purchase?
+                            </option>
+                            <option
+                              value="favorite_art_piece"
+                            >
+                              What is your favorite piece of art?
+                            </option>
+                            <option
+                              value="grandmother_favorite_desert"
+                            >
+                              What was your grandmother's favorite dessert?
+                            </option>
+                            <option
+                              value="first_thing_cooked"
+                            >
+                              What was the first thing you learned to cook?
+                            </option>
+                            <option
+                              value="childhood_dream_job"
+                            >
+                              What was your dream job as a child?
+                            </option>
+                            <option
+                              value="place_where_significant_other_was_met"
+                            >
+                              Where did you meet your spouse/significant other?
+                            </option>
+                            <option
+                              value="favorite_vacation_location"
+                            >
+                              Where did you go for your favorite vacation?
+                            </option>
+                            <option
+                              value="new_years_two_thousand"
+                            >
+                              Where were you on New Year's Eve in the year 2000?
+                            </option>
+                            <option
+                              value="favorite_speaker_actor"
+                            >
+                              Who is your favorite speaker/orator?
+                            </option>
+                            <option
+                              value="favorite_book_movie_character"
+                            >
+                              Who is your favorite book/movie character?
+                            </option>
+                            <option
+                              value="favorite_sports_player"
+                            >
+                              Who is your favorite sports player?
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
                           >
                             <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-41"
-                              data-testid="VisibilityIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
                               />
                             </svg>
-                          </button>
+                          </span>
                         </div>
-                        <fieldset
-                          aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-42"
-                        >
-                          <legend
-                            class="emotion-43"
-                          >
-                            <span
-                              class="notranslate"
-                            >
-                              ​
-                            </span>
-                          </legend>
-                        </fieldset>
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-43"
+                          >
+                            <legend
+                              class="emotion-44"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-46"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-45"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-48"
+                    data-se="switchAuthenticator"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Verify
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-48"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-47"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-47"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -2,63 +2,63 @@
 
 exports[`authenticator-enroll-select-authenticator renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-4"
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="identifierContainer MuiBox-root emotion-5"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-6"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-6"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
-            </div>
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-4"
           >
             <div
-              class="MuiBox-root emotion-8"
+              class="identifier-container MuiBox-root emotion-5"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-6"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-7"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-7"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-9"
@@ -66,176 +66,180 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-11"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Set up security methods
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-12"
+                    >
+                      Set up security methods
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Security methods help protect your account by ensuring only you have access.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Security methods help protect your account by ensuring only you have access.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Set up optional
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Set up optional
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Password
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Choose a password for your account
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_password-password"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Password
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Choose a password for your account
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_password-password"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Phone
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify with a code sent to your phone
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="phone_number"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Phone
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify with a code sent to your phone
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="phone_number"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Key or Biometric Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Use a security key or a biometric authenticator to sign in
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="webauthn-webauthn"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Key or Biometric Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Use a security key or a biometric authenticator to sign in
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="webauthn-webauthn"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-38"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-10"
                 >
-                  Set up later
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-40"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-39"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Set up later
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-10"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-41"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -2,63 +2,63 @@
 
 exports[`authenticator-enroll-select-authenticator renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-4"
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="identifierContainer MuiBox-root emotion-5"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-6"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-6"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
-            </div>
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-4"
           >
             <div
-              class="MuiBox-root emotion-8"
+              class="identifier-container MuiBox-root emotion-5"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-6"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-7"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-7"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-9"
@@ -66,524 +66,528 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-11"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Set up security methods
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-12"
+                    >
+                      Set up security methods
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Security methods help protect your account by ensuring only you have access.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Security methods help protect your account by ensuring only you have access.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Set up required
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Set up required
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Password
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Choose a password for your account
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_password-password"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Password
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Choose a password for your account
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_password-password"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Phone
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify with a code sent to your phone
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="phone_number"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Phone
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify with a code sent to your phone
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="phone_number"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Key or Biometric Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Use a security key or a biometric authenticator to sign in
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="webauthn-webauthn"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Key or Biometric Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Use a security key or a biometric authenticator to sign in
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="webauthn-webauthn"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Question
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Choose a security question and answer that will be used for signing in
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="security_question"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Question
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Choose a security question and answer that will be used for signing in
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="security_question"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Okta Verify
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Okta Verify is an authenticator app, installed on your phone, used to prove your identity
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_verify"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Okta Verify
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Okta Verify is an authenticator app, installed on your phone, used to prove your identity
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_verify"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Google Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Enter a temporary code generated from the Google Authenticator app.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="google_otp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Google Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Enter a temporary code generated from the Google Authenticator app.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="google_otp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Atko Custom On-prem
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify by entering a code generated by Atko Custom On-prem.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="onprem_mfa-otp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Atko Custom On-prem
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify by entering a code generated by Atko Custom On-prem.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="onprem_mfa-otp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      RSA SecurID
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify by entering a code generated by RSA SecurID
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="rsa_token-otp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        RSA SecurID
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify by entering a code generated by RSA SecurID
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="rsa_token-otp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Duo Security
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify your identity using Duo Security.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="duo-idp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Duo Security
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify your identity using Duo Security.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="duo-idp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      IDP Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Redirect to verify with IDP Authenticator.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="external_idp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        IDP Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Redirect to verify with IDP Authenticator.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="external_idp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Atko Custom OTP Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Enter a temporary code generated from an authenticator device.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="custom_otp-otp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Atko Custom OTP Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Enter a temporary code generated from an authenticator device.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="custom_otp-otp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Symantec VIP
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify by entering a temporary code from the Symantec VIP app.
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="symantec_vip"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Symantec VIP
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify by entering a temporary code from the Symantec VIP app.
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="symantec_vip"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-17"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-18"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      YubiKey Authenticator
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Verify your identity using YubiKey
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="yubikey_token-otp"
-                    >
-                      Set up
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        YubiKey Authenticator
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Verify your identity using YubiKey
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="yubikey_token-otp"
+                      >
+                        Set up
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-108"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-10"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-109"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-expired-password-no-complexity should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,181 +71,185 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your password has expired
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your password has expired
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
+                />
+                <div
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-20"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-21"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-22"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-24"
+                        >
+                          <legend
+                            class="emotion-25"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-23"
-                      >
-                        <legend
-                          class="emotion-24"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
-                        data-se="credentials.confirmPassword"
-                        id="credentials.confirmPassword"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-20"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
+                          data-se="credentials.confirmPassword"
+                          id="credentials.confirmPassword"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-21"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-22"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-24"
+                        >
+                          <legend
+                            class="emotion-25"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-23"
-                      >
-                        <legend
-                          class="emotion-24"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-37"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-39"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-38"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Change Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-40"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-expired-password-with-enrollment-authenticator should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="generated"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="generated"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,398 +71,402 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Your password has expired
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                  data-se="password-authenticator--rules"
-                >
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-12"
                   >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Password requirements:
-                    </span>
+                      Your password has expired
+                    </h2>
                   </div>
-                  <ul
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
-                    id="generated"
-                  >
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          At least 8 characters
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A lowercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          An uppercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A number
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          No parts of your username
-                        </span>
-                      </div>
-                    </li>
-                  </ul>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
+                    data-se="password-authenticator--rules"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-35"
+                      class="MuiBox-root emotion-16"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-36"
-                        data-se="credentials.passcode"
-                        id="generated"
-                        name="credentials.passcode"
-                        type="password"
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-37"
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-38"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        Password requirements:
+                      </span>
+                    </div>
+                    <ul
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      id="generated"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-39"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-40"
-                      >
-                        <legend
-                          class="emotion-41"
-                        >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           <span
-                            class="notranslate"
+                            class="MuiBox-root emotion-4"
                           >
-                            ​
+                            At least 8 characters
                           </span>
-                        </legend>
-                      </fieldset>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A lowercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            An uppercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A number
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            No parts of your username
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          data-se="credentials.passcode"
+                          id="generated"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-38"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                        >
+                          <legend
+                            class="emotion-42"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-35"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-36"
-                        data-se="credentials.confirmPassword"
-                        id="generated"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-37"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-38"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
+                          data-se="credentials.confirmPassword"
+                          id="generated"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-38"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-39"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
+                        >
+                          <legend
+                            class="emotion-42"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-40"
-                      >
-                        <legend
-                          class="emotion-41"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-54"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-56"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Change Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-56"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-57"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-57"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-expired-password should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="generated"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="generated"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester8@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester8@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,423 +71,427 @@ exports[`authenticator-expired-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Your password has expired
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                  data-se="password-authenticator--rules"
-                >
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-12"
                   >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Password requirements:
-                    </span>
+                      Your password has expired
+                    </h2>
                   </div>
-                  <ul
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
-                    id="generated"
-                  >
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          At least 8 characters
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A lowercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          An uppercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A number
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          No parts of your username
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Your password cannot be any of your last 4 passwords
-                        </span>
-                      </div>
-                    </li>
-                  </ul>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
+                    data-se="password-authenticator--rules"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-16"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.passcode"
-                        id="generated"
-                        name="credentials.passcode"
-                        type="password"
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        Password requirements:
+                      </span>
+                    </div>
+                    <ul
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      id="generated"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           <span
-                            class="notranslate"
+                            class="MuiBox-root emotion-4"
                           >
-                            ​
+                            At least 8 characters
                           </span>
-                        </legend>
-                      </fieldset>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A lowercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            An uppercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A number
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            No parts of your username
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Your password cannot be any of your last 4 passwords
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.passcode"
+                          id="generated"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.confirmPassword"
-                        id="generated"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.confirmPassword"
+                          id="generated"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-57"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-59"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Change Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-60"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-expiry-warning-password should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="generated"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="generated"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,558 +71,562 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your password will expire in 4 days
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your password will expire in 4 days
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    When your password expires you will be locked out of your Okta account.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                  data-se="password-authenticator--rules"
-                >
                   <div
-                    class="MuiBox-root emotion-17"
+                    class="MuiBox-root emotion-12"
                   >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                     >
-                      Password requirements:
-                    </span>
+                      When your password expires you will be locked out of your Okta account.
+                    </p>
                   </div>
-                  <ul
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
-                    id="generated"
-                  >
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          At least 8 characters
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A lowercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          An uppercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A number
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A symbol
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          No parts of your username
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Does not include your first name
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Does not include your last name
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-19"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Your password cannot be any of your last 4 passwords
-                        </span>
-                      </div>
-                    </li>
-                  </ul>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
+                    data-se="password-authenticator--rules"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-48"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-49"
+                      class="MuiBox-root emotion-18"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
-                        data-se="credentials.passcode"
-                        id="generated"
-                        name="credentials.passcode"
-                        type="password"
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-51"
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-52"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        Password requirements:
+                      </span>
+                    </div>
+                    <ul
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      id="generated"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-53"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-54"
-                      >
-                        <legend
-                          class="emotion-55"
-                        >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           <span
-                            class="notranslate"
+                            class="MuiBox-root emotion-4"
                           >
-                            ​
+                            At least 8 characters
                           </span>
-                        </legend>
-                      </fieldset>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A lowercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            An uppercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A number
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A symbol
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            No parts of your username
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Does not include your first name
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Does not include your last name
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-20"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Your password cannot be any of your last 4 passwords
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-49"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-50"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-51"
+                          data-se="credentials.passcode"
+                          id="generated"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-52"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-53"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-54"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-55"
+                        >
+                          <legend
+                            class="emotion-56"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-48"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-49"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-50"
-                        data-se="credentials.confirmPassword"
-                        id="generated"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-49"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-51"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-50"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-52"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-51"
+                          data-se="credentials.confirmPassword"
+                          id="generated"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-52"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-53"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-53"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-54"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-55"
+                        >
+                          <legend
+                            class="emotion-56"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-54"
-                      >
-                        <legend
-                          class="emotion-55"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-68"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-70"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-69"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Change Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Remind me later
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-70"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-71"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Remind me later
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-71"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-reset-password should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="generated"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="generated"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester8@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester8@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,491 +71,495 @@ exports[`authenticator-reset-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Reset your password
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                  data-se="password-authenticator--rules"
-                >
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-12"
                   >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Password requirements:
-                    </span>
+                      Reset your password
+                    </h2>
                   </div>
-                  <ul
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
-                    id="generated"
-                  >
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          At least 8 characters
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A lowercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          An uppercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A number
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          No parts of your username
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Your password cannot be any of your last 4 passwords
-                        </span>
-                      </div>
-                    </li>
-                  </ul>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
+                    data-se="password-authenticator--rules"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-16"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.passcode"
-                        id="generated"
-                        name="credentials.passcode"
-                        type="password"
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        Password requirements:
+                      </span>
+                    </div>
+                    <ul
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      id="generated"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           <span
-                            class="notranslate"
+                            class="MuiBox-root emotion-4"
                           >
-                            ​
+                            At least 8 characters
                           </span>
-                        </legend>
-                      </fieldset>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A lowercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            An uppercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A number
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            No parts of your username
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Your password cannot be any of your last 4 passwords
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.passcode"
+                          id="generated"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.confirmPassword"
-                        id="generated"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.confirmPassword"
+                          id="generated"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-57"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Reset Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-59"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Reset Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-60"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-reset-password should render form with custom brand name 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="generated"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="generated"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester8@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester8@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -563,423 +567,427 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Reset your Acme Corp password
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                  data-se="password-authenticator--rules"
-                >
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-12"
                   >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Password requirements:
-                    </span>
+                      Reset your Acme Corp password
+                    </h2>
                   </div>
-                  <ul
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
-                    id="generated"
-                  >
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          At least 8 characters
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A lowercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          An uppercase letter
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          A number
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          No parts of your username
-                        </span>
-                      </div>
-                    </li>
-                    <li
-                      class="ods-5vIIsH"
-                    >
-                      <div
-                        class="MuiBox-root emotion-3"
-                      >
-                        <div
-                          class="passwordRequirementIcon info MuiBox-root emotion-17"
-                        >
-                          <svg
-                            aria-labelledby="generated"
-                            class="ods-2icygl"
-                            fill="none"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <title
-                              id="generated"
-                            >
-                              info
-                            </title>
-                            <path
-                              clip-rule="evenodd"
-                              d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </div>
-                        <span
-                          class="MuiBox-root emotion-3"
-                        >
-                          Your password cannot be any of your last 4 passwords
-                        </span>
-                      </div>
-                    </li>
-                  </ul>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
+                    data-se="password-authenticator--rules"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.passcode"
-                    >
-                      New password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-16"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.passcode"
-                        id="generated"
-                        name="credentials.passcode"
-                        type="password"
-                      />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        Password requirements:
+                      </span>
+                    </div>
+                    <ul
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-3ih812"
+                      id="generated"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
                           <span
-                            class="notranslate"
+                            class="MuiBox-root emotion-4"
                           >
-                            ​
+                            At least 8 characters
                           </span>
-                        </legend>
-                      </fieldset>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A lowercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            An uppercase letter
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            A number
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            No parts of your username
+                          </span>
+                        </div>
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        <div
+                          class="MuiBox-root emotion-4"
+                        >
+                          <div
+                            class="passwordRequirementIcon info MuiBox-root emotion-18"
+                          >
+                            <svg
+                              aria-labelledby="generated"
+                              class="ods-2icygl"
+                              fill="none"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <title
+                                id="generated"
+                              >
+                                info
+                              </title>
+                              <path
+                                clip-rule="evenodd"
+                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </div>
+                          <span
+                            class="MuiBox-root emotion-4"
+                          >
+                            Your password cannot be any of your last 4 passwords
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.passcode"
+                      >
+                        New password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.passcode"
+                          id="generated"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
-                      for="credentials.confirmPassword"
-                    >
-                      Re-enter password
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="new-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
-                        data-se="credentials.confirmPassword"
-                        id="generated"
-                        name="credentials.confirmPassword"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        for="credentials.confirmPassword"
+                      >
+                        Re-enter password
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          autocomplete="new-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          data-se="credentials.confirmPassword"
+                          id="generated"
+                          name="credentials.confirmPassword"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-41"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                        >
+                          <legend
+                            class="emotion-45"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-43"
-                      >
-                        <legend
-                          class="emotion-44"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-57"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Reset Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-59"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Reset Password
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-60"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-data-phone-sms-only should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                shaw.yu@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  shaw.yu@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,80 +71,84 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Verify with your phone
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Verify with your phone
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Send a code via SMS to +1 XXX-XXX-4601
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Send a code via SMS to +1 XXX-XXX-4601
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Carrier messaging charges may apply
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Carrier messaging charges may apply
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Receive a code via SMS
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Receive a code via SMS
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -2,493 +2,505 @@
 
 exports[`authenticator-verification-email renders correct form renders the initial form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                firstname.lastname@example.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  firstname.lastname@example.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
-                />
-                <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-12"
+                  />
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-14"
+                    <div
+                      class="MuiBox-root emotion-14"
                     >
-                      Verify with your email
-                    </h2>
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                      >
+                        Verify with your email
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Enter a code from the email instead
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-13"
-                  >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="cancel"
                     tabindex="0"
                     type="button"
                   >
-                    Enter a code from the email instead
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-verification-email renders correct form renders the otp challenage form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                firstname.lastname@example.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  firstname.lastname@example.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
-                />
-                <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
-                  >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-14"
-                    >
-                      Verify with your email
-                    </h2>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
+                    class="MuiBox-root emotion-12"
+                  />
                   <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-12"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
-                      for="credentials.passcode"
-                    >
-                      Enter code
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-20"
+                      class="MuiBox-root emotion-14"
                     >
-                      <input
-                        aria-invalid="false"
-                        autocomplete="one-time-code"
-                        class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="text"
-                      />
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-22"
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
                       >
-                        <legend
-                          class="emotion-23"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
+                        Verify with your email
+                      </h2>
                     </div>
                   </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        for="credentials.passcode"
+                      >
+                        Enter code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-23"
+                        >
+                          <legend
+                            class="emotion-24"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="cancel"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Verify
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-verification-email renders correct form renders the otp challenage form 2`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
-                />
-                <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
-                  >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-14"
-                    >
-                      Verify with your email
-                    </h2>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
+                    class="MuiBox-root emotion-12"
+                  />
                   <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-12"
                   >
-                    <p
-                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      We sent an email to t***t@idx.com. Click the verification link in your email to continue or enter the code below.
-                    </p>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
-                      for="credentials.passcode"
-                    >
-                      Enter code
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-20"
+                      class="MuiBox-root emotion-14"
                     >
-                      <input
-                        aria-invalid="true"
-                        autocomplete="one-time-code"
-                        class="MuiOutlinedInput-input MuiInputBase-input emotion-21"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="text"
-                        value=""
-                      />
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-22"
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
                       >
-                        <legend
-                          class="emotion-23"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
+                        Verify with your email
+                      </h2>
                     </div>
-                    <p
-                      class="MuiFormHelperText-root Mui-error emotion-24"
-                      data-se="credentials.passcode-error"
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
                     >
-                      Invalid code. Try again.
-                    </p>
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        We sent an email to t***t@idx.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        for="credentials.passcode"
+                      >
+                        Enter code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-21"
+                      >
+                        <input
+                          aria-invalid="true"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="text"
+                          value=""
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-23"
+                        >
+                          <legend
+                            class="emotion-24"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-25"
+                        data-se="credentials.passcode-error"
+                      >
+                        Invalid code. Try again.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
-                    data-type="save"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
                     tabindex="0"
-                    type="submit"
+                    type="button"
                   >
-                    Verify
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-google-authenticator should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@icloud.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,108 +71,112 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Verify with Google Authenticator
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Enter the temporary code generated in your Google Authenticator app
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
-                    for="credentials.passcode"
-                  >
-                    Enter code
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-18"
+                    class="MuiBox-root emotion-12"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-19"
-                      data-se="credentials.passcode"
-                      id="credentials.passcode"
-                      name="credentials.passcode"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-20"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <legend
-                        class="emotion-21"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Verify with Google Authenticator
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter the temporary code generated in your Google Authenticator app
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
+                      for="credentials.passcode"
+                    >
+                      Enter code
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-19"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-20"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        name="credentials.passcode"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-21"
+                      >
+                        <legend
+                          class="emotion-22"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -2,203 +2,207 @@
 
 exports[`authenticator-verification-okta-verify-push-code should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@icloud.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-11"
+                />
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-13"
+                  <div
+                    class="MuiBox-root emotion-13"
                   >
-                    Push notification sent
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-15"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-16"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-17"
-                      data-se="autoChallenge"
-                      data-se-for-name="autoChallenge"
-                      id="autoChallenge"
-                      name="autoChallenge"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-18"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-14"
                     >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-19"
-                  >
-                    Send push automatically
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    On your mobile device, open the Okta Verify prompt, then tap 52 in Okta Verify to continue.
-                  </p>
+                      Push notification sent
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-23"
-                  id="code"
+                  class="MuiBox-root emotion-11"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-16"
+                  >
+                    <span
+                      class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-17"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input emotion-18"
+                        data-se="autoChallenge"
+                        data-se-for-name="autoChallenge"
+                        id="autoChallenge"
+                        name="autoChallenge"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-19"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-20"
+                    >
+                      Send push automatically
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      On your mobile device, open the Okta Verify prompt, then tap 52 in Okta Verify to continue.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
                   <div
                     class="MuiBox-root emotion-24"
+                    id="code"
                   >
-                    <mocksvgicon />
+                    <div
+                      class="MuiBox-root emotion-25"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        52
+                      </span>
+                    </div>
                   </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-28"
                   >
                     <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      aria-label="Loading..."
+                      aria-valuetext="Loading..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-29"
+                      role="progressbar"
+                      style="width: 1.14285714rem; height: 1.14285714rem;"
                     >
-                      52
+                      <svg
+                        class="MuiCircularProgress-svg emotion-30"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-31"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="18"
+                          stroke-width="8"
+                        />
+                      </svg>
                     </span>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-27"
+                  class="MuiBox-root emotion-11"
                 >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-28"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-33"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
                   >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-29"
-                      viewBox="22 22 44 44"
-                    >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-30"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
-                      />
-                    </svg>
-                  </span>
+                    Verify with something else
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-32"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -2,180 +2,184 @@
 
 exports[`authenticator-verification-okta-verify-push should render polling form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@icloud.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-10"
+                class="identifierContainer MuiBox-root emotion-7"
               >
-                <div
-                  class="MuiBox-root emotion-11"
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Get a push notification
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-15"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-16"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-17"
-                      data-se="autoChallenge"
-                      data-se-for-name="autoChallenge"
-                      id="autoChallenge"
-                      name="autoChallenge"
-                      type="checkbox"
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
                     />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-18"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-19"
-                  >
-                    Send push automatically
-                  </span>
-                </label>
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
               </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
               <div
                 class="MuiBox-root emotion-10"
               >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Push notification sent
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-23"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuetext="Loading..."
-                    class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-24"
-                    role="progressbar"
-                    style="width: 1.14285714rem; height: 1.14285714rem;"
-                  >
-                    <svg
-                      class="MuiCircularProgress-svg emotion-25"
-                      viewBox="22 22 44 44"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <circle
-                        class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-26"
-                        cx="44"
-                        cy="44"
-                        fill="none"
-                        r="18"
-                        stroke-width="8"
+                      Get a push notification
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                />
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-16"
+                  >
+                    <span
+                      class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-17"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input emotion-18"
+                        data-se="autoChallenge"
+                        data-se-for-name="autoChallenge"
+                        id="autoChallenge"
+                        name="autoChallenge"
+                        type="checkbox"
                       />
-                    </svg>
-                  </span>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-19"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-20"
+                    >
+                      Send push automatically
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Push notification sent
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-24"
+                  >
+                    <span
+                      aria-label="Loading..."
+                      aria-valuetext="Loading..."
+                      class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-25"
+                      role="progressbar"
+                      style="width: 1.14285714rem; height: 1.14285714rem;"
+                    >
+                      <svg
+                        class="MuiCircularProgress-svg emotion-26"
+                        viewBox="22 22 44 44"
+                      >
+                        <circle
+                          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-27"
+                          cx="44"
+                          cy="44"
+                          fill="none"
+                          r="18"
+                          stroke-width="8"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-okta-verify-push should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@icloud.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,90 +71,94 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Get a push notification
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Get a push notification
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-15"
+                  >
+                    <span
+                      class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-16"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input emotion-17"
+                        data-se="authenticator.autoChallenge"
+                        data-se-for-name="authenticator.autoChallenge"
+                        id="authenticator.autoChallenge"
+                        name="authenticator.autoChallenge"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-18"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-19"
+                    >
+                      Send push automatically
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send push
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-14"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-15"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-16"
-                      data-se="authenticator.autoChallenge"
-                      data-se-for-name="authenticator.autoChallenge"
-                      id="authenticator.autoChallenge"
-                      name="authenticator.autoChallenge"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-17"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-18"
-                  >
-                    Send push automatically
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send push
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@icloud.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@icloud.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,95 +71,99 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Enter a code
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="credentials.totp"
-                  >
-                    Enter code from Okta Verify app
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+                    class="MuiBox-root emotion-12"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
-                      data-se="credentials.totp"
-                      id="credentials.totp"
-                      name="credentials.totp"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <legend
-                        class="emotion-19"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Enter a code
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      for="credentials.totp"
+                    >
+                      Enter code from Okta Verify app
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
+                        data-se="credentials.totp"
+                        id="credentials.totp"
+                        name="credentials.totp"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-19"
+                      >
+                        <legend
+                          class="emotion-20"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-23"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-24"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-24"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -2,193 +2,197 @@
 
 exports[`authenticator-verification-phone-sms should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                shaw.yu@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  shaw.yu@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
-              />
-              <div
-                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-13"
-                  >
-                    Verify with your phone
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
+                  class="MuiBox-root emotion-11"
+                />
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    A code was sent to +1 XXX-XXX-4601. Enter the code below to verify.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-12"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Carrier messaging charges may apply
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
-                    for="credentials.passcode"
-                  >
-                    Enter Code
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
+                    class="MuiBox-root emotion-13"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="one-time-code"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-22"
-                      data-se="credentials.passcode"
-                      id="credentials.passcode"
-                      name="credentials.passcode"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-23"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-14"
                     >
-                      <legend
-                        class="emotion-24"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Verify with your phone
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      A code was sent to +1 XXX-XXX-4601. Enter the code below to verify.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-13"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Carrier messaging charges may apply
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <div
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      for="credentials.passcode"
+                    >
+                      Enter Code
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-22"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="one-time-code"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
+                        data-se="credentials.passcode"
+                        id="credentials.passcode"
+                        name="credentials.passcode"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-24"
+                      >
+                        <legend
+                          class="emotion-25"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-security-question renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                shaw.yu
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  shaw.yu
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,109 +71,113 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Verify with your Security Question
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Verify with your Security Question
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-4"
                   >
-                    <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
-                      for="credentials.answer"
-                    >
-                      What is the food you least liked as a child?
-                    </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-17"
+                      class="MuiBox-root emotion-4"
                     >
-                      <input
-                        aria-invalid="false"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-18"
-                        data-se="credentials.answer"
-                        id="credentials.answer"
-                        name="credentials.answer"
-                        type="password"
-                      />
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
+                        for="credentials.answer"
+                      >
+                        What is the food you least liked as a child?
+                      </label>
                       <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-19"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
                       >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-20"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
+                        <input
+                          aria-invalid="false"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
+                          data-se="credentials.answer"
+                          id="credentials.answer"
+                          name="credentials.answer"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-20"
                         >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-21"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
                           >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-23"
+                        >
+                          <legend
+                            class="emotion-24"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
                       </div>
-                      <fieldset
-                        aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-22"
-                      >
-                        <legend
-                          class="emotion-23"
-                        >
-                          <span
-                            class="notranslate"
-                          >
-                            ​
-                          </span>
-                        </legend>
-                      </fieldset>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Verify
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -2,63 +2,63 @@
 
 exports[`authenticator-verification-select-authenticator renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-4"
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="identifierContainer MuiBox-root emotion-5"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-6"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-6"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
-            </div>
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-4"
           >
             <div
-              class="MuiBox-root emotion-8"
+              class="identifier-container MuiBox-root emotion-5"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-6"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-7"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-7"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-9"
@@ -66,588 +66,592 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-11"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Verify it's you with a security method
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-12"
+                    >
+                      Verify it's you with a security method
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Select from the following options
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Select from the following options
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Password
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_password-password"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Password
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_password-password"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Key or Biometric Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="webauthn-webauthn"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Key or Biometric Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="webauthn-webauthn"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Key or Biometric Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="webauthn-webauthn"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Key or Biometric Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="webauthn-webauthn"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Email
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_email-email"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Email
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_email-email"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Phone
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      +1 XXX-XXX-5309
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="phone_number"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Phone
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        +1 XXX-XXX-5309
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="phone_number"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Phone
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      +1 XXX-XXX-5309
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="phone_number"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Phone
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        +1 XXX-XXX-5309
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="phone_number"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Security Question
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="security_question"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Security Question
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="security_question"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Use Okta FastPass
-                    </div>
-                    <div
-                      class="description MuiBox-root emotion-6"
-                    >
-                      Okta Verify
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="okta_verify-signed_nonce"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Use Okta FastPass
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Okta Verify
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="okta_verify-signed_nonce"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Google Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="google_otp"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Google Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="google_otp"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Atko Custom On-prem
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="onprem_mfa"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Atko Custom On-prem
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="onprem_mfa"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      RSA SecurID
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="rsa_token"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        RSA SecurID
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="rsa_token"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Duo Security
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="duo-idp"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Duo Security
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="duo-idp"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      IDP Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="external_idp"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        IDP Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="external_idp"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Atko Custom OTP Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="custom_otp-idp"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Atko Custom OTP Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="custom_otp-idp"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      Symantec VIP
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="symantec_vip"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Symantec VIP
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="symantec_vip"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
+                      class="iconContainer MuiBox-root emotion-7"
                     >
-                      YubiKey Authenticator
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="yubikey_token"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-7"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        YubiKey Authenticator
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="yubikey_token"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-15"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-6"
-                  />
-                  <div
-                    class="infoSection MuiBox-root emotion-6"
+                    class="authButton MuiBox-root emotion-16"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-6"
-                    >
-                      Get a push notification
-                    </div>
+                      class="iconContainer MuiBox-root emotion-7"
+                    />
                     <div
-                      class="description MuiBox-root emotion-6"
+                      class="infoSection MuiBox-root emotion-7"
                     >
-                      Custom Push App
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-6"
-                      data-se="custom_app"
-                    >
-                      Select
-                      <mocksvgicon />
+                      <div
+                        class="title MuiBox-root emotion-7"
+                      >
+                        Get a push notification
+                      </div>
+                      <div
+                        class="description MuiBox-root emotion-7"
+                      >
+                        Custom Push App
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-7"
+                        data-se="custom_app"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-121"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-10"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-122"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`authenticator-verification-webauthn renders form - webauthn not supported 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,123 +71,127 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up security key or biometric authenticator
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up security key or biometric authenticator
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-17"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-17"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-16"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-16"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`authenticator-verification-webauthn renders form - webauthn supported 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -195,93 +199,97 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up security key or biometric authenticator
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuemax="1"
-                    aria-valuemin="0"
-                    aria-valuetext="Loading..."
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-48Fcvf"
-                    id="okta-spinner"
-                    role="progressbar"
-                  >
-                    <svg
-                      class="ods-57SiHN"
-                      role="presentation"
-                      viewBox="0 0 24 24"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <circle
-                        class="ods-3PiY3x"
-                        cx="12"
-                        cy="12"
-                        fill="none"
-                        r="10"
-                      />
-                      <circle
-                        class="ods-627kuP"
-                        cx="12"
-                        cy="12"
-                        fill="none"
-                        r="10"
-                      />
-                    </svg>
-                  </span>
+                      Set up security key or biometric authenticator
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      You will be prompted to use a security key or biometric verification (Windows Hello, Touch ID, etc.). Follow the instructions to complete verification.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <span
+                      aria-label="Loading..."
+                      aria-valuemax="1"
+                      aria-valuemin="0"
+                      aria-valuetext="Loading..."
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-48Fcvf"
+                      id="okta-spinner"
+                      role="progressbar"
+                    >
+                      <svg
+                        class="ods-57SiHN"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          class="ods-3PiY3x"
+                          cx="12"
+                          cy="12"
+                          fill="none"
+                          r="10"
+                        />
+                        <circle
+                          class="ods-627kuP"
+                          cx="12"
+                          cy="12"
+                          fill="none"
+                          r="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-19"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Verify with something else
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-19"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-18"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Verify with something else
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-18"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`email-challenge-consent should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,88 +71,92 @@ exports[`email-challenge-consent should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Did you just try to sign in?
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Did you just try to sign in?
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-14"
-                  id="browser"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
                     class="MuiBox-root emotion-15"
+                    id="browser"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <div
+                      class="MuiBox-root emotion-16"
                     >
-                      CHROME
-                    </span>
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        CHROME
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-14"
-                  id="appName"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
                     class="MuiBox-root emotion-15"
+                    id="appName"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <div
+                      class="MuiBox-root emotion-16"
                     >
-                      Okta Dashboard
-                    </span>
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Okta Dashboard
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
-                  data-type="cancel"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  No, it's not me
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
-                  data-type="save"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                    data-type="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    No, it's not me
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Yes, it's me
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                    data-type="save"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Yes, it's me
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`enroll-profile should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -34,165 +34,169 @@ exports[`enroll-profile should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-7"
-                  >
-                    Sign up
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-9"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                    for="userProfile.firstName"
-                  >
-                    First name
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-11"
+                    class="MuiBox-root emotion-7"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="given-name"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-12"
-                      data-se="userProfile.firstName"
-                      id="userProfile.firstName"
-                      name="userProfile.firstName"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-13"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-8"
                     >
-                      <legend
-                        class="emotion-14"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Sign up
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-6"
                 >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                    for="userProfile.lastName"
-                  >
-                    Last name
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-11"
+                    class="MuiBox-root emotion-10"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="family-name"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-12"
-                      data-se="userProfile.lastName"
-                      id="userProfile.lastName"
-                      name="userProfile.lastName"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-13"
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      for="userProfile.firstName"
                     >
-                      <legend
-                        class="emotion-14"
+                      First name
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-12"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="given-name"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
+                        data-se="userProfile.firstName"
+                        id="userProfile.firstName"
+                        name="userProfile.firstName"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-14"
                       >
-                        <span
-                          class="notranslate"
+                        <legend
+                          class="emotion-15"
                         >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-6"
                 >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                    for="userProfile.email"
-                  >
-                    Email
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-11"
+                    class="MuiBox-root emotion-10"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="email"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-12"
-                      data-se="userProfile.email"
-                      id="userProfile.email"
-                      name="userProfile.email"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-13"
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      for="userProfile.lastName"
                     >
-                      <legend
-                        class="emotion-14"
+                      Last name
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-12"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="family-name"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
+                        data-se="userProfile.lastName"
+                        id="userProfile.lastName"
+                        name="userProfile.lastName"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-14"
                       >
-                        <span
-                          class="notranslate"
+                        <legend
+                          class="emotion-15"
                         >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-30"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Sign Up
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-32"
-                  data-se="back"
-                  tabindex="0"
-                  type="button"
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      for="userProfile.email"
+                    >
+                      Email
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-12"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="email"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
+                        data-se="userProfile.email"
+                        id="userProfile.email"
+                        name="userProfile.email"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-14"
+                      >
+                        <legend
+                          class="emotion-15"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Already have an account?
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-31"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Sign Up
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-33"
+                    data-se="back"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Already have an account?
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`error-400-unauthorized-client should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -35,37 +35,41 @@ exports[`error-400-unauthorized-client should render form 1`] = `
                   class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-7"
-                    role="alert"
+                    class="MuiBox-root emotion-7"
                   >
                     <div
-                      class="MuiAlert-icon emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-9"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-10"
-                    >
-                      Something went wrong. Potential misconfiguration detected. Please contact support.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        Something went wrong. Potential misconfiguration detected. Please contact support.
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`error-account-creation should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -35,51 +35,55 @@ exports[`error-account-creation should render form 1`] = `
                   class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-7"
-                    role="alert"
+                    class="MuiBox-root emotion-7"
                   >
                     <div
-                      class="MuiAlert-icon emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-9"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-10"
-                    >
-                      There was an error creating your account. Please try registering again.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        There was an error creating your account. Please try registering again.
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-6"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
-                    href="/"
+                  <div
+                    class="MuiBox-root emotion-13"
                   >
-                    Back to sign in
-                  </a>
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                      href="/"
+                    >
+                      Back to sign in
+                    </a>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`error-feature-not-enabled should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -35,37 +35,41 @@ exports[`error-feature-not-enabled should render form 1`] = `
                   class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-7"
-                    role="alert"
+                    class="MuiBox-root emotion-7"
                   >
                     <div
-                      class="MuiAlert-icon emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-9"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-10"
-                    >
-                      The requested feature is not enabled in this environment.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        The requested feature is not enabled in this environment.
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`error-recovery-token-invalid should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -35,37 +35,41 @@ exports[`error-recovery-token-invalid should render form 1`] = `
                   class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-7"
-                    role="alert"
+                    class="MuiBox-root emotion-7"
                   >
                     <div
-                      class="MuiAlert-icon emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-9"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-10"
-                    >
-                      The recovery token is invalid.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        The recovery token is invalid.
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`error-session-expired should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -35,51 +35,55 @@ exports[`error-session-expired should render form 1`] = `
                   class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-7"
-                    role="alert"
+                    class="MuiBox-root emotion-7"
                   >
                     <div
-                      class="MuiAlert-icon emotion-8"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-9"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-9"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-10"
-                    >
-                      You have been logged out due to inactivity. Refresh or return to the sign in screen.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        You have been logged out due to inactivity. Refresh or return to the sign in screen.
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-6"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
-                    href="/"
+                  <div
+                    class="MuiBox-root emotion-13"
                   >
-                    Back to sign in
-                  </a>
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                      href="/"
+                    >
+                      Back to sign in
+                    </a>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -2,71 +2,241 @@
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-13"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      >
+                        Set up Okta Verify
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-16"
+                    >
+                      <ol
+                        class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                      >
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          Open the app and follow the instructions to add your account
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          When prompted, tap Scan a QR code, then scan the QR code below:
+                        </li>
+                      </ol>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="qrContainer MuiBox-root emotion-4"
+                    >
+                      <img
+                        alt="Okta Verify"
+                        class="qrImg"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Can't scan?
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 2`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
                   class="MuiBox-root emotion-11"
@@ -77,607 +247,254 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     <h2
                       class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Set up Okta Verify
+                      More options
                     </h2>
                   </div>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-15"
+                  <fieldset
+                    class="MuiFormControl-root emotion-15"
                   >
-                    <ol
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                    <label
+                      class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                     >
-                      <li
-                        class="ods-5vIIsH"
+                      Which option do you want to try?
+                    </label>
+                    <div
+                      class="MuiFormGroup-root emotion-17"
+                      id="authenticator.channel"
+                      role="radiogroup"
+                    >
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
                       >
-                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="email"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Email me a setup link
+                        </span>
+                      </label>
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
                       >
-                        Open the app and follow the instructions to add your account
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        When prompted, tap Scan a QR code, then scan the QR code below:
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="qrContainer MuiBox-root emotion-3"
-                  >
-                    <img
-                      alt="Okta Verify"
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
-                    />
-                  </div>
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="sms"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Text me a setup link
+                        </span>
+                      </label>
+                    </div>
+                  </fieldset>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
+                    data-type="save"
                     tabindex="0"
-                    type="button"
+                    type="submit"
                   >
-                    Can't scan?
+                    Next
                   </button>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 2`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-35"
+                    tabindex="0"
+                    type="button"
                   >
-                    More options
-                  </h2>
+                    Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-37"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-37"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 3`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-10"
+                class="identifierContainer MuiBox-root emotion-7"
               >
-                <div
-                  class="MuiBox-root emotion-11"
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Set up Okta Verify via email link
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="email"
-                  >
-                    Email
-                  </label>
-                  <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
-                  >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="email"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
-                      data-se="email"
-                      id="email"
-                      name="email"
-                      type="text"
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
                     />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
-                    >
-                      <legend
-                        class="emotion-19"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Make sure you can access the email on your mobile device.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
+                  tester2@test.com
+                </span>
               </div>
             </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 4`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                glen.fannin@okta.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="MuiBox-root emotion-10"
               >
-                <div
-                  class="MuiBox-root emotion-11"
-                />
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-12"
                   >
                     <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Check your email
+                      Set up Okta Verify via email link
                     </h2>
                   </div>
                 </div>
@@ -685,12 +502,53 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-4"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      for="email"
+                    >
+                      Email
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="email"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
+                        data-se="email"
+                        id="email"
+                        name="email"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-19"
+                      >
+                        <legend
+                          class="emotion-20"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
                     <p
                       class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                     >
-                      We sent an email to glen.fannin@okta.com with an Okta Verify setup link. To continue, open the link on your mobile device.
+                      Make sure you can access the email on your mobile device.
                     </p>
                   </div>
                 </div>
@@ -698,111 +556,269 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send me the setup link
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                     tabindex="0"
                     type="button"
                   >
                     Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
                   </button>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 4`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
               </div>
             </div>
-          </form>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  />
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                      >
+                        Check your email
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        We sent an email to glen.fannin@okta.com with an Okta Verify setup link. To continue, open the link on your mobile device.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 5`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -810,400 +826,578 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    More options
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      More options
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <fieldset
+                    class="MuiFormControl-root emotion-15"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                    >
+                      Which option do you want to try?
+                    </label>
+                    <div
+                      class="MuiFormGroup-root emotion-17"
+                      id="authenticator.channel"
+                      role="radiogroup"
+                    >
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="qrcode"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Scan a QR code
+                        </span>
+                      </label>
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="sms"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Text me a setup link
+                        </span>
+                      </label>
+                    </div>
+                  </fieldset>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="qrcode"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Scan a QR code
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-34"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-34"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 6`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-12"
                   >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    <div
+                      class="MuiBox-root emotion-13"
                     >
-                      Set up Okta Verify
-                    </h2>
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      >
+                        Set up Okta Verify
+                      </h2>
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
                   <div
-                    class="MuiBox-root emotion-15"
+                    class="MuiBox-root emotion-12"
                   >
-                    <ol
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                    <div
+                      class="MuiBox-root emotion-16"
                     >
-                      <li
-                        class="ods-5vIIsH"
+                      <ol
+                        class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
                       >
-                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        Open the app and follow the instructions to add your account
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        When prompted, tap Scan a QR code, then scan the QR code below:
-                      </li>
-                    </ol>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          Open the app and follow the instructions to add your account
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          When prompted, tap Scan a QR code, then scan the QR code below:
+                        </li>
+                      </ol>
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
                   <div
-                    class="qrContainer MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-12"
                   >
-                    <img
-                      alt="Okta Verify"
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
-                    />
+                    <div
+                      class="qrContainer MuiBox-root emotion-4"
+                    >
+                      <img
+                        alt="Okta Verify"
+                        class="qrImg"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Can't scan?
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-11"
+                  class="MuiBox-root emotion-12"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
                     tabindex="0"
                     type="button"
                   >
-                    Can't scan?
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
             >
               <div
-                class="MuiBox-root emotion-9"
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-13"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      >
+                        Set up Okta Verify
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-16"
+                    >
+                      <ol
+                        class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                      >
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          Open the app and follow the instructions to add your account
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          When prompted, tap Scan a QR code, then scan the QR code below:
+                        </li>
+                      </ol>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="qrContainer MuiBox-root emotion-4"
+                    >
+                      <img
+                        alt="Okta Verify"
+                        class="qrImg"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Can't scan?
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 2`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
               >
                 <div
                   class="MuiBox-root emotion-11"
@@ -1214,7 +1408,254 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     <h2
                       class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      Set up Okta Verify
+                      More options
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <fieldset
+                    class="MuiFormControl-root emotion-15"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                    >
+                      Which option do you want to try?
+                    </label>
+                    <div
+                      class="MuiFormGroup-root emotion-17"
+                      id="authenticator.channel"
+                      role="radiogroup"
+                    >
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="email"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Email me a setup link
+                        </span>
+                      </label>
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="sms"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Text me a setup link
+                        </span>
+                      </label>
+                    </div>
+                  </fieldset>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-35"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-37"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-37"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 3`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up Okta Verify via SMS
                     </h2>
                   </div>
                 </div>
@@ -1222,1865 +1663,1306 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-15"
-                  >
-                    <ol
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
-                    >
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        Open the app and follow the instructions to add your account
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        When prompted, tap Scan a QR code, then scan the QR code below:
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="qrContainer MuiBox-root emotion-3"
-                  >
-                    <img
-                      alt="Okta Verify"
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
-                    />
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
-                    tabindex="0"
-                    type="button"
-                  >
-                    Can't scan?
-                  </button>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 2`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    More options
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 3`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Set up Okta Verify via SMS
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <div
-                    class="MuiBox-root emotion-10"
+                    class="MuiBox-root emotion-4"
                   >
                     <div
-                      class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
-                    >
-                      <label
-                        class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                        for="countryList"
-                      >
-                        <span
-                          class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                        >
-                          Country
-                        </span>
-                      </label>
-                      <div
-                        class="ods-mUkyrD"
-                      >
-                        <select
-                          autocomplete="tel-country-code"
-                          class="ods-1B2Zfy"
-                          data-se="countryList"
-                          id="countryList"
-                        >
-                          <option
-                            value="AF"
-                          >
-                            Afghanistan
-                          </option>
-                          <option
-                            value="AL"
-                          >
-                            Albania
-                          </option>
-                          <option
-                            value="DZ"
-                          >
-                            Algeria
-                          </option>
-                          <option
-                            value="AS"
-                          >
-                            American Samoa
-                          </option>
-                          <option
-                            value="AD"
-                          >
-                            Andorra
-                          </option>
-                          <option
-                            value="AO"
-                          >
-                            Angola
-                          </option>
-                          <option
-                            value="AI"
-                          >
-                            Anguilla
-                          </option>
-                          <option
-                            value="AQ"
-                          >
-                            Antarctica
-                          </option>
-                          <option
-                            value="AG"
-                          >
-                            Antigua and Barbuda
-                          </option>
-                          <option
-                            value="AR"
-                          >
-                            Argentina
-                          </option>
-                          <option
-                            value="AM"
-                          >
-                            Armenia
-                          </option>
-                          <option
-                            value="AW"
-                          >
-                            Aruba
-                          </option>
-                          <option
-                            value="AU"
-                          >
-                            Australia
-                          </option>
-                          <option
-                            value="AT"
-                          >
-                            Austria
-                          </option>
-                          <option
-                            value="AZ"
-                          >
-                            Azerbaijan
-                          </option>
-                          <option
-                            value="BS"
-                          >
-                            Bahamas
-                          </option>
-                          <option
-                            value="BH"
-                          >
-                            Bahrain
-                          </option>
-                          <option
-                            value="BD"
-                          >
-                            Bangladesh
-                          </option>
-                          <option
-                            value="BB"
-                          >
-                            Barbados
-                          </option>
-                          <option
-                            value="BY"
-                          >
-                            Belarus
-                          </option>
-                          <option
-                            value="BE"
-                          >
-                            Belgium
-                          </option>
-                          <option
-                            value="BZ"
-                          >
-                            Belize
-                          </option>
-                          <option
-                            value="BJ"
-                          >
-                            Benin
-                          </option>
-                          <option
-                            value="BM"
-                          >
-                            Bermuda
-                          </option>
-                          <option
-                            value="BT"
-                          >
-                            Bhutan
-                          </option>
-                          <option
-                            value="BO"
-                          >
-                            Bolivia, Plurinational State of
-                          </option>
-                          <option
-                            value="BA"
-                          >
-                            Bosnia and Herzegovina
-                          </option>
-                          <option
-                            value="BW"
-                          >
-                            Botswana
-                          </option>
-                          <option
-                            value="BR"
-                          >
-                            Brazil
-                          </option>
-                          <option
-                            value="IO"
-                          >
-                            British Indian Ocean Territory
-                          </option>
-                          <option
-                            value="BN"
-                          >
-                            Brunei Darussalam
-                          </option>
-                          <option
-                            value="BG"
-                          >
-                            Bulgaria
-                          </option>
-                          <option
-                            value="BF"
-                          >
-                            Burkina Faso
-                          </option>
-                          <option
-                            value="BI"
-                          >
-                            Burundi
-                          </option>
-                          <option
-                            value="KH"
-                          >
-                            Cambodia
-                          </option>
-                          <option
-                            value="CM"
-                          >
-                            Cameroon
-                          </option>
-                          <option
-                            value="CA"
-                          >
-                            Canada
-                          </option>
-                          <option
-                            value="CV"
-                          >
-                            Cape Verde
-                          </option>
-                          <option
-                            value="KY"
-                          >
-                            Cayman Islands
-                          </option>
-                          <option
-                            value="CF"
-                          >
-                            Central African Republic
-                          </option>
-                          <option
-                            value="TD"
-                          >
-                            Chad
-                          </option>
-                          <option
-                            value="CL"
-                          >
-                            Chile
-                          </option>
-                          <option
-                            value="CN"
-                          >
-                            China
-                          </option>
-                          <option
-                            value="CX"
-                          >
-                            Christmas Island
-                          </option>
-                          <option
-                            value="CO"
-                          >
-                            Colombia
-                          </option>
-                          <option
-                            value="KM"
-                          >
-                            Comoros
-                          </option>
-                          <option
-                            value="CG"
-                          >
-                            Congo
-                          </option>
-                          <option
-                            value="CD"
-                          >
-                            Congo, the Democratic Republic of the
-                          </option>
-                          <option
-                            value="CK"
-                          >
-                            Cook Islands
-                          </option>
-                          <option
-                            value="CR"
-                          >
-                            Costa Rica
-                          </option>
-                          <option
-                            value="HR"
-                          >
-                            Croatia
-                          </option>
-                          <option
-                            value="CU"
-                          >
-                            Cuba
-                          </option>
-                          <option
-                            value="CY"
-                          >
-                            Cyprus
-                          </option>
-                          <option
-                            value="CZ"
-                          >
-                            Czech Republic
-                          </option>
-                          <option
-                            value="CI"
-                          >
-                            Côte d'Ivoire
-                          </option>
-                          <option
-                            value="DK"
-                          >
-                            Denmark
-                          </option>
-                          <option
-                            value="DJ"
-                          >
-                            Djibouti
-                          </option>
-                          <option
-                            value="DM"
-                          >
-                            Dominica
-                          </option>
-                          <option
-                            value="DO"
-                          >
-                            Dominican Republic
-                          </option>
-                          <option
-                            value="EC"
-                          >
-                            Ecuador
-                          </option>
-                          <option
-                            value="EG"
-                          >
-                            Egypt
-                          </option>
-                          <option
-                            value="SV"
-                          >
-                            El Salvador
-                          </option>
-                          <option
-                            value="GQ"
-                          >
-                            Equatorial Guinea
-                          </option>
-                          <option
-                            value="ER"
-                          >
-                            Eritrea
-                          </option>
-                          <option
-                            value="EE"
-                          >
-                            Estonia
-                          </option>
-                          <option
-                            value="ET"
-                          >
-                            Ethiopia
-                          </option>
-                          <option
-                            value="FK"
-                          >
-                            Falkland Islands (Malvinas)
-                          </option>
-                          <option
-                            value="FO"
-                          >
-                            Faroe Islands
-                          </option>
-                          <option
-                            value="FJ"
-                          >
-                            Fiji
-                          </option>
-                          <option
-                            value="FI"
-                          >
-                            Finland
-                          </option>
-                          <option
-                            value="FR"
-                          >
-                            France
-                          </option>
-                          <option
-                            value="GF"
-                          >
-                            French Guiana
-                          </option>
-                          <option
-                            value="PF"
-                          >
-                            French Polynesia
-                          </option>
-                          <option
-                            value="GA"
-                          >
-                            Gabon
-                          </option>
-                          <option
-                            value="GM"
-                          >
-                            Gambia
-                          </option>
-                          <option
-                            value="GE"
-                          >
-                            Georgia
-                          </option>
-                          <option
-                            value="DE"
-                          >
-                            Germany
-                          </option>
-                          <option
-                            value="GH"
-                          >
-                            Ghana
-                          </option>
-                          <option
-                            value="GI"
-                          >
-                            Gibraltar
-                          </option>
-                          <option
-                            value="GR"
-                          >
-                            Greece
-                          </option>
-                          <option
-                            value="GL"
-                          >
-                            Greenland
-                          </option>
-                          <option
-                            value="GD"
-                          >
-                            Grenada
-                          </option>
-                          <option
-                            value="GP"
-                          >
-                            Guadeloupe
-                          </option>
-                          <option
-                            value="GU"
-                          >
-                            Guam
-                          </option>
-                          <option
-                            value="GT"
-                          >
-                            Guatemala
-                          </option>
-                          <option
-                            value="GG"
-                          >
-                            Guernsey
-                          </option>
-                          <option
-                            value="GN"
-                          >
-                            Guinea
-                          </option>
-                          <option
-                            value="GW"
-                          >
-                            Guinea-Bissau
-                          </option>
-                          <option
-                            value="GY"
-                          >
-                            Guyana
-                          </option>
-                          <option
-                            value="HT"
-                          >
-                            Haiti
-                          </option>
-                          <option
-                            value="VA"
-                          >
-                            Holy See (Vatican City State)
-                          </option>
-                          <option
-                            value="HN"
-                          >
-                            Honduras
-                          </option>
-                          <option
-                            value="HK"
-                          >
-                            Hong Kong
-                          </option>
-                          <option
-                            value="HU"
-                          >
-                            Hungary
-                          </option>
-                          <option
-                            value="IS"
-                          >
-                            Iceland
-                          </option>
-                          <option
-                            value="IN"
-                          >
-                            India
-                          </option>
-                          <option
-                            value="ID"
-                          >
-                            Indonesia
-                          </option>
-                          <option
-                            value="IR"
-                          >
-                            Iran, Islamic Republic of
-                          </option>
-                          <option
-                            value="IQ"
-                          >
-                            Iraq
-                          </option>
-                          <option
-                            value="IE"
-                          >
-                            Ireland
-                          </option>
-                          <option
-                            value="IL"
-                          >
-                            Israel
-                          </option>
-                          <option
-                            value="IT"
-                          >
-                            Italy
-                          </option>
-                          <option
-                            value="JM"
-                          >
-                            Jamaica
-                          </option>
-                          <option
-                            value="JP"
-                          >
-                            Japan
-                          </option>
-                          <option
-                            value="JE"
-                          >
-                            Jersey
-                          </option>
-                          <option
-                            value="JO"
-                          >
-                            Jordan
-                          </option>
-                          <option
-                            value="KZ"
-                          >
-                            Kazakhstan
-                          </option>
-                          <option
-                            value="KE"
-                          >
-                            Kenya
-                          </option>
-                          <option
-                            value="KI"
-                          >
-                            Kiribati
-                          </option>
-                          <option
-                            value="KP"
-                          >
-                            Korea, Democratic People's Republic of
-                          </option>
-                          <option
-                            value="KR"
-                          >
-                            Korea, Republic of
-                          </option>
-                          <option
-                            value="XK"
-                          >
-                            Kosovo, Republic of
-                          </option>
-                          <option
-                            value="KW"
-                          >
-                            Kuwait
-                          </option>
-                          <option
-                            value="KG"
-                          >
-                            Kyrgyzstan
-                          </option>
-                          <option
-                            value="LA"
-                          >
-                            Lao People's Democratic Republic
-                          </option>
-                          <option
-                            value="LV"
-                          >
-                            Latvia
-                          </option>
-                          <option
-                            value="LB"
-                          >
-                            Lebanon
-                          </option>
-                          <option
-                            value="LS"
-                          >
-                            Lesotho
-                          </option>
-                          <option
-                            value="LR"
-                          >
-                            Liberia
-                          </option>
-                          <option
-                            value="LY"
-                          >
-                            Libya
-                          </option>
-                          <option
-                            value="LI"
-                          >
-                            Liechtenstein
-                          </option>
-                          <option
-                            value="LT"
-                          >
-                            Lithuania
-                          </option>
-                          <option
-                            value="LU"
-                          >
-                            Luxembourg
-                          </option>
-                          <option
-                            value="MO"
-                          >
-                            Macao
-                          </option>
-                          <option
-                            value="MK"
-                          >
-                            Macedonia, the former Yugoslav Republic of
-                          </option>
-                          <option
-                            value="MG"
-                          >
-                            Madagascar
-                          </option>
-                          <option
-                            value="MW"
-                          >
-                            Malawi
-                          </option>
-                          <option
-                            value="MY"
-                          >
-                            Malaysia
-                          </option>
-                          <option
-                            value="MV"
-                          >
-                            Maldives
-                          </option>
-                          <option
-                            value="ML"
-                          >
-                            Mali
-                          </option>
-                          <option
-                            value="MT"
-                          >
-                            Malta
-                          </option>
-                          <option
-                            value="MH"
-                          >
-                            Marshall Islands
-                          </option>
-                          <option
-                            value="MQ"
-                          >
-                            Martinique
-                          </option>
-                          <option
-                            value="MR"
-                          >
-                            Mauritania
-                          </option>
-                          <option
-                            value="MU"
-                          >
-                            Mauritius
-                          </option>
-                          <option
-                            value="YT"
-                          >
-                            Mayotte
-                          </option>
-                          <option
-                            value="MX"
-                          >
-                            Mexico
-                          </option>
-                          <option
-                            value="FM"
-                          >
-                            Micronesia, Federated States of
-                          </option>
-                          <option
-                            value="MD"
-                          >
-                            Moldova, Republic of
-                          </option>
-                          <option
-                            value="MC"
-                          >
-                            Monaco
-                          </option>
-                          <option
-                            value="MN"
-                          >
-                            Mongolia
-                          </option>
-                          <option
-                            value="ME"
-                          >
-                            Montenegro
-                          </option>
-                          <option
-                            value="MS"
-                          >
-                            Montserrat
-                          </option>
-                          <option
-                            value="MA"
-                          >
-                            Morocco
-                          </option>
-                          <option
-                            value="MZ"
-                          >
-                            Mozambique
-                          </option>
-                          <option
-                            value="MM"
-                          >
-                            Myanmar
-                          </option>
-                          <option
-                            value="NA"
-                          >
-                            Namibia
-                          </option>
-                          <option
-                            value="NR"
-                          >
-                            Nauru
-                          </option>
-                          <option
-                            value="NP"
-                          >
-                            Nepal
-                          </option>
-                          <option
-                            value="NL"
-                          >
-                            Netherlands
-                          </option>
-                          <option
-                            value="AN"
-                          >
-                            Netherlands Antilles
-                          </option>
-                          <option
-                            value="NC"
-                          >
-                            New Caledonia
-                          </option>
-                          <option
-                            value="NZ"
-                          >
-                            New Zealand
-                          </option>
-                          <option
-                            value="NI"
-                          >
-                            Nicaragua
-                          </option>
-                          <option
-                            value="NE"
-                          >
-                            Niger
-                          </option>
-                          <option
-                            value="NG"
-                          >
-                            Nigeria
-                          </option>
-                          <option
-                            value="NU"
-                          >
-                            Niue
-                          </option>
-                          <option
-                            value="NF"
-                          >
-                            Norfolk Island
-                          </option>
-                          <option
-                            value="MP"
-                          >
-                            Northern Mariana Islands
-                          </option>
-                          <option
-                            value="NO"
-                          >
-                            Norway
-                          </option>
-                          <option
-                            value="OM"
-                          >
-                            Oman
-                          </option>
-                          <option
-                            value="PK"
-                          >
-                            Pakistan
-                          </option>
-                          <option
-                            value="PW"
-                          >
-                            Palau
-                          </option>
-                          <option
-                            value="PS"
-                          >
-                            Palestine, State of
-                          </option>
-                          <option
-                            value="PA"
-                          >
-                            Panama
-                          </option>
-                          <option
-                            value="PG"
-                          >
-                            Papua New Guinea
-                          </option>
-                          <option
-                            value="PY"
-                          >
-                            Paraguay
-                          </option>
-                          <option
-                            value="PE"
-                          >
-                            Peru
-                          </option>
-                          <option
-                            value="PH"
-                          >
-                            Philippines
-                          </option>
-                          <option
-                            value="PN"
-                          >
-                            Pitcairn
-                          </option>
-                          <option
-                            value="PL"
-                          >
-                            Poland
-                          </option>
-                          <option
-                            value="PT"
-                          >
-                            Portugal
-                          </option>
-                          <option
-                            value="PR"
-                          >
-                            Puerto Rico
-                          </option>
-                          <option
-                            value="QA"
-                          >
-                            Qatar
-                          </option>
-                          <option
-                            value="RO"
-                          >
-                            Romania
-                          </option>
-                          <option
-                            value="RU"
-                          >
-                            Russian Federation
-                          </option>
-                          <option
-                            value="RW"
-                          >
-                            Rwanda
-                          </option>
-                          <option
-                            value="RE"
-                          >
-                            Réunion
-                          </option>
-                          <option
-                            value="SH"
-                          >
-                            Saint Helena, Ascension and Tristan da Cunha
-                          </option>
-                          <option
-                            value="KN"
-                          >
-                            Saint Kitts and Nevis
-                          </option>
-                          <option
-                            value="LC"
-                          >
-                            Saint Lucia
-                          </option>
-                          <option
-                            value="PM"
-                          >
-                            Saint Pierre and Miquelon
-                          </option>
-                          <option
-                            value="VC"
-                          >
-                            Saint Vincent and the Grenadines
-                          </option>
-                          <option
-                            value="WS"
-                          >
-                            Samoa
-                          </option>
-                          <option
-                            value="SM"
-                          >
-                            San Marino
-                          </option>
-                          <option
-                            value="SA"
-                          >
-                            Saudi Arabia
-                          </option>
-                          <option
-                            value="SN"
-                          >
-                            Senegal
-                          </option>
-                          <option
-                            value="RS"
-                          >
-                            Serbia
-                          </option>
-                          <option
-                            value="SC"
-                          >
-                            Seychelles
-                          </option>
-                          <option
-                            value="SL"
-                          >
-                            Sierra Leone
-                          </option>
-                          <option
-                            value="SG"
-                          >
-                            Singapore
-                          </option>
-                          <option
-                            value="SK"
-                          >
-                            Slovakia
-                          </option>
-                          <option
-                            value="SI"
-                          >
-                            Slovenia
-                          </option>
-                          <option
-                            value="SB"
-                          >
-                            Solomon Islands
-                          </option>
-                          <option
-                            value="SO"
-                          >
-                            Somalia
-                          </option>
-                          <option
-                            value="ZA"
-                          >
-                            South Africa
-                          </option>
-                          <option
-                            value="GS"
-                          >
-                            South Georgia and the South Sandwich Islands
-                          </option>
-                          <option
-                            value="SS"
-                          >
-                            South Sudan
-                          </option>
-                          <option
-                            value="ES"
-                          >
-                            Spain
-                          </option>
-                          <option
-                            value="LK"
-                          >
-                            Sri Lanka
-                          </option>
-                          <option
-                            value="SD"
-                          >
-                            Sudan
-                          </option>
-                          <option
-                            value="SR"
-                          >
-                            Suriname
-                          </option>
-                          <option
-                            value="SJ"
-                          >
-                            Svalbard and Jan Mayen
-                          </option>
-                          <option
-                            value="SZ"
-                          >
-                            Swaziland
-                          </option>
-                          <option
-                            value="SE"
-                          >
-                            Sweden
-                          </option>
-                          <option
-                            value="CH"
-                          >
-                            Switzerland
-                          </option>
-                          <option
-                            value="SY"
-                          >
-                            Syrian Arab Republic
-                          </option>
-                          <option
-                            value="ST"
-                          >
-                            São Tomé and Príncipe
-                          </option>
-                          <option
-                            value="TW"
-                          >
-                            Taiwan
-                          </option>
-                          <option
-                            value="TJ"
-                          >
-                            Tajikistan
-                          </option>
-                          <option
-                            value="TZ"
-                          >
-                            Tanzania, United Republic of
-                          </option>
-                          <option
-                            value="TH"
-                          >
-                            Thailand
-                          </option>
-                          <option
-                            value="TL"
-                          >
-                            Timor-Leste
-                          </option>
-                          <option
-                            value="TG"
-                          >
-                            Togo
-                          </option>
-                          <option
-                            value="TK"
-                          >
-                            Tokelau
-                          </option>
-                          <option
-                            value="TO"
-                          >
-                            Tonga
-                          </option>
-                          <option
-                            value="TT"
-                          >
-                            Trinidad and Tobago
-                          </option>
-                          <option
-                            value="TN"
-                          >
-                            Tunisia
-                          </option>
-                          <option
-                            value="TR"
-                          >
-                            Turkey
-                          </option>
-                          <option
-                            value="TM"
-                          >
-                            Turkmenistan
-                          </option>
-                          <option
-                            value="TC"
-                          >
-                            Turks and Caicos Islands
-                          </option>
-                          <option
-                            value="TV"
-                          >
-                            Tuvalu
-                          </option>
-                          <option
-                            value="UG"
-                          >
-                            Uganda
-                          </option>
-                          <option
-                            value="UA"
-                          >
-                            Ukraine
-                          </option>
-                          <option
-                            value="AE"
-                          >
-                            United Arab Emirates
-                          </option>
-                          <option
-                            value="GB"
-                          >
-                            United Kingdom
-                          </option>
-                          <option
-                            value="US"
-                          >
-                            United States
-                          </option>
-                          <option
-                            value="UM"
-                          >
-                            United States Minor Outlying Islands
-                          </option>
-                          <option
-                            value="UY"
-                          >
-                            Uruguay
-                          </option>
-                          <option
-                            value="UZ"
-                          >
-                            Uzbekistan
-                          </option>
-                          <option
-                            value="VU"
-                          >
-                            Vanuatu
-                          </option>
-                          <option
-                            value="VE"
-                          >
-                            Venezuela, Bolivarian Republic of
-                          </option>
-                          <option
-                            value="VN"
-                          >
-                            Viet Nam
-                          </option>
-                          <option
-                            value="VG"
-                          >
-                            Virgin Islands, British
-                          </option>
-                          <option
-                            value="VI"
-                          >
-                            Virgin Islands, U.S.
-                          </option>
-                          <option
-                            value="WF"
-                          >
-                            Wallis and Futuna
-                          </option>
-                          <option
-                            value="EH"
-                          >
-                            Western Sahara
-                          </option>
-                          <option
-                            value="YE"
-                          >
-                            Yemen
-                          </option>
-                          <option
-                            value="ZM"
-                          >
-                            Zambia
-                          </option>
-                          <option
-                            value="ZW"
-                          >
-                            Zimbabwe
-                          </option>
-                          <option
-                            value="AX"
-                          >
-                            Åland Islands
-                          </option>
-                        </select>
-                        <span
-                          class="ods-7mdg51"
-                        >
-                          <svg
-                            class="ods-2icygl"
-                            fill="none"
-                            role="presentation"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-16"
-                  >
-                    <div
-                      class="MuiBox-root emotion-17"
+                      class="MuiBox-root emotion-11"
                     >
                       <div
                         class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
                       >
                         <label
                           class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="phoneNumber"
+                          for="countryList"
                         >
                           <span
                             class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                           >
-                            Phone Number
+                            Country
                           </span>
                         </label>
                         <div
-                          class="ods-10aW0m"
+                          class="ods-mUkyrD"
                         >
-                          <input
-                            autocomplete="tel-national"
-                            class="ods-7qBw9I"
-                            data-se="phoneNumber"
-                            id="phoneNumber"
-                            name="phoneNumber"
-                            type="tel"
-                          />
+                          <select
+                            autocomplete="tel-country-code"
+                            class="ods-1B2Zfy"
+                            data-se="countryList"
+                            id="countryList"
+                          >
+                            <option
+                              value="AF"
+                            >
+                              Afghanistan
+                            </option>
+                            <option
+                              value="AL"
+                            >
+                              Albania
+                            </option>
+                            <option
+                              value="DZ"
+                            >
+                              Algeria
+                            </option>
+                            <option
+                              value="AS"
+                            >
+                              American Samoa
+                            </option>
+                            <option
+                              value="AD"
+                            >
+                              Andorra
+                            </option>
+                            <option
+                              value="AO"
+                            >
+                              Angola
+                            </option>
+                            <option
+                              value="AI"
+                            >
+                              Anguilla
+                            </option>
+                            <option
+                              value="AQ"
+                            >
+                              Antarctica
+                            </option>
+                            <option
+                              value="AG"
+                            >
+                              Antigua and Barbuda
+                            </option>
+                            <option
+                              value="AR"
+                            >
+                              Argentina
+                            </option>
+                            <option
+                              value="AM"
+                            >
+                              Armenia
+                            </option>
+                            <option
+                              value="AW"
+                            >
+                              Aruba
+                            </option>
+                            <option
+                              value="AU"
+                            >
+                              Australia
+                            </option>
+                            <option
+                              value="AT"
+                            >
+                              Austria
+                            </option>
+                            <option
+                              value="AZ"
+                            >
+                              Azerbaijan
+                            </option>
+                            <option
+                              value="BS"
+                            >
+                              Bahamas
+                            </option>
+                            <option
+                              value="BH"
+                            >
+                              Bahrain
+                            </option>
+                            <option
+                              value="BD"
+                            >
+                              Bangladesh
+                            </option>
+                            <option
+                              value="BB"
+                            >
+                              Barbados
+                            </option>
+                            <option
+                              value="BY"
+                            >
+                              Belarus
+                            </option>
+                            <option
+                              value="BE"
+                            >
+                              Belgium
+                            </option>
+                            <option
+                              value="BZ"
+                            >
+                              Belize
+                            </option>
+                            <option
+                              value="BJ"
+                            >
+                              Benin
+                            </option>
+                            <option
+                              value="BM"
+                            >
+                              Bermuda
+                            </option>
+                            <option
+                              value="BT"
+                            >
+                              Bhutan
+                            </option>
+                            <option
+                              value="BO"
+                            >
+                              Bolivia, Plurinational State of
+                            </option>
+                            <option
+                              value="BA"
+                            >
+                              Bosnia and Herzegovina
+                            </option>
+                            <option
+                              value="BW"
+                            >
+                              Botswana
+                            </option>
+                            <option
+                              value="BR"
+                            >
+                              Brazil
+                            </option>
+                            <option
+                              value="IO"
+                            >
+                              British Indian Ocean Territory
+                            </option>
+                            <option
+                              value="BN"
+                            >
+                              Brunei Darussalam
+                            </option>
+                            <option
+                              value="BG"
+                            >
+                              Bulgaria
+                            </option>
+                            <option
+                              value="BF"
+                            >
+                              Burkina Faso
+                            </option>
+                            <option
+                              value="BI"
+                            >
+                              Burundi
+                            </option>
+                            <option
+                              value="KH"
+                            >
+                              Cambodia
+                            </option>
+                            <option
+                              value="CM"
+                            >
+                              Cameroon
+                            </option>
+                            <option
+                              value="CA"
+                            >
+                              Canada
+                            </option>
+                            <option
+                              value="CV"
+                            >
+                              Cape Verde
+                            </option>
+                            <option
+                              value="KY"
+                            >
+                              Cayman Islands
+                            </option>
+                            <option
+                              value="CF"
+                            >
+                              Central African Republic
+                            </option>
+                            <option
+                              value="TD"
+                            >
+                              Chad
+                            </option>
+                            <option
+                              value="CL"
+                            >
+                              Chile
+                            </option>
+                            <option
+                              value="CN"
+                            >
+                              China
+                            </option>
+                            <option
+                              value="CX"
+                            >
+                              Christmas Island
+                            </option>
+                            <option
+                              value="CO"
+                            >
+                              Colombia
+                            </option>
+                            <option
+                              value="KM"
+                            >
+                              Comoros
+                            </option>
+                            <option
+                              value="CG"
+                            >
+                              Congo
+                            </option>
+                            <option
+                              value="CD"
+                            >
+                              Congo, the Democratic Republic of the
+                            </option>
+                            <option
+                              value="CK"
+                            >
+                              Cook Islands
+                            </option>
+                            <option
+                              value="CR"
+                            >
+                              Costa Rica
+                            </option>
+                            <option
+                              value="HR"
+                            >
+                              Croatia
+                            </option>
+                            <option
+                              value="CU"
+                            >
+                              Cuba
+                            </option>
+                            <option
+                              value="CY"
+                            >
+                              Cyprus
+                            </option>
+                            <option
+                              value="CZ"
+                            >
+                              Czech Republic
+                            </option>
+                            <option
+                              value="CI"
+                            >
+                              Côte d'Ivoire
+                            </option>
+                            <option
+                              value="DK"
+                            >
+                              Denmark
+                            </option>
+                            <option
+                              value="DJ"
+                            >
+                              Djibouti
+                            </option>
+                            <option
+                              value="DM"
+                            >
+                              Dominica
+                            </option>
+                            <option
+                              value="DO"
+                            >
+                              Dominican Republic
+                            </option>
+                            <option
+                              value="EC"
+                            >
+                              Ecuador
+                            </option>
+                            <option
+                              value="EG"
+                            >
+                              Egypt
+                            </option>
+                            <option
+                              value="SV"
+                            >
+                              El Salvador
+                            </option>
+                            <option
+                              value="GQ"
+                            >
+                              Equatorial Guinea
+                            </option>
+                            <option
+                              value="ER"
+                            >
+                              Eritrea
+                            </option>
+                            <option
+                              value="EE"
+                            >
+                              Estonia
+                            </option>
+                            <option
+                              value="ET"
+                            >
+                              Ethiopia
+                            </option>
+                            <option
+                              value="FK"
+                            >
+                              Falkland Islands (Malvinas)
+                            </option>
+                            <option
+                              value="FO"
+                            >
+                              Faroe Islands
+                            </option>
+                            <option
+                              value="FJ"
+                            >
+                              Fiji
+                            </option>
+                            <option
+                              value="FI"
+                            >
+                              Finland
+                            </option>
+                            <option
+                              value="FR"
+                            >
+                              France
+                            </option>
+                            <option
+                              value="GF"
+                            >
+                              French Guiana
+                            </option>
+                            <option
+                              value="PF"
+                            >
+                              French Polynesia
+                            </option>
+                            <option
+                              value="GA"
+                            >
+                              Gabon
+                            </option>
+                            <option
+                              value="GM"
+                            >
+                              Gambia
+                            </option>
+                            <option
+                              value="GE"
+                            >
+                              Georgia
+                            </option>
+                            <option
+                              value="DE"
+                            >
+                              Germany
+                            </option>
+                            <option
+                              value="GH"
+                            >
+                              Ghana
+                            </option>
+                            <option
+                              value="GI"
+                            >
+                              Gibraltar
+                            </option>
+                            <option
+                              value="GR"
+                            >
+                              Greece
+                            </option>
+                            <option
+                              value="GL"
+                            >
+                              Greenland
+                            </option>
+                            <option
+                              value="GD"
+                            >
+                              Grenada
+                            </option>
+                            <option
+                              value="GP"
+                            >
+                              Guadeloupe
+                            </option>
+                            <option
+                              value="GU"
+                            >
+                              Guam
+                            </option>
+                            <option
+                              value="GT"
+                            >
+                              Guatemala
+                            </option>
+                            <option
+                              value="GG"
+                            >
+                              Guernsey
+                            </option>
+                            <option
+                              value="GN"
+                            >
+                              Guinea
+                            </option>
+                            <option
+                              value="GW"
+                            >
+                              Guinea-Bissau
+                            </option>
+                            <option
+                              value="GY"
+                            >
+                              Guyana
+                            </option>
+                            <option
+                              value="HT"
+                            >
+                              Haiti
+                            </option>
+                            <option
+                              value="VA"
+                            >
+                              Holy See (Vatican City State)
+                            </option>
+                            <option
+                              value="HN"
+                            >
+                              Honduras
+                            </option>
+                            <option
+                              value="HK"
+                            >
+                              Hong Kong
+                            </option>
+                            <option
+                              value="HU"
+                            >
+                              Hungary
+                            </option>
+                            <option
+                              value="IS"
+                            >
+                              Iceland
+                            </option>
+                            <option
+                              value="IN"
+                            >
+                              India
+                            </option>
+                            <option
+                              value="ID"
+                            >
+                              Indonesia
+                            </option>
+                            <option
+                              value="IR"
+                            >
+                              Iran, Islamic Republic of
+                            </option>
+                            <option
+                              value="IQ"
+                            >
+                              Iraq
+                            </option>
+                            <option
+                              value="IE"
+                            >
+                              Ireland
+                            </option>
+                            <option
+                              value="IL"
+                            >
+                              Israel
+                            </option>
+                            <option
+                              value="IT"
+                            >
+                              Italy
+                            </option>
+                            <option
+                              value="JM"
+                            >
+                              Jamaica
+                            </option>
+                            <option
+                              value="JP"
+                            >
+                              Japan
+                            </option>
+                            <option
+                              value="JE"
+                            >
+                              Jersey
+                            </option>
+                            <option
+                              value="JO"
+                            >
+                              Jordan
+                            </option>
+                            <option
+                              value="KZ"
+                            >
+                              Kazakhstan
+                            </option>
+                            <option
+                              value="KE"
+                            >
+                              Kenya
+                            </option>
+                            <option
+                              value="KI"
+                            >
+                              Kiribati
+                            </option>
+                            <option
+                              value="KP"
+                            >
+                              Korea, Democratic People's Republic of
+                            </option>
+                            <option
+                              value="KR"
+                            >
+                              Korea, Republic of
+                            </option>
+                            <option
+                              value="XK"
+                            >
+                              Kosovo, Republic of
+                            </option>
+                            <option
+                              value="KW"
+                            >
+                              Kuwait
+                            </option>
+                            <option
+                              value="KG"
+                            >
+                              Kyrgyzstan
+                            </option>
+                            <option
+                              value="LA"
+                            >
+                              Lao People's Democratic Republic
+                            </option>
+                            <option
+                              value="LV"
+                            >
+                              Latvia
+                            </option>
+                            <option
+                              value="LB"
+                            >
+                              Lebanon
+                            </option>
+                            <option
+                              value="LS"
+                            >
+                              Lesotho
+                            </option>
+                            <option
+                              value="LR"
+                            >
+                              Liberia
+                            </option>
+                            <option
+                              value="LY"
+                            >
+                              Libya
+                            </option>
+                            <option
+                              value="LI"
+                            >
+                              Liechtenstein
+                            </option>
+                            <option
+                              value="LT"
+                            >
+                              Lithuania
+                            </option>
+                            <option
+                              value="LU"
+                            >
+                              Luxembourg
+                            </option>
+                            <option
+                              value="MO"
+                            >
+                              Macao
+                            </option>
+                            <option
+                              value="MK"
+                            >
+                              Macedonia, the former Yugoslav Republic of
+                            </option>
+                            <option
+                              value="MG"
+                            >
+                              Madagascar
+                            </option>
+                            <option
+                              value="MW"
+                            >
+                              Malawi
+                            </option>
+                            <option
+                              value="MY"
+                            >
+                              Malaysia
+                            </option>
+                            <option
+                              value="MV"
+                            >
+                              Maldives
+                            </option>
+                            <option
+                              value="ML"
+                            >
+                              Mali
+                            </option>
+                            <option
+                              value="MT"
+                            >
+                              Malta
+                            </option>
+                            <option
+                              value="MH"
+                            >
+                              Marshall Islands
+                            </option>
+                            <option
+                              value="MQ"
+                            >
+                              Martinique
+                            </option>
+                            <option
+                              value="MR"
+                            >
+                              Mauritania
+                            </option>
+                            <option
+                              value="MU"
+                            >
+                              Mauritius
+                            </option>
+                            <option
+                              value="YT"
+                            >
+                              Mayotte
+                            </option>
+                            <option
+                              value="MX"
+                            >
+                              Mexico
+                            </option>
+                            <option
+                              value="FM"
+                            >
+                              Micronesia, Federated States of
+                            </option>
+                            <option
+                              value="MD"
+                            >
+                              Moldova, Republic of
+                            </option>
+                            <option
+                              value="MC"
+                            >
+                              Monaco
+                            </option>
+                            <option
+                              value="MN"
+                            >
+                              Mongolia
+                            </option>
+                            <option
+                              value="ME"
+                            >
+                              Montenegro
+                            </option>
+                            <option
+                              value="MS"
+                            >
+                              Montserrat
+                            </option>
+                            <option
+                              value="MA"
+                            >
+                              Morocco
+                            </option>
+                            <option
+                              value="MZ"
+                            >
+                              Mozambique
+                            </option>
+                            <option
+                              value="MM"
+                            >
+                              Myanmar
+                            </option>
+                            <option
+                              value="NA"
+                            >
+                              Namibia
+                            </option>
+                            <option
+                              value="NR"
+                            >
+                              Nauru
+                            </option>
+                            <option
+                              value="NP"
+                            >
+                              Nepal
+                            </option>
+                            <option
+                              value="NL"
+                            >
+                              Netherlands
+                            </option>
+                            <option
+                              value="AN"
+                            >
+                              Netherlands Antilles
+                            </option>
+                            <option
+                              value="NC"
+                            >
+                              New Caledonia
+                            </option>
+                            <option
+                              value="NZ"
+                            >
+                              New Zealand
+                            </option>
+                            <option
+                              value="NI"
+                            >
+                              Nicaragua
+                            </option>
+                            <option
+                              value="NE"
+                            >
+                              Niger
+                            </option>
+                            <option
+                              value="NG"
+                            >
+                              Nigeria
+                            </option>
+                            <option
+                              value="NU"
+                            >
+                              Niue
+                            </option>
+                            <option
+                              value="NF"
+                            >
+                              Norfolk Island
+                            </option>
+                            <option
+                              value="MP"
+                            >
+                              Northern Mariana Islands
+                            </option>
+                            <option
+                              value="NO"
+                            >
+                              Norway
+                            </option>
+                            <option
+                              value="OM"
+                            >
+                              Oman
+                            </option>
+                            <option
+                              value="PK"
+                            >
+                              Pakistan
+                            </option>
+                            <option
+                              value="PW"
+                            >
+                              Palau
+                            </option>
+                            <option
+                              value="PS"
+                            >
+                              Palestine, State of
+                            </option>
+                            <option
+                              value="PA"
+                            >
+                              Panama
+                            </option>
+                            <option
+                              value="PG"
+                            >
+                              Papua New Guinea
+                            </option>
+                            <option
+                              value="PY"
+                            >
+                              Paraguay
+                            </option>
+                            <option
+                              value="PE"
+                            >
+                              Peru
+                            </option>
+                            <option
+                              value="PH"
+                            >
+                              Philippines
+                            </option>
+                            <option
+                              value="PN"
+                            >
+                              Pitcairn
+                            </option>
+                            <option
+                              value="PL"
+                            >
+                              Poland
+                            </option>
+                            <option
+                              value="PT"
+                            >
+                              Portugal
+                            </option>
+                            <option
+                              value="PR"
+                            >
+                              Puerto Rico
+                            </option>
+                            <option
+                              value="QA"
+                            >
+                              Qatar
+                            </option>
+                            <option
+                              value="RO"
+                            >
+                              Romania
+                            </option>
+                            <option
+                              value="RU"
+                            >
+                              Russian Federation
+                            </option>
+                            <option
+                              value="RW"
+                            >
+                              Rwanda
+                            </option>
+                            <option
+                              value="RE"
+                            >
+                              Réunion
+                            </option>
+                            <option
+                              value="SH"
+                            >
+                              Saint Helena, Ascension and Tristan da Cunha
+                            </option>
+                            <option
+                              value="KN"
+                            >
+                              Saint Kitts and Nevis
+                            </option>
+                            <option
+                              value="LC"
+                            >
+                              Saint Lucia
+                            </option>
+                            <option
+                              value="PM"
+                            >
+                              Saint Pierre and Miquelon
+                            </option>
+                            <option
+                              value="VC"
+                            >
+                              Saint Vincent and the Grenadines
+                            </option>
+                            <option
+                              value="WS"
+                            >
+                              Samoa
+                            </option>
+                            <option
+                              value="SM"
+                            >
+                              San Marino
+                            </option>
+                            <option
+                              value="SA"
+                            >
+                              Saudi Arabia
+                            </option>
+                            <option
+                              value="SN"
+                            >
+                              Senegal
+                            </option>
+                            <option
+                              value="RS"
+                            >
+                              Serbia
+                            </option>
+                            <option
+                              value="SC"
+                            >
+                              Seychelles
+                            </option>
+                            <option
+                              value="SL"
+                            >
+                              Sierra Leone
+                            </option>
+                            <option
+                              value="SG"
+                            >
+                              Singapore
+                            </option>
+                            <option
+                              value="SK"
+                            >
+                              Slovakia
+                            </option>
+                            <option
+                              value="SI"
+                            >
+                              Slovenia
+                            </option>
+                            <option
+                              value="SB"
+                            >
+                              Solomon Islands
+                            </option>
+                            <option
+                              value="SO"
+                            >
+                              Somalia
+                            </option>
+                            <option
+                              value="ZA"
+                            >
+                              South Africa
+                            </option>
+                            <option
+                              value="GS"
+                            >
+                              South Georgia and the South Sandwich Islands
+                            </option>
+                            <option
+                              value="SS"
+                            >
+                              South Sudan
+                            </option>
+                            <option
+                              value="ES"
+                            >
+                              Spain
+                            </option>
+                            <option
+                              value="LK"
+                            >
+                              Sri Lanka
+                            </option>
+                            <option
+                              value="SD"
+                            >
+                              Sudan
+                            </option>
+                            <option
+                              value="SR"
+                            >
+                              Suriname
+                            </option>
+                            <option
+                              value="SJ"
+                            >
+                              Svalbard and Jan Mayen
+                            </option>
+                            <option
+                              value="SZ"
+                            >
+                              Swaziland
+                            </option>
+                            <option
+                              value="SE"
+                            >
+                              Sweden
+                            </option>
+                            <option
+                              value="CH"
+                            >
+                              Switzerland
+                            </option>
+                            <option
+                              value="SY"
+                            >
+                              Syrian Arab Republic
+                            </option>
+                            <option
+                              value="ST"
+                            >
+                              São Tomé and Príncipe
+                            </option>
+                            <option
+                              value="TW"
+                            >
+                              Taiwan
+                            </option>
+                            <option
+                              value="TJ"
+                            >
+                              Tajikistan
+                            </option>
+                            <option
+                              value="TZ"
+                            >
+                              Tanzania, United Republic of
+                            </option>
+                            <option
+                              value="TH"
+                            >
+                              Thailand
+                            </option>
+                            <option
+                              value="TL"
+                            >
+                              Timor-Leste
+                            </option>
+                            <option
+                              value="TG"
+                            >
+                              Togo
+                            </option>
+                            <option
+                              value="TK"
+                            >
+                              Tokelau
+                            </option>
+                            <option
+                              value="TO"
+                            >
+                              Tonga
+                            </option>
+                            <option
+                              value="TT"
+                            >
+                              Trinidad and Tobago
+                            </option>
+                            <option
+                              value="TN"
+                            >
+                              Tunisia
+                            </option>
+                            <option
+                              value="TR"
+                            >
+                              Turkey
+                            </option>
+                            <option
+                              value="TM"
+                            >
+                              Turkmenistan
+                            </option>
+                            <option
+                              value="TC"
+                            >
+                              Turks and Caicos Islands
+                            </option>
+                            <option
+                              value="TV"
+                            >
+                              Tuvalu
+                            </option>
+                            <option
+                              value="UG"
+                            >
+                              Uganda
+                            </option>
+                            <option
+                              value="UA"
+                            >
+                              Ukraine
+                            </option>
+                            <option
+                              value="AE"
+                            >
+                              United Arab Emirates
+                            </option>
+                            <option
+                              value="GB"
+                            >
+                              United Kingdom
+                            </option>
+                            <option
+                              value="US"
+                            >
+                              United States
+                            </option>
+                            <option
+                              value="UM"
+                            >
+                              United States Minor Outlying Islands
+                            </option>
+                            <option
+                              value="UY"
+                            >
+                              Uruguay
+                            </option>
+                            <option
+                              value="UZ"
+                            >
+                              Uzbekistan
+                            </option>
+                            <option
+                              value="VU"
+                            >
+                              Vanuatu
+                            </option>
+                            <option
+                              value="VE"
+                            >
+                              Venezuela, Bolivarian Republic of
+                            </option>
+                            <option
+                              value="VN"
+                            >
+                              Viet Nam
+                            </option>
+                            <option
+                              value="VG"
+                            >
+                              Virgin Islands, British
+                            </option>
+                            <option
+                              value="VI"
+                            >
+                              Virgin Islands, U.S.
+                            </option>
+                            <option
+                              value="WF"
+                            >
+                              Wallis and Futuna
+                            </option>
+                            <option
+                              value="EH"
+                            >
+                              Western Sahara
+                            </option>
+                            <option
+                              value="YE"
+                            >
+                              Yemen
+                            </option>
+                            <option
+                              value="ZM"
+                            >
+                              Zambia
+                            </option>
+                            <option
+                              value="ZW"
+                            >
+                              Zimbabwe
+                            </option>
+                            <option
+                              value="AX"
+                            >
+                              Åland Islands
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
+                          >
+                            <svg
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-17"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <div
+                          class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                        >
+                          <label
+                            class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                            for="phoneNumber"
+                          >
+                            <span
+                              class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                            >
+                              Phone Number
+                            </span>
+                          </label>
+                          <div
+                            class="ods-10aW0m"
+                          >
+                            <input
+                              autocomplete="tel-national"
+                              class="ods-7qBw9I"
+                              data-se="phoneNumber"
+                              id="phoneNumber"
+                              name="phoneNumber"
+                              type="tel"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Make sure you can access the text on your mobile device.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 4`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester3@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                />
                 <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-13"
-                  >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-14"
-                    >
-                      Check your text messages
-                    </h2>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-13"
+                    class="MuiBox-root emotion-12"
                   >
                     <p
                       class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                     >
-                      We sent an SMS to +12165332241 with an Okta Verify setup link. To continue, open the link on your mobile device.
+                      Make sure you can access the text on your mobile device.
                     </p>
                   </div>
                 </div>
@@ -3088,111 +2970,269 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send me the setup link
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
                     tabindex="0"
                     type="button"
                   >
                     Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
                   </button>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-20"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 4`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester3@test.com
+                </span>
               </div>
             </div>
-          </form>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  />
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                      >
+                        Check your text messages
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-14"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        We sent an SMS to +12165332241 with an Okta Verify setup link. To continue, open the link on your mobile device.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-21"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 5`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3200,163 +3240,167 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    More options
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      More options
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <fieldset
+                    class="MuiFormControl-root emotion-15"
+                  >
+                    <label
+                      class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                    >
+                      Which option do you want to try?
+                    </label>
+                    <div
+                      class="MuiFormGroup-root emotion-17"
+                      id="authenticator.channel"
+                      role="radiogroup"
+                    >
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="qrcode"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Scan a QR code
+                        </span>
+                      </label>
+                      <label
+                        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                      >
+                        <span
+                          class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                        >
+                          <input
+                            class="PrivateSwitchBase-input emotion-20"
+                            name="authenticator.channel"
+                            type="radio"
+                            value="email"
+                          />
+                          <span
+                            class="emotion-21"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                              data-testid="RadioButtonUncheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                              />
+                            </svg>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                              data-testid="RadioButtonCheckedIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                        <span
+                          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                        >
+                          Email me a setup link
+                        </span>
+                      </label>
+                    </div>
+                  </fieldset>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Next
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="qrcode"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Scan a QR code
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-34"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-34"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`identify-with-password renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -34,110 +34,46 @@ exports[`identify-with-password renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-7"
-                  >
-                    Sign In
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-9"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                    for="identifier"
-                  >
-                    Username
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-11"
+                    class="MuiBox-root emotion-7"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="username"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-12"
-                      data-se="identifier"
-                      id="identifier"
-                      name="identifier"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-13"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-8"
                     >
-                      <legend
-                        class="emotion-14"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Sign In
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="MuiBox-root emotion-9"
+                    class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                      for="credentials.passcode"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      for="identifier"
                     >
-                      Password
+                      Username
                     </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-19"
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-12"
                     >
                       <input
                         aria-invalid="false"
-                        autocomplete="current-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-20"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="password"
+                        autocomplete="username"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
+                        data-se="identifier"
+                        id="identifier"
+                        name="identifier"
+                        type="text"
                       />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-21"
-                      >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-22"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
                       <fieldset
                         aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-13"
+                        class="MuiOutlinedInput-notchedOutline emotion-14"
                       >
                         <legend
-                          class="emotion-14"
+                          class="emotion-15"
                         >
                           <span
                             class="notranslate"
@@ -149,196 +85,268 @@ exports[`identify-with-password renders form 1`] = `
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-27"
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-28"
+                  <div
+                    class="MuiBox-root emotion-10"
                   >
-                    <input
-                      class="PrivateSwitchBase-input emotion-29"
-                      data-se="rememberMe"
-                      data-se-for-name="rememberMe"
-                      id="rememberMe"
-                      name="rememberMe"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-23"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
+                    <div
+                      class="MuiBox-root emotion-10"
                     >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-31"
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                        for="credentials.passcode"
+                      >
+                        Password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-20"
+                      >
+                        <input
+                          aria-invalid="false"
+                          autocomplete="current-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-21"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-23"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-24"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-14"
+                        >
+                          <legend
+                            class="emotion-15"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-28"
                   >
-                    Keep me signed in
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
+                    <span
+                      class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-29"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input emotion-30"
+                        data-se="rememberMe"
+                        data-se-for-name="rememberMe"
+                        id="rememberMe"
+                        name="rememberMe"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-24"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-32"
+                    >
+                      Keep me signed in
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Sign in
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
-                  data-se="forgot-password"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Sign in
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Forgot password?
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-35"
-                  data-se="enroll"
-                  tabindex="0"
-                  type="button"
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
+                    data-se="forgot-password"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Forgot password?
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Register
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-36"
+                    data-se="enroll"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Register
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`identify-with-password renders the loading state first 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
           <div
             class="MuiBox-root emotion-4"
           >
-            <span
-              aria-label="Loading..."
-              aria-valuetext="Loading..."
-              class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-5"
-              role="progressbar"
-              style="width: 1.14285714rem; height: 1.14285714rem;"
+            <div
+              class="MuiBox-root emotion-5"
             >
-              <svg
-                class="MuiCircularProgress-svg emotion-6"
-                viewBox="22 22 44 44"
+              <span
+                aria-label="Loading..."
+                aria-valuetext="Loading..."
+                class="MuiCircularProgress-root MuiCircularProgress-indeterminate MuiCircularProgress-colorPrimary emotion-6"
+                role="progressbar"
+                style="width: 1.14285714rem; height: 1.14285714rem;"
               >
-                <circle
-                  class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-7"
-                  cx="44"
-                  cy="44"
-                  fill="none"
-                  r="18"
-                  stroke-width="8"
-                />
-              </svg>
-            </span>
+                <svg
+                  class="MuiCircularProgress-svg emotion-7"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate emotion-8"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="18"
+                    stroke-width="8"
+                  />
+                </svg>
+              </span>
+            </div>
           </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`identify-with-password sends correct payload fails client side validation with no inputs 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
           <div
             class="MuiBox-root emotion-4"
           >
             <div
-              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-5"
-              role="alert"
+              class="MuiBox-root emotion-5"
             >
               <div
-                class="MuiAlert-icon emotion-6"
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-6"
+                role="alert"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-7"
-                  data-testid="ErrorOutlineIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <div
+                  class="MuiAlert-icon emotion-7"
                 >
-                  <path
-                    d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                  />
-                </svg>
-              </div>
-              <div
-                class="MuiAlert-message emotion-8"
-              >
-                We found some errors. Please review the form and make corrections.
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-8"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-9"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
               </div>
             </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -346,116 +354,46 @@ exports[`identify-with-password sends correct payload fails client side validati
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Sign In
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-14"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="identifier"
-                  >
-                    Username
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-16"
+                    class="MuiBox-root emotion-12"
                   >
-                    <input
-                      aria-invalid="true"
-                      autocomplete="username"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
-                      data-se="identifier"
-                      id="identifier"
-                      name="identifier"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <legend
-                        class="emotion-19"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Sign In
+                    </h2>
                   </div>
-                  <p
-                    class="MuiFormHelperText-root Mui-error emotion-20"
-                    data-se="identifier-error"
-                  >
-                    This field cannot be left blank
-                  </p>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-14"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-14"
+                    class="MuiBox-root emotion-15"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                      for="credentials.passcode"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      for="identifier"
                     >
-                      Password
+                      Username
                     </label>
                     <div
-                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-25"
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-17"
                     >
                       <input
                         aria-invalid="true"
-                        autocomplete="current-password"
-                        class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-26"
-                        data-se="credentials.passcode"
-                        id="credentials.passcode"
-                        name="credentials.passcode"
-                        type="password"
+                        autocomplete="username"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
+                        data-se="identifier"
+                        id="identifier"
+                        name="identifier"
+                        type="text"
                       />
-                      <div
-                        class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-27"
-                      >
-                        <button
-                          aria-label="toggle password visibility"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-28"
-                          data-mui-internal-clone-element="true"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
-                            data-testid="VisibilityIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                            />
-                          </svg>
-                        </button>
-                      </div>
                       <fieldset
                         aria-hidden="true"
-                        class="MuiOutlinedInput-notchedOutline emotion-18"
+                        class="MuiOutlinedInput-notchedOutline emotion-19"
                       >
                         <legend
-                          class="emotion-19"
+                          class="emotion-20"
                         >
                           <span
                             class="notranslate"
@@ -465,92 +403,166 @@ exports[`identify-with-password sends correct payload fails client side validati
                         </legend>
                       </fieldset>
                     </div>
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-21"
+                      data-se="identifier-error"
+                    >
+                      This field cannot be left blank
+                    </p>
                   </div>
-                  <p
-                    class="MuiFormHelperText-root Mui-error emotion-20"
-                    data-se="credentials.passcode-error"
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-15"
                   >
-                    This field cannot be left blank
-                  </p>
+                    <div
+                      class="MuiBox-root emotion-15"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                        for="credentials.passcode"
+                      >
+                        Password
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-26"
+                      >
+                        <input
+                          aria-invalid="true"
+                          autocomplete="current-password"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="password"
+                        />
+                        <div
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-28"
+                        >
+                          <button
+                            aria-label="toggle password visibility"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-29"
+                            data-mui-internal-clone-element="true"
+                            tabindex="0"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-30"
+                              data-testid="VisibilityIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-19"
+                        >
+                          <legend
+                            class="emotion-20"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                    <p
+                      class="MuiFormHelperText-root Mui-error emotion-21"
+                      data-se="credentials.passcode-error"
+                    >
+                      This field cannot be left blank
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <label
+                    class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-35"
+                  >
+                    <span
+                      class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-36"
+                    >
+                      <input
+                        class="PrivateSwitchBase-input emotion-37"
+                        data-se="rememberMe"
+                        data-se-for-name="rememberMe"
+                        id="rememberMe"
+                        name="rememberMe"
+                        type="checkbox"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-30"
+                        data-testid="CheckBoxOutlineBlankIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-39"
+                    >
+                      Keep me signed in
+                    </span>
+                  </label>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-41"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Sign in
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-43"
+                    data-se="forgot-password"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Forgot password?
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-43"
+                    data-se="enroll"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Register
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-34"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-35"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-36"
-                      data-se="rememberMe"
-                      data-se-for-name="rememberMe"
-                      id="rememberMe"
-                      name="rememberMe"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
-                  >
-                    Keep me signed in
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Sign in
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
-                  data-se="forgot-password"
-                  tabindex="0"
-                  type="button"
-                >
-                  Forgot password?
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-42"
-                  data-se="enroll"
-                  tabindex="0"
-                  type="button"
-                >
-                  Register
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`okta-verify-email-channel-enrollment should render email channel form and send correct payload 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,119 +71,123 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Set up Okta Verify via email link
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                    for="email"
-                  >
-                    Email
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-16"
+                    class="MuiBox-root emotion-12"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="email"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-17"
-                      data-se="email"
-                      id="email"
-                      name="email"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-18"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <legend
-                        class="emotion-19"
-                      >
-                        <span
-                          class="notranslate"
-                        >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                      Set up Okta Verify via email link
+                    </h2>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-4"
                   >
-                    Make sure you can access the email on your mobile device.
-                  </p>
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      for="email"
+                    >
+                      Email
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-17"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="email"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
+                        data-se="email"
+                        id="email"
+                        name="email"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-19"
+                      >
+                        <legend
+                          class="emotion-20"
+                        >
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Make sure you can access the email on your mobile device.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send me the setup link
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -72,130 +72,134 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-12"
-                    role="alert"
-                    title="Update Okta Verify"
+                    class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiAlert-icon emotion-13"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-13"
+                      role="alert"
+                      title="Update Okta Verify"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-14"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-14"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-15"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-16"
+                      >
+                        The device used to set up Okta Verify does not meet your organization’s security requirements because it is not FIPS compliant. Contact your administrator for help.
+                      </div>
                     </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-11"
+                  >
                     <div
-                      class="MuiAlert-message emotion-15"
+                      class="MuiBox-root emotion-19"
                     >
-                      The device used to set up Okta Verify does not meet your organization’s security requirements because it is not FIPS compliant. Contact your administrator for help.
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-20"
+                      >
+                        Set up Okta Verify
+                      </h2>
                     </div>
                   </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-10"
-                >
                   <div
-                    class="MuiBox-root emotion-18"
+                    class="MuiBox-root emotion-11"
                   >
-                    <h2
-                      class="MuiTypography-root MuiTypography-h3 emotion-19"
+                    <div
+                      class="MuiBox-root emotion-22"
                     >
-                      Set up Okta Verify
-                    </h2>
+                      <ol
+                        class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                      >
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          Open the app and follow the instructions to add your account
+                        </li>
+                        <li
+                          class="ods-5vIIsH"
+                        >
+                          When prompted, tap Scan a QR code, then scan the QR code below:
+                        </li>
+                      </ol>
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
                   <div
-                    class="MuiBox-root emotion-21"
+                    class="MuiBox-root emotion-11"
                   >
-                    <ol
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                    <div
+                      class="qrContainer MuiBox-root emotion-4"
                     >
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        Open the app and follow the instructions to add your account
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        When prompted, tap Scan a QR code, then scan the QR code below:
-                      </li>
-                    </ol>
+                      <img
+                        alt=""
+                        class="qrImg"
+                        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAe1BMVEX+/v4AAAD///90dHS9vb3Ozs6ZmZmJiYkeHh6dnZ1bW1tQUFBgYGDq6ur5+fnz8/OSkpJ9fX3ExMRqamrU1NRERES3t7cwMDClpaXb29vk5OSsrKzY2NgPDw/t7e1vb28mJiY+Pj55eXkXFxdKSko5OTlUVFQrKyuFhYX3xPd8AAAGcklEQVR4nO2d2XraMBBGicIW9kDCYiCQlBLe/wnbxjPKx4hBsiwToP+5I5Y0PtBqt1yrAQAAAAAAAAAAAAAAADiPiad4CcliFhGcbx7jmLzk4cxiEppjSDnqsTE30+KKZvMQS53utxGco085nqJjNiMMH6OjwdAFhn5gCMNi3JrhrhXIaO0zfKSUPZ/hbBQac5bAsBXcrWj7DBeUsO4z7AXH5C+rnGFoDq8hd3amPsNOcEwYnssLQzcHDK/e0Dc0CzHMCTf0xkxqONAwqmE7h0UaeRk1a8jXNUPjjZnQ0AzkF8+8K4bfP4CWcyZ+EtdQy/lwUcOuZmiL0g1FQhjCEIYwhGGE4b21FvV+9o/+nD6v990v3t+0Fv/WDFdFe203Z1i45w1DGMIQhj5DZ/R0b4am/zQ/4olFFnTBTnHfqqGdxXDmHghb5O0bKiGGMIQhDGEYaLgLNpTDwWszfO+eZPcYamjy4WGW8XBw+O4bH54O+TdoBYZndmRxDq9hTy2ydtrwwrP63hxewwl9Hmn/MW927QmGtgQYujlgeC7v/2M40psJQWFDtbUI308zSWC4bofyUNDwb59GWQMOj7lOYFicAobEze/cgyEMYQhDxXDiLzbYkOBHOJr02ZlNbEbH1DoR5wxf6rH0pSHt+B39ps9d3uFLGaa0xcksomMuihuWfwbJv897K3Jc9rmn8vgN5U6FWwOGMLx+rt4wuNqKr0tnbtbQqjJBXWoWDYXBcWlmIBO8yfZQY7vSYihFfgeVCbKUfRpRmMlkguLPPXkZi5jOdH9Mn0btl16lYdKeNwxhCEMYVm/YF21tXyaYpjdsiM5EUkNnzvtVFP5auE/TdHIQvHnYznnLnBs5W55izluuW5iuiNpVCtcNg9ctHMNneTNVrMzAEIYwhGE6Q66HDz7DfeHWQltWdldIZc4PMeAtZZi95MixpWPY3kyO6DVki794OUYbrlrDLRVpzzmar74yrqYchL/FEoZyE5pu6KDvEVaKdAwdxpRR3WYVY6iaRxiGFn3GME8whiEMYXhfhinrUl8Ivl91hVStSzvxhqYxzXnR2sPe6DStVaChGSzzEEteIR23jouyxq06peQrbEh/aI0jDL19mqU2jnX6NJqhXMd35+rlbyn7NOq/tBBDb7907ik1wtBJIQ1lv7QMMIQhDGvXZChwDLUq1RlbnDFUUA3jq1DX8DAYHjFwDIenGdgOCKdwDNezL35lWhEz4pcwNMPTRUYZqpChO6uv4nQemJmWgxO0jg2/f9xV/K94CUMbS06jW2oU46AZxuz2giEMYQjDyxl69wg/RRvKIY9uyAnZ8CC7AmVai2HfAx2GXxso19/sYbpcFA90679fv7CT96phnu51t6XP7R39RRQZp+jFl1I7NcKe/PHpNVRxbuInUHve1nBWwvDyPi4whCEMy99gPI6hgJsRu0d4F21Yok419adImtTPMP35Mkem4IXP9jz/PP+kPzxSBv/TQbbhoZiNiBnh0u+Z8Z8j7MCTzP5ukpzVT7pH2Evw2ZcOS/r1F96UCVZmYHgGGOrA8JvrMIyvS8MNy6yQsuGs1wmjJ98zM1zkZF1KsBW3uaaiezzh28zyHOO9KJonVD8px54NW3nK/bKEYYpzMQjZxKp9GmcjmTPGt7dZok9T4dkm34Z0QfZL5dkmcp4mCTA8kQOGMIRh1YZ6K+E3LNpaOKcoifVDZzdVCsP4s6AL9Gm8VLJuUcKQv+f7NeSiYAhDGMLwlgyTrpBWaLhpjMNwnit6P+Q8U4L68DoNwwfVWswUK6TVGobehG4YbwZDGMLwrgzVGlE1jKhL4+vUBO9GeONW7eP5iI+pcj8m87WHFtmixpyiVMV7Zjxf+IVPhqz+/RZuzJ85vxSGMIThfRhqVai4cK2GAW/SURRl8/GzhmXmvBmxz1t/htQ5eoo5+G6ijKE/R3lDvqCu41/rygwMYQjDOP4jwwT7aZiFaP7U1kLdX+oYpmgtZr1AJnJPlGPYzRN27AamVb4FasUP00w7eYpn2hvFZBvF0LTyHB1tUB1iWBzv2Zd2uKr1aTryn4e2jp9kX1uVhjKm9r4n3fBH9ybCEIYwLG1Y+nmLiFMFeTZxL0We6cKHVpfGzCZOm5GM+JmZbKSk0I48Mg3KIXf8mjrldBYM6C5HEc/MJHjnizeBHrP8BQAAAAAAAAAAAAAAAACCP5IF57xc3OReAAAAAElFTkSuQmCC"
+                      />
+                    </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-10"
-                >
                   <div
-                    class="qrContainer MuiBox-root emotion-3"
+                    class="MuiBox-root emotion-11"
                   >
-                    <img
-                      alt=""
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAe1BMVEX+/v4AAAD///90dHS9vb3Ozs6ZmZmJiYkeHh6dnZ1bW1tQUFBgYGDq6ur5+fnz8/OSkpJ9fX3ExMRqamrU1NRERES3t7cwMDClpaXb29vk5OSsrKzY2NgPDw/t7e1vb28mJiY+Pj55eXkXFxdKSko5OTlUVFQrKyuFhYX3xPd8AAAGcklEQVR4nO2d2XraMBBGicIW9kDCYiCQlBLe/wnbxjPKx4hBsiwToP+5I5Y0PtBqt1yrAQAAAAAAAAAAAAAAADiPiad4CcliFhGcbx7jmLzk4cxiEppjSDnqsTE30+KKZvMQS53utxGco085nqJjNiMMH6OjwdAFhn5gCMNi3JrhrhXIaO0zfKSUPZ/hbBQac5bAsBXcrWj7DBeUsO4z7AXH5C+rnGFoDq8hd3amPsNOcEwYnssLQzcHDK/e0Dc0CzHMCTf0xkxqONAwqmE7h0UaeRk1a8jXNUPjjZnQ0AzkF8+8K4bfP4CWcyZ+EtdQy/lwUcOuZmiL0g1FQhjCEIYwhGGE4b21FvV+9o/+nD6v990v3t+0Fv/WDFdFe203Z1i45w1DGMIQhj5DZ/R0b4am/zQ/4olFFnTBTnHfqqGdxXDmHghb5O0bKiGGMIQhDGEYaLgLNpTDwWszfO+eZPcYamjy4WGW8XBw+O4bH54O+TdoBYZndmRxDq9hTy2ydtrwwrP63hxewwl9Hmn/MW927QmGtgQYujlgeC7v/2M40psJQWFDtbUI308zSWC4bofyUNDwb59GWQMOj7lOYFicAobEze/cgyEMYQhDxXDiLzbYkOBHOJr02ZlNbEbH1DoR5wxf6rH0pSHt+B39ps9d3uFLGaa0xcksomMuihuWfwbJv897K3Jc9rmn8vgN5U6FWwOGMLx+rt4wuNqKr0tnbtbQqjJBXWoWDYXBcWlmIBO8yfZQY7vSYihFfgeVCbKUfRpRmMlkguLPPXkZi5jOdH9Mn0btl16lYdKeNwxhCEMYVm/YF21tXyaYpjdsiM5EUkNnzvtVFP5auE/TdHIQvHnYznnLnBs5W55izluuW5iuiNpVCtcNg9ctHMNneTNVrMzAEIYwhGE6Q66HDz7DfeHWQltWdldIZc4PMeAtZZi95MixpWPY3kyO6DVki794OUYbrlrDLRVpzzmar74yrqYchL/FEoZyE5pu6KDvEVaKdAwdxpRR3WYVY6iaRxiGFn3GME8whiEMYXhfhinrUl8Ivl91hVStSzvxhqYxzXnR2sPe6DStVaChGSzzEEteIR23jouyxq06peQrbEh/aI0jDL19mqU2jnX6NJqhXMd35+rlbyn7NOq/tBBDb7907ik1wtBJIQ1lv7QMMIQhDGvXZChwDLUq1RlbnDFUUA3jq1DX8DAYHjFwDIenGdgOCKdwDNezL35lWhEz4pcwNMPTRUYZqpChO6uv4nQemJmWgxO0jg2/f9xV/K94CUMbS06jW2oU46AZxuz2giEMYQjDyxl69wg/RRvKIY9uyAnZ8CC7AmVai2HfAx2GXxso19/sYbpcFA90679fv7CT96phnu51t6XP7R39RRQZp+jFl1I7NcKe/PHpNVRxbuInUHve1nBWwvDyPi4whCEMy99gPI6hgJsRu0d4F21Yok419adImtTPMP35Mkem4IXP9jz/PP+kPzxSBv/TQbbhoZiNiBnh0u+Z8Z8j7MCTzP5ukpzVT7pH2Evw2ZcOS/r1F96UCVZmYHgGGOrA8JvrMIyvS8MNy6yQsuGs1wmjJ98zM1zkZF1KsBW3uaaiezzh28zyHOO9KJonVD8px54NW3nK/bKEYYpzMQjZxKp9GmcjmTPGt7dZok9T4dkm34Z0QfZL5dkmcp4mCTA8kQOGMIRh1YZ6K+E3LNpaOKcoifVDZzdVCsP4s6AL9Gm8VLJuUcKQv+f7NeSiYAhDGMLwlgyTrpBWaLhpjMNwnit6P+Q8U4L68DoNwwfVWswUK6TVGobehG4YbwZDGMLwrgzVGlE1jKhL4+vUBO9GeONW7eP5iI+pcj8m87WHFtmixpyiVMV7Zjxf+IVPhqz+/RZuzJ85vxSGMIThfRhqVai4cK2GAW/SURRl8/GzhmXmvBmxz1t/htQ5eoo5+G6ijKE/R3lDvqCu41/rygwMYQjDOP4jwwT7aZiFaP7U1kLdX+oYpmgtZr1AJnJPlGPYzRN27AamVb4FasUP00w7eYpn2hvFZBvF0LTyHB1tUB1iWBzv2Zd2uKr1aTryn4e2jp9kX1uVhjKm9r4n3fBH9ybCEIYwLG1Y+nmLiFMFeTZxL0We6cKHVpfGzCZOm5GM+JmZbKSk0I48Mg3KIXf8mjrldBYM6C5HEc/MJHjnizeBHrP8BQAAAAAAAAAAAAAAAACCP5IF57xc3OReAAAAAElFTkSuQmCC"
-                    />
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Can't scan?
+                    </button>
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="switchAuthenticator"
                     tabindex="0"
                     type="button"
                   >
-                    Can't scan?
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
                   </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`okta-verify-sms-channel-enrollment should render sms channel form and send correct payload 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester2@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,1372 +71,1376 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up Okta Verify via SMS
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up Okta Verify via SMS
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-11"
                 >
                   <div
-                    class="MuiBox-root emotion-10"
+                    class="MuiBox-root emotion-4"
                   >
                     <div
-                      class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
-                    >
-                      <label
-                        class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                        for="countryList"
-                      >
-                        <span
-                          class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                        >
-                          Country
-                        </span>
-                      </label>
-                      <div
-                        class="ods-mUkyrD"
-                      >
-                        <select
-                          autocomplete="tel-country-code"
-                          class="ods-1B2Zfy"
-                          data-se="countryList"
-                          id="countryList"
-                        >
-                          <option
-                            value="AF"
-                          >
-                            Afghanistan
-                          </option>
-                          <option
-                            value="AL"
-                          >
-                            Albania
-                          </option>
-                          <option
-                            value="DZ"
-                          >
-                            Algeria
-                          </option>
-                          <option
-                            value="AS"
-                          >
-                            American Samoa
-                          </option>
-                          <option
-                            value="AD"
-                          >
-                            Andorra
-                          </option>
-                          <option
-                            value="AO"
-                          >
-                            Angola
-                          </option>
-                          <option
-                            value="AI"
-                          >
-                            Anguilla
-                          </option>
-                          <option
-                            value="AQ"
-                          >
-                            Antarctica
-                          </option>
-                          <option
-                            value="AG"
-                          >
-                            Antigua and Barbuda
-                          </option>
-                          <option
-                            value="AR"
-                          >
-                            Argentina
-                          </option>
-                          <option
-                            value="AM"
-                          >
-                            Armenia
-                          </option>
-                          <option
-                            value="AW"
-                          >
-                            Aruba
-                          </option>
-                          <option
-                            value="AU"
-                          >
-                            Australia
-                          </option>
-                          <option
-                            value="AT"
-                          >
-                            Austria
-                          </option>
-                          <option
-                            value="AZ"
-                          >
-                            Azerbaijan
-                          </option>
-                          <option
-                            value="BS"
-                          >
-                            Bahamas
-                          </option>
-                          <option
-                            value="BH"
-                          >
-                            Bahrain
-                          </option>
-                          <option
-                            value="BD"
-                          >
-                            Bangladesh
-                          </option>
-                          <option
-                            value="BB"
-                          >
-                            Barbados
-                          </option>
-                          <option
-                            value="BY"
-                          >
-                            Belarus
-                          </option>
-                          <option
-                            value="BE"
-                          >
-                            Belgium
-                          </option>
-                          <option
-                            value="BZ"
-                          >
-                            Belize
-                          </option>
-                          <option
-                            value="BJ"
-                          >
-                            Benin
-                          </option>
-                          <option
-                            value="BM"
-                          >
-                            Bermuda
-                          </option>
-                          <option
-                            value="BT"
-                          >
-                            Bhutan
-                          </option>
-                          <option
-                            value="BO"
-                          >
-                            Bolivia, Plurinational State of
-                          </option>
-                          <option
-                            value="BA"
-                          >
-                            Bosnia and Herzegovina
-                          </option>
-                          <option
-                            value="BW"
-                          >
-                            Botswana
-                          </option>
-                          <option
-                            value="BR"
-                          >
-                            Brazil
-                          </option>
-                          <option
-                            value="IO"
-                          >
-                            British Indian Ocean Territory
-                          </option>
-                          <option
-                            value="BN"
-                          >
-                            Brunei Darussalam
-                          </option>
-                          <option
-                            value="BG"
-                          >
-                            Bulgaria
-                          </option>
-                          <option
-                            value="BF"
-                          >
-                            Burkina Faso
-                          </option>
-                          <option
-                            value="BI"
-                          >
-                            Burundi
-                          </option>
-                          <option
-                            value="KH"
-                          >
-                            Cambodia
-                          </option>
-                          <option
-                            value="CM"
-                          >
-                            Cameroon
-                          </option>
-                          <option
-                            value="CA"
-                          >
-                            Canada
-                          </option>
-                          <option
-                            value="CV"
-                          >
-                            Cape Verde
-                          </option>
-                          <option
-                            value="KY"
-                          >
-                            Cayman Islands
-                          </option>
-                          <option
-                            value="CF"
-                          >
-                            Central African Republic
-                          </option>
-                          <option
-                            value="TD"
-                          >
-                            Chad
-                          </option>
-                          <option
-                            value="CL"
-                          >
-                            Chile
-                          </option>
-                          <option
-                            value="CN"
-                          >
-                            China
-                          </option>
-                          <option
-                            value="CX"
-                          >
-                            Christmas Island
-                          </option>
-                          <option
-                            value="CO"
-                          >
-                            Colombia
-                          </option>
-                          <option
-                            value="KM"
-                          >
-                            Comoros
-                          </option>
-                          <option
-                            value="CG"
-                          >
-                            Congo
-                          </option>
-                          <option
-                            value="CD"
-                          >
-                            Congo, the Democratic Republic of the
-                          </option>
-                          <option
-                            value="CK"
-                          >
-                            Cook Islands
-                          </option>
-                          <option
-                            value="CR"
-                          >
-                            Costa Rica
-                          </option>
-                          <option
-                            value="HR"
-                          >
-                            Croatia
-                          </option>
-                          <option
-                            value="CU"
-                          >
-                            Cuba
-                          </option>
-                          <option
-                            value="CY"
-                          >
-                            Cyprus
-                          </option>
-                          <option
-                            value="CZ"
-                          >
-                            Czech Republic
-                          </option>
-                          <option
-                            value="CI"
-                          >
-                            Côte d'Ivoire
-                          </option>
-                          <option
-                            value="DK"
-                          >
-                            Denmark
-                          </option>
-                          <option
-                            value="DJ"
-                          >
-                            Djibouti
-                          </option>
-                          <option
-                            value="DM"
-                          >
-                            Dominica
-                          </option>
-                          <option
-                            value="DO"
-                          >
-                            Dominican Republic
-                          </option>
-                          <option
-                            value="EC"
-                          >
-                            Ecuador
-                          </option>
-                          <option
-                            value="EG"
-                          >
-                            Egypt
-                          </option>
-                          <option
-                            value="SV"
-                          >
-                            El Salvador
-                          </option>
-                          <option
-                            value="GQ"
-                          >
-                            Equatorial Guinea
-                          </option>
-                          <option
-                            value="ER"
-                          >
-                            Eritrea
-                          </option>
-                          <option
-                            value="EE"
-                          >
-                            Estonia
-                          </option>
-                          <option
-                            value="ET"
-                          >
-                            Ethiopia
-                          </option>
-                          <option
-                            value="FK"
-                          >
-                            Falkland Islands (Malvinas)
-                          </option>
-                          <option
-                            value="FO"
-                          >
-                            Faroe Islands
-                          </option>
-                          <option
-                            value="FJ"
-                          >
-                            Fiji
-                          </option>
-                          <option
-                            value="FI"
-                          >
-                            Finland
-                          </option>
-                          <option
-                            value="FR"
-                          >
-                            France
-                          </option>
-                          <option
-                            value="GF"
-                          >
-                            French Guiana
-                          </option>
-                          <option
-                            value="PF"
-                          >
-                            French Polynesia
-                          </option>
-                          <option
-                            value="GA"
-                          >
-                            Gabon
-                          </option>
-                          <option
-                            value="GM"
-                          >
-                            Gambia
-                          </option>
-                          <option
-                            value="GE"
-                          >
-                            Georgia
-                          </option>
-                          <option
-                            value="DE"
-                          >
-                            Germany
-                          </option>
-                          <option
-                            value="GH"
-                          >
-                            Ghana
-                          </option>
-                          <option
-                            value="GI"
-                          >
-                            Gibraltar
-                          </option>
-                          <option
-                            value="GR"
-                          >
-                            Greece
-                          </option>
-                          <option
-                            value="GL"
-                          >
-                            Greenland
-                          </option>
-                          <option
-                            value="GD"
-                          >
-                            Grenada
-                          </option>
-                          <option
-                            value="GP"
-                          >
-                            Guadeloupe
-                          </option>
-                          <option
-                            value="GU"
-                          >
-                            Guam
-                          </option>
-                          <option
-                            value="GT"
-                          >
-                            Guatemala
-                          </option>
-                          <option
-                            value="GG"
-                          >
-                            Guernsey
-                          </option>
-                          <option
-                            value="GN"
-                          >
-                            Guinea
-                          </option>
-                          <option
-                            value="GW"
-                          >
-                            Guinea-Bissau
-                          </option>
-                          <option
-                            value="GY"
-                          >
-                            Guyana
-                          </option>
-                          <option
-                            value="HT"
-                          >
-                            Haiti
-                          </option>
-                          <option
-                            value="VA"
-                          >
-                            Holy See (Vatican City State)
-                          </option>
-                          <option
-                            value="HN"
-                          >
-                            Honduras
-                          </option>
-                          <option
-                            value="HK"
-                          >
-                            Hong Kong
-                          </option>
-                          <option
-                            value="HU"
-                          >
-                            Hungary
-                          </option>
-                          <option
-                            value="IS"
-                          >
-                            Iceland
-                          </option>
-                          <option
-                            value="IN"
-                          >
-                            India
-                          </option>
-                          <option
-                            value="ID"
-                          >
-                            Indonesia
-                          </option>
-                          <option
-                            value="IR"
-                          >
-                            Iran, Islamic Republic of
-                          </option>
-                          <option
-                            value="IQ"
-                          >
-                            Iraq
-                          </option>
-                          <option
-                            value="IE"
-                          >
-                            Ireland
-                          </option>
-                          <option
-                            value="IL"
-                          >
-                            Israel
-                          </option>
-                          <option
-                            value="IT"
-                          >
-                            Italy
-                          </option>
-                          <option
-                            value="JM"
-                          >
-                            Jamaica
-                          </option>
-                          <option
-                            value="JP"
-                          >
-                            Japan
-                          </option>
-                          <option
-                            value="JE"
-                          >
-                            Jersey
-                          </option>
-                          <option
-                            value="JO"
-                          >
-                            Jordan
-                          </option>
-                          <option
-                            value="KZ"
-                          >
-                            Kazakhstan
-                          </option>
-                          <option
-                            value="KE"
-                          >
-                            Kenya
-                          </option>
-                          <option
-                            value="KI"
-                          >
-                            Kiribati
-                          </option>
-                          <option
-                            value="KP"
-                          >
-                            Korea, Democratic People's Republic of
-                          </option>
-                          <option
-                            value="KR"
-                          >
-                            Korea, Republic of
-                          </option>
-                          <option
-                            value="XK"
-                          >
-                            Kosovo, Republic of
-                          </option>
-                          <option
-                            value="KW"
-                          >
-                            Kuwait
-                          </option>
-                          <option
-                            value="KG"
-                          >
-                            Kyrgyzstan
-                          </option>
-                          <option
-                            value="LA"
-                          >
-                            Lao People's Democratic Republic
-                          </option>
-                          <option
-                            value="LV"
-                          >
-                            Latvia
-                          </option>
-                          <option
-                            value="LB"
-                          >
-                            Lebanon
-                          </option>
-                          <option
-                            value="LS"
-                          >
-                            Lesotho
-                          </option>
-                          <option
-                            value="LR"
-                          >
-                            Liberia
-                          </option>
-                          <option
-                            value="LY"
-                          >
-                            Libya
-                          </option>
-                          <option
-                            value="LI"
-                          >
-                            Liechtenstein
-                          </option>
-                          <option
-                            value="LT"
-                          >
-                            Lithuania
-                          </option>
-                          <option
-                            value="LU"
-                          >
-                            Luxembourg
-                          </option>
-                          <option
-                            value="MO"
-                          >
-                            Macao
-                          </option>
-                          <option
-                            value="MK"
-                          >
-                            Macedonia, the former Yugoslav Republic of
-                          </option>
-                          <option
-                            value="MG"
-                          >
-                            Madagascar
-                          </option>
-                          <option
-                            value="MW"
-                          >
-                            Malawi
-                          </option>
-                          <option
-                            value="MY"
-                          >
-                            Malaysia
-                          </option>
-                          <option
-                            value="MV"
-                          >
-                            Maldives
-                          </option>
-                          <option
-                            value="ML"
-                          >
-                            Mali
-                          </option>
-                          <option
-                            value="MT"
-                          >
-                            Malta
-                          </option>
-                          <option
-                            value="MH"
-                          >
-                            Marshall Islands
-                          </option>
-                          <option
-                            value="MQ"
-                          >
-                            Martinique
-                          </option>
-                          <option
-                            value="MR"
-                          >
-                            Mauritania
-                          </option>
-                          <option
-                            value="MU"
-                          >
-                            Mauritius
-                          </option>
-                          <option
-                            value="YT"
-                          >
-                            Mayotte
-                          </option>
-                          <option
-                            value="MX"
-                          >
-                            Mexico
-                          </option>
-                          <option
-                            value="FM"
-                          >
-                            Micronesia, Federated States of
-                          </option>
-                          <option
-                            value="MD"
-                          >
-                            Moldova, Republic of
-                          </option>
-                          <option
-                            value="MC"
-                          >
-                            Monaco
-                          </option>
-                          <option
-                            value="MN"
-                          >
-                            Mongolia
-                          </option>
-                          <option
-                            value="ME"
-                          >
-                            Montenegro
-                          </option>
-                          <option
-                            value="MS"
-                          >
-                            Montserrat
-                          </option>
-                          <option
-                            value="MA"
-                          >
-                            Morocco
-                          </option>
-                          <option
-                            value="MZ"
-                          >
-                            Mozambique
-                          </option>
-                          <option
-                            value="MM"
-                          >
-                            Myanmar
-                          </option>
-                          <option
-                            value="NA"
-                          >
-                            Namibia
-                          </option>
-                          <option
-                            value="NR"
-                          >
-                            Nauru
-                          </option>
-                          <option
-                            value="NP"
-                          >
-                            Nepal
-                          </option>
-                          <option
-                            value="NL"
-                          >
-                            Netherlands
-                          </option>
-                          <option
-                            value="AN"
-                          >
-                            Netherlands Antilles
-                          </option>
-                          <option
-                            value="NC"
-                          >
-                            New Caledonia
-                          </option>
-                          <option
-                            value="NZ"
-                          >
-                            New Zealand
-                          </option>
-                          <option
-                            value="NI"
-                          >
-                            Nicaragua
-                          </option>
-                          <option
-                            value="NE"
-                          >
-                            Niger
-                          </option>
-                          <option
-                            value="NG"
-                          >
-                            Nigeria
-                          </option>
-                          <option
-                            value="NU"
-                          >
-                            Niue
-                          </option>
-                          <option
-                            value="NF"
-                          >
-                            Norfolk Island
-                          </option>
-                          <option
-                            value="MP"
-                          >
-                            Northern Mariana Islands
-                          </option>
-                          <option
-                            value="NO"
-                          >
-                            Norway
-                          </option>
-                          <option
-                            value="OM"
-                          >
-                            Oman
-                          </option>
-                          <option
-                            value="PK"
-                          >
-                            Pakistan
-                          </option>
-                          <option
-                            value="PW"
-                          >
-                            Palau
-                          </option>
-                          <option
-                            value="PS"
-                          >
-                            Palestine, State of
-                          </option>
-                          <option
-                            value="PA"
-                          >
-                            Panama
-                          </option>
-                          <option
-                            value="PG"
-                          >
-                            Papua New Guinea
-                          </option>
-                          <option
-                            value="PY"
-                          >
-                            Paraguay
-                          </option>
-                          <option
-                            value="PE"
-                          >
-                            Peru
-                          </option>
-                          <option
-                            value="PH"
-                          >
-                            Philippines
-                          </option>
-                          <option
-                            value="PN"
-                          >
-                            Pitcairn
-                          </option>
-                          <option
-                            value="PL"
-                          >
-                            Poland
-                          </option>
-                          <option
-                            value="PT"
-                          >
-                            Portugal
-                          </option>
-                          <option
-                            value="PR"
-                          >
-                            Puerto Rico
-                          </option>
-                          <option
-                            value="QA"
-                          >
-                            Qatar
-                          </option>
-                          <option
-                            value="RO"
-                          >
-                            Romania
-                          </option>
-                          <option
-                            value="RU"
-                          >
-                            Russian Federation
-                          </option>
-                          <option
-                            value="RW"
-                          >
-                            Rwanda
-                          </option>
-                          <option
-                            value="RE"
-                          >
-                            Réunion
-                          </option>
-                          <option
-                            value="SH"
-                          >
-                            Saint Helena, Ascension and Tristan da Cunha
-                          </option>
-                          <option
-                            value="KN"
-                          >
-                            Saint Kitts and Nevis
-                          </option>
-                          <option
-                            value="LC"
-                          >
-                            Saint Lucia
-                          </option>
-                          <option
-                            value="PM"
-                          >
-                            Saint Pierre and Miquelon
-                          </option>
-                          <option
-                            value="VC"
-                          >
-                            Saint Vincent and the Grenadines
-                          </option>
-                          <option
-                            value="WS"
-                          >
-                            Samoa
-                          </option>
-                          <option
-                            value="SM"
-                          >
-                            San Marino
-                          </option>
-                          <option
-                            value="SA"
-                          >
-                            Saudi Arabia
-                          </option>
-                          <option
-                            value="SN"
-                          >
-                            Senegal
-                          </option>
-                          <option
-                            value="RS"
-                          >
-                            Serbia
-                          </option>
-                          <option
-                            value="SC"
-                          >
-                            Seychelles
-                          </option>
-                          <option
-                            value="SL"
-                          >
-                            Sierra Leone
-                          </option>
-                          <option
-                            value="SG"
-                          >
-                            Singapore
-                          </option>
-                          <option
-                            value="SK"
-                          >
-                            Slovakia
-                          </option>
-                          <option
-                            value="SI"
-                          >
-                            Slovenia
-                          </option>
-                          <option
-                            value="SB"
-                          >
-                            Solomon Islands
-                          </option>
-                          <option
-                            value="SO"
-                          >
-                            Somalia
-                          </option>
-                          <option
-                            value="ZA"
-                          >
-                            South Africa
-                          </option>
-                          <option
-                            value="GS"
-                          >
-                            South Georgia and the South Sandwich Islands
-                          </option>
-                          <option
-                            value="SS"
-                          >
-                            South Sudan
-                          </option>
-                          <option
-                            value="ES"
-                          >
-                            Spain
-                          </option>
-                          <option
-                            value="LK"
-                          >
-                            Sri Lanka
-                          </option>
-                          <option
-                            value="SD"
-                          >
-                            Sudan
-                          </option>
-                          <option
-                            value="SR"
-                          >
-                            Suriname
-                          </option>
-                          <option
-                            value="SJ"
-                          >
-                            Svalbard and Jan Mayen
-                          </option>
-                          <option
-                            value="SZ"
-                          >
-                            Swaziland
-                          </option>
-                          <option
-                            value="SE"
-                          >
-                            Sweden
-                          </option>
-                          <option
-                            value="CH"
-                          >
-                            Switzerland
-                          </option>
-                          <option
-                            value="SY"
-                          >
-                            Syrian Arab Republic
-                          </option>
-                          <option
-                            value="ST"
-                          >
-                            São Tomé and Príncipe
-                          </option>
-                          <option
-                            value="TW"
-                          >
-                            Taiwan
-                          </option>
-                          <option
-                            value="TJ"
-                          >
-                            Tajikistan
-                          </option>
-                          <option
-                            value="TZ"
-                          >
-                            Tanzania, United Republic of
-                          </option>
-                          <option
-                            value="TH"
-                          >
-                            Thailand
-                          </option>
-                          <option
-                            value="TL"
-                          >
-                            Timor-Leste
-                          </option>
-                          <option
-                            value="TG"
-                          >
-                            Togo
-                          </option>
-                          <option
-                            value="TK"
-                          >
-                            Tokelau
-                          </option>
-                          <option
-                            value="TO"
-                          >
-                            Tonga
-                          </option>
-                          <option
-                            value="TT"
-                          >
-                            Trinidad and Tobago
-                          </option>
-                          <option
-                            value="TN"
-                          >
-                            Tunisia
-                          </option>
-                          <option
-                            value="TR"
-                          >
-                            Turkey
-                          </option>
-                          <option
-                            value="TM"
-                          >
-                            Turkmenistan
-                          </option>
-                          <option
-                            value="TC"
-                          >
-                            Turks and Caicos Islands
-                          </option>
-                          <option
-                            value="TV"
-                          >
-                            Tuvalu
-                          </option>
-                          <option
-                            value="UG"
-                          >
-                            Uganda
-                          </option>
-                          <option
-                            value="UA"
-                          >
-                            Ukraine
-                          </option>
-                          <option
-                            value="AE"
-                          >
-                            United Arab Emirates
-                          </option>
-                          <option
-                            value="GB"
-                          >
-                            United Kingdom
-                          </option>
-                          <option
-                            value="US"
-                          >
-                            United States
-                          </option>
-                          <option
-                            value="UM"
-                          >
-                            United States Minor Outlying Islands
-                          </option>
-                          <option
-                            value="UY"
-                          >
-                            Uruguay
-                          </option>
-                          <option
-                            value="UZ"
-                          >
-                            Uzbekistan
-                          </option>
-                          <option
-                            value="VU"
-                          >
-                            Vanuatu
-                          </option>
-                          <option
-                            value="VE"
-                          >
-                            Venezuela, Bolivarian Republic of
-                          </option>
-                          <option
-                            value="VN"
-                          >
-                            Viet Nam
-                          </option>
-                          <option
-                            value="VG"
-                          >
-                            Virgin Islands, British
-                          </option>
-                          <option
-                            value="VI"
-                          >
-                            Virgin Islands, U.S.
-                          </option>
-                          <option
-                            value="WF"
-                          >
-                            Wallis and Futuna
-                          </option>
-                          <option
-                            value="EH"
-                          >
-                            Western Sahara
-                          </option>
-                          <option
-                            value="YE"
-                          >
-                            Yemen
-                          </option>
-                          <option
-                            value="ZM"
-                          >
-                            Zambia
-                          </option>
-                          <option
-                            value="ZW"
-                          >
-                            Zimbabwe
-                          </option>
-                          <option
-                            value="AX"
-                          >
-                            Åland Islands
-                          </option>
-                        </select>
-                        <span
-                          class="ods-7mdg51"
-                        >
-                          <svg
-                            class="ods-2icygl"
-                            fill="none"
-                            role="presentation"
-                            viewBox="0 0 16 16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              clip-rule="evenodd"
-                              d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
-                              fill="currentColor"
-                              fill-rule="evenodd"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-16"
-                  >
-                    <div
-                      class="MuiBox-root emotion-17"
+                      class="MuiBox-root emotion-11"
                     >
                       <div
                         class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
                       >
                         <label
                           class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
-                          for="phoneNumber"
+                          for="countryList"
                         >
                           <span
                             class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
                           >
-                            Phone Number
+                            Country
                           </span>
                         </label>
                         <div
-                          class="ods-10aW0m"
+                          class="ods-mUkyrD"
                         >
-                          <input
-                            autocomplete="tel-national"
-                            class="ods-7qBw9I"
-                            data-se="phoneNumber"
-                            id="phoneNumber"
-                            name="phoneNumber"
-                            type="tel"
-                          />
+                          <select
+                            autocomplete="tel-country-code"
+                            class="ods-1B2Zfy"
+                            data-se="countryList"
+                            id="countryList"
+                          >
+                            <option
+                              value="AF"
+                            >
+                              Afghanistan
+                            </option>
+                            <option
+                              value="AL"
+                            >
+                              Albania
+                            </option>
+                            <option
+                              value="DZ"
+                            >
+                              Algeria
+                            </option>
+                            <option
+                              value="AS"
+                            >
+                              American Samoa
+                            </option>
+                            <option
+                              value="AD"
+                            >
+                              Andorra
+                            </option>
+                            <option
+                              value="AO"
+                            >
+                              Angola
+                            </option>
+                            <option
+                              value="AI"
+                            >
+                              Anguilla
+                            </option>
+                            <option
+                              value="AQ"
+                            >
+                              Antarctica
+                            </option>
+                            <option
+                              value="AG"
+                            >
+                              Antigua and Barbuda
+                            </option>
+                            <option
+                              value="AR"
+                            >
+                              Argentina
+                            </option>
+                            <option
+                              value="AM"
+                            >
+                              Armenia
+                            </option>
+                            <option
+                              value="AW"
+                            >
+                              Aruba
+                            </option>
+                            <option
+                              value="AU"
+                            >
+                              Australia
+                            </option>
+                            <option
+                              value="AT"
+                            >
+                              Austria
+                            </option>
+                            <option
+                              value="AZ"
+                            >
+                              Azerbaijan
+                            </option>
+                            <option
+                              value="BS"
+                            >
+                              Bahamas
+                            </option>
+                            <option
+                              value="BH"
+                            >
+                              Bahrain
+                            </option>
+                            <option
+                              value="BD"
+                            >
+                              Bangladesh
+                            </option>
+                            <option
+                              value="BB"
+                            >
+                              Barbados
+                            </option>
+                            <option
+                              value="BY"
+                            >
+                              Belarus
+                            </option>
+                            <option
+                              value="BE"
+                            >
+                              Belgium
+                            </option>
+                            <option
+                              value="BZ"
+                            >
+                              Belize
+                            </option>
+                            <option
+                              value="BJ"
+                            >
+                              Benin
+                            </option>
+                            <option
+                              value="BM"
+                            >
+                              Bermuda
+                            </option>
+                            <option
+                              value="BT"
+                            >
+                              Bhutan
+                            </option>
+                            <option
+                              value="BO"
+                            >
+                              Bolivia, Plurinational State of
+                            </option>
+                            <option
+                              value="BA"
+                            >
+                              Bosnia and Herzegovina
+                            </option>
+                            <option
+                              value="BW"
+                            >
+                              Botswana
+                            </option>
+                            <option
+                              value="BR"
+                            >
+                              Brazil
+                            </option>
+                            <option
+                              value="IO"
+                            >
+                              British Indian Ocean Territory
+                            </option>
+                            <option
+                              value="BN"
+                            >
+                              Brunei Darussalam
+                            </option>
+                            <option
+                              value="BG"
+                            >
+                              Bulgaria
+                            </option>
+                            <option
+                              value="BF"
+                            >
+                              Burkina Faso
+                            </option>
+                            <option
+                              value="BI"
+                            >
+                              Burundi
+                            </option>
+                            <option
+                              value="KH"
+                            >
+                              Cambodia
+                            </option>
+                            <option
+                              value="CM"
+                            >
+                              Cameroon
+                            </option>
+                            <option
+                              value="CA"
+                            >
+                              Canada
+                            </option>
+                            <option
+                              value="CV"
+                            >
+                              Cape Verde
+                            </option>
+                            <option
+                              value="KY"
+                            >
+                              Cayman Islands
+                            </option>
+                            <option
+                              value="CF"
+                            >
+                              Central African Republic
+                            </option>
+                            <option
+                              value="TD"
+                            >
+                              Chad
+                            </option>
+                            <option
+                              value="CL"
+                            >
+                              Chile
+                            </option>
+                            <option
+                              value="CN"
+                            >
+                              China
+                            </option>
+                            <option
+                              value="CX"
+                            >
+                              Christmas Island
+                            </option>
+                            <option
+                              value="CO"
+                            >
+                              Colombia
+                            </option>
+                            <option
+                              value="KM"
+                            >
+                              Comoros
+                            </option>
+                            <option
+                              value="CG"
+                            >
+                              Congo
+                            </option>
+                            <option
+                              value="CD"
+                            >
+                              Congo, the Democratic Republic of the
+                            </option>
+                            <option
+                              value="CK"
+                            >
+                              Cook Islands
+                            </option>
+                            <option
+                              value="CR"
+                            >
+                              Costa Rica
+                            </option>
+                            <option
+                              value="HR"
+                            >
+                              Croatia
+                            </option>
+                            <option
+                              value="CU"
+                            >
+                              Cuba
+                            </option>
+                            <option
+                              value="CY"
+                            >
+                              Cyprus
+                            </option>
+                            <option
+                              value="CZ"
+                            >
+                              Czech Republic
+                            </option>
+                            <option
+                              value="CI"
+                            >
+                              Côte d'Ivoire
+                            </option>
+                            <option
+                              value="DK"
+                            >
+                              Denmark
+                            </option>
+                            <option
+                              value="DJ"
+                            >
+                              Djibouti
+                            </option>
+                            <option
+                              value="DM"
+                            >
+                              Dominica
+                            </option>
+                            <option
+                              value="DO"
+                            >
+                              Dominican Republic
+                            </option>
+                            <option
+                              value="EC"
+                            >
+                              Ecuador
+                            </option>
+                            <option
+                              value="EG"
+                            >
+                              Egypt
+                            </option>
+                            <option
+                              value="SV"
+                            >
+                              El Salvador
+                            </option>
+                            <option
+                              value="GQ"
+                            >
+                              Equatorial Guinea
+                            </option>
+                            <option
+                              value="ER"
+                            >
+                              Eritrea
+                            </option>
+                            <option
+                              value="EE"
+                            >
+                              Estonia
+                            </option>
+                            <option
+                              value="ET"
+                            >
+                              Ethiopia
+                            </option>
+                            <option
+                              value="FK"
+                            >
+                              Falkland Islands (Malvinas)
+                            </option>
+                            <option
+                              value="FO"
+                            >
+                              Faroe Islands
+                            </option>
+                            <option
+                              value="FJ"
+                            >
+                              Fiji
+                            </option>
+                            <option
+                              value="FI"
+                            >
+                              Finland
+                            </option>
+                            <option
+                              value="FR"
+                            >
+                              France
+                            </option>
+                            <option
+                              value="GF"
+                            >
+                              French Guiana
+                            </option>
+                            <option
+                              value="PF"
+                            >
+                              French Polynesia
+                            </option>
+                            <option
+                              value="GA"
+                            >
+                              Gabon
+                            </option>
+                            <option
+                              value="GM"
+                            >
+                              Gambia
+                            </option>
+                            <option
+                              value="GE"
+                            >
+                              Georgia
+                            </option>
+                            <option
+                              value="DE"
+                            >
+                              Germany
+                            </option>
+                            <option
+                              value="GH"
+                            >
+                              Ghana
+                            </option>
+                            <option
+                              value="GI"
+                            >
+                              Gibraltar
+                            </option>
+                            <option
+                              value="GR"
+                            >
+                              Greece
+                            </option>
+                            <option
+                              value="GL"
+                            >
+                              Greenland
+                            </option>
+                            <option
+                              value="GD"
+                            >
+                              Grenada
+                            </option>
+                            <option
+                              value="GP"
+                            >
+                              Guadeloupe
+                            </option>
+                            <option
+                              value="GU"
+                            >
+                              Guam
+                            </option>
+                            <option
+                              value="GT"
+                            >
+                              Guatemala
+                            </option>
+                            <option
+                              value="GG"
+                            >
+                              Guernsey
+                            </option>
+                            <option
+                              value="GN"
+                            >
+                              Guinea
+                            </option>
+                            <option
+                              value="GW"
+                            >
+                              Guinea-Bissau
+                            </option>
+                            <option
+                              value="GY"
+                            >
+                              Guyana
+                            </option>
+                            <option
+                              value="HT"
+                            >
+                              Haiti
+                            </option>
+                            <option
+                              value="VA"
+                            >
+                              Holy See (Vatican City State)
+                            </option>
+                            <option
+                              value="HN"
+                            >
+                              Honduras
+                            </option>
+                            <option
+                              value="HK"
+                            >
+                              Hong Kong
+                            </option>
+                            <option
+                              value="HU"
+                            >
+                              Hungary
+                            </option>
+                            <option
+                              value="IS"
+                            >
+                              Iceland
+                            </option>
+                            <option
+                              value="IN"
+                            >
+                              India
+                            </option>
+                            <option
+                              value="ID"
+                            >
+                              Indonesia
+                            </option>
+                            <option
+                              value="IR"
+                            >
+                              Iran, Islamic Republic of
+                            </option>
+                            <option
+                              value="IQ"
+                            >
+                              Iraq
+                            </option>
+                            <option
+                              value="IE"
+                            >
+                              Ireland
+                            </option>
+                            <option
+                              value="IL"
+                            >
+                              Israel
+                            </option>
+                            <option
+                              value="IT"
+                            >
+                              Italy
+                            </option>
+                            <option
+                              value="JM"
+                            >
+                              Jamaica
+                            </option>
+                            <option
+                              value="JP"
+                            >
+                              Japan
+                            </option>
+                            <option
+                              value="JE"
+                            >
+                              Jersey
+                            </option>
+                            <option
+                              value="JO"
+                            >
+                              Jordan
+                            </option>
+                            <option
+                              value="KZ"
+                            >
+                              Kazakhstan
+                            </option>
+                            <option
+                              value="KE"
+                            >
+                              Kenya
+                            </option>
+                            <option
+                              value="KI"
+                            >
+                              Kiribati
+                            </option>
+                            <option
+                              value="KP"
+                            >
+                              Korea, Democratic People's Republic of
+                            </option>
+                            <option
+                              value="KR"
+                            >
+                              Korea, Republic of
+                            </option>
+                            <option
+                              value="XK"
+                            >
+                              Kosovo, Republic of
+                            </option>
+                            <option
+                              value="KW"
+                            >
+                              Kuwait
+                            </option>
+                            <option
+                              value="KG"
+                            >
+                              Kyrgyzstan
+                            </option>
+                            <option
+                              value="LA"
+                            >
+                              Lao People's Democratic Republic
+                            </option>
+                            <option
+                              value="LV"
+                            >
+                              Latvia
+                            </option>
+                            <option
+                              value="LB"
+                            >
+                              Lebanon
+                            </option>
+                            <option
+                              value="LS"
+                            >
+                              Lesotho
+                            </option>
+                            <option
+                              value="LR"
+                            >
+                              Liberia
+                            </option>
+                            <option
+                              value="LY"
+                            >
+                              Libya
+                            </option>
+                            <option
+                              value="LI"
+                            >
+                              Liechtenstein
+                            </option>
+                            <option
+                              value="LT"
+                            >
+                              Lithuania
+                            </option>
+                            <option
+                              value="LU"
+                            >
+                              Luxembourg
+                            </option>
+                            <option
+                              value="MO"
+                            >
+                              Macao
+                            </option>
+                            <option
+                              value="MK"
+                            >
+                              Macedonia, the former Yugoslav Republic of
+                            </option>
+                            <option
+                              value="MG"
+                            >
+                              Madagascar
+                            </option>
+                            <option
+                              value="MW"
+                            >
+                              Malawi
+                            </option>
+                            <option
+                              value="MY"
+                            >
+                              Malaysia
+                            </option>
+                            <option
+                              value="MV"
+                            >
+                              Maldives
+                            </option>
+                            <option
+                              value="ML"
+                            >
+                              Mali
+                            </option>
+                            <option
+                              value="MT"
+                            >
+                              Malta
+                            </option>
+                            <option
+                              value="MH"
+                            >
+                              Marshall Islands
+                            </option>
+                            <option
+                              value="MQ"
+                            >
+                              Martinique
+                            </option>
+                            <option
+                              value="MR"
+                            >
+                              Mauritania
+                            </option>
+                            <option
+                              value="MU"
+                            >
+                              Mauritius
+                            </option>
+                            <option
+                              value="YT"
+                            >
+                              Mayotte
+                            </option>
+                            <option
+                              value="MX"
+                            >
+                              Mexico
+                            </option>
+                            <option
+                              value="FM"
+                            >
+                              Micronesia, Federated States of
+                            </option>
+                            <option
+                              value="MD"
+                            >
+                              Moldova, Republic of
+                            </option>
+                            <option
+                              value="MC"
+                            >
+                              Monaco
+                            </option>
+                            <option
+                              value="MN"
+                            >
+                              Mongolia
+                            </option>
+                            <option
+                              value="ME"
+                            >
+                              Montenegro
+                            </option>
+                            <option
+                              value="MS"
+                            >
+                              Montserrat
+                            </option>
+                            <option
+                              value="MA"
+                            >
+                              Morocco
+                            </option>
+                            <option
+                              value="MZ"
+                            >
+                              Mozambique
+                            </option>
+                            <option
+                              value="MM"
+                            >
+                              Myanmar
+                            </option>
+                            <option
+                              value="NA"
+                            >
+                              Namibia
+                            </option>
+                            <option
+                              value="NR"
+                            >
+                              Nauru
+                            </option>
+                            <option
+                              value="NP"
+                            >
+                              Nepal
+                            </option>
+                            <option
+                              value="NL"
+                            >
+                              Netherlands
+                            </option>
+                            <option
+                              value="AN"
+                            >
+                              Netherlands Antilles
+                            </option>
+                            <option
+                              value="NC"
+                            >
+                              New Caledonia
+                            </option>
+                            <option
+                              value="NZ"
+                            >
+                              New Zealand
+                            </option>
+                            <option
+                              value="NI"
+                            >
+                              Nicaragua
+                            </option>
+                            <option
+                              value="NE"
+                            >
+                              Niger
+                            </option>
+                            <option
+                              value="NG"
+                            >
+                              Nigeria
+                            </option>
+                            <option
+                              value="NU"
+                            >
+                              Niue
+                            </option>
+                            <option
+                              value="NF"
+                            >
+                              Norfolk Island
+                            </option>
+                            <option
+                              value="MP"
+                            >
+                              Northern Mariana Islands
+                            </option>
+                            <option
+                              value="NO"
+                            >
+                              Norway
+                            </option>
+                            <option
+                              value="OM"
+                            >
+                              Oman
+                            </option>
+                            <option
+                              value="PK"
+                            >
+                              Pakistan
+                            </option>
+                            <option
+                              value="PW"
+                            >
+                              Palau
+                            </option>
+                            <option
+                              value="PS"
+                            >
+                              Palestine, State of
+                            </option>
+                            <option
+                              value="PA"
+                            >
+                              Panama
+                            </option>
+                            <option
+                              value="PG"
+                            >
+                              Papua New Guinea
+                            </option>
+                            <option
+                              value="PY"
+                            >
+                              Paraguay
+                            </option>
+                            <option
+                              value="PE"
+                            >
+                              Peru
+                            </option>
+                            <option
+                              value="PH"
+                            >
+                              Philippines
+                            </option>
+                            <option
+                              value="PN"
+                            >
+                              Pitcairn
+                            </option>
+                            <option
+                              value="PL"
+                            >
+                              Poland
+                            </option>
+                            <option
+                              value="PT"
+                            >
+                              Portugal
+                            </option>
+                            <option
+                              value="PR"
+                            >
+                              Puerto Rico
+                            </option>
+                            <option
+                              value="QA"
+                            >
+                              Qatar
+                            </option>
+                            <option
+                              value="RO"
+                            >
+                              Romania
+                            </option>
+                            <option
+                              value="RU"
+                            >
+                              Russian Federation
+                            </option>
+                            <option
+                              value="RW"
+                            >
+                              Rwanda
+                            </option>
+                            <option
+                              value="RE"
+                            >
+                              Réunion
+                            </option>
+                            <option
+                              value="SH"
+                            >
+                              Saint Helena, Ascension and Tristan da Cunha
+                            </option>
+                            <option
+                              value="KN"
+                            >
+                              Saint Kitts and Nevis
+                            </option>
+                            <option
+                              value="LC"
+                            >
+                              Saint Lucia
+                            </option>
+                            <option
+                              value="PM"
+                            >
+                              Saint Pierre and Miquelon
+                            </option>
+                            <option
+                              value="VC"
+                            >
+                              Saint Vincent and the Grenadines
+                            </option>
+                            <option
+                              value="WS"
+                            >
+                              Samoa
+                            </option>
+                            <option
+                              value="SM"
+                            >
+                              San Marino
+                            </option>
+                            <option
+                              value="SA"
+                            >
+                              Saudi Arabia
+                            </option>
+                            <option
+                              value="SN"
+                            >
+                              Senegal
+                            </option>
+                            <option
+                              value="RS"
+                            >
+                              Serbia
+                            </option>
+                            <option
+                              value="SC"
+                            >
+                              Seychelles
+                            </option>
+                            <option
+                              value="SL"
+                            >
+                              Sierra Leone
+                            </option>
+                            <option
+                              value="SG"
+                            >
+                              Singapore
+                            </option>
+                            <option
+                              value="SK"
+                            >
+                              Slovakia
+                            </option>
+                            <option
+                              value="SI"
+                            >
+                              Slovenia
+                            </option>
+                            <option
+                              value="SB"
+                            >
+                              Solomon Islands
+                            </option>
+                            <option
+                              value="SO"
+                            >
+                              Somalia
+                            </option>
+                            <option
+                              value="ZA"
+                            >
+                              South Africa
+                            </option>
+                            <option
+                              value="GS"
+                            >
+                              South Georgia and the South Sandwich Islands
+                            </option>
+                            <option
+                              value="SS"
+                            >
+                              South Sudan
+                            </option>
+                            <option
+                              value="ES"
+                            >
+                              Spain
+                            </option>
+                            <option
+                              value="LK"
+                            >
+                              Sri Lanka
+                            </option>
+                            <option
+                              value="SD"
+                            >
+                              Sudan
+                            </option>
+                            <option
+                              value="SR"
+                            >
+                              Suriname
+                            </option>
+                            <option
+                              value="SJ"
+                            >
+                              Svalbard and Jan Mayen
+                            </option>
+                            <option
+                              value="SZ"
+                            >
+                              Swaziland
+                            </option>
+                            <option
+                              value="SE"
+                            >
+                              Sweden
+                            </option>
+                            <option
+                              value="CH"
+                            >
+                              Switzerland
+                            </option>
+                            <option
+                              value="SY"
+                            >
+                              Syrian Arab Republic
+                            </option>
+                            <option
+                              value="ST"
+                            >
+                              São Tomé and Príncipe
+                            </option>
+                            <option
+                              value="TW"
+                            >
+                              Taiwan
+                            </option>
+                            <option
+                              value="TJ"
+                            >
+                              Tajikistan
+                            </option>
+                            <option
+                              value="TZ"
+                            >
+                              Tanzania, United Republic of
+                            </option>
+                            <option
+                              value="TH"
+                            >
+                              Thailand
+                            </option>
+                            <option
+                              value="TL"
+                            >
+                              Timor-Leste
+                            </option>
+                            <option
+                              value="TG"
+                            >
+                              Togo
+                            </option>
+                            <option
+                              value="TK"
+                            >
+                              Tokelau
+                            </option>
+                            <option
+                              value="TO"
+                            >
+                              Tonga
+                            </option>
+                            <option
+                              value="TT"
+                            >
+                              Trinidad and Tobago
+                            </option>
+                            <option
+                              value="TN"
+                            >
+                              Tunisia
+                            </option>
+                            <option
+                              value="TR"
+                            >
+                              Turkey
+                            </option>
+                            <option
+                              value="TM"
+                            >
+                              Turkmenistan
+                            </option>
+                            <option
+                              value="TC"
+                            >
+                              Turks and Caicos Islands
+                            </option>
+                            <option
+                              value="TV"
+                            >
+                              Tuvalu
+                            </option>
+                            <option
+                              value="UG"
+                            >
+                              Uganda
+                            </option>
+                            <option
+                              value="UA"
+                            >
+                              Ukraine
+                            </option>
+                            <option
+                              value="AE"
+                            >
+                              United Arab Emirates
+                            </option>
+                            <option
+                              value="GB"
+                            >
+                              United Kingdom
+                            </option>
+                            <option
+                              value="US"
+                            >
+                              United States
+                            </option>
+                            <option
+                              value="UM"
+                            >
+                              United States Minor Outlying Islands
+                            </option>
+                            <option
+                              value="UY"
+                            >
+                              Uruguay
+                            </option>
+                            <option
+                              value="UZ"
+                            >
+                              Uzbekistan
+                            </option>
+                            <option
+                              value="VU"
+                            >
+                              Vanuatu
+                            </option>
+                            <option
+                              value="VE"
+                            >
+                              Venezuela, Bolivarian Republic of
+                            </option>
+                            <option
+                              value="VN"
+                            >
+                              Viet Nam
+                            </option>
+                            <option
+                              value="VG"
+                            >
+                              Virgin Islands, British
+                            </option>
+                            <option
+                              value="VI"
+                            >
+                              Virgin Islands, U.S.
+                            </option>
+                            <option
+                              value="WF"
+                            >
+                              Wallis and Futuna
+                            </option>
+                            <option
+                              value="EH"
+                            >
+                              Western Sahara
+                            </option>
+                            <option
+                              value="YE"
+                            >
+                              Yemen
+                            </option>
+                            <option
+                              value="ZM"
+                            >
+                              Zambia
+                            </option>
+                            <option
+                              value="ZW"
+                            >
+                              Zimbabwe
+                            </option>
+                            <option
+                              value="AX"
+                            >
+                              Åland Islands
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
+                          >
+                            <svg
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-17"
+                    >
+                      <div
+                        class="MuiBox-root emotion-18"
+                      >
+                        <div
+                          class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                        >
+                          <label
+                            class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                            for="phoneNumber"
+                          >
+                            <span
+                              class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                            >
+                              Phone Number
+                            </span>
+                          </label>
+                          <div
+                            class="ods-10aW0m"
+                          >
+                            <input
+                              autocomplete="tel-national"
+                              class="ods-7qBw9I"
+                              data-se="phoneNumber"
+                              id="phoneNumber"
+                              name="phoneNumber"
+                              type="tel"
+                            />
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Make sure you can access the text on your mobile device.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Make sure you can access the text on your mobile device.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-22"
+                    data-type="save"
+                    tabindex="0"
+                    type="submit"
+                  >
+                    Send me the setup link
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-24"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-26"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-25"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -2,36 +2,36 @@
 
 exports[`terminal-return-email-error should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
           <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="MuiBox-root emotion-5"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-6"
@@ -40,51 +40,55 @@ exports[`terminal-return-email-error should render form 1`] = `
                   class="MuiBox-root emotion-7"
                 >
                   <div
-                    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
-                    role="alert"
+                    class="MuiBox-root emotion-8"
                   >
                     <div
-                      class="MuiAlert-icon emotion-9"
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-9"
+                      role="alert"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
-                        data-testid="ErrorOutlineIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
+                      <div
+                        class="MuiAlert-icon emotion-10"
                       >
-                        <path
-                          d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                        />
-                      </svg>
-                    </div>
-                    <div
-                      class="MuiAlert-message emotion-11"
-                    >
-                      Could not process this email link. Return to the screen where you requested it.
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-11"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-12"
+                      >
+                        Could not process this email link. Return to the screen where you requested it.
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-6"
-              >
                 <div
-                  class="MuiBox-root emotion-13"
+                  class="MuiBox-root emotion-7"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
-                    href="/"
+                  <div
+                    class="MuiBox-root emotion-14"
                   >
-                    Back to sign in
-                  </a>
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-15"
+                      href="/"
+                    >
+                      Back to sign in
+                    </a>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-email renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                testUser@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,44 +71,48 @@ exports[`terminal-return-email renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Success! Return to the original tab or window
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Success! Return to the original tab or window
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    To continue, please return to the original browser tab or window you used to verify.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      To continue, please return to the original browser tab or window you used to verify.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Close this window anytime.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Close this window anytime.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,139 +71,143 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the sign up page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the sign up page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Request from:
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
-                >
                   <div
-                    class="MuiBox-root emotion-22"
+                    class="MuiBox-root emotion-17"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      FIREFOX on iOS
-                    </span>
+                      123456
+                    </h3>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="location"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Toronto, Ontario, Canada
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="browser"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on iOS
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="location"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Toronto, Ontario, Canada
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,139 +71,143 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the password reset page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the password reset page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Request from:
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
-                >
                   <div
-                    class="MuiBox-root emotion-22"
+                    class="MuiBox-root emotion-17"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      FIREFOX on Android
-                    </span>
+                      123456
+                    </h3>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="location"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Toronto, Ontario, Canada
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="browser"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on Android
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="location"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Toronto, Ontario, Canada
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,139 +71,143 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the account unlock page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the account unlock page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Request from:
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
-                >
                   <div
-                    class="MuiBox-root emotion-22"
+                    class="MuiBox-root emotion-17"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      FIREFOX on iOS
-                    </span>
+                      123456
+                    </h3>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="location"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Toronto, Ontario, Canada
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="browser"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on iOS
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="location"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Toronto, Ontario, Canada
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-full-location renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,139 +71,143 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the sign-in page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the sign-in page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Request from:
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
-                >
                   <div
-                    class="MuiBox-root emotion-22"
+                    class="MuiBox-root emotion-17"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      FIREFOX on Mac OS X
-                    </span>
+                      123456
+                    </h3>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="location"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Toronto, Ontario, Canada
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="browser"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on Mac OS X
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="location"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Toronto, Ontario, Canada
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-no-location renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,116 +71,120 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the sign-in page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the sign-in page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-17"
                   >
-                    Request from:
-                  </p>
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      123456
+                    </h3>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
                 >
                   <div
                     class="MuiBox-root emotion-22"
+                    id="browser"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <div
+                      class="MuiBox-root emotion-23"
                     >
-                      FIREFOX on Mac OS X
-                    </span>
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on Mac OS X
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`terminal-return-otp-only-partial-location renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                test@okta.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  test@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,139 +71,143 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Your verification code
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Your verification code
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Enter this code on the sign-in page.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Enter this code on the sign-in page.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <h3
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    123456
-                  </h3>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Request from:
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="browser"
-                >
                   <div
-                    class="MuiBox-root emotion-22"
+                    class="MuiBox-root emotion-17"
                   >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    <h3
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      FIREFOX on Mac OS X
-                    </span>
+                      123456
+                    </h3>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="app"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      my 3rd magic link spa
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                  id="location"
-                >
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="MuiBox-root emotion-3"
-                  >
-                    <span
-                      class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                    >
-                      Toronto, Canada
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Request from:
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="browser"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        FIREFOX on Mac OS X
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="app"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        my 3rd magic link spa
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-22"
+                    id="location"
+                  >
+                    <div
+                      class="MuiBox-root emotion-23"
+                    >
+                      <mocksvgicon />
+                    </div>
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <span
+                        class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Toronto, Canada
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      If you didn’t request this code, you can ignore this message. Your account is safe and can only be accessed with this code.
+                    </p>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -2,63 +2,63 @@
 
 exports[`unlock-account-success renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-4"
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="identifierContainer MuiBox-root emotion-5"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-6"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-6"
-                data-se="identifier"
-              >
-                glen.fannin@okta.com
-              </span>
-            </div>
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-4"
           >
             <div
-              class="MuiBox-root emotion-8"
+              class="identifier-container MuiBox-root emotion-5"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-6"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-7"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-7"
+                  data-se="identifier"
+                >
+                  glen.fannin@okta.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-9"
@@ -66,45 +66,49 @@ exports[`unlock-account-success renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-11"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    Account successfully unlocked!
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-12"
+                    >
+                      Account successfully unlocked!
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
-                    You can log in using your existing username and password.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      You can log in using your existing username and password.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
                 <div
-                  class="MuiBox-root emotion-15"
+                  class="MuiBox-root emotion-10"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-16"
-                    href="javascript:void(0)"
+                  <div
+                    class="MuiBox-root emotion-16"
                   >
-                    Back to sign in
-                  </a>
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                      href="javascript:void(0)"
+                    >
+                      Back to sign in
+                    </a>
+                  </div>
                 </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -2,31 +2,31 @@
 
 exports[`user-unlock-account renders form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader"
+          class="siwContainer MuiBox-root emotion-2"
         >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-        </div>
-        <div
-          class="MuiBox-root emotion-3"
-        >
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
           >
-            <div
-              class="MuiBox-root emotion-4"
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-5"
@@ -34,133 +34,137 @@ exports[`user-unlock-account renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-7"
-                  >
-                    Unlock account?
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-9"
-                >
-                  <label
-                    class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-10"
-                    for="identifier"
-                  >
-                    Username
-                  </label>
                   <div
-                    class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-11"
+                    class="MuiBox-root emotion-7"
                   >
-                    <input
-                      aria-invalid="false"
-                      autocomplete="username"
-                      class="MuiOutlinedInput-input MuiInputBase-input emotion-12"
-                      data-se="identifier"
-                      id="identifier"
-                      name="identifier"
-                      type="text"
-                    />
-                    <fieldset
-                      aria-hidden="true"
-                      class="MuiOutlinedInput-notchedOutline emotion-13"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-8"
                     >
-                      <legend
-                        class="emotion-14"
+                      Unlock account?
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <div
+                    class="MuiBox-root emotion-10"
+                  >
+                    <label
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      for="identifier"
+                    >
+                      Username
+                    </label>
+                    <div
+                      class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-12"
+                    >
+                      <input
+                        aria-invalid="false"
+                        autocomplete="username"
+                        class="MuiOutlinedInput-input MuiInputBase-input emotion-13"
+                        data-se="identifier"
+                        id="identifier"
+                        name="identifier"
+                        type="text"
+                      />
+                      <fieldset
+                        aria-hidden="true"
+                        class="MuiOutlinedInput-notchedOutline emotion-14"
                       >
-                        <span
-                          class="notranslate"
+                        <legend
+                          class="emotion-15"
                         >
-                          ​
-                        </span>
-                      </legend>
-                    </fieldset>
+                          <span
+                            class="notranslate"
+                          >
+                            ​
+                          </span>
+                        </legend>
+                      </fieldset>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-16"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-9"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-9"
+                    class="authButton MuiBox-root emotion-17"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-9"
+                      class="iconContainer MuiBox-root emotion-10"
                     >
-                      Email
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-9"
-                      data-se="okta_email-email"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-10"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-10"
+                      >
+                        Email
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-10"
+                        data-se="okta_email-email"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="authButton MuiBox-root emotion-16"
-                  role="button"
-                  tabindex="0"
+                  class="MuiBox-root emotion-6"
                 >
                   <div
-                    class="iconContainer MuiBox-root emotion-9"
-                  >
-                    <mocksvgicon />
-                  </div>
-                  <div
-                    class="infoSection MuiBox-root emotion-9"
+                    class="authButton MuiBox-root emotion-17"
+                    role="button"
+                    tabindex="0"
                   >
                     <div
-                      class="title MuiBox-root emotion-9"
+                      class="iconContainer MuiBox-root emotion-10"
                     >
-                      Phone
-                    </div>
-                    <div
-                      class="actionName MuiBox-root emotion-9"
-                      data-se="phone_number"
-                    >
-                      Select
                       <mocksvgicon />
                     </div>
+                    <div
+                      class="infoSection MuiBox-root emotion-10"
+                    >
+                      <div
+                        class="title MuiBox-root emotion-10"
+                      >
+                        Phone
+                      </div>
+                      <div
+                        class="actionName MuiBox-root emotion-10"
+                        data-se="phone_number"
+                      >
+                        Select
+                        <mocksvgicon />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-28"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiBox-root emotion-6"
                 >
-                  Back to sign in
-                </button>
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -2,68 +2,68 @@
 
 exports[`webauthn-enroll should render form 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester5@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester5@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -71,161 +71,165 @@ exports[`webauthn-enroll should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up security key or biometric authenticator
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    You will be prompted to register a security key or biometric authenticator (Windows Hello, Touch ID, Face ID, etc.). Follow the instructions to complete set up.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <span
-                    aria-label="Loading..."
-                    aria-valuemax="1"
-                    aria-valuemin="0"
-                    aria-valuetext="Loading..."
-                    class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-48Fcvf"
-                    id="okta-spinner"
-                    role="progressbar"
-                  >
-                    <svg
-                      class="ods-57SiHN"
-                      role="presentation"
-                      viewBox="0 0 24 24"
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
                     >
-                      <circle
-                        class="ods-3PiY3x"
-                        cx="12"
-                        cy="12"
-                        fill="none"
-                        r="10"
-                      />
-                      <circle
-                        class="ods-627kuP"
-                        cx="12"
-                        cy="12"
-                        fill="none"
-                        r="10"
-                      />
-                    </svg>
-                  </span>
+                      Set up security key or biometric authenticator
+                    </h2>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      You will be prompted to register a security key or biometric authenticator (Windows Hello, Touch ID, Face ID, etc.). Follow the instructions to complete set up.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <span
+                      aria-label="Loading..."
+                      aria-valuemax="1"
+                      aria-valuemin="0"
+                      aria-valuetext="Loading..."
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-48Fcvf"
+                      id="okta-spinner"
+                      role="progressbar"
+                    >
+                      <svg
+                        class="ods-57SiHN"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          class="ods-3PiY3x"
+                          cx="12"
+                          cy="12"
+                          fill="none"
+                          r="10"
+                        />
+                        <circle
+                          class="ods-627kuP"
+                          cx="12"
+                          cy="12"
+                          fill="none"
+                          r="10"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-19"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-19"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-18"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-18"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;
 
 exports[`webauthn-enroll should render form when Credentials API is not available 1`] = `
 <div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
       >
         <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
+          class="siwContainer MuiBox-root emotion-2"
         >
           <div
-            class="identifier-container MuiBox-root emotion-5"
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
           >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
             <div
-              class="identifierContainer MuiBox-root emotion-6"
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
             >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester5@test.com
-              </span>
+              <mocksvgicon />
             </div>
           </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
+          <div
+            class="MuiBox-root emotion-5"
           >
             <div
-              class="MuiBox-root emotion-9"
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester5@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -233,55 +237,59 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Set up security key or biometric authenticator
-                  </h2>
+                    <h2
+                      class="MuiTypography-root MuiTypography-h3 emotion-13"
+                    >
+                      Set up security key or biometric authenticator
+                    </h2>
+                  </div>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  <div
+                    class="MuiBox-root emotion-12"
                   >
-                    Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
-                  </p>
+                    <p
+                      class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                    >
+                      Security key or biometric authenticator is not supported on this browser. Select another factor or contact your admin for assistance.
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-17"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Return to authenticator list
+                  </button>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-17"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Back to sign in
+                  </button>
                 </div>
               </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-16"
-                  data-se="switchAuthenticator"
-                  tabindex="0"
-                  type="button"
-                >
-                  Return to authenticator list
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-16"
-                  data-se="cancel"
-                  tabindex="0"
-                  type="button"
-                >
-                  Back to sign in
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-    </main>
-  </span>
+      </main>
+    </span>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Description:

Applies some common font, color, and box-sizing styles to the root element of the application. Prevents page global styles on these styles from affecting the inner styles of our application (unless they use `!important`)

```css
/* example injected CSS for this addition */
.css-oers02-MuiScopedCssBaseline-root {
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
    box-sizing: border-box;
    -webkit-text-size-adjust: 100%;
    color: #1d1d21;
    background-color: #ffffff;
}
```

## PR Checklist

- [x] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-520969](https://oktainc.atlassian.net/browse/OKTA-520969)


