### PR TITLE
OKTA-520001: render terminal view for session expired error

### DIFF
--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    // 'identify',
+    'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -56,7 +56,7 @@ const idx = {
     // 'authenticator-verification-data-phone-voice-then-sms',
     // 'authenticator-verification-email',
     // 'authenticator-verification-password',
-    'authenticator-verification-phone-sms',
+    // 'authenticator-verification-phone-sms',
     // 'authenticator-verification-phone-voice',
     // 'authenticator-verification-security-question',
     // 'authenticator-verification-select-authenticator',
@@ -135,8 +135,7 @@ const idx = {
     // 'error-unsupported-idx-response'
   ],
   '/idp/idx/challenge/answer': [
-    'error-401-session-expired',
-    // 'error-401-invalid-otp-passcode',
+    'error-401-invalid-otp-passcode',
     // 'error-401-invalid-otp-passcode',
     // 'error-429-too-many-request-operation-ratelimit',
     // 'error-429-too-many-request',
@@ -146,9 +145,9 @@ const idx = {
     // 'error-authenticator-enroll-security-question',
     // 'error-authenticator-webauthn-failure',
     // 'error-authenticator-enroll-password-common',
-    // 'error-authenticator-reset-password-requirement',
-    // 'error-authenticator-enroll-security-question-html-tags',
-    // 'error-authenticator-enroll-password-common',
+    'error-authenticator-reset-password-requirement',
+    'error-authenticator-enroll-security-question-html-tags',
+    'error-authenticator-enroll-password-common',
     // 'error-authenticator-reset-password-requirement',
     // 'error-authenticator-enroll-security-question-html-tags',
   ],

--- a/playground/mocks/config/responseConfig.js
+++ b/playground/mocks/config/responseConfig.js
@@ -18,7 +18,7 @@ const idx = {
   ],
 
   '/idp/idx/introspect': [
-    'identify',
+    // 'identify',
     // 'error-identify-multiple-errors',
     // 'authenticator-enroll-ov-qr-enable-biometrics',
     // 'authenticator-verification-okta-verify-push',
@@ -56,7 +56,7 @@ const idx = {
     // 'authenticator-verification-data-phone-voice-then-sms',
     // 'authenticator-verification-email',
     // 'authenticator-verification-password',
-    // 'authenticator-verification-phone-sms',
+    'authenticator-verification-phone-sms',
     // 'authenticator-verification-phone-voice',
     // 'authenticator-verification-security-question',
     // 'authenticator-verification-select-authenticator',
@@ -135,7 +135,8 @@ const idx = {
     // 'error-unsupported-idx-response'
   ],
   '/idp/idx/challenge/answer': [
-    'error-401-invalid-otp-passcode',
+    'error-401-session-expired',
+    // 'error-401-invalid-otp-passcode',
     // 'error-401-invalid-otp-passcode',
     // 'error-429-too-many-request-operation-ratelimit',
     // 'error-429-too-many-request',
@@ -145,9 +146,9 @@ const idx = {
     // 'error-authenticator-enroll-security-question',
     // 'error-authenticator-webauthn-failure',
     // 'error-authenticator-enroll-password-common',
-    'error-authenticator-reset-password-requirement',
-    'error-authenticator-enroll-security-question-html-tags',
-    'error-authenticator-enroll-password-common',
+    // 'error-authenticator-reset-password-requirement',
+    // 'error-authenticator-enroll-security-question-html-tags',
+    // 'error-authenticator-enroll-password-common',
     // 'error-authenticator-reset-password-requirement',
     // 'error-authenticator-enroll-security-question-html-tags',
   ],

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -271,10 +271,6 @@ export default Controller.extend({
         ...values
       });
 
-      if (resp.status === IdxStatus.TERMINAL) {
-        
-      }
-
       if (resp.status === IdxStatus.FAILURE) {
         throw resp.error; // caught and handled in this function
       }

--- a/src/v2/controllers/FormController.ts
+++ b/src/v2/controllers/FormController.ts
@@ -272,17 +272,18 @@ export default Controller.extend({
       });
 
       if (resp.status === IdxStatus.TERMINAL) {
-        // 'idx.session.expired' requires special handling, otherwise the widget can lock up into an unrecoverable state
-        if (IonResponseHelper.isIdxSessionExpiredError(resp)) {
-          const authClient = this.settings.getAuthClient();
-          authClient.transactionManager.clear();
-        }
-        await this.handleIdxResponse(resp);
-        return;
+        
       }
 
       if (resp.status === IdxStatus.FAILURE) {
         throw resp.error; // caught and handled in this function
+      }
+      // follow idx transaction to render terminal view for session expired error
+      if (IonResponseHelper.isIdxSessionExpiredError(resp)) {
+        const authClient = this.settings.getAuthClient();
+        authClient.transactionManager.clear();
+        await this.handleIdxResponse(resp);
+        return;
       }
       // If the last request did not succeed, show errors on the current form
       // Special case: Okta server responds 401 status code with WWW-Authenticate header and new remediation

--- a/test/testcafe/spec/IdxSessionExpired_spec.js
+++ b/test/testcafe/spec/IdxSessionExpired_spec.js
@@ -1,6 +1,7 @@
 import { RequestMock } from 'testcafe';
 import { checkConsoleMessages, renderWidget as rerenderWidget } from '../framework/shared';
 import IdentityPageObject from '../framework/page-objects/IdentityPageObject';
+import TerminalPageObject from '../framework/page-objects/TerminalPageObject';
 import xhrWellKnownResponse from '../../../playground/mocks/data/oauth2/well-known-openid-configuration.json';
 import xhrInteractResponse from '../../../playground/mocks/data/oauth2/interact.json';
 import xhrIdentify from '../../../playground/mocks/data/idp/idx/identify';
@@ -72,9 +73,11 @@ test.requestHooks(sessionExpiresDuringPasswordChallenge)('reloads into fresh sta
   await identityPage.fillPasswordField('credentials.passcode', 'test');
   await identityPage.clickNextButton();
 
-  await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
-  await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  const terminalPageObject = new TerminalPageObject(t);
+  const errors = terminalPageObject.getErrorMessages();
+  await t.expect(errors.isError()).ok();
+  await t.expect(errors.getTextContent()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
+  await t.expect(identityPage.getGoBackLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
 
   await identityPage.refresh();
 
@@ -92,11 +95,13 @@ test.requestHooks(sessionExpiresBackToSignIn)('back to sign loads identify after
   await identityPage.fillPasswordField('credentials.passcode', 'test');
   await identityPage.clickNextButton();
 
-  await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
-  await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  const terminalPageObject = new TerminalPageObject(t);
+  const errors = terminalPageObject.getErrorMessages();
+  await t.expect(errors.isError()).ok();
+  await t.expect(errors.getTextContent()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
+  await t.expect(terminalPageObject.getGoBackLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
 
-  await identityPage.clickSignOutLink();
+  await terminalPageObject.clickGoBackLink();
 
   // ensure SIW does not load with the SessionExpired error
   await t.expect(identityPage.getPageTitle()).eql('Sign In');
@@ -112,10 +117,12 @@ test.requestHooks(interactionCodeFlowBaseMock)('Int. Code Flow: reloads into fre
   await identityPage.fillPasswordField('credentials.passcode', 'test');
   await identityPage.clickNextButton();
 
-  await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
-  await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
-
+  const terminalPageObject = new TerminalPageObject(t);
+  const errors = terminalPageObject.getErrorMessages();
+  await t.expect(errors.isError()).ok();
+  await t.expect(errors.getTextContent()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
+  await t.expect(terminalPageObject.getGoBackLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
+  
   await identityPage.refresh();
   identityPage = await setupInteractionCodeFlow(t);
 
@@ -133,11 +140,13 @@ test.requestHooks(interactionCodeFlowBaseMock)('Int. Code Flow: back to sign loa
   await identityPage.fillPasswordField('credentials.passcode', 'test');
   await identityPage.clickNextButton();
 
-  await t.expect(identityPage.getGlobalErrors()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
-  await t.expect(identityPage.getSignoutLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
-  await t.expect(identityPage.getIdentifier()).eql('testUser@okta.com');
+  const terminalPageObject = new TerminalPageObject(t);
+  const errors = terminalPageObject.getErrorMessages();
+  await t.expect(errors.isError()).ok();
+  await t.expect(errors.getTextContent()).eql('You have been logged out due to inactivity. Refresh or return to the sign in screen.');
+  await t.expect(terminalPageObject.getGoBackLinkText()).eql('Back to sign in'); // confirm they can get out of terminal state
 
-  await identityPage.clickSignOutLink();
+  await terminalPageObject.clickGoBackLink();
 
   // ensure SIW does not load with the SessionExpired error
   await t.expect(identityPage.getPageTitle()).eql('Sign In');


### PR DESCRIPTION
## Description:

Fixes button action issues when session expired by rendering terminal view with only `back to signin` button

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-520001](https://oktainc.atlassian.net/browse/OKTA-520001)

### Reviewers:

### Screenshot/Video:

<img width="344" alt="Screen Shot 2022-08-17 at 4 03 21 PM" src="https://user-images.githubusercontent.com/60160041/185232208-da1c175e-5d55-4267-a653-593f16d56305.png">


### Downstream Monolith Build:

https://bacon-go.aue1e.saasure.net/commits?artifact=monolith&page=1&pageSize=6&sha=afe554bb2b44b34627259f3815ec51c75ef9490e&tab=main

