### PR TITLE
OKTA-520236 - Implementation for Resend Link that contains HTML

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -106,6 +106,7 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
+      style={{ maxWidth: '100%' }}
     >
       <Layout
         uischema={uischema}

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -106,7 +106,6 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
-      style={{ maxWidth: '100%' }}
     >
       <Layout
         uischema={uischema}

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -12,43 +12,39 @@
 
 import '@testing-library/jest-dom';
 
-import { IdxTransaction } from '@okta/okta-auth-js';
 import { fireEvent, render, within } from '@testing-library/preact';
 import { h } from 'preact';
 import { act } from 'preact/test-utils';
-import { getStubTransaction } from 'src/mocks/utils/utils';
 
 import {
-  ReminderElement, UISchemaElementComponentProps, WidgetProps,
+  ReminderElement,
+  UISchemaElementComponentProps,
 } from '../../types';
 import ReminderPrompt, { DEFAULT_TIMEOUT_MS } from './ReminderPrompt';
 
 jest.useFakeTimers();
 
-let transaction: IdxTransaction;
-let mockProps: WidgetProps = {};
-jest.mock('../../contexts', () => ({
-  useWidgetContext: jest.fn().mockImplementation(
-    () => ({ widgetProps: mockProps, idxTransaction: transaction }),
-  ),
+const mockSubmitHook = jest.fn().mockImplementation(() => ({}));
+jest.mock('../../hooks', () => ({
+  useOnSubmit: () => mockSubmitHook,
 }));
 
 describe('ReminderPrompt', () => {
   beforeEach(() => {
-    transaction = getStubTransaction();
-    mockProps = {};
+    mockSubmitHook.mockRestore();
   });
 
   it('should show prompt with working link after default timeout passes', async () => {
-    const mockActionFn = jest.fn();
-
+    const step = 'currentAuthenticator-resend';
     const props: UISchemaElementComponentProps & { uischema: ReminderElement; } = {
       uischema: {
         type: 'Reminder',
         options: {
           ctaText: 'Didnt receive the email?',
           linkLabel: 'Send again?',
-          action: mockActionFn,
+          step,
+          actionParams: { resend: true },
+          isActionStep: true,
         },
       },
     };
@@ -66,28 +62,27 @@ describe('ReminderPrompt', () => {
     const box = getByRole('alert');
     const sendAgainLink = await within(box).findByText('Send again?');
 
-    expect(mockActionFn).not.toHaveBeenCalled();
+    expect(mockSubmitHook).not.toHaveBeenCalled();
     fireEvent.click(sendAgainLink);
-    expect(mockActionFn).toHaveBeenCalledTimes(1);
-    expect(mockActionFn).toHaveBeenCalledWith({ resend: true });
+    expect(mockSubmitHook).toHaveBeenCalledTimes(1);
+    expect(mockSubmitHook).toHaveBeenCalledWith({
+      step,
+      isActionStep: true,
+      params: { resend: true },
+    });
   });
 
-  it('should show prompt with working link after default timeout passes and include stateHandle when stateToken is set', async () => {
-    const mockStateHandle = 'abc12356789';
-    mockProps = { stateToken: '123abc' };
-    transaction.context = {
-      ...transaction.context,
-      stateHandle: mockStateHandle,
-    };
-    const mockActionFn = jest.fn();
-
+  it('should show prompt with working link after default timeout passes where ctaText contains HTML', async () => {
+    const step = 'currentAuthenticator-resend';
     const props: UISchemaElementComponentProps & { uischema: ReminderElement; } = {
       uischema: {
         type: 'Reminder',
         options: {
-          ctaText: 'Didnt receive the email?',
-          linkLabel: 'Send again?',
-          action: mockActionFn,
+          ctaText: 'Didnt receive the email? Click <a href="#" class="send-again">send again</a>',
+          step,
+          className: 'send-again',
+          actionParams: { resend: true },
+          isActionStep: true,
         },
       },
     };
@@ -103,16 +98,19 @@ describe('ReminderPrompt', () => {
     expect(container.firstChild).not.toBeNull();
 
     const box = getByRole('alert');
-    const sendAgainLink = await within(box).findByText('Send again?');
+    const sendAgainLink = await within(box).findByText('send again');
 
-    expect(mockActionFn).not.toHaveBeenCalled();
+    expect(mockSubmitHook).not.toHaveBeenCalled();
     fireEvent.click(sendAgainLink);
-    expect(mockActionFn).toHaveBeenCalledTimes(1);
-    expect(mockActionFn).toHaveBeenCalledWith({ resend: true, stateHandle: mockStateHandle });
+    expect(mockSubmitHook).toHaveBeenCalledTimes(1);
+    expect(mockSubmitHook).toHaveBeenCalledWith({
+      step,
+      isActionStep: true,
+      params: { resend: true },
+    });
   });
 
   it('should show prompt after custom timeout passes', async () => {
-    const mockActionFn = jest.fn();
     const CUSTOM_TIMEOUT = 1_000 * 60 * 5;
 
     const props: UISchemaElementComponentProps & { uischema: ReminderElement; } = {
@@ -122,7 +120,9 @@ describe('ReminderPrompt', () => {
           ctaText: 'Didnt receive the email?',
           linkLabel: 'Send again?',
           timeout: CUSTOM_TIMEOUT,
-          action: mockActionFn,
+          step: 'currentAuthenticator-resend',
+          actionParams: { resend: true },
+          isActionStep: true,
         },
       },
     };

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.test.tsx
@@ -40,8 +40,8 @@ describe('ReminderPrompt', () => {
       uischema: {
         type: 'Reminder',
         options: {
-          ctaText: 'Didnt receive the email?',
-          linkLabel: 'Send again?',
+          content: 'Didnt receive the email?',
+          buttonText: 'Send again?',
           step,
           actionParams: { resend: true },
           isActionStep: true,
@@ -62,6 +62,8 @@ describe('ReminderPrompt', () => {
     const box = getByRole('alert');
     const sendAgainLink = await within(box).findByText('Send again?');
 
+    expect(container).toMatchSnapshot();
+
     expect(mockSubmitHook).not.toHaveBeenCalled();
     fireEvent.click(sendAgainLink);
     expect(mockSubmitHook).toHaveBeenCalledTimes(1);
@@ -78,9 +80,10 @@ describe('ReminderPrompt', () => {
       uischema: {
         type: 'Reminder',
         options: {
-          ctaText: 'Didnt receive the email? Click <a href="#" class="send-again">send again</a>',
+          content: "Didn't receive the email? Click <a href='#' class='send-again'>send again</a>",
+          contentHasHtml: true,
           step,
-          className: 'send-again',
+          contentClassname: 'send-again',
           actionParams: { resend: true },
           isActionStep: true,
         },
@@ -100,6 +103,8 @@ describe('ReminderPrompt', () => {
     const box = getByRole('alert');
     const sendAgainLink = await within(box).findByText('send again');
 
+    expect(container).toMatchSnapshot();
+
     expect(mockSubmitHook).not.toHaveBeenCalled();
     fireEvent.click(sendAgainLink);
     expect(mockSubmitHook).toHaveBeenCalledTimes(1);
@@ -117,8 +122,8 @@ describe('ReminderPrompt', () => {
       uischema: {
         type: 'Reminder',
         options: {
-          ctaText: 'Didnt receive the email?',
-          linkLabel: 'Send again?',
+          content: 'Didnt receive the email?',
+          buttonText: 'Send again?',
           timeout: CUSTOM_TIMEOUT,
           step: 'currentAuthenticator-resend',
           actionParams: { resend: true },
@@ -128,6 +133,8 @@ describe('ReminderPrompt', () => {
     };
 
     const { container } = render(<ReminderPrompt {...props} />);
+
+    expect(container).toMatchSnapshot();
 
     act(() => {
       jest.advanceTimersByTime(CUSTOM_TIMEOUT);

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -28,13 +28,13 @@ const ReminderPrompt: UISchemaElementComponent<{
   uischema: ReminderElement
 }> = ({ uischema }) => {
   const {
-    content: ctaText,
+    content,
     step,
     actionParams,
     isActionStep,
-    buttonText: linkLabel,
+    buttonText,
     timeout: customTimeout,
-    contentClassname: className,
+    contentClassname,
     contentHasHtml,
   } = uischema.options;
   const onSubmitHandler = useOnSubmit();
@@ -70,7 +70,7 @@ const ReminderPrompt: UISchemaElementComponent<{
   };
 
   const renderActionLink = () => {
-    if (!linkLabel) {
+    if (!buttonText) {
       return undefined;
     }
 
@@ -81,20 +81,20 @@ const ReminderPrompt: UISchemaElementComponent<{
         href="javascript:void(0);"
         onClick={() => resendHandler()}
       >
-        {linkLabel}
+        {buttonText}
       </Link>
     );
   };
 
   const renderAlertContent = () => {
-    if (contentHasHtml && className) {
+    if (contentHasHtml && contentClassname) {
       return (
         <TextWithHtml
           uischema={{
             type: 'TextWithHtml',
             options: {
-              className,
-              content: ctaText,
+              contentClassname,
+              content,
               step,
               isActionStep,
               actionParams,
@@ -103,7 +103,7 @@ const ReminderPrompt: UISchemaElementComponent<{
         />
       );
     }
-    return (<Box marginBottom={2}>{ctaText}</Box>);
+    return (<Box marginBottom={2}>{content}</Box>);
   };
 
   return show ? (

--- a/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
+++ b/src/v3/src/components/ReminderPrompt/ReminderPrompt.tsx
@@ -28,13 +28,14 @@ const ReminderPrompt: UISchemaElementComponent<{
   uischema: ReminderElement
 }> = ({ uischema }) => {
   const {
-    ctaText,
+    content: ctaText,
     step,
     actionParams,
     isActionStep,
-    linkLabel,
+    buttonText: linkLabel,
     timeout: customTimeout,
-    className,
+    contentClassname: className,
+    contentHasHtml,
   } = uischema.options;
   const onSubmitHandler = useOnSubmit();
 
@@ -86,7 +87,7 @@ const ReminderPrompt: UISchemaElementComponent<{
   };
 
   const renderAlertContent = () => {
-    if (className) {
+    if (contentHasHtml && className) {
       return (
         <TextWithHtml
           uischema={{

--- a/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
+++ b/src/v3/src/components/ReminderPrompt/__snapshots__/ReminderPrompt.test.tsx.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReminderPrompt should show prompt after custom timeout passes 1`] = `<div />`;
+
+exports[`ReminderPrompt should show prompt with working link after default timeout passes 1`] = `
+<div>
+  <div
+    class="MuiBox-root emotion-0"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-1"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon emotion-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-3"
+          data-testid="ReportProblemOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message emotion-4"
+      >
+        <div
+          class="MuiBox-root emotion-5"
+        >
+          Didnt receive the email?
+        </div>
+        <a
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-6"
+          href="javascript:void(0);"
+        >
+          Send again?
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ReminderPrompt should show prompt with working link after default timeout passes where ctaText contains HTML 1`] = `
+<div>
+  <div
+    class="MuiBox-root emotion-0"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-1"
+      role="alert"
+    >
+      <div
+        class="MuiAlert-icon emotion-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-3"
+          data-testid="ReportProblemOutlinedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiAlert-message emotion-4"
+      >
+        <div
+          class="MuiBox-root emotion-5"
+        >
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            Didn't receive the email? Click 
+            <a
+              class="send-again"
+              href="#"
+            >
+              send again
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
+++ b/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
@@ -24,9 +24,11 @@ const TextWithHtml: UISchemaElementComponent<{
 }> = ({ uischema }) => {
   const {
     content,
+    actionParams,
     step,
     stepToRender,
     className,
+    isActionStep,
   } = uischema.options;
   const onSubmitHandler = useOnSubmit();
 
@@ -38,6 +40,8 @@ const TextWithHtml: UISchemaElementComponent<{
       onSubmitHandler({
         step,
         stepToRender,
+        params: actionParams,
+        isActionStep,
       });
     }
   };

--- a/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
+++ b/src/v3/src/components/TextWithHtml/TextWithHtml.tsx
@@ -27,7 +27,7 @@ const TextWithHtml: UISchemaElementComponent<{
     actionParams,
     step,
     stepToRender,
-    className,
+    contentClassname,
     isActionStep,
   } = uischema.options;
   const onSubmitHandler = useOnSubmit();
@@ -36,7 +36,7 @@ const TextWithHtml: UISchemaElementComponent<{
     e.preventDefault();
 
     // only submit when className matches
-    if ((e.target as HTMLElement).className.includes(className)) {
+    if ((e.target as HTMLElement).className.includes(contentClassname)) {
       onSubmitHandler({
         step,
         stepToRender,

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams, NextStep } from '@okta/okta-auth-js';
+import { NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -28,14 +28,9 @@ import {
 import { loc } from '../../../util';
 import { getUIElementWithName } from '../../utils';
 
-export const transformEmailChallenge: IdxStepTransformer = ({
-  transaction,
-  formBag,
-  widgetProps,
-}) => {
+export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
-  const { authClient } = widgetProps;
 
   let reminderElement: ReminderElement | undefined;
 
@@ -47,15 +42,9 @@ export const transformEmailChallenge: IdxStepTransformer = ({
       options: {
         ctaText: loc('email.code.not.received', 'login'),
         linkLabel: loc('email.button.resend', 'login'),
-        // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-        action: (params?: IdxActionParams) => {
-          const { stateHandle, ...rest } = params ?? {};
-          return authClient?.idx.proceed({
-            // @ts-ignore stateHandle can be undefined
-            stateHandle,
-            actions: [{ name, params: rest }],
-          });
-        },
+        step: name,
+        isActionStep: true,
+        actionParams: { resend: true },
       },
     };
   }

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -40,8 +40,8 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
     reminderElement = {
       type: 'Reminder',
       options: {
-        ctaText: loc('email.code.not.received', 'login'),
-        linkLabel: loc('email.button.resend', 'login'),
+        content: loc('email.code.not.received', 'login'),
+        buttonText: loc('email.button.resend', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.test.ts
@@ -78,9 +78,9 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
     expect((updatedFormBag.uischema.elements[0] as TitleElement).options?.content)
       .toBe('oie.okta_verify.push.title');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Reminder');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.ctaText)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.content)
       .toBe('oktaverify.warning');
-    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.linkLabel)
+    expect((updatedFormBag.uischema.elements[1] as ReminderElement).options?.buttonText)
       .toBeUndefined();
     expect(updatedFormBag.uischema.elements[2].type).toBe('Description');
     expect((updatedFormBag.uischema.elements[2] as DescriptionElement).options?.content)
@@ -109,9 +109,9 @@ describe('Transform Okta Verify Challenge Poll Tests', () => {
 
     expect(updatedFormBag.uischema.elements.length).toBe(5);
     expect(updatedFormBag.uischema.elements[0].type).toBe('Reminder');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.ctaText)
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.content)
       .toBe('oie.numberchallenge.warning');
-    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.linkLabel)
+    expect((updatedFormBag.uischema.elements[0] as ReminderElement).options?.buttonText)
       .toBe('email.button.resend');
     expect(updatedFormBag.uischema.elements[1].type).toBe('Title');
     expect((updatedFormBag.uischema.elements[1] as TitleElement).options?.content)

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -47,8 +47,8 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({ transacti
       uischema.elements.unshift({
         type: 'Reminder',
         options: {
-          ctaText: loc('oie.numberchallenge.warning', 'login'),
-          linkLabel: loc('email.button.resend', 'login'),
+          content: loc('oie.numberchallenge.warning', 'login'),
+          buttonText: loc('email.button.resend', 'login'),
           step: name,
           isActionStep: true,
           actionParams: { resend: true },
@@ -86,7 +86,7 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({ transacti
     uischema.elements.unshift({
       type: 'Reminder',
       options: {
-        ctaText: loc('oktaverify.warning', 'login'),
+        content: loc('oktaverify.warning', 'login'),
       },
     } as ReminderElement);
     uischema.elements.unshift({

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams, NextStep } from '@okta/okta-auth-js';
+import { NextStep } from '@okta/okta-auth-js';
 
 import PhoneSvg from '../../img/phone-icon.svg';
 import {
@@ -23,15 +23,10 @@ import {
 } from '../../types';
 import { loc } from '../../util';
 
-export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({
-  transaction,
-  formBag,
-  widgetProps,
-}) => {
+export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { relatesTo } = nextStep;
   const { uischema } = formBag;
-  const { authClient } = widgetProps;
 
   const [selectedMethod] = relatesTo?.value?.methods || [];
   if (!selectedMethod) {
@@ -54,15 +49,9 @@ export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({
         options: {
           ctaText: loc('oie.numberchallenge.warning', 'login'),
           linkLabel: loc('email.button.resend', 'login'),
-          // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-          action: (params?: IdxActionParams) => {
-            const { stateHandle, ...rest } = params ?? {};
-            return authClient?.idx.proceed({
-              // @ts-ignore stateHandle can be undefined
-              stateHandle,
-              actions: [{ name, params: rest }],
-            });
-          },
+          step: name,
+          isActionStep: true,
+          actionParams: { resend: true },
         },
       } as ReminderElement);
     }

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChannelSelection.ts
@@ -83,7 +83,7 @@ export const transformOktaVerifyChannelSelection: IdxStepTransformer = ({
       type: 'TextWithHtml',
       options: {
         content: loc('oie.enroll.okta_verify.switch.channel.link.text', 'login'),
-        className: 'switch-channel-link',
+        contentClassname: 'switch-channel-link',
         step: IDX_STEP.SELECT_ENROLLMENT_CHANNEL,
       },
     };

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollChannel.ts
@@ -89,7 +89,7 @@ export const transformOktaVerifyEnrollChannel: IdxStepTransformer = ({
     type: 'TextWithHtml',
     options: {
       content: loc('oie.enroll.okta_verify.switch.channel.link.text', 'login'),
-      className: 'switch-channel-link',
+      contentClassname: 'switch-channel-link',
       step: IDX_STEP.SELECT_ENROLLMENT_CHANNEL,
       stepToRender: IDX_STEP.SELECT_ENROLLMENT_CHANNEL,
     },

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -34,8 +34,6 @@ const STEPS = {
 
 const REMINDER_CHANNELS = ['sms', 'email'];
 const CHANNEL_TO_CTA_KEY: { [channel: string]: string } = {
-  // TODO: OKTA-520236 These i18n keys contain anchor tags in them, how to proceed?
-  // See OVResendView.js
   email: 'oie.enroll.okta_verify.email.notReceived',
   sms: 'oie.enroll.okta_verify.sms.notReceived',
 };
@@ -80,7 +78,6 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({ transaction,
     reminder = {
       type: 'Reminder',
       options: {
-        // TODO: OKTA-520236 - i18n key has anchor tag
         ctaText: loc(CHANNEL_TO_CTA_KEY[selectedChannel], 'login'),
         step: name,
         isActionStep: true,

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -10,8 +10,6 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams } from '@okta/okta-auth-js';
-
 import { IDX_STEP } from '../../constants';
 import {
   ButtonElement,
@@ -65,14 +63,9 @@ export const switchChannelButton = (
   },
 });
 
-export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
-  transaction,
-  formBag,
-  widgetProps,
-}) => {
+export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({ transaction, formBag }) => {
   const { context, availableSteps } = transaction;
   const { uischema } = formBag;
-  const { authClient } = widgetProps;
 
   const authenticator = context.currentAuthenticator.value;
   // @ts-ignore OKTA-496373 - missing props from interface
@@ -89,16 +82,10 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({
       options: {
         // TODO: OKTA-520236 - i18n key has anchor tag
         ctaText: loc(CHANNEL_TO_CTA_KEY[selectedChannel], 'login'),
-        linkLabel: loc('email.button.resend', 'login'),
-        // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-        action: (params?: IdxActionParams) => {
-          const { stateHandle, ...rest } = params ?? {};
-          return authClient?.idx.proceed({
-            // @ts-ignore stateHandle can be undefined
-            stateHandle,
-            actions: [{ name, params: rest }],
-          });
-        },
+        step: name,
+        isActionStep: true,
+        actionParams: { resend: true },
+        className: 'resend-link',
       },
     };
   }

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -55,7 +55,7 @@ export const switchChannelButton = (
   type: 'TextWithHtml',
   options: {
     content: loc(label, 'login'),
-    className: 'switch-channel-link',
+    contentClassname: 'switch-channel-link',
     step: IDX_STEP.SELECT_ENROLLMENT_CHANNEL,
     stepToRender: IDX_STEP.SELECT_ENROLLMENT_CHANNEL,
   },

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyEnrollPoll.ts
@@ -78,11 +78,12 @@ export const transformOktaVerifyEnrollPoll: IdxStepTransformer = ({ transaction,
     reminder = {
       type: 'Reminder',
       options: {
-        ctaText: loc(CHANNEL_TO_CTA_KEY[selectedChannel], 'login'),
+        content: loc(CHANNEL_TO_CTA_KEY[selectedChannel], 'login'),
+        contentHasHtml: true,
         step: name,
         isActionStep: true,
         actionParams: { resend: true },
-        className: 'resend-link',
+        contentClassname: 'resend-link',
       },
     };
   }

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams, NextStep } from '@okta/okta-auth-js';
+import { NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -22,14 +22,9 @@ import {
 } from '../../types';
 import { loc } from '../../util';
 
-export const transformPhoneChallenge: IdxStepTransformer = ({
-  transaction,
-  formBag,
-  widgetProps,
-}) => {
+export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
-  const { authClient } = widgetProps;
 
   const { methods, profile } = nextStep.relatesTo?.value || {};
   const { phoneNumber } = profile || {};
@@ -38,21 +33,15 @@ export const transformPhoneChallenge: IdxStepTransformer = ({
 
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
   if (resendStep) {
-    const { name, action } = resendStep;
+    const { name } = resendStep;
     reminderElement = {
       type: 'Reminder',
       options: {
         ctaText: loc('oie.phone.verify.sms.resendText', 'login'),
         linkLabel: loc('email.button.resend', 'login'),
-        // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-        action: action && ((params?: IdxActionParams) => {
-          const { stateHandle, ...rest } = params ?? {};
-          return authClient?.idx.proceed({
-            // @ts-ignore stateHandle can be undefined
-            stateHandle,
-            actions: [{ name, params: rest }],
-          });
-        }),
+        step: name,
+        isActionStep: true,
+        actionParams: { resend: true },
       },
     };
   }

--- a/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneChallengeTransformer.ts
@@ -37,8 +37,8 @@ export const transformPhoneChallenge: IdxStepTransformer = ({ transaction, formB
     reminderElement = {
       type: 'Reminder',
       options: {
-        ctaText: loc('oie.phone.verify.sms.resendText', 'login'),
-        linkLabel: loc('email.button.resend', 'login'),
+        content: loc('oie.phone.verify.sms.resendText', 'login'),
+        buttonText: loc('email.button.resend', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams, NextStep } from '@okta/okta-auth-js';
+import { NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -22,34 +22,23 @@ import {
 } from '../../types';
 import { loc } from '../../util';
 
-export const transformPhoneCodeEnrollment: IdxStepTransformer = ({
-  transaction,
-  formBag,
-  widgetProps,
-}) => {
+export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { uischema } = formBag;
-  const { authClient } = widgetProps;
 
   let reminderElement: ReminderElement | undefined;
 
   const resendStep = availableSteps?.find(({ name }) => name?.endsWith('resend'));
   if (resendStep) {
-    const { name, action } = resendStep;
+    const { name } = resendStep;
     reminderElement = {
       type: 'Reminder',
       options: {
         ctaText: loc('oie.phone.verify.sms.resendText', 'login'),
         linkLabel: loc('email.button.resend', 'login'),
-        // @ts-ignore OKTA-512706 temporary until auth-js applies this fix
-        action: action && ((params?: IdxActionParams) => {
-          const { stateHandle, ...rest } = params ?? {};
-          return authClient?.idx.proceed({
-            // @ts-ignore stateHandle can be undefined
-            stateHandle,
-            actions: [{ name, params: rest }],
-          });
-        }),
+        step: name,
+        isActionStep: true,
+        actionParams: { resend: true },
       },
     };
   }

--- a/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
+++ b/src/v3/src/transformer/phone/phoneEnrollmentCodeTransformer.ts
@@ -34,8 +34,8 @@ export const transformPhoneCodeEnrollment: IdxStepTransformer = ({ transaction, 
     reminderElement = {
       type: 'Reminder',
       options: {
-        ctaText: loc('oie.phone.verify.sms.resendText', 'login'),
-        linkLabel: loc('email.button.resend', 'login'),
+        content: loc('oie.phone.verify.sms.resendText', 'login'),
+        buttonText: loc('email.button.resend', 'login'),
         step: name,
         isActionStep: true,
         actionParams: { resend: true },

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -231,13 +231,14 @@ export interface ReminderElement extends UISchemaElement {
     /**
      * The call to action text in the reminder content area
      */
-    ctaText: string;
+    content: string;
     /**
      * Override the default timeout before reminder appears
      */
+    contentHasHtml?: boolean;
     timeout?: number;
-    linkLabel?: string;
-    className?: string;
+    buttonText?: string;
+    contentClassname?: string;
   };
 }
 

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -220,7 +220,7 @@ export interface TextWithHtmlElement extends UISchemaElement {
   type: 'TextWithHtml';
   options: ActionOptions & {
     content: string;
-    className: string;
+    contentClassname: string;
     stepToRender?: string;
   };
 }

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -15,7 +15,6 @@ import {
   IdxMessage,
   IdxTransaction,
   Input,
-  NextStep,
   WebauthnVerificationValues,
 } from '@okta/okta-auth-js';
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
@@ -219,16 +218,16 @@ export interface DescriptionElement extends UISchemaElement {
 
 export interface TextWithHtmlElement extends UISchemaElement {
   type: 'TextWithHtml';
-  options: DescriptionElement['options'] & {
+  options: ActionOptions & {
+    content: string;
     className: string;
-    step: string;
     stepToRender?: string;
   };
 }
 
 export interface ReminderElement extends UISchemaElement {
   type: 'Reminder';
-  options: {
+  options: ActionOptions & {
     /**
      * The call to action text in the reminder content area
      */
@@ -238,7 +237,7 @@ export interface ReminderElement extends UISchemaElement {
      */
     timeout?: number;
     linkLabel?: string;
-    action?: NextStep['action'];
+    className?: string;
   };
 }
 

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -137,7 +137,184 @@ exports[`authenticator-verification-email renders correct form renders the initi
 </div>
 `;
 
-exports[`authenticator-verification-email renders correct form renders the otp challenage form 1`] = `
+exports[`authenticator-verification-email renders correct form renders the initial form with resend alert box 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-4"
+            >
+              <mocksvgicon />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  firstname.lastname@example.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-14"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-icon emotion-15"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-16"
+                            data-testid="ReportProblemOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiAlert-message emotion-17"
+                        >
+                          <div
+                            class="MuiBox-root emotion-18"
+                          >
+                            Haven't received an email?
+                          </div>
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                            href="javascript:void(0);"
+                          >
+                            Send again
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-21"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-22"
+                        data-se="o-form-head"
+                      >
+                        Verify with your email
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-21"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
+                        data-se="o-form-explain"
+                      >
+                        We sent an email to f****************e@example.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-secondary MuiButton-secondaryPrimary MuiButton-sizeMedium MuiButton-secondarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-27"
+                      tabindex="0"
+                      type="button"
+                    >
+                      Enter a code from the email instead
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-19"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-verification-email renders correct form renders the otp challenge form 1`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"
@@ -316,7 +493,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
 </div>
 `;
 
-exports[`authenticator-verification-email renders correct form renders the otp challenage form 2`] = `
+exports[`authenticator-verification-email renders correct form renders the otp challenge form 2`] = `
 <div>
   <div
     class="MuiScopedCssBaseline-root emotion-0"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -707,15 +707,59 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   <div
                     class="MuiBox-root emotion-12"
-                  />
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-14"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-icon emotion-15"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-16"
+                            data-testid="ReportProblemOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiAlert-message emotion-17"
+                        >
+                          <div
+                            class="MuiBox-root emotion-4"
+                          >
+                            <div
+                              class="MuiBox-root emotion-4"
+                            >
+                              Haven’t received an email? Check your spam folder or 
+                              <a
+                                class="resend-link"
+                                href="#"
+                              >
+                                send again
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                   <div
                     class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-21"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                        class="MuiTypography-root MuiTypography-h3 emotion-22"
                         data-se="o-form-head"
                       >
                         Check your email
@@ -726,10 +770,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-21"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="o-form-explain"
                       >
                         We sent an email to glen.fannin@okta.com with an Okta Verify setup link. To continue, open the link on your mobile device.
@@ -761,7 +805,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -772,7 +816,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -3174,15 +3218,59 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                 >
                   <div
                     class="MuiBox-root emotion-12"
-                  />
+                  >
+                    <div
+                      class="MuiBox-root emotion-12"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-14"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-icon emotion-15"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-16"
+                            data-testid="ReportProblemOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiAlert-message emotion-17"
+                        >
+                          <div
+                            class="MuiBox-root emotion-4"
+                          >
+                            <div
+                              class="MuiBox-root emotion-4"
+                            >
+                              Haven’t received an SMS? 
+                              <a
+                                class="resend-link"
+                                href="#"
+                              >
+                                Send again
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                   <div
                     class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-21"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                        class="MuiTypography-root MuiTypography-h3 emotion-22"
                         data-se="o-form-head"
                       >
                         Check your text messages
@@ -3193,10 +3281,10 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                     class="MuiBox-root emotion-12"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-21"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="o-form-explain"
                       >
                         We sent an SMS to +12165332241 with an Okta Verify setup link. To continue, open the link on your mobile device.
@@ -3228,7 +3316,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -3239,7 +3327,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
                   class="MuiBox-root emotion-12"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-23"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { act } from 'preact/test-utils';
 import { setup } from './util';
 
 import authenticatorVerificationEmail from '../../src/mocks/response/idp/idx/challenge/default.json';
@@ -56,7 +57,22 @@ describe('authenticator-verification-email', () => {
       );
     });
 
-    it('renders the otp challenage form', async () => {
+    it('renders the initial form with resend alert box', async () => {
+      const {
+        container, findByText,
+      } = await setup({
+        mockResponse: authenticatorVerificationEmail,
+      });
+
+      // renders the form
+      await findByText(/Verify with your email/);
+      act(() => {
+        jest.advanceTimersByTime(31_000);
+      });
+      expect(container).toMatchSnapshot();
+    });
+
+    it('renders the otp challenge form', async () => {
       const {
         authClient,
         container,

--- a/src/v3/test/integration/flow-okta-verify-enrollment.test.tsx
+++ b/src/v3/test/integration/flow-okta-verify-enrollment.test.tsx
@@ -11,6 +11,7 @@
  */
 
 import { HttpRequestClient } from '@okta/okta-auth-js';
+import { act } from 'preact/test-utils';
 import { setup, updateStateHandleInMock } from './util';
 import qrPollingResponse from '../../src/mocks/response/idp/idx/credential/enroll/enroll-okta-verify-mfa.json';
 import emailPollingResponse from '../../src/mocks/response/idp/idx/challenge/send/enroll-ov-email-mfa.json';
@@ -73,6 +74,14 @@ const createTestContext = async () => {
 };
 
 describe('flow-okta-verify-enrollment', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('qr polling -> channel selection -> data enrollment (email/default) -> email polling -> try different -> channel selection -> qr polling', async () => {
     const {
       authClient,
@@ -159,6 +168,10 @@ describe('flow-okta-verify-enrollment', () => {
 
     // email polling
     await findByText(/Check your email/);
+
+    act(() => {
+      jest.advanceTimersByTime(31_000);
+    });
     expect(container).toMatchSnapshot();
     await user.click(await findByText(/try a different way/));
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
@@ -300,6 +313,9 @@ describe('flow-okta-verify-enrollment', () => {
 
     // sms polling
     await findByText(/Check your text messages/);
+    act(() => {
+      jest.advanceTimersByTime(31_000);
+    });
     expect(container).toMatchSnapshot();
     await user.click(await findByText(/try a different way/));
     expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
@@ -353,6 +369,7 @@ describe('flow-okta-verify-enrollment', () => {
     await findByAltText('QR code');
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('qr polling -> channel selection -> qr polling', async () => {
     const { user, findByText, findByAltText } = await createTestContext();
 
@@ -374,6 +391,7 @@ describe('flow-okta-verify-enrollment', () => {
     await findByAltText('QR code');
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it('qr polling -> channel selection -> data enrollment -> channel selection', async () => {
     const { user, findByText, findByAltText } = await createTestContext();
 


### PR DESCRIPTION
## Description:
Purpose of this PR is to fix the raw HTML that is contained in resend alert prompt for OV enrollment. 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-520236](https://oktainc.atlassian.net/browse/OKTA-520236)

### Reviewers:

### Screenshot/Video:


https://user-images.githubusercontent.com/97472729/184239564-860d9053-12a7-4f5e-aca4-9f931e4694ab.mov

<img width="524" alt="Screen Shot 2022-08-11 at 4 30 08 PM" src="https://user-images.githubusercontent.com/97472729/184239586-37957aee-0efd-4210-a4bf-5b62a481f670.png">

### Downstream Monolith Build:



