### PR TITLE
OKTA-523741 : Applying fix to load OK-PL

### DIFF
--- a/src/v3/src/util/settingsUtils.test.ts
+++ b/src/v3/src/util/settingsUtils.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { WidgetProps } from '../types';
+import { getLanguageCode } from './settingsUtils';
+
+jest.mock('../../../util/BrowserFeatures', () => ({
+  getUserLanguages: jest.fn().mockReturnValue(['en', 'en-US']),
+}));
+
+jest.mock('../../../config/config.json', () => ({
+  defaultLanguage: 'en',
+  supportedLanguages: ['en', 'ok-PL', 'es', 'ko', 'ja', 'nl', 'pt'],
+}));
+
+describe('Settings Utils Tests', () => {
+  let widgetProps: WidgetProps = {};
+
+  beforeEach(() => {
+    widgetProps = { language: 'en' };
+  });
+
+  it('should return requested language even if it is not a supported language', () => {
+    widgetProps.language = 'foobar';
+
+    expect(getLanguageCode(widgetProps)).toBe('foobar');
+  });
+
+  it('should return requested language code when other supported languages are available', () => {
+    widgetProps.language = 'ok-PL';
+
+    expect(getLanguageCode(widgetProps)).toBe('ok-PL');
+  });
+
+  it('should return requested language code when other language prop is provided as a function', () => {
+    widgetProps.language = () => ('es');
+
+    expect(getLanguageCode(widgetProps)).toBe('es');
+  });
+});

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -64,16 +64,12 @@ export const getLanguageCode = (widgetProps: WidgetProps): LanguageCode => {
 
   // Perform a case insensitive search - this is necessary in the case
   // of browsers like Safari
-  let supportedPos;
-  let supportedLanguage = config.defaultLanguage;
+  const foundLang = expanded.find(
+    (preferredLang) => supportedLangsLowercase.includes(preferredLang),
+  );
+  const supportedPos = supportedLangsLowercase.findIndex(
+    (supportedLang) => supportedLang === foundLang,
+  );
 
-  for (let i = 0; i < expanded.length; i += 1) {
-    supportedPos = supportedLangsLowercase.indexOf(expanded[i]);
-    if (supportedPos > -1) {
-      supportedLanguage = supportedLanguages[supportedPos];
-      break;
-    }
-  }
-
-  return supportedLanguage as LanguageCode;
+  return (supportedLanguages[supportedPos] ?? config.defaultLanguage) as LanguageCode;
 };

--- a/src/v3/src/util/settingsUtils.ts
+++ b/src/v3/src/util/settingsUtils.ts
@@ -67,12 +67,13 @@ export const getLanguageCode = (widgetProps: WidgetProps): LanguageCode => {
   let supportedPos;
   let supportedLanguage = config.defaultLanguage;
 
-  expanded.forEach((expandedVal) => {
-    supportedPos = supportedLangsLowercase.indexOf(expandedVal);
+  for (let i = 0; i < expanded.length; i += 1) {
+    supportedPos = supportedLangsLowercase.indexOf(expanded[i]);
     if (supportedPos > -1) {
       supportedLanguage = supportedLanguages[supportedPos];
+      break;
     }
-  });
+  }
 
   return supportedLanguage as LanguageCode;
 };


### PR DESCRIPTION
## Description:
Purpose of this is to fix the OK-PL and alternate language loading.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:
<img width="480" alt="Screen Shot 2022-08-12 at 11 04 03 AM" src="https://user-images.githubusercontent.com/97472729/184384119-8682955f-7031-4bb8-a972-1cd459d6b4ce.png">


### Downstream Monolith Build:



