### PR TITLE
OKTA-486130 registration/login entry

### DIFF
--- a/src/v3/src/components/Divider/Divider.tsx
+++ b/src/v3/src/components/Divider/Divider.tsx
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { Box, Divider as MuiDivider } from '@mui/material';
+import { FunctionComponent, h } from 'preact';
+
+const Divider: FunctionComponent = () => ( 
+  <MuiDivider />
+)
+
+export default Divider;

--- a/src/v3/src/components/Divider/Divider.tsx
+++ b/src/v3/src/components/Divider/Divider.tsx
@@ -10,11 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box, Divider as MuiDivider } from '@mui/material';
+import { Divider as MuiDivider } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
-const Divider: FunctionComponent = () => ( 
+const Divider: FunctionComponent = () => (
   <MuiDivider />
-)
+);
 
 export default Divider;

--- a/src/v3/src/components/Divider/index.tsx
+++ b/src/v3/src/components/Divider/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Divider from './Divider';
+
+export default Divider;

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -32,11 +32,14 @@ type LayoutProps = {
 const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
   const { type, elements } = uischema;
 
-  const flexDirection = type === UISchemaLayoutType.HORIZONTAL ? 'row' : 'column';
+  const isHorizontalLayout = type === UISchemaLayoutType.HORIZONTAL;
+  const flexDirection = isHorizontalLayout ? 'row' : 'column';
   return (
     <Box
       display="flex"
       flexDirection={flexDirection}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...(isHorizontalLayout && { gap: 1 })}
     >
       {
         elements.map((element, index) => {

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -16,6 +16,7 @@ import { FieldElement, InputTextElement, Renderer } from '../../types';
 import AuthenticatorButton from '../AuthenticatorButton';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
+import Divider from '../Divider/Divider';
 import Heading from '../Heading';
 import ImageWithText from '../ImageWithText';
 import InfoBox from '../InfoBox';
@@ -127,6 +128,10 @@ export default [
   {
     tester: ({ type }) => type === 'InfoBox',
     renderer: InfoBox,
+  },
+  {
+    tester: ({ type }) => type === 'Divider',
+    renderer: Divider,
   },
   {
     tester: ({

--- a/src/v3/src/components/Form/renderers.tsx
+++ b/src/v3/src/components/Form/renderers.tsx
@@ -16,7 +16,7 @@ import { FieldElement, InputTextElement, Renderer } from '../../types';
 import AuthenticatorButton from '../AuthenticatorButton';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
-import Divider from '../Divider/Divider';
+import Divider from '../Divider';
 import Heading from '../Heading';
 import ImageWithText from '../ImageWithText';
 import InfoBox from '../InfoBox';

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Box, Link as LinkMui } from '@mui/material';
+import { Link as LinkMui } from '@mui/material';
 import { h } from 'preact';
 
 import { useOnSubmit } from '../../hooks';
@@ -43,21 +43,28 @@ const Link: UISchemaElementComponent<{
   };
 
   return (
-    <Box marginTop={4}>
-      {
-        typeof href === 'undefined' ? (
-          <LinkMui
-            // eslint-disable-next-line no-script-url
-            href="javascript:void(0)"
-            onClick={onClick}
-            // eslint-disable-next-line react/jsx-props-no-spreading
-            {...(dataSe && { 'data-se': dataSe } )}
-          >
-            {getLabelName(label)}
-          </LinkMui>
-        ) : <LinkMui href={href}>{getLabelName(label)}</LinkMui>
-      }
-    </Box>
+    typeof href === 'undefined' ? (
+      <LinkMui
+        // eslint-disable-next-line no-script-url
+        href="javascript:void(0)"
+        onClick={onClick}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...(dataSe && { 'data-se': dataSe } )}
+        sx={{
+          verticalAlign: 'middle',
+        }}
+      >
+        {getLabelName(label)}
+      </LinkMui>
+    )
+      : (
+        <LinkMui
+          href={href}
+          sx={{ verticalAlign: 'middle' }}
+        >
+          {getLabelName(label)}
+        </LinkMui>
+      )
   );
 };
 

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -21,6 +21,7 @@ import {
   ButtonType,
   LinkElement,
   UISchemaElement,
+  UISchemaLayoutType,
 } from '../../types';
 import { loc } from '../../util';
 
@@ -142,16 +143,31 @@ export const getButtonControls = (
 
   const registerStep = getButtonStep(IDX_STEP.SELECT_ENROLL_PROFILE);
   if (config.stepWithRegister && registerStep) {
+    elements.push({
+      type: 'Divider',
+    });
     const { name: step } = registerStep;
     const register: LinkElement = {
       type: 'Link',
       options: {
-        label: loc('registration.form.submit', 'login'),
+        label: loc('signup', 'login'),
         step,
       },
     };
+    const registerEntryLayout = {
+      type: UISchemaLayoutType.HORIZONTAL,
+      elements: [
+        {
+          type: 'Description',
+          options: {
+            content: loc('registration.signup.label', 'login'),
+          },
+        },
+        register,
+      ],
+    };
 
-    elements.push(register);
+    elements.push(registerEntryLayout);
   }
 
   const cancelStep = getButtonStep('cancel');

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -71,7 +71,7 @@ export const getButtonControls = (
       options: {
         label: loc('forgotpassword', 'login'),
         isActionStep: true,
-        step
+        step,
       },
     };
 

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -163,7 +163,7 @@ export const getButtonControls = (
     };
     const registerEntryLayout = {
       type: UISchemaLayoutType.HORIZONTAL,
-      elements: [registrationLabel,registerLink],
+      elements: [registrationLabel, registerLink],
     };
 
     elements.push(registerEntryLayout);

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -19,6 +19,7 @@ import { IDX_STEP } from '../../constants';
 import {
   ButtonElement,
   ButtonType,
+  DescriptionElement,
   LinkElement,
   UISchemaElement,
   UISchemaLayoutType,
@@ -147,24 +148,22 @@ export const getButtonControls = (
       type: 'Divider',
     });
     const { name: step } = registerStep;
-    const register: LinkElement = {
+    const registerLink: LinkElement = {
       type: 'Link',
       options: {
         label: loc('signup', 'login'),
         step,
       },
     };
+    const registrationLabel: DescriptionElement = {
+      type: 'Description',
+      options: {
+        content: loc('registration.signup.label', 'login'),
+      },
+    };
     const registerEntryLayout = {
       type: UISchemaLayoutType.HORIZONTAL,
-      elements: [
-        {
-          type: 'Description',
-          options: {
-            content: loc('registration.signup.label', 'login'),
-          },
-        },
-        register,
-      ],
+      elements: [registrationLabel,registerLink],
     };
 
     elements.push(registerEntryLayout);

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -71,7 +71,7 @@ export const getButtonControls = (
       options: {
         label: loc('forgotpassword', 'login'),
         isActionStep: true,
-        step,
+        step
       },
     };
 

--- a/src/v3/src/transformer/profile/transformEnrollProfile.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.ts
@@ -78,6 +78,9 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
 
   const selectIdentifyStep = availableSteps?.find(({ name }) => name === IDX_STEP.SELECT_IDENTIFY);
   if (selectIdentifyStep) {
+    uischema.elements.push({
+      type: 'Divider',
+    } );
     const { name: step } = selectIdentifyStep;
     uischema.elements.push({
       type: 'Link',

--- a/src/v3/src/transformer/profile/transformEnrollProfile.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.ts
@@ -21,6 +21,7 @@ import {
   PasswordRequirementsElement,
   TitleElement,
   UISchemaElement,
+  UISchemaLayoutType,
 } from '../../types';
 import { getUserInfo, loc } from '../../util';
 import { buildPasswordRequirementListItems } from '../password';
@@ -80,15 +81,29 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
   if (selectIdentifyStep) {
     uischema.elements.push({
       type: 'Divider',
-    } );
+    });
     const { name: step } = selectIdentifyStep;
-    uischema.elements.push({
+    const login: LinkElement = {
       type: 'Link',
       options: {
-        label: loc('haveaccount', 'login'),
+        label: loc('signin', 'login'),
         step,
       },
-    } as LinkElement);
+    };
+    const loginEntryLayout = {
+      type: UISchemaLayoutType.HORIZONTAL,
+      elements: [
+        {
+          type: 'Description',
+          options: {
+            content: loc('haveaccount', 'login'),
+          },
+        },
+        login,
+      ],
+    };
+
+    uischema.elements.push(loginEntryLayout);
   }
 
   return formBag;

--- a/src/v3/src/transformer/profile/transformEnrollProfile.ts
+++ b/src/v3/src/transformer/profile/transformEnrollProfile.ts
@@ -14,6 +14,7 @@ import { IDX_STEP, PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS } from '../../consta
 import {
   ButtonElement,
   ButtonType,
+  DescriptionElement,
   FieldElement,
   IdxStepTransformer,
   LinkElement,
@@ -83,24 +84,22 @@ export const transformEnrollProfile: IdxStepTransformer = ({ transaction, formBa
       type: 'Divider',
     });
     const { name: step } = selectIdentifyStep;
-    const login: LinkElement = {
+    const signinLink: LinkElement = {
       type: 'Link',
       options: {
         label: loc('signin', 'login'),
         step,
       },
     };
+    const signinLabel: DescriptionElement = {
+      type: 'Description',
+      options: {
+        content: loc('haveaccount', 'login'),
+      },
+    };
     const loginEntryLayout = {
       type: UISchemaLayoutType.HORIZONTAL,
-      elements: [
-        {
-          type: 'Description',
-          options: {
-            content: loc('haveaccount', 'login'),
-          },
-        },
-        login,
-      ],
+      elements: [signinLabel, signinLink],
     };
 
     uischema.elements.push(loginEntryLayout);

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -114,7 +114,10 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -122,40 +125,8 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-16"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me an email
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-18"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -109,20 +109,13 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-19"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -122,8 +122,40 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-16"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send me an email
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-18"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1511,38 +1511,24 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-42"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-42"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1539,8 +1539,43 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1547,7 +1547,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-41"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
@@ -1562,7 +1562,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-41"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -1516,7 +1516,10 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1531,7 +1534,10 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1539,43 +1545,8 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-41"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-41"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                         for="credentials.passcode"
                       >
                         Enter code
@@ -606,7 +606,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                         for="credentials.passcode"
                       >
                         Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -141,7 +141,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -156,7 +159,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -164,43 +170,8 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-23"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-23"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -367,7 +338,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -382,7 +356,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -390,43 +367,8 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-26"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-26"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -564,7 +506,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -579,7 +524,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -587,43 +535,8 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -790,7 +703,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -805,7 +721,10 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -813,43 +732,8 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-26"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-26"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -164,8 +164,43 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -355,8 +390,43 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -517,8 +587,43 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -708,8 +813,43 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-23"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
@@ -187,7 +187,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-23"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
@@ -398,7 +398,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-26"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
@@ -413,7 +413,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-26"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
@@ -595,7 +595,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -610,7 +610,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -821,7 +821,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-26"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
@@ -836,7 +836,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-26"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -269,7 +269,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                         for="credentials.passcode"
                       >
                         Enter code
@@ -606,7 +606,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                         for="credentials.passcode"
                       >
                         Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -136,38 +136,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-24"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-24"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -333,38 +319,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -501,38 +473,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -698,38 +656,24 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -220,7 +220,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -166,55 +166,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="switchAuthenticator"
@@ -223,12 +174,8 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     Return to authenticator list
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-28"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -237,10 +184,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -184,6 +185,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-29"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
@@ -192,6 +194,43 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -172,7 +171,10 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -186,14 +188,20 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-29"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -231,6 +239,8 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -220,7 +220,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -184,6 +185,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-29"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
@@ -192,6 +194,43 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -172,7 +171,10 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -186,14 +188,20 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     class="MuiBox-root emotion-29"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -231,6 +239,8 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -166,55 +166,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="switchAuthenticator"
@@ -223,12 +174,8 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                     Return to authenticator list
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-28"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -237,10 +184,6 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -803,7 +803,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-47"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
@@ -818,7 +818,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-47"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                         for="credentials.question"
                       >
                         Create my own security question
@@ -238,7 +238,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                           for="credentials.answer"
                         >
                           Answer
@@ -255,7 +255,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-45"
                           >
                             <button
                               aria-label="toggle password visibility"
@@ -311,32 +311,24 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-53"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
-                      data-se="switchAuthenticator"
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-53"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
-                      data-se="cancel"
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -694,7 +686,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                           for="credentials.answer"
                         >
                           Answer
@@ -711,7 +703,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                         for="credentials.question"
                       >
                         Create my own security question
@@ -238,7 +238,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-34"
                           for="credentials.answer"
                         >
                           Answer
@@ -255,7 +255,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-45"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
                           >
                             <button
                               aria-label="toggle password visibility"
@@ -686,7 +686,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                           for="credentials.answer"
                         >
                           Answer
@@ -703,7 +703,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -795,8 +795,43 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -772,7 +772,10 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -787,7 +790,10 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -795,43 +801,8 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-47"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-47"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -767,38 +767,24 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-48"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-48"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -213,6 +213,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-39"
                     data-type="save"
@@ -228,6 +229,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   <div
                     class="MuiBox-root emotion-41"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="cancel"
@@ -236,6 +238,28 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Set up later
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -249,7 +249,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <div
-                  class="MuiBox-root emotion-6"
+                  class="MuiBox-root emotion-40"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -225,37 +225,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
-                    class="MuiBox-root emotion-41"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Set up later
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-40"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
                     data-se="cancel"
@@ -263,10 +232,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -213,7 +213,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-39"
                     data-type="save"
@@ -230,14 +229,20 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiBox-root emotion-41"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-42"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -260,6 +265,8 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -570,12 +570,14 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-109"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-110"
                       data-se="cancel"
@@ -584,6 +586,26 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-109"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -595,7 +595,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <div
-                  class="MuiBox-root emotion-6"
+                  class="MuiBox-root emotion-108"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-109"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -570,7 +570,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-10"
                 >
@@ -578,14 +577,20 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     class="MuiBox-root emotion-109"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-110"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-110"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -606,6 +611,8 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -573,35 +573,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
-                    class="MuiBox-root emotion-109"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-110"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-110"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-108"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-109"
                     data-se="cancel"
@@ -609,10 +580,6 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                             for="credentials.passcode"
                           >
                             New password
@@ -115,7 +115,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -162,7 +162,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -180,7 +180,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -224,7 +224,6 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-38"
                     data-type="save"
@@ -241,14 +240,20 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                     class="MuiBox-root emotion-40"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -271,6 +276,8 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-39"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -236,37 +236,6 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-40"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-39"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
                     data-se="cancel"
@@ -274,10 +243,6 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                             for="credentials.passcode"
                           >
                             New password
@@ -115,7 +115,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -162,7 +162,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-19"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -180,7 +180,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -224,6 +224,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-38"
                     data-type="save"
@@ -239,6 +240,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-40"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-41"
                       data-se="cancel"
@@ -247,6 +249,28 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-40"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -483,7 +483,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-56"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
@@ -498,7 +498,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-56"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                             for="credentials.passcode"
                           >
                             New password
@@ -323,7 +323,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -370,7 +370,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -388,7 +388,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -432,6 +432,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
@@ -462,6 +463,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   <div
                     class="MuiBox-root emotion-58"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                       data-se="cancel"
@@ -470,6 +472,43 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -305,7 +305,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                             for="credentials.passcode"
                           >
                             New password
@@ -323,7 +323,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -370,7 +370,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -388,7 +388,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-40"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -432,7 +432,6 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-56"
                     data-type="save"
@@ -446,11 +445,18 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-58"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                       data-se="switchAuthenticator"
+=======
+                    class="MuiBox-root emotion-57"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -461,17 +467,25 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-58"
                   >
 <<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                       data-se="cancel"
+=======
+                    class="MuiBox-root emotion-57"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -509,6 +523,8 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -444,87 +444,24 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-58"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
-                      data-se="switchAuthenticator"
-=======
-                    class="MuiBox-root emotion-57"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-58"
-                  >
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
-                      data-se="cancel"
-=======
-                    class="MuiBox-root emotion-57"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-56"
-                >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
                     Return to authenticator list
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-56"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-58"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -469,6 +469,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -484,6 +485,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-61"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
@@ -492,6 +494,28 @@ exports[`authenticator-expired-password should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Change Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -481,50 +481,13 @@ exports[`authenticator-expired-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-61"
-                  >
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
-                      data-se="cancel"
-=======
-                    class="MuiBox-root emotion-60"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Change Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-59"
-                >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -342,7 +342,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -360,7 +360,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -407,7 +407,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -425,7 +425,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -342,7 +342,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -360,7 +360,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -407,7 +407,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -425,7 +425,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -469,7 +469,6 @@ exports[`authenticator-expired-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -483,17 +482,25 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-61"
                   >
 <<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
+=======
+                    class="MuiBox-root emotion-60"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -516,6 +523,8 @@ exports[`authenticator-expired-password should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -505,7 +505,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-59"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -616,50 +616,13 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-74"
-                  >
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-75"
-                      data-se="cancel"
-=======
-                    class="MuiBox-root emotion-73"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-74"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Remind me later
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-72"
-                >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-73"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-74"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -605,6 +605,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-72"
                     tabindex="0"
@@ -619,6 +620,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-74"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-75"
                       data-se="cancel"
@@ -627,6 +629,28 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Remind me later
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-73"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -640,7 +640,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-72"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-73"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -605,7 +605,6 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-72"
                     tabindex="0"
@@ -618,17 +617,25 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-74"
                   >
 <<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-75"
                       data-se="cancel"
+=======
+                    class="MuiBox-root emotion-73"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-74"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -651,6 +658,8 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -466,7 +466,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
                             for="credentials.passcode"
                           >
                             New password
@@ -484,7 +484,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-54"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-54"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -531,7 +531,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -549,7 +549,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-54"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-54"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -466,7 +466,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
                             for="credentials.passcode"
                           >
                             New password
@@ -484,7 +484,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-54"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-54"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -531,7 +531,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-51"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -549,7 +549,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-54"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-54"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -342,7 +342,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -360,7 +360,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -407,7 +407,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -425,7 +425,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"
@@ -841,7 +841,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -859,7 +859,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -906,7 +906,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -924,7 +924,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -505,7 +505,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-59"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
@@ -1032,7 +1032,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-59"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -469,7 +469,6 @@ exports[`authenticator-reset-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -483,17 +482,25 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-61"
                   >
 <<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
+=======
+                    class="MuiBox-root emotion-60"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -516,6 +523,8 @@ exports[`authenticator-reset-password should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>
@@ -996,7 +1005,6 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -1010,17 +1018,25 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-61"
                   >
 <<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
+=======
+                    class="MuiBox-root emotion-60"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -1043,6 +1059,8 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -469,6 +469,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -484,6 +485,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-61"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
@@ -492,6 +494,28 @@ exports[`authenticator-reset-password should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Reset Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>
@@ -972,6 +996,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-59"
                     data-type="save"
@@ -987,6 +1012,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   <div
                     class="MuiBox-root emotion-61"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
                       data-se="cancel"
@@ -995,6 +1021,28 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Reset Password
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -342,7 +342,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -360,7 +360,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -407,7 +407,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -425,7 +425,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"
@@ -841,7 +841,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           class="MuiBox-root emotion-4"
                         >
                           <label
-                            class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                            class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                             for="credentials.passcode"
                           >
                             New password
@@ -859,7 +859,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                               type="password"
                             />
                             <div
-                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                              class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                             >
                               <button
                                 aria-label="toggle password visibility"
@@ -906,7 +906,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         class="MuiBox-root emotion-4"
                       >
                         <label
-                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
+                          class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-40"
                           for="confirmPassword"
                         >
                           Re-enter password
@@ -924,7 +924,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                             type="password"
                           />
                           <div
-                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-43"
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-43"
                           >
                             <button
                               aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -481,50 +481,13 @@ exports[`authenticator-reset-password should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-61"
-                  >
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
-                      data-se="cancel"
-=======
-                    class="MuiBox-root emotion-60"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Reset Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-59"
-                >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>
@@ -1017,50 +980,13 @@ exports[`authenticator-reset-password should render form with custom brand name 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-<<<<<<< HEAD
-                    class="MuiBox-root emotion-61"
-                  >
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-62"
-                      data-se="cancel"
-=======
-                    class="MuiBox-root emotion-60"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Reset Password
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-59"
-                >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-61"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -185,7 +185,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -122,38 +122,24 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-21"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-21"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -150,8 +150,55 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Receive a code via SMS
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -127,7 +127,10 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -142,7 +145,10 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -150,55 +156,8 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-18"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Receive a code via SMS
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -128,8 +128,28 @@ exports[`authenticator-verification-email renders correct form renders the initi
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -307,8 +327,28 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -508,8 +548,43 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -120,7 +120,10 @@ exports[`authenticator-verification-email renders correct form renders the initi
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -128,28 +131,8 @@ exports[`authenticator-verification-email renders correct form renders the initi
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -319,7 +302,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -327,28 +313,8 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -525,7 +491,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -540,7 +509,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -548,43 +520,8 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
                         for="credentials.passcode"
                       >
                         Enter code
@@ -415,7 +415,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
                         for="credentials.passcode"
                       >
                         Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -335,7 +335,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
@@ -556,7 +556,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -571,7 +571,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -240,7 +240,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
                         for="credentials.passcode"
                       >
                         Enter code
@@ -415,7 +415,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
                         for="credentials.passcode"
                       >
                         Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -115,20 +115,13 @@ exports[`authenticator-verification-email renders correct form renders the initi
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-21"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -297,20 +290,13 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-28"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -486,38 +472,24 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-12"
                   >
@@ -168,6 +169,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   <div
                     class="MuiBox-root emotion-26"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                       data-se="cancel"
@@ -176,6 +178,43 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
@@ -204,7 +204,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-12"
                   >
@@ -156,7 +155,10 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -170,14 +172,20 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-26"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -215,6 +223,8 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                       for="credentials.passcode"
                     >
                       Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -150,55 +150,6 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-26"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-26"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-25"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
                     data-se="switchAuthenticator"
@@ -207,12 +158,8 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     Verify with something else
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-25"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
@@ -221,10 +168,6 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-18"
                       for="credentials.passcode"
                     >
                       Enter code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-32"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -201,8 +201,28 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -193,7 +193,10 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -201,28 +204,8 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-32"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -188,20 +188,13 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-33"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -170,7 +170,10 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -178,28 +181,8 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -178,8 +178,28 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -165,20 +165,13 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -132,38 +132,24 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-23"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-23"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -160,8 +160,91 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <label
+                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-14"
+                >
+                  <span
+                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-15"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input emotion-16"
+                      data-se="authenticator.autoChallenge"
+                      data-se-for-name="authenticator.autoChallenge"
+                      id="authenticator.autoChallenge"
+                      name="authenticator.autoChallenge"
+                      type="checkbox"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-17"
+                      data-testid="CheckBoxOutlineBlankIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-18"
+                  >
+                    Send push automatically
+                  </span>
+                </label>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send push
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-22"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
@@ -231,7 +231,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-22"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -137,7 +137,10 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -152,7 +155,10 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -160,91 +166,8 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-14"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-15"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-16"
-                      data-se="authenticator.autoChallenge"
-                      data-se-for-name="authenticator.autoChallenge"
-                      id="authenticator.autoChallenge"
-                      name="authenticator.autoChallenge"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-17"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-18"
-                  >
-                    Send push automatically
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-20"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send push
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-22"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-22"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-4"
                   >
@@ -143,7 +142,10 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -157,14 +159,20 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-24"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -202,6 +210,8 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-23"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
@@ -191,7 +191,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-23"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -137,55 +137,6 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-24"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-24"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-23"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
                     data-se="switchAuthenticator"
@@ -194,12 +145,8 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     Verify with something else
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-23"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
@@ -208,10 +155,6 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="credentials.totp"
                     >
                       Enter code from Okta Verify app

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="credentials.totp"
                     >
                       Enter code from Okta Verify app

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-4"
                   >
@@ -155,6 +156,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-24"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-25"
                       data-se="cancel"
@@ -163,6 +165,43 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
                       for="credentials.passcode"
                     >
                       Enter Code

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -220,7 +220,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -166,55 +166,6 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="switchAuthenticator"
@@ -223,12 +174,8 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     Verify with something else
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
                 <div
-                  class="MuiBox-root emotion-28"
+                  class="MuiBox-root emotion-11"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
@@ -237,10 +184,6 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -184,6 +185,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-29"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
@@ -192,6 +194,43 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -87,7 +87,6 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
                   >
@@ -172,7 +171,10 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -186,14 +188,20 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                     class="MuiBox-root emotion-29"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -231,6 +239,8 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -163,37 +163,6 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-28"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-                  Verify
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                     data-se="cancel"
@@ -201,10 +170,6 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -151,7 +151,6 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                     data-type="save"
@@ -168,14 +167,20 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                     class="MuiBox-root emotion-28"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -198,6 +203,8 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
                         for="credentials.answer"
                       >
                         What is the food you least liked as a child?
@@ -108,7 +108,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-20"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-20"
                         >
                           <button
                             aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                     data-type="save"
@@ -166,6 +167,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   <div
                     class="MuiBox-root emotion-28"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                       data-se="cancel"
@@ -174,6 +176,28 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+                  Verify
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
                         for="credentials.answer"
                       >
                         What is the food you least liked as a child?
@@ -108,7 +108,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-20"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-20"
                         >
                           <button
                             aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -659,7 +659,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 class="MuiBox-root emotion-9"
               >
                 <div
-                  class="MuiBox-root emotion-6"
+                  class="MuiBox-root emotion-121"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-122"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -637,35 +637,6 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
-                    class="MuiBox-root emotion-122"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-123"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-123"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-121"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-122"
                     data-se="cancel"
@@ -673,10 +644,6 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -634,12 +634,14 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-122"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-123"
                       data-se="cancel"
@@ -648,6 +650,26 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-122"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -634,7 +634,6 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-10"
                 >
@@ -642,14 +641,20 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     class="MuiBox-root emotion-122"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-123"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-123"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -670,6 +675,8 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -102,7 +102,10 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -117,7 +120,10 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -125,43 +131,8 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -289,7 +260,10 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Verify with something else
@@ -304,7 +278,10 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -312,43 +289,8 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-18"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Verify with something else
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-18"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -97,38 +97,24 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-17"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-17"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -255,38 +241,24 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-19"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Verify with something else
-                    </a>
-                  </div>
+                    Verify with something else
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-19"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -125,8 +125,43 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -277,8 +312,43 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -133,7 +133,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-16"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
@@ -148,7 +148,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-16"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
@@ -320,7 +320,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-18"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
@@ -335,7 +335,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-18"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.firstName"
                     >
                       First name
@@ -92,7 +92,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.lastName"
                     >
                       Last name
@@ -133,7 +133,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -182,48 +182,37 @@ exports[`enroll-profile should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth emotion-33"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root emotion-34"
+                >
                   <div
-                    class="MuiBox-root emotion-33"
+                    class="MuiBox-root emotion-6"
                   >
-<<<<<<< HEAD
-<<<<<<< HEAD
+                    <div
+                      class="MuiBox-root emotion-7"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Already have an account?
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-6"
+                  >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
                       data-se="back"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
->>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
-                      Already have an account?
+                      Sign In
                     </a>
                   </div>
-<<<<<<< HEAD
-=======
-                    Already have an account?
-                  </button>
-=======
-                  Sign Up
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-32"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
-                    data-se="back"
-                    href="javascript:void(0)"
-                  >
-                    Already have an account?
-                  </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`enroll-profile should render form 1`] = `
                 class="MuiBox-root emotion-5"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-32"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`enroll-profile should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-10"
                   >
@@ -185,6 +186,7 @@ exports[`enroll-profile should render form 1`] = `
                   <div
                     class="MuiBox-root emotion-33"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="back"
@@ -193,6 +195,28 @@ exports[`enroll-profile should render form 1`] = `
                       Already have an account?
                     </a>
                   </div>
+=======
+                    Already have an account?
+                  </button>
+=======
+                  Sign Up
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-5"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-33"
+                    data-se="back"
+                    href="javascript:void(0)"
+                  >
+                    Already have an account?
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.firstName"
                     >
                       First name
@@ -92,7 +92,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.lastName"
                     >
                       Last name
@@ -133,7 +133,7 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="userProfile.email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile.test.tsx.snap
@@ -129,7 +129,6 @@ exports[`enroll-profile should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-10"
                   >
@@ -187,14 +186,20 @@ exports[`enroll-profile should render form 1`] = `
                     class="MuiBox-root emotion-33"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
                       data-se="back"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-34"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Already have an account?
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Already have an account?
                   </button>
@@ -217,6 +222,8 @@ exports[`enroll-profile should render form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -67,8 +67,15 @@ exports[`error-account-creation should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
+=======
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+>>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -67,15 +67,8 @@ exports[`error-account-creation should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
-=======
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
-                    data-se="cancel"
-                    href="javascript:void(0)"
->>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -67,16 +67,12 @@ exports[`error-account-creation should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
-                    class="MuiBox-root emotion-13"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
+                    href="/"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
-                      href="/"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -67,16 +67,12 @@ exports[`error-session-expired should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
-                    class="MuiBox-root emotion-13"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
+                    href="/"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
-                      href="/"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -67,15 +67,8 @@ exports[`error-session-expired should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
-=======
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
-                    data-se="cancel"
-                    href="javascript:void(0)"
->>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -67,8 +67,15 @@ exports[`error-session-expired should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-13"
+=======
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+>>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -379,6 +379,117 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     Next
                   </button>
                 </div>
+<<<<<<< HEAD
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </span>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 2`] = `
+<div>
+  <span>
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
+      id="okta-sign-in"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-1"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-2"
+          />
+          <div
+            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
+          >
+            <mocksvgicon />
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-4"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-5"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-6"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-3"
+              >
+                <svg
+                  class="ods-2icygl"
+                  fill="none"
+                  role="presentation"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="identifier identifierSpan MuiBox-root emotion-3"
+                data-se="identifier"
+              >
+                tester2@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+>>>>>>> 4f7938868 (update snapshots)
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -430,8 +541,175 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <fieldset
+                  class="MuiFormControl-root emotion-14"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                  >
+                    Which option do you want to try?
+                  </label>
+                  <div
+                    class="MuiFormGroup-root emotion-16"
+                    id="authenticator.channel"
+                    role="radiogroup"
+                  >
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="email"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Email me a setup link
+                      </span>
+                    </label>
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="sms"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Text me a setup link
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Next
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -495,8 +773,70 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="identifier identifierSpan MuiBox-root emotion-4"
                   data-se="identifier"
                 >
+<<<<<<< HEAD
                   tester2@test.com
                 </span>
+=======
+                  <p
+                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  >
+                    Make sure you can access the email on your mobile device.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                  data-se="#/properties/setupLink"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send me the setup link
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+>>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -606,6 +946,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -704,6 +1045,38 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   glen.fannin@okta.com
                 </span>
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+>>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -1040,8 +1413,164 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <fieldset
+                  class="MuiFormControl-root emotion-14"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                  >
+                    Which option do you want to try?
+                  </label>
+                  <div
+                    class="MuiFormGroup-root emotion-16"
+                    id="authenticator.channel"
+                    role="radiogroup"
+                  >
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="qrcode"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Scan a QR code
+                      </span>
+                    </label>
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="sms"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Text me a setup link
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Next
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -1217,8 +1746,43 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -1750,7 +2314,432 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <div
+<<<<<<< HEAD
                     class="MuiBox-root emotion-4"
+=======
+                    class="MuiBox-root emotion-15"
+                  >
+                    <ol
+                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
+                    >
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        Open the app and follow the instructions to add your account
+                      </li>
+                      <li
+                        class="ods-5vIIsH"
+                      >
+                        When prompted, tap Scan a QR code, then scan the QR code below:
+                      </li>
+                    </ol>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <div
+                    class="qrContainer MuiBox-root emotion-3"
+                  >
+                    <img
+                      alt="Okta Verify"
+                      class="qrImg"
+                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
+                    />
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <button
+                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
+                    tabindex="0"
+                    type="button"
+                  >
+                    Can't scan?
+                  </button>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </span>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 2`] = `
+<div>
+  <span>
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
+      id="okta-sign-in"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-1"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-2"
+          />
+          <div
+            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
+          >
+            <mocksvgicon />
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-4"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-5"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-6"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-3"
+              >
+                <svg
+                  class="ods-2icygl"
+                  fill="none"
+                  role="presentation"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="identifier identifierSpan MuiBox-root emotion-3"
+                data-se="identifier"
+              >
+                tester2@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  >
+                    More options
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <fieldset
+                  class="MuiFormControl-root emotion-14"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                  >
+                    Which option do you want to try?
+                  </label>
+                  <div
+                    class="MuiFormGroup-root emotion-16"
+                    id="authenticator.channel"
+                    role="radiogroup"
+                  >
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="email"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Email me a setup link
+                      </span>
+                    </label>
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="sms"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Text me a setup link
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Next
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </span>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 3`] = `
+<div>
+  <span>
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
+      id="okta-sign-in"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-1"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-2"
+          />
+          <div
+            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
+          >
+            <mocksvgicon />
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-4"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-5"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-6"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-3"
+              >
+                <svg
+                  class="ods-2icygl"
+                  fill="none"
+                  role="presentation"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="identifier identifierSpan MuiBox-root emotion-3"
+                data-se="identifier"
+              >
+                tester2@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <h2
+                    class="MuiTypography-root MuiTypography-h3 emotion-12"
+                  >
+                    Set up Okta Verify via SMS
+                  </h2>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <div
+                    class="MuiBox-root emotion-10"
+>>>>>>> 4f7938868 (update snapshots)
                   >
                     <div
                       class="MuiBox-root emotion-11"
@@ -3040,6 +4029,156 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                >
+                  <p
+                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                  >
+                    Make sure you can access the text on your mobile device.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                  data-se="#/properties/setupLink"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send me the setup link
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  </span>
+</div>
+`;
+
+exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 4`] = `
+<div>
+  <span>
+    <main
+      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
+      id="okta-sign-in"
+    >
+      <div
+        class="siwContainer MuiBox-root emotion-1"
+      >
+        <div
+          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+        >
+          <h1
+            class="MuiTypography-root MuiTypography-h1 emotion-2"
+          />
+          <div
+            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
+          >
+            <mocksvgicon />
+          </div>
+        </div>
+        <div
+          class="MuiBox-root emotion-4"
+        >
+          <div
+            class="identifier-container MuiBox-root emotion-5"
+          >
+            <div
+              class="identifierContainer MuiBox-root emotion-6"
+            >
+              <span
+                class="userIconContainer MuiBox-root emotion-3"
+              >
+                <svg
+                  class="ods-2icygl"
+                  fill="none"
+                  role="presentation"
+                  viewBox="0 0 16 16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    clip-rule="evenodd"
+                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </span>
+              <span
+                class="identifier identifierSpan MuiBox-root emotion-3"
+                data-se="identifier"
+              >
+                tester3@test.com
+              </span>
+            </div>
+          </div>
+          <form
+            class="o-form"
+            data-se="form"
+            novalidate=""
+          >
+            <div
+              class="MuiBox-root emotion-9"
+            >
+              <div
+                class="MuiBox-root emotion-9"
+              >
+                <div
+                  class="MuiBox-root emotion-11"
+                />
+>>>>>>> 4f7938868 (update snapshots)
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -3085,6 +4224,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -3183,6 +4323,38 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   tester3@test.com
                 </span>
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-11"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+>>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -3519,8 +4691,164 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <fieldset
+                  class="MuiFormControl-root emotion-14"
+                >
+                  <label
+                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
+                  >
+                    Which option do you want to try?
+                  </label>
+                  <div
+                    class="MuiFormGroup-root emotion-16"
+                    id="authenticator.channel"
+                    role="radiogroup"
+                  >
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="qrcode"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Scan a QR code
+                      </span>
+                    </label>
+                    <label
+                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
+                    >
+                      <span
+                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
+                      >
+                        <input
+                          class="PrivateSwitchBase-input emotion-19"
+                          name="authenticator.channel"
+                          type="radio"
+                          value="email"
+                        />
+                        <span
+                          class="emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
+                            data-testid="RadioButtonUncheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                            />
+                          </svg>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
+                            data-testid="RadioButtonCheckedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
+                      >
+                        Email me a setup link
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
+                  data-se="#/properties/submit"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Next
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -145,7 +145,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -160,7 +163,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -379,117 +385,6 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     Next
                   </button>
                 </div>
-<<<<<<< HEAD
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling 2`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
->>>>>>> 4f7938868 (update snapshots)
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -513,12 +408,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-37"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -528,12 +439,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-37"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -541,175 +468,8 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-36"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-36"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -773,70 +533,8 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="identifier identifierSpan MuiBox-root emotion-4"
                   data-se="identifier"
                 >
-<<<<<<< HEAD
                   tester2@test.com
                 </span>
-=======
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Make sure you can access the email on your mobile device.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  data-se="#/properties/setupLink"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
->>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -946,16 +644,31 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-28"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -965,12 +678,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-28"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1045,38 +774,6 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   glen.fannin@okta.com
                 </span>
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
->>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -1143,12 +840,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-21"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1158,12 +871,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-21"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1390,7 +1119,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1405,7 +1137,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1413,164 +1148,8 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="qrcode"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Scan a QR code
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-34"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-34"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -1723,7 +1302,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1738,7 +1320,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1746,43 +1331,8 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -1935,7 +1485,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1950,7 +1503,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -2192,12 +1748,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-37"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -2207,12 +1779,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-37"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -2314,432 +1902,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
                   <div
-<<<<<<< HEAD
                     class="MuiBox-root emotion-4"
-=======
-                    class="MuiBox-root emotion-15"
-                  >
-                    <ol
-                      class="ods-4o5zYQ ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-5GAsrW ods-1goWbr"
-                    >
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        On your mobile device, download the Okta Verify app from the App Store (iPhone and iPad) or Google Play (Android devices).
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        Open the app and follow the instructions to add your account
-                      </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        When prompted, tap Scan a QR code, then scan the QR code below:
-                      </li>
-                    </ol>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <div
-                    class="qrContainer MuiBox-root emotion-3"
-                  >
-                    <img
-                      alt="Okta Verify"
-                      class="qrImg"
-                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAAFq0lEQVR42u3dy07kQAwF0P7/n4YFayRCfG1Xcq40G4S6SVJnFNfz8yUiv+bjFogAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIAPLzRZ9P+b/fPv/O33PnMxOfX3Vdf/l77vwNf7nGxHMHBBBAAAEEEEBKLrDzQSQacOc92dCAO68REEAAAQQQQAC59IASDzr9mel6If1+fhVd4t4CAggggAACCCCrgNz5/KpGeEoXceKeAwIIIIAAAgggjwEy9eC2dUdX1SwbuuUBAQQQQAABBJDoO/mdG76hWzINrbNG66zFAAEEEEAAAQSQf3ddpifF+fmen1sPAoifAwKInwPyyCTeh9Pv5OnJkFVdwVMNGBBAAAEEEEBeDqTq5ieWuHa+G2/7rsTfmb7/gAACCCCAAALIJSAbaoR0V/bV6003wsTv3OkWVoMAAggggAACyHhXbdWkwalu2/R+wp31y1O7jgEBBBBAAAHkAUA6d9Wo6t5MdGneuZbOhr1hEikggAACCCCAvBxI57v3VJdpYoQ6/R/F5hHzV9UggAACCCCAANJTX0zVMunR/M21TGIv39PXlQACCCCAAALIQd28p4/wdv6H0Dl6nr5vJy7RBQQQQAABBJCDgFR1UVY90M4jCRI7jUxN2kz8vsmKgAACCCCAAFJed0wdCtl5tMGG89y3jZ5vrlkAAQQQQAAB5AE1SOf6iDtdsp27eaQPD03cz0R3sSIdEEAAAQQQQEoaTHokOv1Qpkb2N+xj3AkWEEAAAQQQQAAZWXORfm9PXHti8mT62tP33DgIIIAAAggggJR3e06NjKe7ptObs21owIkjIQABBBBAAAEEkLb35/RI8YbN7tLfu2F/YAumAAEEEEAAASTandi5fLVzYuGGE6+2LUPeHEAAAQQQQAA5CEi6YUx1mSZG5Kf2Ct62sd5rp5oAAggggAACSK4GSTfCdN2RxtW5cdxTD+sEBBBAAAEEkIcBmfr9zsZ8ynEPU7u1WHILCCCAAAIIICNAOt+f0yO/G/bIraoT0zUOIIAAAggggABS8s6Z6CLuxNLZwBJd3527uBhJBwQQQAABBJCvTYjSI86dNUW6juicJJk+DBQQQAABBBBAACmpKRI3p3PtQ7pbu6rW6PxPxsZxgAACCCCAADJSayQa8NQ7ebr+2nwyV+ekR0AAAQQQQAB5OZCp/WA3v+dX3cOq+5+YqLnhvgECCCCAAALIyzeOSzSS9J69pxymmT6GoHMDQEAAAQQQQAABJPqOvWEJauc7/9SpVYnr6jwLHhBAAAEEEEBeUoNUvRunuwq31SNVtV4a+ClduIAAAggggADysBpk2yGPGybgTTWezpH0RLc2IIAAAggggLwcyLZ1HOkz1jd8V1U37NQ6lA11CiCAAAIIIIAcVINs6/69873p76qqIxJ1wdSERkAAAQQQQAAB5N+Np6ohpU8+6pxgWQVnc/esbX8AAQQQQAABpPzBTa0H2bwZWueIdqL+OvHgTkAAAQQQQAA5CEjnyHgaQqKeOn0Dt221HiCAAAIIIIC8BMgUwMT79obDNNOHnKbrLOtBAAEEEEAAAaStBpk6Z3zD4Z4bToZKfP7Uga2AAAIIIIAA8kIgic9Jb78/taV/Z5dvYsmtGgQQQAABBBBARoBsWC6aaEib668NZ9MbSQcEEEAAAQSQI4BcfY9Nv2+n65SpYwg2zzoABBBAAAEEEEDagFR1gXY+0EQX6LZZCqdgAQQQQAABBJBDgXRCmxoBT9c+m89kT4MFBBBAAAEEEEDaTjhKdzlOTeTbUE9tG3kHBBBAAAEEkJcDETkxgIgAIgKICCAigIgAIgKICCAigIgAIiKAiAAiAogIICKAiAAiAogIICKAiAAiIoCIACICiAggIoCIACJybr4BVbQ91L3A8YAAAAAASUVORK5CYII="
-                    />
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <button
-                    class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-19"
-                    tabindex="0"
-                    type="button"
-                  >
-                    Can't scan?
-                  </button>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-21"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 2`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    More options
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="sms"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Text me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-36"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-36"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 3`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester2@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <h2
-                    class="MuiTypography-root MuiTypography-h3 emotion-12"
-                  >
-                    Set up Okta Verify via SMS
-                  </h2>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-3"
-                >
-                  <div
-                    class="MuiBox-root emotion-10"
->>>>>>> 4f7938868 (update snapshots)
                   >
                     <div
                       class="MuiBox-root emotion-11"
@@ -4029,156 +3192,6 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                >
-                  <p
-                    class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
-                  >
-                    Make sure you can access the text on your mobile device.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
-                  data-se="#/properties/setupLink"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-25"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-25"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    </main>
-  </span>
-</div>
-`;
-
-exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enrollment (sms) -> sms polling -> try different -> channel selection -> qr polling 4`] = `
-<div>
-  <span>
-    <main
-      class="auth-container main-container mainViewContainer MuiBox-root emotion-0"
-      id="okta-sign-in"
-    >
-      <div
-        class="siwContainer MuiBox-root emotion-1"
-      >
-        <div
-          class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
-        >
-          <h1
-            class="MuiTypography-root MuiTypography-h1 emotion-2"
-          />
-          <div
-            class="iconContainer authCoinOverlay MuiBox-root emotion-3"
-          >
-            <mocksvgicon />
-          </div>
-        </div>
-        <div
-          class="MuiBox-root emotion-4"
-        >
-          <div
-            class="identifier-container MuiBox-root emotion-5"
-          >
-            <div
-              class="identifierContainer MuiBox-root emotion-6"
-            >
-              <span
-                class="userIconContainer MuiBox-root emotion-3"
-              >
-                <svg
-                  class="ods-2icygl"
-                  fill="none"
-                  role="presentation"
-                  viewBox="0 0 16 16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </span>
-              <span
-                class="identifier identifierSpan MuiBox-root emotion-3"
-                data-se="identifier"
-              >
-                tester3@test.com
-              </span>
-            </div>
-          </div>
-          <form
-            class="o-form"
-            data-se="form"
-            novalidate=""
-          >
-            <div
-              class="MuiBox-root emotion-9"
-            >
-              <div
-                class="MuiBox-root emotion-9"
-              >
-                <div
-                  class="MuiBox-root emotion-11"
-                />
->>>>>>> 4f7938868 (update snapshots)
                 <div
                   class="MuiBox-root emotion-11"
                 >
@@ -4224,16 +3237,31 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-26"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -4243,12 +3271,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-26"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -4323,38 +3367,6 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   tester3@test.com
                 </span>
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-11"
-              >
-                <div
-                  class="MuiBox-root emotion-20"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
->>>>>>> 4f7938868 (update snapshots)
               </div>
             </div>
             <form
@@ -4421,12 +3433,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-21"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -4436,12 +3464,28 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-21"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -4668,7 +3712,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -4683,7 +3730,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -4691,164 +3741,8 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <fieldset
-                  class="MuiFormControl-root emotion-14"
-                >
-                  <label
-                    class="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-15"
-                  >
-                    Which option do you want to try?
-                  </label>
-                  <div
-                    class="MuiFormGroup-root emotion-16"
-                    id="authenticator.channel"
-                    role="radiogroup"
-                  >
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="qrcode"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Scan a QR code
-                      </span>
-                    </label>
-                    <label
-                      class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-17"
-                    >
-                      <span
-                        class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-18"
-                      >
-                        <input
-                          class="PrivateSwitchBase-input emotion-19"
-                          name="authenticator.channel"
-                          type="radio"
-                          value="email"
-                        />
-                        <span
-                          class="emotion-20"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-21"
-                            data-testid="RadioButtonUncheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                            />
-                          </svg>
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-29"
-                            data-testid="RadioButtonCheckedIcon"
-                            focusable="false"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-23"
-                      >
-                        Email me a setup link
-                      </span>
-                    </label>
-                  </div>
-                </fieldset>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-32"
-                  data-se="#/properties/submit"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Next
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-34"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-34"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -511,7 +511,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -386,7 +386,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -401,7 +401,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -681,7 +681,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-36"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
@@ -696,7 +696,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-36"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
@@ -811,7 +811,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
@@ -826,7 +826,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
@@ -1051,7 +1051,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -1066,7 +1066,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -1542,7 +1542,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-34"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
@@ -1557,7 +1557,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-34"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
@@ -1754,7 +1754,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -1769,7 +1769,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -2369,7 +2369,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -2384,7 +2384,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-21"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
@@ -2618,7 +2618,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-36"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
@@ -2633,7 +2633,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-36"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
@@ -4072,7 +4072,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
@@ -4087,7 +4087,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
@@ -4329,7 +4329,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -4344,7 +4344,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-11"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-20"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-21"
@@ -4820,7 +4820,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-34"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
@@ -4835,7 +4835,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-34"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -140,38 +140,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -408,78 +394,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-38"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-38"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-38"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-38"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -661,78 +593,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-29"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-29"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -868,78 +746,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-22"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-22"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -1156,38 +980,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-35"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-35"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -1339,38 +1149,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -1522,38 +1318,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-                  <div
-                    class="MuiBox-root emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -1790,78 +1572,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-38"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-38"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-38"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-38"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-38"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -3296,78 +3024,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-27"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-27"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-27"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-27"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -3503,78 +3177,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-22"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-12"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-22"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-22"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-22"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -3791,38 +3411,24 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-35"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-35"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -511,7 +511,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -409,6 +409,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
@@ -423,13 +424,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-37"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-38"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -439,6 +446,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
@@ -454,13 +462,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-37"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-38"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -648,6 +662,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
@@ -662,13 +677,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-28"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-29"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -678,6 +699,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
@@ -693,13 +715,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-28"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-29"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -841,6 +869,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
@@ -855,13 +884,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-21"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-22"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -871,6 +906,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
@@ -886,13 +922,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-21"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-22"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1749,6 +1791,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
                   >
@@ -1763,13 +1806,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-37"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-38"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1779,6 +1828,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-38"
@@ -1794,13 +1844,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-37"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-38"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-38"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-39"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -3241,6 +3297,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
@@ -3255,13 +3312,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-26"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-27"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -3271,6 +3334,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
@@ -3286,13 +3350,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-26"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-27"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -3434,6 +3504,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
                   >
@@ -3448,13 +3519,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-21"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-22"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -3464,6 +3541,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 <div
                   class="MuiBox-root emotion-12"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-22"
@@ -3479,13 +3557,19 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-21"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-22"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-22"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`identify-with-password renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="identifier"
                     >
                       Username
@@ -95,7 +95,7 @@ exports[`identify-with-password renders form 1`] = `
                       class="MuiBox-root emotion-10"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                         for="credentials.passcode"
                       >
                         Password
@@ -113,7 +113,7 @@ exports[`identify-with-password renders form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
                         >
                           <button
                             aria-label="toggle password visibility"
@@ -393,7 +393,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                     class="MuiBox-root emotion-15"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="identifier"
                     >
                       Username
@@ -443,7 +443,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                       class="MuiBox-root emotion-15"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                         for="credentials.passcode"
                       >
                         Password
@@ -461,7 +461,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-28"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-28"
                         >
                           <button
                             aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`identify-with-password renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
+<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
                     data-type="save"
@@ -222,6 +223,7 @@ exports[`identify-with-password renders form 1`] = `
                   <div
                     class="MuiBox-root emotion-36"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
                       data-se="enroll"
@@ -230,6 +232,43 @@ exports[`identify-with-password renders form 1`] = `
                       Register
                     </a>
                   </div>
+=======
+                    Register
+                  </button>
+=======
+                  Sign in
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-5"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                    data-se="forgot-password"
+                    href="javascript:void(0)"
+                  >
+                    Forgot password?
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-5"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                    data-se="enroll"
+                    href="javascript:void(0)"
+                  >
+                    Register
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>
@@ -570,8 +609,92 @@ exports[`identify-with-password sends correct payload fails client side validati
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <label
+                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-34"
+                >
+                  <span
+                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-35"
+                  >
+                    <input
+                      class="PrivateSwitchBase-input emotion-36"
+                      data-se="rememberMe"
+                      data-se-for-name="rememberMe"
+                      id="rememberMe"
+                      name="rememberMe"
+                      type="checkbox"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
+                      data-testid="CheckBoxOutlineBlankIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
+                  >
+                    Keep me signed in
+                  </span>
+                </label>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
+                  data-se="#/properties/submit"
+                  data-type="save"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                    data-se="forgot-password"
+                    href="javascript:void(0)"
+                  >
+                    Forgot password?
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-14"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                    data-se="enroll"
+                    href="javascript:void(0)"
+                  >
+                    Register
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -192,7 +192,6 @@ exports[`identify-with-password renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-<<<<<<< HEAD
                   <button
                     class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-34"
                     data-type="save"
@@ -210,7 +209,10 @@ exports[`identify-with-password renders form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+<<<<<<< HEAD
                       data-se="forgot-password"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Forgot password?
@@ -224,14 +226,20 @@ exports[`identify-with-password renders form 1`] = `
                     class="MuiBox-root emotion-36"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
                       data-se="enroll"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Register
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Register
                   </button>
@@ -269,6 +277,8 @@ exports[`identify-with-password renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>
@@ -586,7 +596,10 @@ exports[`identify-with-password sends correct payload fails client side validati
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+<<<<<<< HEAD
                       data-se="forgot-password"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Forgot password?
@@ -601,7 +614,10 @@ exports[`identify-with-password sends correct payload fails client side validati
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
+<<<<<<< HEAD
                       data-se="enroll"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Register
@@ -609,92 +625,8 @@ exports[`identify-with-password sends correct payload fails client side validati
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <label
-                  class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-34"
-                >
-                  <span
-                    class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root emotion-35"
-                  >
-                    <input
-                      class="PrivateSwitchBase-input emotion-36"
-                      data-se="rememberMe"
-                      data-se-for-name="rememberMe"
-                      id="rememberMe"
-                      name="rememberMe"
-                      type="checkbox"
-                    />
-                    <svg
-                      aria-hidden="true"
-                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-29"
-                      data-testid="CheckBoxOutlineBlankIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-38"
-                  >
-                    Keep me signed in
-                  </span>
-                </label>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
-                  data-se="#/properties/submit"
-                  data-type="save"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Sign in
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-42"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
-                    data-se="forgot-password"
-                    href="javascript:void(0)"
-                  >
-                    Forgot password?
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-42"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
-                    data-se="enroll"
-                    href="javascript:void(0)"
-                  >
-                    Register
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -204,55 +204,6 @@ exports[`identify-with-password renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
-                    class="MuiBox-root emotion-36"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-<<<<<<< HEAD
-                      data-se="forgot-password"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Forgot password?
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root emotion-6"
-                >
-                  <div
-                    class="MuiBox-root emotion-36"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
-                      data-se="enroll"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-37"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Register
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Register
-                  </button>
-=======
-                  Sign in
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-35"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
                     data-se="forgot-password"
@@ -261,24 +212,40 @@ exports[`identify-with-password renders form 1`] = `
                     Forgot password?
                   </a>
                 </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
                 <div
-                  class="MuiBox-root emotion-35"
+                  class="MuiBox-root emotion-6"
                 >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
-                    data-se="enroll"
-                    href="javascript:void(0)"
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth emotion-38"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root emotion-39"
+                >
+                  <div
+                    class="MuiBox-root emotion-6"
                   >
-                    Register
-                  </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
+                    <div
+                      class="MuiBox-root emotion-7"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Don't have an account?
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-6"
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
+                      data-se="enroll"
+                      href="javascript:void(0)"
+                    >
+                      Sign Up
+                    </a>
+                  </div>
                 </div>
               </div>
             </form>
@@ -591,36 +558,46 @@ exports[`identify-with-password sends correct payload fails client side validati
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-43"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
+                    data-se="forgot-password"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
-<<<<<<< HEAD
-                      data-se="forgot-password"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Forgot password?
-                    </a>
-                  </div>
+                    Forgot password?
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth emotion-45"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root emotion-46"
+                >
                   <div
-                    class="MuiBox-root emotion-43"
+                    class="MuiBox-root emotion-11"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <p
+                        class="ods-4o5zYQ ods-nqMobL ods-4amLpn ods-5fvoER ods-6BF3N5 ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                      >
+                        Don't have an account?
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-11"
                   >
                     <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-44"
-<<<<<<< HEAD
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
                       data-se="enroll"
-=======
->>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
-                      Register
+                      Sign Up
                     </a>
                   </div>
                 </div>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`identify-with-password renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="identifier"
                     >
                       Username
@@ -95,7 +95,7 @@ exports[`identify-with-password renders form 1`] = `
                       class="MuiBox-root emotion-10"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                         for="credentials.passcode"
                       >
                         Password
@@ -113,7 +113,7 @@ exports[`identify-with-password renders form 1`] = `
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-22"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-22"
                         >
                           <button
                             aria-label="toggle password visibility"
@@ -393,7 +393,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                     class="MuiBox-root emotion-15"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="identifier"
                     >
                       Username
@@ -443,7 +443,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                       class="MuiBox-root emotion-15"
                     >
                       <label
-                        class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                         for="credentials.passcode"
                       >
                         Password
@@ -461,7 +461,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd emotion-28"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-28"
                         >
                           <button
                             aria-label="toggle password visibility"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -243,7 +243,7 @@ exports[`identify-with-password renders form 1`] = `
                 class="MuiBox-root emotion-5"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-35"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
@@ -258,7 +258,7 @@ exports[`identify-with-password renders form 1`] = `
                 class="MuiBox-root emotion-5"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-35"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-36"
@@ -666,7 +666,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-14"
+                  class="MuiBox-root emotion-42"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"
@@ -681,7 +681,7 @@ exports[`identify-with-password sends correct payload fails client side validati
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-14"
+                  class="MuiBox-root emotion-42"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-43"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -170,78 +170,24 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-29"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-29"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
@@ -185,13 +186,19 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-28"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-29"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -201,6 +208,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
@@ -216,13 +224,19 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-28"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-29"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -170,12 +170,28 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-28"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -185,12 +201,28 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-29"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-29"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-28"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -198,66 +230,8 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  data-se="#/properties/setupLink"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                     class="MuiBox-root emotion-4"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-16"
                       for="email"
                     >
                       Email

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
@@ -244,7 +244,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -198,8 +198,66 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                  data-se="#/properties/setupLink"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send me the setup link
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-25"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -174,38 +174,24 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-28"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-28"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -210,7 +210,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
@@ -225,7 +225,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-27"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -202,8 +202,43 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -179,7 +179,10 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -194,7 +197,10 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -202,43 +208,8 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-27"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1424,6 +1424,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   class="MuiBox-root emotion-11"
                 >
 <<<<<<< HEAD
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
@@ -1438,13 +1439,19 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-26"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-27"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      data-se="switchAuthenticator"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1454,6 +1461,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
 <<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
@@ -1469,13 +1477,19 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                     tabindex="0"
                     type="button"
 =======
+=======
+>>>>>>> 5ad8a409f (update snapshots)
                   <div
-                    class="MuiBox-root emotion-26"
->>>>>>> 13c109de4 (update snapshots)
+                    class="MuiBox-root emotion-27"
                   >
                     <a
+<<<<<<< HEAD
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
 >>>>>>> e79316d05 (update snapshots)
+=======
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
+                      data-se="cancel"
+>>>>>>> 5ad8a409f (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1423,78 +1423,24 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-27"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="switchAuthenticator"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                     data-se="switchAuthenticator"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-27"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="switchAuthenticator"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                  <div
-                    class="MuiBox-root emotion-27"
-                  >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="cancel"
-=======
-<<<<<<< HEAD
-                  <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
                     data-se="cancel"
-                    tabindex="0"
-                    type="button"
-=======
-=======
->>>>>>> 5ad8a409f (update snapshots)
-                  <div
-                    class="MuiBox-root emotion-27"
+                    href="javascript:void(0)"
                   >
-                    <a
-<<<<<<< HEAD
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
->>>>>>> e79316d05 (update snapshots)
-=======
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
-                      data-se="cancel"
->>>>>>> 5ad8a409f (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1482,7 +1482,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
@@ -1497,7 +1497,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-25"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1423,12 +1423,28 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="switchAuthenticator"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="switchAuthenticator"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-26"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -1438,12 +1454,28 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                 <div
                   class="MuiBox-root emotion-11"
                 >
+<<<<<<< HEAD
                   <div
                     class="MuiBox-root emotion-27"
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                       data-se="cancel"
+=======
+<<<<<<< HEAD
+                  <button
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-27"
+                    data-se="cancel"
+                    tabindex="0"
+                    type="button"
+=======
+                  <div
+                    class="MuiBox-root emotion-26"
+>>>>>>> 13c109de4 (update snapshots)
+                  >
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-27"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -1451,66 +1483,8 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
-                  data-se="#/properties/setupLink"
-                  tabindex="0"
-                  type="submit"
-                >
-                  Send me the setup link
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <button
-                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
-                  tabindex="0"
-                  type="button"
-                >
-                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
-                </button>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-25"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-25"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -1451,8 +1451,66 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-21"
+                  data-se="#/properties/setupLink"
+                  tabindex="0"
+                  type="submit"
+                >
+                  Send me the setup link
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <button
+                  class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-23"
+                  tabindex="0"
+                  type="button"
+                >
+                  Or &lt;a href="#" class="switch-channel-link"&gt;try a different way&lt;/a&gt; to set up Okta Verify.
+                </button>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-26"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -72,16 +72,12 @@ exports[`terminal-return-email-error should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-7"
                 >
-                  <div
-                    class="MuiBox-root emotion-14"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                    href="/"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-15"
-                      href="/"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -70,10 +70,19 @@ exports[`terminal-return-email-error should render form 1`] = `
                   </div>
                 </div>
                 <div
+<<<<<<< HEAD
                   class="MuiBox-root emotion-7"
                 >
                   <div
                     class="MuiBox-root emotion-14"
+=======
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+>>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-15"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -71,12 +71,16 @@ exports[`terminal-return-email-error should render form 1`] = `
                 </div>
                 <div
 <<<<<<< HEAD
+<<<<<<< HEAD
                   class="MuiBox-root emotion-7"
                 >
                   <div
                     class="MuiBox-root emotion-14"
 =======
                   class="MuiBox-root emotion-3"
+=======
+                  class="MuiBox-root emotion-13"
+>>>>>>> 84e3da984 (update snapshots)
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -70,23 +70,10 @@ exports[`terminal-return-email-error should render form 1`] = `
                   </div>
                 </div>
                 <div
-<<<<<<< HEAD
-<<<<<<< HEAD
                   class="MuiBox-root emotion-7"
                 >
                   <div
                     class="MuiBox-root emotion-14"
-=======
-                  class="MuiBox-root emotion-3"
-=======
-                  class="MuiBox-root emotion-13"
->>>>>>> 84e3da984 (update snapshots)
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-14"
-                    data-se="cancel"
-                    href="javascript:void(0)"
->>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-15"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -92,16 +92,12 @@ exports[`unlock-account-success renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
-                    class="MuiBox-root emotion-16"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-16"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -90,23 +90,10 @@ exports[`unlock-account-success renders form 1`] = `
                   </div>
                 </div>
                 <div
-<<<<<<< HEAD
-<<<<<<< HEAD
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-16"
-=======
-                  class="MuiBox-root emotion-6"
-=======
-                  class="MuiBox-root emotion-15"
->>>>>>> 84e3da984 (update snapshots)
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-16"
-                    data-se="cancel"
-                    href="javascript:void(0)"
->>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -91,12 +91,16 @@ exports[`unlock-account-success renders form 1`] = `
                 </div>
                 <div
 <<<<<<< HEAD
+<<<<<<< HEAD
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-16"
 =======
                   class="MuiBox-root emotion-6"
+=======
+                  class="MuiBox-root emotion-15"
+>>>>>>> 84e3da984 (update snapshots)
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-16"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -90,10 +90,19 @@ exports[`unlock-account-success renders form 1`] = `
                   </div>
                 </div>
                 <div
+<<<<<<< HEAD
                   class="MuiBox-root emotion-10"
                 >
                   <div
                     class="MuiBox-root emotion-16"
+=======
+                  class="MuiBox-root emotion-6"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-16"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+>>>>>>> 4f7938868 (update snapshots)
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -150,35 +150,6 @@ exports[`user-unlock-account renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
-                    class="MuiBox-root emotion-29"
-                  >
-<<<<<<< HEAD
-<<<<<<< HEAD
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
-                      data-se="cancel"
-=======
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
-<<<<<<< HEAD
-=======
-                    Back to sign in
-                  </button>
-=======
-              </div>
-              <div
-                class="MuiBox-root emotion-5"
-              >
-                <div
-                  class="MuiBox-root emotion-28"
-                >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
                     data-se="cancel"
@@ -186,10 +157,6 @@ exports[`user-unlock-account renders form 1`] = `
                   >
                     Back to sign in
                   </a>
->>>>>>> 4f7938868 (update snapshots)
->>>>>>> e94a7e4d1 (update snapshots)
-=======
->>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`user-unlock-account renders form 1`] = `
                 class="MuiBox-root emotion-5"
               >
                 <div
-                  class="MuiBox-root emotion-9"
+                  class="MuiBox-root emotion-28"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -147,12 +147,14 @@ exports[`user-unlock-account renders form 1`] = `
                     </div>
                   </div>
                 </div>
+<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-6"
                 >
                   <div
                     class="MuiBox-root emotion-29"
                   >
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
@@ -161,6 +163,26 @@ exports[`user-unlock-account renders form 1`] = `
                       Back to sign in
                     </a>
                   </div>
+=======
+                    Back to sign in
+                  </button>
+=======
+              </div>
+              <div
+                class="MuiBox-root emotion-5"
+              >
+                <div
+                  class="MuiBox-root emotion-9"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-29"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+>>>>>>> 4f7938868 (update snapshots)
+>>>>>>> e94a7e4d1 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="identifier"
                     >
                       Username

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiBox-root emotion-10"
                   >
                     <label
-                      class="MuiInputLabel-root MuiInputLabel-animated MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
+                      class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-11"
                       for="identifier"
                     >
                       Username

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -147,7 +147,6 @@ exports[`user-unlock-account renders form 1`] = `
                     </div>
                   </div>
                 </div>
-<<<<<<< HEAD
                 <div
                   class="MuiBox-root emotion-6"
                 >
@@ -155,14 +154,20 @@ exports[`user-unlock-account renders form 1`] = `
                     class="MuiBox-root emotion-29"
                   >
 <<<<<<< HEAD
+<<<<<<< HEAD
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                       data-se="cancel"
+=======
+                    <a
+                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
                     </a>
                   </div>
+<<<<<<< HEAD
 =======
                     Back to sign in
                   </button>
@@ -183,6 +188,8 @@ exports[`user-unlock-account renders form 1`] = `
                   </a>
 >>>>>>> 4f7938868 (update snapshots)
 >>>>>>> e94a7e4d1 (update snapshots)
+=======
+>>>>>>> e79316d05 (update snapshots)
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -120,7 +120,10 @@ exports[`webauthn-enroll should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -135,7 +138,10 @@ exports[`webauthn-enroll should render form 1`] = `
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -143,43 +149,8 @@ exports[`webauthn-enroll should render form 1`] = `
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-18"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-18"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -289,7 +260,10 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+<<<<<<< HEAD
                       data-se="switchAuthenticator"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Return to authenticator list
@@ -304,7 +278,10 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   >
                     <a
                       class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
+<<<<<<< HEAD
                       data-se="cancel"
+=======
+>>>>>>> e79316d05 (update snapshots)
                       href="javascript:void(0)"
                     >
                       Back to sign in
@@ -312,43 +289,8 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   </div>
                 </div>
               </div>
-<<<<<<< HEAD
             </form>
           </div>
-=======
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
-                    data-se="switchAuthenticator"
-                    href="javascript:void(0)"
-                  >
-                    Return to authenticator list
-                  </a>
-                </div>
-              </div>
-              <div
-                class="MuiBox-root emotion-10"
-              >
-                <div
-                  class="MuiBox-root emotion-16"
-                >
-                  <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
-                    data-se="cancel"
-                    href="javascript:void(0)"
-                  >
-                    Back to sign in
-                  </a>
-                </div>
-              </div>
-            </div>
-          </form>
->>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -115,38 +115,24 @@ exports[`webauthn-enroll should render form 1`] = `
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-19"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-19"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-20"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>
@@ -255,38 +241,24 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-17"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
-<<<<<<< HEAD
-                      data-se="switchAuthenticator"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Return to authenticator list
-                    </a>
-                  </div>
+                    Return to authenticator list
+                  </a>
                 </div>
                 <div
                   class="MuiBox-root emotion-11"
                 >
-                  <div
-                    class="MuiBox-root emotion-17"
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="cancel"
+                    href="javascript:void(0)"
                   >
-                    <a
-                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-18"
-<<<<<<< HEAD
-                      data-se="cancel"
-=======
->>>>>>> e79316d05 (update snapshots)
-                      href="javascript:void(0)"
-                    >
-                      Back to sign in
-                    </a>
-                  </div>
+                    Back to sign in
+                  </a>
                 </div>
               </div>
             </form>

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`webauthn-enroll should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-18"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
@@ -166,7 +166,7 @@ exports[`webauthn-enroll should render form 1`] = `
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-18"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
@@ -320,7 +320,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-16"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
@@ -335,7 +335,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                 class="MuiBox-root emotion-10"
               >
                 <div
-                  class="MuiBox-root emotion-3"
+                  class="MuiBox-root emotion-16"
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -143,8 +143,43 @@ exports[`webauthn-enroll should render form 1`] = `
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>
@@ -277,8 +312,43 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
                   </div>
                 </div>
               </div>
+<<<<<<< HEAD
             </form>
           </div>
+=======
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-3"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-17"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </div>
+          </form>
+>>>>>>> 4f7938868 (update snapshots)
         </div>
       </main>
     </span>


### PR DESCRIPTION
## Description:

Changes the Sign in and Sign up entry links to match V2.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-486130](https://oktainc.atlassian.net/browse/OKTA-486130)

### Reviewers:

### Screenshot/Video:
<img width="598" alt="Screen Shot 2022-08-08 at 5 12 27 PM" src="https://user-images.githubusercontent.com/107433508/183536656-33029cd8-cb97-40a6-8d2a-18f55c58414e.png">
<img width="571" alt="Screen Shot 2022-08-09 at 11 23 19 AM" src="https://user-images.githubusercontent.com/107433508/183733802-14a3c5b0-d3da-45b1-89a7-84535fda94bd.png">

### Downstream Monolith Build:



