### PR TITLE
OKTA-523716 : Fix for global error messages persisting between views

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -258,6 +258,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       widgetProps,
       onSuccessCallback: onSuccess,
       idxTransaction,
+      authApiError,
+      setAuthApiError,
       setIdxTransaction,
       setIsClientTransaction,
       stepToRender,

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -258,7 +258,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       widgetProps,
       onSuccessCallback: onSuccess,
       idxTransaction,
-      authApiError,
       setAuthApiError,
       setIdxTransaction,
       setIsClientTransaction,

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -51,6 +51,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
       stepToRender,
     } = options;
 
+    // TODO: Revisit and refactor this function as it is a dupe of handleError fn in Widget/index.tsx
     const handleError = (error: unknown) => {
       // TODO: handle error based on types
       // AuthApiError is one of the potential error that can be thrown here

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxActionParams } from '@okta/okta-auth-js';
+import { AuthApiError, IdxActionParams } from '@okta/okta-auth-js';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
 import { useCallback } from 'preact/hooks';
@@ -33,52 +33,72 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     data,
     idxTransaction: currTransaction,
     dataSchemaRef,
+    setAuthApiError,
     setIdxTransaction,
     setIsClientTransaction,
     setStepToRender,
+    widgetProps,
   } = useWidgetContext();
 
+  const handleError = (error: unknown) => {
+    // TODO: handle error based on types
+    // AuthApiError is one of the potential error that can be thrown here
+    // We will want to expose development stage errors from auth-js and file jiras against it
+    setAuthApiError(error as AuthApiError);
+    console.error(error);
+    // error event
+    widgetProps.events?.afterError?.({
+      stepName: currTransaction?.nextStep?.name,
+    }, error);
+    return null;
+  };
+
   return useCallback(async (options: OnSubmitHandlerOptions) => {
-    const {
-      params,
-      includeData,
-      includeImmutableData = true,
-      step,
-      isActionStep,
-      stepToRender,
-    } = options;
-    const { fieldsToExclude } = dataSchemaRef.current!;
+    try {
+      const {
+        params,
+        includeData,
+        includeImmutableData = true,
+        step,
+        isActionStep,
+        stepToRender,
+      } = options;
+      const { fieldsToExclude } = dataSchemaRef.current!;
 
-    const immutableData = getImmutableData(currTransaction!, step);
+      const immutableData = getImmutableData(currTransaction!, step);
 
-    const fn = authClient.idx.proceed;
+      const fn = authClient.idx.proceed;
 
-    let payload: IdxActionParams = {};
-    if (includeData) {
-      payload = merge(payload, omit(data, fieldsToExclude));
+      let payload: IdxActionParams = {};
+      if (includeData) {
+        payload = merge(payload, omit(data, fieldsToExclude));
+      }
+      if (params) {
+        payload = merge(payload, params);
+      }
+      if (isActionStep) {
+        payload = {
+          ...payload,
+          actions: [{ name: step, params }],
+        };
+      } else {
+        payload = { ...payload, step };
+      }
+      if (includeImmutableData) {
+        payload = merge(payload, immutableData);
+      }
+      payload = toNestedObject(payload);
+      if (currTransaction!.context.stateHandle) {
+        payload.stateHandle = currTransaction!.context.stateHandle;
+      }
+      const newTransaction = await fn(payload);
+      setIdxTransaction(newTransaction);
+      setIsClientTransaction(false);
+      setStepToRender(stepToRender);
+    } catch (error) {
+      handleError(error);
+      setIdxTransaction(undefined);
     }
-    if (params) {
-      payload = merge(payload, params);
-    }
-    if (isActionStep) {
-      payload = {
-        ...payload,
-        actions: [{ name: step, params }],
-      };
-    } else {
-      payload = { ...payload, step };
-    }
-    if (includeImmutableData) {
-      payload = merge(payload, immutableData);
-    }
-    payload = toNestedObject(payload);
-    if (currTransaction!.context.stateHandle) {
-      payload.stateHandle = currTransaction!.context.stateHandle;
-    }
-    const newTransaction = await fn(payload);
-    setIdxTransaction(newTransaction);
-    setIsClientTransaction(false);
-    setStepToRender(stepToRender);
   }, [
     data,
     authClient,
@@ -87,5 +107,6 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setIdxTransaction,
     setIsClientTransaction,
     setStepToRender,
+    handleError,
   ]);
 };

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -36,77 +36,81 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     setAuthApiError,
     setIdxTransaction,
     setIsClientTransaction,
+    setMessage,
     setStepToRender,
-    widgetProps,
+    widgetProps: { events },
   } = useWidgetContext();
 
