### PR TITLE
Re-enabling Captcha testcafe tests

### DIFF
--- a/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyRecoveryWithCaptcha_spec.js
@@ -64,7 +64,7 @@ test.requestHooks(identifyRequestLogger, reCaptchaRequestLogger, identifyRecover
 });
 
 // TODO: enable this test OKTA-504996
-test.requestHooks(identifyRequestLogger, identifyRecoveryWithHCaptchaMock).skip('should be able to submit identifier with hCaptcha enabled', async t => {
+test.requestHooks(identifyRequestLogger, identifyRecoveryWithHCaptchaMock)('should be able to submit identifier with hCaptcha enabled', async t => {
   const identityPage = await setup(t);
 
   // Wait for the hCaptcha container to appear in the DOM and become visible.

--- a/test/testcafe/spec/IdentifyRegistrationWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyRegistrationWithCaptcha_spec.js
@@ -57,7 +57,7 @@ test.requestHooks(reCaptchaRequestLogger, mockWithReCaptcha)('should be able to 
 });
 
 // TODO: enable this test OKTA-504996
-test.requestHooks(mockWithHCaptcha).skip('should be able to create account with hCaptcha enabled', async t => {
+test.requestHooks(mockWithHCaptcha)('should be able to create account with hCaptcha enabled', async t => {
   // mock is configured to show registration page immediately
   const registrationPage = new RegistrationPageObject(t);
   await registrationPage.navigateToPage();

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -49,7 +49,7 @@ async function setup(t) {
 }
 
 // TODO: enable this test OKTA-504996
-test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha).skip('should sign in with hCaptcha enabled', async t => {
+test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha)('should sign in with hCaptcha enabled', async t => {
   const identityPage = await setup(t);
 
   await identityPage.fillIdentifierField('Test Identifier');

--- a/test/testcafe/spec/IdentifyWithCaptcha_spec.js
+++ b/test/testcafe/spec/IdentifyWithCaptcha_spec.js
@@ -52,6 +52,7 @@ async function setup(t) {
 test.requestHooks(identifyRequestLogger, identifyMockwithHCaptcha)('should sign in with hCaptcha enabled', async t => {
   const identityPage = await setup(t);
 
+  
   await identityPage.fillIdentifierField('Test Identifier');
   await identityPage.fillPasswordField('random password 123');
   await t.expect(await identityPage.hasForgotPasswordLinkText()).ok();


### PR DESCRIPTION
## Description:
- After investigating the intermittent failures from a month ago, it looks like the issue does not manifest itself anymore in Bacon nor locally. I've ran the tests multiple times in a row in both env successfully (see Jira for full details).
- Re-enabling the tests for now and we can keep an eye on them.


## PR Checklist

- [ ] Have you verified the basic functionality for this change?

- [ ] Added unit tests?

- [ ] Added e2e tests

- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?

- Did you verify the change by running downstream monolith artifacts? (YES | NO | UNSURE)

### Screenshot/Video:


### Reviewers:


### Issue:

- [OKTA-505668](https://oktainc.atlassian.net/browse/OKTA-505668)


