### PR TITLE
OKTA-521364 : Fix for field level data being carried over between transactions

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -107,7 +107,10 @@ const Form: FunctionComponent<{
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
     >
-      <Layout uischema={uischema} stepName={currTransaction?.nextStep?.name} />
+      <Layout
+        uischema={uischema}
+        stepName={currTransaction?.nextStep?.name}
+      />
     </form>
   );
 };

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -107,7 +107,7 @@ const Form: FunctionComponent<{
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
     >
-      <Layout uischema={uischema} />
+      <Layout uischema={uischema} stepName={currTransaction?.nextStep?.name} />
     </form>
   );
 };

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -78,11 +78,12 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
 
           const uischemaElement = (element as UISchemaElement);
           const fieldElement = (uischemaElement as FieldElement);
-          const key = fieldElement.options?.inputMeta?.name && fieldElement.label ? `${fieldElement.options?.inputMeta?.name}_${fieldElement.label}` : elementKey;
+          const key = fieldElement.options?.inputMeta?.name && fieldElement.label
+            ? `${fieldElement.options?.inputMeta?.name}_${fieldElement.label}`
+            : elementKey;
           const Component = renderer.renderer as UISchemaElementComponent;
           return (
             <Box
-              // key={elementKey}
               key={key}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...(!(uischemaElement).noMargin && { marginBottom: 4 })}

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -14,6 +14,7 @@ import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
 import {
+  FieldElement,
   StepperLayout,
   UISchemaElement,
   UISchemaElementComponent,
@@ -75,14 +76,18 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
             return null;
           }
 
+          const uischemaElement = (element as UISchemaElement);
+          const fieldElement = (uischemaElement as FieldElement);
+          const key = fieldElement.options?.inputMeta?.name && fieldElement.label ? `${fieldElement.options?.inputMeta?.name}_${fieldElement.label}` : elementKey;
           const Component = renderer.renderer as UISchemaElementComponent;
           return (
             <Box
-              key={elementKey}
+              // key={elementKey}
+              key={key}
               // eslint-disable-next-line react/jsx-props-no-spreading
-              {...(!(element as UISchemaElement).noMargin && { marginBottom: 4 })}
+              {...(!(uischemaElement).noMargin && { marginBottom: 4 })}
             >
-              <Component uischema={element as UISchemaElement} />
+              <Component uischema={uischemaElement} />
             </Box>
           );
         })

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -28,9 +28,10 @@ import Stepper from './Stepper';
 
 type LayoutProps = {
   uischema: UISchemaLayout;
+  stepName?: string;
 };
 
-const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
+const Layout: FunctionComponent<LayoutProps> = ({ uischema, stepName }) => {
   const { type, elements } = uischema;
 
   const isHorizontalLayout = type === UISchemaLayoutType.HORIZONTAL;
@@ -44,7 +45,8 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
     >
       {
         elements.map((element, index) => {
-          const elementKey = `${element.type}_${index}`;
+          const stepNameKeyPart = stepName ? `_${stepName}_` : '';
+          const elementKey = `${element.type}${stepNameKeyPart}${index}`;
 
           if (element.type === UISchemaLayoutType.STEPPER) {
             return (
@@ -61,6 +63,7 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
               <Layout
                 key={elementKey}
                 uischema={element as UISchemaLayout}
+                stepName={stepName}
               />
             );
           }
@@ -78,8 +81,8 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
 
           const uischemaElement = (element as UISchemaElement);
           const fieldElement = (uischemaElement as FieldElement);
-          const key = fieldElement.options?.inputMeta?.name && fieldElement.label
-            ? `${fieldElement.options?.inputMeta?.name}_${fieldElement.label}`
+          const key = fieldElement.options?.inputMeta?.name && stepNameKeyPart
+            ? `${fieldElement.options?.inputMeta?.name}${stepNameKeyPart}`
             : elementKey;
           const Component = renderer.renderer as UISchemaElementComponent;
           return (

--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -45,8 +45,7 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema, stepName }) => {
     >
       {
         elements.map((element, index) => {
-          const stepNameKeyPart = stepName ? `_${stepName}_` : '';
-          const elementKey = `${element.type}${stepNameKeyPart}${index}`;
+          const elementKey = [element.type, stepName, index].join('_');
 
           if (element.type === UISchemaLayoutType.STEPPER) {
             return (
@@ -81,8 +80,8 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema, stepName }) => {
 
           const uischemaElement = (element as UISchemaElement);
           const fieldElement = (uischemaElement as FieldElement);
-          const key = fieldElement.options?.inputMeta?.name && stepNameKeyPart
-            ? `${fieldElement.options?.inputMeta?.name}${stepNameKeyPart}`
+          const key = fieldElement.options?.inputMeta?.name && stepName
+            ? `${fieldElement.options?.inputMeta?.name}_${stepName}`
             : elementKey;
           const Component = renderer.renderer as UISchemaElementComponent;
           return (

--- a/src/v3/src/components/InformationalText/InformationalText.tsx
+++ b/src/v3/src/components/InformationalText/InformationalText.tsx
@@ -20,7 +20,7 @@ const InformationalText: UISchemaElementComponent<{
 }> = ({
   uischema,
 }) => {
-  const { content, variant } = uischema.options;
+  const { content } = uischema.options;
 
   return (
     <Box
@@ -30,8 +30,6 @@ const InformationalText: UISchemaElementComponent<{
       <Typography
         paragraph
         data-se="o-form-explain"
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(variant && { variant })}
       >
         {content}
       </Typography>

--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -33,7 +33,6 @@ const InputPassword: UISchemaElementComponent<{
       messages = {},
       name,
     },
-    hideLabel,
   } = uischema.options;
   const error = messages?.value?.[0] && getMessage(messages.value[0]);
 
@@ -44,8 +43,7 @@ const InputPassword: UISchemaElementComponent<{
   return (
     <Box>
       <PasswordInput
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...(!hideLabel && { label })}
+        label={label}
         tooltipLabel={
           (isHidden: boolean) => (isHidden ? getTranslation(translations, 'show') : getTranslation(translations, 'hide'))
         }
@@ -57,7 +55,6 @@ const InputPassword: UISchemaElementComponent<{
         fullWidth
         inputProps={{
           'data-se': name,
-          ...(hideLabel && { 'aria-label': label }),
           ...attributes,
         }}
       />

--- a/src/v3/src/mocks/scenario/index.ts
+++ b/src/v3/src/mocks/scenario/index.ts
@@ -35,7 +35,7 @@ import './error-401-invalid-otp-passcode';
 import './google-auth-scan-enroll';
 import './authenticator-verification-google-authenticator';
 import './identify-with-username';
-import './remove-sq-challenge';
+import './remove-security-question-challenge-flow';
 import './register-with-email-mfa';
 import './resetpassword-email-securityquestion';
 import './resetpassword-email-google-auth-verify';

--- a/src/v3/src/mocks/scenario/index.ts
+++ b/src/v3/src/mocks/scenario/index.ts
@@ -35,6 +35,7 @@ import './error-401-invalid-otp-passcode';
 import './google-auth-scan-enroll';
 import './authenticator-verification-google-authenticator';
 import './identify-with-username';
+import './remove-sq-challenge';
 import './register-with-email-mfa';
 import './resetpassword-email-securityquestion';
 import './resetpassword-email-google-auth-verify';

--- a/src/v3/src/mocks/scenario/remove-security-question-challenge-flow.ts
+++ b/src/v3/src/mocks/scenario/remove-security-question-challenge-flow.ts
@@ -12,7 +12,7 @@
 
 import { scenario } from '../registry';
 
-scenario('remove-sq-challenge', (rest) => ([
+scenario('remove-security-question-challenge-flow', (rest) => ([
   // bootstrap
   rest.get('*/oauth2/default/.well-known/openid-configuration', async (req, res, ctx) => {
     const { default: body } = await import('../response/oauth2/default/well-known/openid-configuration/default.json');

--- a/src/v3/src/mocks/scenario/remove-sq-challenge.ts
+++ b/src/v3/src/mocks/scenario/remove-sq-challenge.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { scenario } from '../registry';
+
+scenario('remove-sq-challenge', (rest) => ([
+  // bootstrap
+  rest.get('*/oauth2/default/.well-known/openid-configuration', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/well-known/openid-configuration/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/oauth2/default/v1/interact', async (req, res, ctx) => {
+    const { default: body } = await import('../response/oauth2/default/v1/interact/default.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  rest.post('*/idp/idx/introspect', async (req, res, ctx) => {
+    const { default: body } = await import('@okta/mocks/data/idp/idx/authenticator-verification-password.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+  // return security question challenge response remediation
+  rest.post('*/idp/idx/challenge/answer', async (req, res, ctx) => {
+    const { default: body } = await import('../response/idp/idx/identify/securityquestion-verify.json');
+    return res(
+      ctx.status(200),
+      ctx.json(body),
+    );
+  }),
+]));

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -13,27 +13,27 @@
 import { Input, NextStep } from '@okta/okta-auth-js';
 
 import {
-  FormBag, TransformStepFnWithOptions, UISchemaElement,
+  FieldElement,
+  FormBag, TransformStepFnWithOptions,
 } from '../../types';
 import { flattenInputs } from '../../util';
 import { transformer as attributesTransformer } from './attributes';
 import { transformer as typeTransformer } from './type';
 
-const mapUiElement = (input: Input): UISchemaElement => {
-  const { name, label } = input;
+const mapUiElement = (input: Input): FieldElement => {
+  const { label } = input;
   const fieldType = typeTransformer(input);
   const attributes = attributesTransformer(input);
 
   return {
     type: 'Field',
     label,
-    name,
     options: {
       inputMeta: { ...input },
       ...fieldType?.[input.name],
       ...attributes,
     },
-  } as UISchemaElement;
+  };
 };
 
 export const transformStepInputs = (

--- a/src/v3/src/transformer/field/transform.ts
+++ b/src/v3/src/transformer/field/transform.ts
@@ -14,7 +14,8 @@ import { Input, NextStep } from '@okta/okta-auth-js';
 
 import {
   FieldElement,
-  FormBag, TransformStepFnWithOptions,
+  FormBag,
+  TransformStepFnWithOptions,
 } from '../../types';
 import { flattenInputs } from '../../util';
 import { transformer as attributesTransformer } from './attributes';

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionEnroll.ts
@@ -46,6 +46,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
   const { uischema, data, dataSchema } = formBag;
 
   const predefinedQuestionOptions = inputs?.[0]?.options?.filter(({ value }) => !(value as Input[])?.some(({ name }) => name === 'question'));
+  const customQuestionOptions = inputs?.[0]?.options?.filter(({ value }) => (value as Input[])?.some(({ name }) => name === 'question'));
 
   const predefinedAnswerElement = getUIElementWithName(
     ANSWER_INPUT_NAME,
@@ -53,7 +54,7 @@ export const transformSecurityQuestionEnroll: IdxStepTransformer = ({ transactio
   ) as FieldElement;
   predefinedAnswerElement.options.inputMeta.secret = true;
 
-  const customAnswerInput = (predefinedQuestionOptions?.[0].value as Input[]).find(({ name }) => name === 'answer');
+  const customAnswerInput = (customQuestionOptions?.[0].value as Input[]).find(({ name }) => name === 'answer');
   const customAnswerElement: FieldElement = {
     type: 'Field',
     label: customAnswerInput?.label ?? customAnswerInput?.name,

--- a/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
+++ b/src/v3/src/transformer/layout/securityQuestion/securityQuestionVerify.ts
@@ -15,9 +15,8 @@ import { NextStep } from '@okta/okta-auth-js';
 import {
   ButtonElement,
   ButtonType,
-  DescriptionElement,
+  FieldElement,
   IdxStepTransformer,
-  InputTextElement,
   TitleElement,
   UISchemaElement,
 } from '../../../types';
@@ -35,20 +34,15 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
     },
   };
 
-  const questionElement: DescriptionElement = {
-    type: 'Description',
-    noMargin: true,
-    options: {
-      content: relatesTo?.value?.profile?.question as string,
-      variant: 'h6',
-    },
-  };
-
-  const answerElement: InputTextElement = getUIElementWithName(
+  const answerElement: FieldElement = getUIElementWithName(
     'credentials.answer',
     uischema.elements as UISchemaElement[],
-  ) as InputTextElement;
-  answerElement.options.hideLabel = true;
+  ) as FieldElement;
+  answerElement.translations = [{
+    name: 'label',
+    i18nKey: '',
+    value: relatesTo?.value?.profile?.question as string,
+  }];
 
   const submitButton: ButtonElement = {
     type: 'Button',
@@ -61,7 +55,6 @@ export const transformSecurityQuestionVerify: IdxStepTransformer = ({ transactio
 
   uischema.elements = [
     titleElement,
-    questionElement,
     answerElement,
     submitButton,
   ];

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -149,7 +149,6 @@ export interface FieldElement extends UISchemaElement {
      */
     translations?: TranslationInfo[];
     dataSe?: string;
-    hideLabel?: boolean;
   };
 }
 
@@ -215,6 +214,7 @@ export interface TitleElement extends UISchemaElement {
 export interface HeadingElement extends UISchemaElement {
   type: 'Heading';
   options: {
+    // https://mui.com/material-ui/api/typography/
     level: 1 | 2 | 3 | 4 | 5 | 6;
     visualLevel: 1 | 2 | 3 | 4 | 5 | 6;
     content: string;
@@ -225,9 +225,6 @@ export interface DescriptionElement extends UISchemaElement {
   type: 'Description';
   options: {
     content: string;
-    // this field uses a subset of mui Typography variant
-    // https://mui.com/material-ui/api/typography/
-    variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   };
 }
 

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -85,20 +85,6 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-4"
-                >
-                  <div
-                    class="MuiBox-root emotion-12"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-h6 MuiTypography-paragraph emotion-16"
-                      data-se="o-form-explain"
-                    >
-                      What is the food you least liked as a child?
-                    </p>
-                  </div>
-                </div>
-                <div
                   class="MuiBox-root emotion-11"
                 >
                   <div
@@ -108,34 +94,35 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-20"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-17"
                         for="credentials.answer"
-                      />
+                      >
+                        What is the food you least liked as a child?
+                      </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-21"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-18"
                       >
                         <input
                           aria-invalid="false"
-                          aria-label="Answer"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-22"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-19"
                           data-se="credentials.answer"
                           id="credentials.answer"
                           name="credentials.answer"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-23"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-20"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-24"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-21"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-25"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-22"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -148,10 +135,10 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-26"
+                          class="MuiOutlinedInput-notchedOutline emotion-23"
                         >
                           <legend
-                            class="emotion-27"
+                            class="emotion-24"
                           >
                             <span
                               class="notranslate"
@@ -168,7 +155,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-29"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-26"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -180,7 +167,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-31"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-28"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
+++ b/src/v3/test/integration/flow-password-authentication-security-question-authentication.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import identifyWithPassword from '@okta/mocks/data/idp/idx/authenticator-verification-password.json';
+
+import authenticatorSecurityQuestion from '../../src/mocks/response/idp/idx/identify/securityquestion-verify.json';
+import { setup } from './util';
+
+describe('Flow transition from password authentication to security question authentication', () => {
+  it('clears field data when transition from identify-with-password to authentication-verification-ga', async () => {
+    const {
+      user,
+      findByTestId,
+      findByText,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: identifyWithPassword,
+          status: 200,
+        },
+        '/idx/challenge/answer': {
+          data: authenticatorSecurityQuestion,
+          status: 200,
+        },
+      },
+    });
+
+    // form: identify with password
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+    const submitButton = await findByText('Verify', { selector: 'button' });
+
+    await user.type(passwordEl, 'fake-password');
+    expect(passwordEl.value).toEqual('fake-password');
+    await user.click(submitButton);
+
+    // form: verify with security question
+    await findByText(/Verify with your Security Question/);
+    const securityQuestionEl = await findByTestId('credentials.answer') as HTMLInputElement;
+    expect(securityQuestionEl.value).toEqual('');
+  });
+});


### PR DESCRIPTION
## Description:
This PR fixes the issue that surfaces when navigating between pages that re-use the same component (i.e. Navigating from password page and security question verification page). 


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521364](https://oktainc.atlassian.net/browse/OKTA-521364)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



