### PR TITLE
OKTA-523201 fix v2 testcafe suite

### DIFF
--- a/test/testcafe/framework/page-objects/IdentityPageObject.js
+++ b/test/testcafe/framework/page-objects/IdentityPageObject.js
@@ -83,7 +83,7 @@ export default class IdentityPageObject extends BasePageObject {
   }
 
   async hasShowTogglePasswordIcon() {
-    return await Selector('[data-se="password-toggle"]').count > 0;
+    return await Selector('.password-toggle').count;
   }
 
   getSaveButtonLabel() {


### PR DESCRIPTION
## Description:

Reverts change to password toggle selector in IdentifyPageObject causing v2 testcafe suite to fail.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-523201](https://oktainc.atlassian.net/browse/OKTA-523201)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



