### PR TITLE
feat: client validation for sq enrollment

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -18,7 +18,7 @@ import { useCallback } from 'preact/hooks';
 import { useWidgetContext } from '../../contexts';
 import { useOnSubmit } from '../../hooks';
 import {
-  ActionOptions, DataSchema, SubmitEvent, UISchemaLayout,
+  DataSchema, SubmitEvent, UISchemaLayout,
 } from '../../types';
 import { loc, resetMessagesToInputs } from '../../util';
 import Layout from './Layout';
@@ -41,7 +41,14 @@ const Form: FunctionComponent<{
     e.preventDefault();
     setMessage(undefined);
 
-    const { actionParams: params, step } = dataSchemaRef.current!.submit as ActionOptions;
+    const {
+      submit: {
+        actionParams: params,
+        step,
+        includeImmutableData,
+      },
+      fieldsToValidate,
+    } = dataSchemaRef.current!;
 
     // client side validation - only validate for fields in nextStep
     const { nextStep } = currTransaction!;
@@ -51,7 +58,7 @@ const Form: FunctionComponent<{
         .reduce((acc: Record<string, Partial<IdxMessage & { name?: string }>[]>, curr) => {
           const name = curr[0];
           const elementSchema = curr[1] as DataSchema;
-          if (typeof elementSchema.validate === 'function') {
+          if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
             const validationMessages = elementSchema.validate({
               ...additionalData,
               ...data,
@@ -81,6 +88,7 @@ const Form: FunctionComponent<{
     // submit request
     onSubmitHandler({
       includeData: true,
+      includeImmutableData,
       params,
       step,
     });

--- a/src/v3/src/components/StepperRadio/StepperRadio.tsx
+++ b/src/v3/src/components/StepperRadio/StepperRadio.tsx
@@ -23,8 +23,6 @@ import { useState } from 'preact/hooks';
 
 import { useStepperContext, useWidgetContext } from '../../contexts';
 import {
-  ButtonElement,
-  ButtonType,
   ChangeEvent,
   StepperRadioElement,
   UISchemaElementComponent,
@@ -34,7 +32,8 @@ const StepperRadio: UISchemaElementComponent<{
   uischema: StepperRadioElement
 }> = ({ uischema }) => {
   const { setStepIndex } = useStepperContext();
-  const { setData, dataSchemaRef } = useWidgetContext();
+  const widgetContext = useWidgetContext();
+  const { setData, setMessage } = widgetContext;
   const {
     label = '',
     options: {
@@ -48,7 +47,8 @@ const StepperRadio: UISchemaElementComponent<{
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const stepIdx = customOptions.findIndex((opt) => opt.value === e.currentTarget.value);
     const option = customOptions[stepIdx];
-    setStepIndex!(stepIdx);
+    option.callback(widgetContext, stepIdx);
+    setStepIndex(stepIdx);
     setValue(e.currentTarget.value);
 
     // update data state
@@ -56,10 +56,8 @@ const StepperRadio: UISchemaElementComponent<{
       setData({ [option.key]: option.value });
     }
 
-    // update submit options in dataSchemaRef
-    const currentLayout = option.layout();
-    const submitButtomElement = currentLayout.elements.find((element) => element.type === 'Button' && (element as ButtonElement).options?.type === ButtonType.SUBMIT) as ButtonElement;
-    dataSchemaRef.current!.submit = submitButtomElement.options;
+    // reset form level alert message
+    setMessage(undefined);
   };
 
   return (

--- a/src/v3/src/contexts.ts
+++ b/src/v3/src/contexts.ts
@@ -10,35 +10,10 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage, IdxTransaction, OktaAuth } from '@okta/okta-auth-js';
 import { createContext } from 'preact';
-import { MutableRef, StateUpdater, useContext } from 'preact/hooks';
+import { StateUpdater, useContext } from 'preact/hooks';
 
-import {
-  FormBag,
-  WidgetProps,
-} from './types';
-
-// Widget context
-type IWidgetContext = {
-  authClient: OktaAuth;
-  widgetProps: WidgetProps;
-  setMessage: StateUpdater<IdxMessage | undefined>;
-  // // TODO: OKTA-502849 - Update param type
-  // (RenderSuccessCallback / RenderErrorCallback) once merged into okta-signin-widget
-  onSuccessCallback?: (data: Record<string, unknown>) => void;
-  onErrorCallback?: (data: Record<string, unknown>) => void;
-  idxTransaction: IdxTransaction | undefined;
-  setIdxTransaction: StateUpdater<IdxTransaction | undefined>;
-  setIsClientTransaction: StateUpdater<boolean>;
-  stepToRender: string | undefined;
-  setStepToRender: StateUpdater<string | undefined>;
-  data: FormBag['data'];
-  setData: StateUpdater<FormBag['data']>;
-  additionalData: FormBag['data'];
-  setAdditionalData: StateUpdater<FormBag['data']>;
-  dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
-};
+import { IWidgetContext } from './types';
 
 const createWidgetContext = <T extends unknown>() => {
   // Create a context with a generic parameter or undefined

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -19,6 +19,7 @@ import { getImmutableData, toNestedObject } from '../util';
 
 type OnSubmitHandlerOptions = {
   includeData?: boolean;
+  includeImmutableData?: boolean;
   params?: Record<string, unknown>;
   step: string;
   isActionStep?: boolean;
@@ -40,6 +41,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     const {
       params,
       includeData,
+      includeImmutableData = true,
       step,
       isActionStep,
       stepToRender,
@@ -64,7 +66,9 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     } else {
       payload = { ...payload, step };
     }
-    payload = merge(payload, immutableData);
+    if (includeImmutableData) {
+      payload = merge(payload, immutableData);
+    }
     payload = toNestedObject(payload);
     if (currTransaction!.context.stateHandle) {
       payload.stateHandle = currTransaction!.context.stateHandle;

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -74,6 +74,7 @@ export const transformStepInputs = (
             }];
           },
         };
+        acc.dataSchema.fieldsToValidate.push(name);
       }
 
       return acc;

--- a/src/v3/src/transformer/main.ts
+++ b/src/v3/src/transformer/main.ts
@@ -56,6 +56,8 @@ export const transformIdxTransaction = (options: TransformationOptions): FormBag
       elements: [],
     },
     data: {},
-    dataSchema: {},
+    dataSchema: {
+      fieldsToValidate: [],
+    },
   });
 };

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
@@ -13,12 +13,12 @@
 import { NextStep } from '@okta/okta-auth-js';
 
 import {
+  FieldElement,
   IdxStepTransformer,
   TitleElement,
-  UISchemaElement,
 } from '../../types';
 import { loc } from '../../util';
-import { removeUIElementWithName } from '../utils';
+import { getUIElementWithName } from '../utils';
 import { getAuthenticatorVerifyButtonElements } from './utils';
 
 export const transformSelectAuthenticatorUnlockVerify: IdxStepTransformer = ({
@@ -26,27 +26,25 @@ export const transformSelectAuthenticatorUnlockVerify: IdxStepTransformer = ({
   formBag,
 }) => {
   const { nextStep: { inputs } = {} as NextStep } = transaction;
-  const authenticator = inputs?.find(({ name }) => name === 'authenticator');
-  if (!authenticator?.options) {
-    return formBag;
-  }
-
   const { uischema } = formBag;
 
-  const authenticatorButtonElements = getAuthenticatorVerifyButtonElements(authenticator.options);
-  uischema.elements = removeUIElementWithName(
-    'authenticator',
-    uischema.elements as UISchemaElement[],
-  );
-  uischema.elements = uischema.elements.concat(authenticatorButtonElements);
+  const authenticator = inputs?.find(({ name }) => name === 'authenticator');
+  const authenticatorButtons = getAuthenticatorVerifyButtonElements(authenticator!.options!);
 
-  const titleElement: TitleElement = {
+  const title: TitleElement = {
     type: 'Title',
     options: {
       content: loc('unlockaccount', 'login'),
     },
   };
-  uischema.elements.unshift(titleElement);
+
+  const identifier = getUIElementWithName('identifier', uischema.elements) as FieldElement;
+
+  uischema.elements = [
+    title,
+    identifier,
+    ...authenticatorButtons,
+  ];
 
   return formBag;
 };

--- a/src/v3/src/transformer/utils.ts
+++ b/src/v3/src/transformer/utils.ts
@@ -25,7 +25,9 @@ export const createForm = (): FormBag => ({
     elements: [],
   },
   data: {},
-  dataSchema: {},
+  dataSchema: {
+    fieldsToValidate: [] as string[],
+  } as FormBag['dataSchema'],
 });
 
 export const removeUIElementWithName = (

--- a/src/v3/src/types/.eslintrc.js
+++ b/src/v3/src/types/.eslintrc.js
@@ -10,21 +10,8 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './browserUtils';
-export * from './cookieUtils';
-export * from './environmentUtils';
-export * from './flattenInputs';
-export * from './formUtils';
-export * from './getAuthenticatorKey';
-export * from './getImmutableData';
-export * from './getTranslation';
-export * from './idxUtils';
-export * from './isPasswordRecovery';
-export * from './languageUtils';
-export * from './locUtil';
-export * from './passwordUtils';
-export * from './removeFieldLevelMessages';
-export * from './resetMessagesToInputs';
-export * from './settingsUtils';
-export * from './toNestedObject';
-export * from './webauthnUtils';
+module.exports = {
+  rules: {
+    'import/no-cycle': 'off',
+  },
+};

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxMessage, IdxTransaction, OktaAuth } from '@okta/okta-auth-js';
+import { MutableRef, StateUpdater } from 'preact/hooks';
+
+import { FormBag } from './schema';
+import { WidgetProps } from './widget';
+
+export type IWidgetContext = {
+  authClient: OktaAuth;
+  widgetProps: WidgetProps;
+  setMessage: StateUpdater<IdxMessage | undefined>;
+  // // TODO: OKTA-502849 - Update param type
+  // (RenderSuccessCallback / RenderErrorCallback) once merged into okta-signin-widget
+  onSuccessCallback?: (data: Record<string, unknown>) => void;
+  onErrorCallback?: (data: Record<string, unknown>) => void;
+  idxTransaction: IdxTransaction | undefined;
+  setIdxTransaction: StateUpdater<IdxTransaction | undefined>;
+  setIsClientTransaction: StateUpdater<boolean>;
+  stepToRender: string | undefined;
+  setStepToRender: StateUpdater<string | undefined>;
+  data: FormBag['data'];
+  setData: StateUpdater<FormBag['data']>;
+  additionalData: FormBag['data'];
+  setAdditionalData: StateUpdater<FormBag['data']>;
+  dataSchemaRef: MutableRef<FormBag['dataSchema'] | undefined>;
+};

--- a/src/v3/src/types/index.ts
+++ b/src/v3/src/types/index.ts
@@ -13,6 +13,7 @@
 export * from './appInfo';
 export * from './authcoin';
 export * from './component';
+export * from './context';
 export * from './error';
 export * from './handlers';
 export * from './ion';

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -20,16 +20,22 @@ import {
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
 import { FunctionComponent } from 'preact';
 
+import { IWidgetContext } from './context';
 import { ClickHandler } from './handlers';
 import { ListItem, PasswordSettings } from './password';
 import { UserInfo } from './userInfo';
+
+type GeneralDataSchemaBag = Record<string, DataSchema>;
 
 export type FormBag = {
   schema: Record<string, unknown>;
   uischema: UISchemaLayout;
   data: Record<string, unknown>;
   // temp schema bag to handle client validation and form submission
-  dataSchema: Record<string, DataSchema | ActionOptions>;
+  dataSchema: GeneralDataSchemaBag & {
+    submit: ActionOptions;
+    fieldsToValidate: string[];
+  }
 };
 
 export type AutoCompleteValue = 'username'
@@ -52,6 +58,8 @@ export interface ActionOptions {
   actionParams?: ActionParams;
   isActionStep?: boolean;
   step: string;
+  includeData?: boolean;
+  includeImmutableData?: boolean;
 }
 
 /**
@@ -113,7 +121,7 @@ export enum UISchemaLayoutType {
   STEPPER = 'Stepper',
 }
 
-export function isUISchemaLayoutType(type: string) {
+export function isUISchemaLayoutType(type: string): boolean {
   return Object.values(UISchemaLayoutType).includes(type as UISchemaLayoutType);
 }
 
@@ -153,7 +161,6 @@ export interface ButtonElement extends UISchemaElement {
     variant?: 'primary' | 'floating' | 'secondary';
     wide?: boolean;
     deviceChallengeUrl?: string;
-    includeData?: boolean;
     dataType?: 'cancel' | 'save';
     dataSe?: string;
     stepToRender?: string;
@@ -332,7 +339,7 @@ export interface StepperRadioElement {
   options: {
     customOptions: Array<IdxOption & {
       key?: string;
-      layout: () => UISchemaLayout;
+      callback: (widgetContext: IWidgetContext, stepIndex: number) => void;
     }>,
     name: string;
     defaultOption: string | number | boolean;

--- a/src/v3/src/util/flattenInputs.ts
+++ b/src/v3/src/util/flattenInputs.ts
@@ -16,7 +16,7 @@ export const flattenInputs = (input: Input): Input[] => {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const fn = (input: Input, nameTracker = '', requiredTracker: Input['required']): Input[] => {
     const res: Input[] = [];
-    const { value } = input;
+    const { value, options, type } = input;
 
     // Calculate "required" attribute for the flatten input
     // 1. when upper value is falsy - take "required" value from the current level
@@ -31,7 +31,20 @@ export const flattenInputs = (input: Input): Input[] => {
     } else {
       required = input.required;
     }
-    const name = nameTracker ? `${nameTracker}.${input.name}` : input.name;
+    let name: Input['name'];
+    if (nameTracker) {
+      name = typeof input.name === 'undefined' ? nameTracker : `${nameTracker}.${input.name}`;
+    } else {
+      name = input.name;
+    }
+
+    // flatten stepper related fields
+    if (type === 'object' && name !== 'authenticator' && Array.isArray(options)) {
+      return options.reduce((acc, curr) => [
+        ...acc,
+        ...fn(curr as Input, name, required),
+      ], res);
+    }
 
     if (Array.isArray(value)) {
       return value.reduce((acc, curr) => [

--- a/src/v3/src/util/removeFieldLevelMessages.ts
+++ b/src/v3/src/util/removeFieldLevelMessages.ts
@@ -10,21 +10,15 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-export * from './browserUtils';
-export * from './cookieUtils';
-export * from './environmentUtils';
-export * from './flattenInputs';
-export * from './formUtils';
-export * from './getAuthenticatorKey';
-export * from './getImmutableData';
-export * from './getTranslation';
-export * from './idxUtils';
-export * from './isPasswordRecovery';
-export * from './languageUtils';
-export * from './locUtil';
-export * from './passwordUtils';
-export * from './removeFieldLevelMessages';
-export * from './resetMessagesToInputs';
-export * from './settingsUtils';
-export * from './toNestedObject';
-export * from './webauthnUtils';
+import { FieldElement, UISchemaLayout } from '../types';
+
+export const removeFieldLevelMessages = (
+  elements: UISchemaLayout['elements'],
+): UISchemaLayout['elements'] => elements.map((el) => {
+  if (el.type === 'Field') {
+    // @ts-ignore - add type in authjs Input
+    // eslint-disable-next-line no-param-reassign
+    delete (el as FieldElement).options.inputMeta.messages;
+  }
+  return el;
+});

--- a/src/v3/src/util/resetMessagesToInputs.ts
+++ b/src/v3/src/util/resetMessagesToInputs.ts
@@ -18,7 +18,21 @@ export function resetMessagesToInputs(
 ): void {
   const fn = (items: Input[], namePrefix: string) => {
     items.forEach((input) => {
-      const name = namePrefix ? `${namePrefix}.${input.name}` : input.name;
+      let name: Input['name'];
+      if (namePrefix) {
+        name = typeof input.name === 'undefined' ? namePrefix : `${namePrefix}.${input.name}`;
+      } else {
+        name = input.name;
+      }
+
+      // add message to stepper related fields
+      if (input.type === 'object' && name !== 'authenticator' && Array.isArray(input.options)) {
+        input.options.forEach((option) => {
+          fn(option.value as Input[], name);
+        });
+        return;
+      }
+
       if (Array.isArray(input.value)) {
         fn(input.value, name);
         return;

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -1,6 +1,354 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`authenticator-enroll-security-question should render form 1`] = `
+exports[`authenticator-enroll-security-question custom question renders correct form 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester14@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-13"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
+                      >
+                        Set up security question
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root emotion-16"
+                    >
+                      
+                      <div
+                        class="MuiFormGroup-root emotion-17"
+                        role="radiogroup"
+                      >
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
+                            />
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                        for="credentials.question"
+                      >
+                        Create my own security question
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-35"
+                      >
+                        <input
+                          aria-invalid="false"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-36"
+                          data-se="credentials.question"
+                          id="credentials.question"
+                          name="credentials.question"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-37"
+                        >
+                          <legend
+                            class="emotion-38"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                        >
+                          <input
+                            aria-invalid="false"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-45"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-46"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-47"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-37"
+                          >
+                            <legend
+                              class="emotion-38"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-51"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <div
+                    class="MuiBox-root emotion-53"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                      data-se="switchAuthenticator"
+                      href="javascript:void(0)"
+                    >
+                      Return to authenticator list
+                    </a>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <div
+                    class="MuiBox-root emotion-53"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                      data-se="cancel"
+                      href="javascript:void(0)"
+                    >
+                      Back to sign in
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-enroll-security-question predefined question renders correct form 1`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -10,97 +10,281 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/credential/enroll/securityquestion-enroll-mfa.json';
 
 describe('authenticator-enroll-security-question', () => {
-  it('should render form', async () => {
-    const { container, findByText } = await setup({ mockResponse });
+  describe('predefined question', () => {
+    it('renders correct form', async () => {
+      const { container, findByText } = await setup({ mockResponse });
 
-    await findByText(/Set up security question/);
-    await findByText(/What is the food you least liked/);
-    expect(container).toMatchSnapshot();
+      await findByText(/Set up security question/);
+      await findByText(/What is the food you least liked/);
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should send correct payload', async () => {
+      const {
+        authClient, user, findByTestId, findByText,
+      } = await setup({ mockResponse });
+
+      await findByText(/Set up security question/);
+
+      const submitButton = await findByText('Verify', { selector: 'button' });
+      const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
+
+      const answer = 'pizza';
+      await user.type(answerEle, answer);
+
+      expect(answerEle.value).toEqual(answer);
+
+      await user.click(submitButton);
+      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        {
+          data: JSON.stringify({
+            credentials: {
+              questionKey: 'disliked_food',
+              answer,
+            },
+            stateHandle: 'fake-stateHandle',
+          }),
+          headers: {
+            Accept: 'application/json; okta-version=1.0.0',
+            'Content-Type': 'application/json',
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
+          },
+          withCredentials: true,
+        },
+      );
+    });
+
+    it('fails client side validation when answer is missing', async () => {
+      const {
+        authClient, user, findByRole, findByTestId, findByText,
+      } = await setup({ mockResponse });
+
+      await findByText(/Set up security question/);
+      await user.click(await findByText('Verify', { selector: 'button' }));
+
+      // assert no network request
+      expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        expect.anything(),
+      );
+      // assert global alert
+      const globalError = await findByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      // assert field level error
+      const answerFieldError = await findByTestId('credentials.answer-error');
+      expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
+    });
+
+    it('clears messages when switch to custom question form', async () => {
+      const {
+        user, queryByRole, queryByTestId, findByText, findByLabelText,
+      } = await setup({ mockResponse });
+
+      await findByText(/Set up security question/);
+      await user.click(await findByText('Verify', { selector: 'button' }));
+
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
+
+      // assert no error message
+      await waitFor(() => {
+        const globalError = queryByRole('alert');
+        expect(globalError).toBeNull();
+        const answerFieldError = queryByTestId('credentials.answer-error');
+        expect(answerFieldError).toBeNull();
+      });
+    });
   });
 
-  it('should send correct payload with default selections', async () => {
-    const {
-      authClient, user, findByTestId, findByText,
-    } = await setup({ mockResponse });
+  describe('custom question', () => {
+    it('renders correct form', async () => {
+      const {
+        container,
+        user,
+        findByText,
+        findByTestId,
+        findByLabelText,
+      } = await setup({ mockResponse });
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
+      await findByText(/Set up security question/);
+      await findByTestId('credentials.question');
+      expect(container).toMatchSnapshot();
+    });
 
-    await findByText(/Set up security question/);
+    it('should send correct payload', async () => {
+      const {
+        authClient, user, findByTestId, findByText, findByLabelText,
+      } = await setup({ mockResponse });
 
-    const submitButton = await findByText('Verify', { selector: 'button' });
-    const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
 
-    const answer = 'pizza';
-    await user.type(answerEle, answer);
+      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
+      const submitButton = await findByText('Verify', { selector: 'button' });
 
-    expect(answerEle.value).toEqual(answer);
+      const question = 'What is the meaning of life?';
+      const answer = '42';
+      await user.type(customQuestionEle, question);
+      await user.type(answerEle, answer);
 
-    await user.click(submitButton);
-    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
-      'POST',
-      'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
-      {
-        data: JSON.stringify({
-          credentials: {
-            questionKey: 'disliked_food',
-            answer,
+      expect(customQuestionEle.value).toEqual(question);
+      expect(answerEle.value).toEqual(answer);
+
+      await user.click(submitButton);
+      expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        {
+          data: JSON.stringify({
+            credentials: {
+              questionKey: 'custom',
+              question,
+              answer,
+            },
+            stateHandle: 'fake-stateHandle',
+          }),
+          headers: {
+            Accept: 'application/json; okta-version=1.0.0',
+            'Content-Type': 'application/json',
+            'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
           },
-          stateHandle: 'fake-stateHandle',
-        }),
-        headers: {
-          Accept: 'application/json; okta-version=1.0.0',
-          'Content-Type': 'application/json',
-          'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
+          withCredentials: true,
         },
-        withCredentials: true,
-      },
-    );
-  });
+      );
+    });
 
-  it('should send correct payload with custom selections', async () => {
-    const {
-      authClient, user, findByTestId, findByText, findByLabelText,
-    } = await setup({ mockResponse });
+    it('fails client side validation when custom question is missing', async () => {
+      const {
+        authClient,
+        user,
+        findByTestId,
+        findByText,
+        findByLabelText,
+        findByRole,
+        queryByTestId,
+      } = await setup({ mockResponse });
 
-    await findByText(/Set up security question/);
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
 
-    user.click(await findByLabelText(/Create my own security question/));
+      const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
+      const answer = '42';
+      await user.type(answerEle, answer);
+      await user.click(await findByText('Verify', { selector: 'button' }));
 
-    const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
-    const answerEle = await findByTestId('credentials.answer') as HTMLInputElement;
-    const submitButton = await findByText('Verify', { selector: 'button' });
+      // assert no network request
+      expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        expect.anything(),
+      );
+      // assert global alert
+      const globalError = await findByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      // assert field level error
+      const questionFieldError = await findByTestId('credentials.question-error');
+      expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
+      const answerFieldError = queryByTestId('credentials.answer-error');
+      expect(answerFieldError).toBeNull();
+    });
 
-    const question = 'What is the meaning of life?';
-    const answer = '42';
-    await user.type(customQuestionEle, question);
-    await user.type(answerEle, answer);
+    it('fails client side validation when answer is missing', async () => {
+      const {
+        authClient,
+        user,
+        findByTestId,
+        findByText,
+        findByLabelText,
+        findByRole,
+        queryByTestId,
+      } = await setup({ mockResponse });
 
-    expect(customQuestionEle.value).toEqual(question);
-    expect(answerEle.value).toEqual(answer);
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
 
-    await user.click(submitButton);
-    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
-      'POST',
-      'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
-      {
-        data: JSON.stringify({
-          credentials: {
-            questionKey: 'custom',
-            question,
-            answer,
-          },
-          stateHandle: 'fake-stateHandle',
-        }),
-        headers: {
-          Accept: 'application/json; okta-version=1.0.0',
-          'Content-Type': 'application/json',
-          'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
-        },
-        withCredentials: true,
-      },
-    );
+      const customQuestionEle = await findByTestId('credentials.question') as HTMLInputElement;
+      const question = 'What is the meaning of life?';
+      await user.type(customQuestionEle, question);
+      expect(customQuestionEle.value).toEqual(question);
+      await user.click(await findByText('Verify', { selector: 'button' }));
+
+      // assert no network request
+      expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        expect.anything(),
+      );
+      // assert global alert
+      const globalError = await findByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      // assert field level error
+      const answerFieldError = await findByTestId('credentials.answer-error');
+      expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
+      const questionFieldError = queryByTestId('credentials.question-error');
+      expect(questionFieldError).toBeNull();
+    });
+
+    it('fails client side validation when both custom question and answer are missing', async () => {
+      const {
+        authClient,
+        user,
+        findByTestId,
+        findByText,
+        findByLabelText,
+        findByRole,
+      } = await setup({ mockResponse });
+
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
+
+      await user.click(await findByText('Verify', { selector: 'button' }));
+      expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
+        'POST',
+        'https://oie-4695462.oktapreview.com/idp/idx/challenge/answer',
+        expect.anything(),
+      );
+      // assert global alert
+      const globalError = await findByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      // assert field level error
+      const questionFieldError = await findByTestId('credentials.question-error');
+      expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
+      const answerFieldError = await findByTestId('credentials.answer-error');
+      expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
+    });
+
+    it('clears messages when switch to predefined question form', async () => {
+      const {
+        user, queryByRole, queryByTestId, findByText, findByLabelText,
+      } = await setup({ mockResponse });
+
+      // switch to custom question form
+      user.click(await findByLabelText(/Create my own security question/));
+      await user.click(await findByText('Verify', { selector: 'button' }));
+
+      // switch to predefined question form
+      user.click(await findByLabelText(/Choose a security question/));
+
+      // assert no error message
+      await waitFor(() => {
+        const globalError = queryByRole('alert');
+        expect(globalError).toBeNull();
+        const questionFieldError = queryByTestId('credentials.question-error');
+        expect(questionFieldError).toBeNull();
+        const answerFieldError = queryByTestId('credentials.answer-error');
+        expect(answerFieldError).toBeNull();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description:

* adds fieldsToValidate array in dataSchema to support stepper fields validation
  * by default it contains all fields in non-stepper form
  * this field can be configurable in when step changes (stepper form)
* add 'callback' option for StepperRadio component to update schema while step changing 

<img width="446" alt="Screen Shot 2022-08-08 at 2 20 24 PM" src="https://user-images.githubusercontent.com/60160041/183486511-f132dccd-7bec-4d4c-9254-1b53dfc74e07.png">


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-516694](https://oktainc.atlassian.net/browse/OKTA-516694)