-  const handleError = (error: unknown) => {
-    // TODO: handle error based on types
-    // AuthApiError is one of the potential error that can be thrown here
-    // We will want to expose development stage errors from auth-js and file jiras against it
-    setAuthApiError(error as AuthApiError);
-    console.error(error);
-    // error event
-    widgetProps.events?.afterError?.({
-      stepName: currTransaction?.nextStep?.name,
-    }, error);
-    return null;
-  };
-
   return useCallback(async (options: OnSubmitHandlerOptions) => {
+    const {
+      params,
+      includeData,
+      includeImmutableData = true,
+      step,
+      isActionStep,
+      stepToRender,
+    } = options;
+
+    const handleError = (error: unknown) => {
+      // TODO: handle error based on types
+      // AuthApiError is one of the potential error that can be thrown here
+      // We will want to expose development stage errors from auth-js and file jiras against it
+      setAuthApiError(error as AuthApiError);
+      console.error(error);
+      // error event
+      events?.afterError?.({
+        stepName: currTransaction?.nextStep?.name,
+      }, error);
+      return null;
+    };
+
+    const { fieldsToExclude } = dataSchemaRef.current!;
+
+    const immutableData = getImmutableData(currTransaction!, step);
+
+    const fn = authClient.idx.proceed;
+
+    let payload: IdxActionParams = {};
+    if (includeData) {
+      payload = merge(payload, omit(data, fieldsToExclude));
+    }
+    if (params) {
+      payload = merge(payload, params);
+    }
+    if (isActionStep) {
+      payload = {
+        ...payload,
+        actions: [{ name: step, params }],
+      };
+    } else {
+      payload = { ...payload, step };
+    }
+    if (includeImmutableData) {
+      payload = merge(payload, immutableData);
+    }
+    payload = toNestedObject(payload);
+    if (currTransaction!.context.stateHandle) {
+      payload.stateHandle = currTransaction!.context.stateHandle;
+    }
+    setMessage(undefined);
     try {
-      const {
-        params,
-        includeData,
-        includeImmutableData = true,
-        step,
-        isActionStep,
-        stepToRender,
-      } = options;
-      const { fieldsToExclude } = dataSchemaRef.current!;
-
-      const immutableData = getImmutableData(currTransaction!, step);
-
-      const fn = authClient.idx.proceed;
-
-      let payload: IdxActionParams = {};
-      if (includeData) {
-        payload = merge(payload, omit(data, fieldsToExclude));
-      }
-      if (params) {
-        payload = merge(payload, params);
-      }
-      if (isActionStep) {
-        payload = {
-          ...payload,
-          actions: [{ name: step, params }],
-        };
-      } else {
-        payload = { ...payload, step };
-      }
-      if (includeImmutableData) {
-        payload = merge(payload, immutableData);
-      }
-      payload = toNestedObject(payload);
-      if (currTransaction!.context.stateHandle) {
-        payload.stateHandle = currTransaction!.context.stateHandle;
-      }
       const newTransaction = await fn(payload);
       setIdxTransaction(newTransaction);
       setIsClientTransaction(false);
       setStepToRender(stepToRender);
     } catch (error) {
       handleError(error);
-      setIdxTransaction(undefined);
     }
   }, [
     data,
     authClient,
     currTransaction,
     dataSchemaRef,
+    events,
+    setAuthApiError,
     setIdxTransaction,
     setIsClientTransaction,
+    setMessage,
     setStepToRender,
-    handleError,
   ]);
 };

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -10,7 +10,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage, IdxTransaction, OktaAuth } from '@okta/okta-auth-js';
+import {
+  AuthApiError,
+  IdxMessage,
+  IdxTransaction,
+  OktaAuth,
+} from '@okta/okta-auth-js';
 import { MutableRef, StateUpdater } from 'preact/hooks';
 
 import { FormBag } from './schema';
@@ -25,6 +30,8 @@ export type IWidgetContext = {
   onSuccessCallback?: (data: Record<string, unknown>) => void;
   onErrorCallback?: (data: Record<string, unknown>) => void;
   idxTransaction: IdxTransaction | undefined;
+  authApiError: AuthApiError | undefined;
+  setAuthApiError: StateUpdater<AuthApiError | undefined>;
   setIdxTransaction: StateUpdater<IdxTransaction | undefined>;
   setIsClientTransaction: StateUpdater<boolean>;
   stepToRender: string | undefined;

--- a/src/v3/src/types/context.ts
+++ b/src/v3/src/types/context.ts
@@ -30,7 +30,6 @@ export type IWidgetContext = {
   onSuccessCallback?: (data: Record<string, unknown>) => void;
   onErrorCallback?: (data: Record<string, unknown>) => void;
   idxTransaction: IdxTransaction | undefined;
-  authApiError: AuthApiError | undefined;
   setAuthApiError: StateUpdater<AuthApiError | undefined>;
   setIdxTransaction: StateUpdater<IdxTransaction | undefined>;
   setIsClientTransaction: StateUpdater<boolean>;

--- a/src/v3/test/integration/flow-enroll-profile-identify-transition-clear-errors.test.tsx
+++ b/src/v3/test/integration/flow-enroll-profile-identify-transition-clear-errors.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import enrollProfile from '@okta/mocks/data/idp/idx/enroll-profile-new.json';
+import identifyWithPassword from '../../src/mocks/response/idp/idx/identify/select/default.json';
+import { setup } from './util';
+
+describe('flow-enroll-profile-transition-clear-errors', () => {
+  it('should clear global errors when transitioning between pages', async () => {
+    const {
+      user,
+      queryByText,
+      findByText,
+      authClient,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: enrollProfile,
+          status: 200,
+        },
+        '/idx/identify/select': {
+          data: identifyWithPassword,
+          status: 200,
+        },
+      },
+    });
+
+    const submitButton = await findByText('Sign Up', { selector: 'button' });
+
+    await user.click(submitButton);
+    expect(authClient.options.httpRequestClient).not.toHaveBeenCalledWith(
+      'POST',
+      'http://localhost:3000/idp/idx/enroll/new',
+      expect.anything(),
+    );
+    await findByText(/We found some errors./);
+    const signinLink = await findByText('Sign In', { selector: 'a' });
+    await user.click(signinLink);
+    await findByText(/Sign In/);
+    expect(queryByText(/We found some errors./)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description:

Fixes the issue of global error messages persisting between views.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-523716](https://oktainc.atlassian.net/browse/OKTA-523716)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



