### PR TITLE
OKTA 525465 cache codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ test-reports/
 package-lock.json
 .eslintcache
 types/
+.codegen.sum
 
 # Test dist package
 node_modules2
 /test/package/**/yarn.lock
+

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "clean": "rimraf target && rimraf dist && rimraf build2",
     "clean:esm": "rimraf target/esm",
-    "codegen": "grunt codegen",
+    "codegen": "./scripts/codegen.sh",
     "generate-phone-codes": "node scripts/buildtools generate-phone-codes",
     "generate-config": "node scripts/buildtools generate-language-config",
     "update-readme": "node scripts/buildtools update-readme",

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+CACHE_FILE=".codegen.sum"
+
+first () {
+	awk '{print $1}'
+}
+
+dir-sum () (
+	SUM=$(tar -cf - $@ | md5sum | first)
+	echo "$SUM $@"
+)
+
+get-sum () {
+	grep "$@" $CACHE_FILE | first
+}
+
+update-cache () {
+	rm $CACHE_FILE # disable
+	dir-sum packages/@okta/i18n >> $CACHE_FILE
+	dir-sum src/types >> $CACHE_FILE
+}
+
+if [ $(get-sum src/types) != $(dir-sum src/types | first) ]; then
+	echo '[codegen]: changes detected in src/types'
+	yarn build:types
+	# update-cache types
+else
+	echo '[codegen]: no changes detected in src/types'
+fi
+
+if [ $(get-sum packages/@okta/i18n) != $(dir-sum packages/@okta/i18n | first) ]; then
+	echo '[codegen]: changes detected in packages/@okta/i18n'
+	yarn grunt propertiesToJSON && \
+	yarn generate-config
+	# update-cache packages/@okta/i18n
+else
+	echo '[codegen]: no changes detected in packages/@okta/i18n'
+fi
+
+update-cache && cat $CACHE_FILE

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -6,36 +6,45 @@ first () {
 	awk '{print $1}'
 }
 
+# sums a dir
+# input: packages/@okta/i18n
+# output: d39d70a51af9ccba5710a089f87a4470 packages/@okta/i18n
 dir-sum () (
 	SUM=$(tar -cf - $@ | md5sum | first)
 	echo "$SUM $@"
 )
 
+# find a sum from cache
+# input: packages/@okta/i18n
+# output: d39d70a51af9ccba5710a089f87a4470 packages/@okta/i18n
 get-sum () {
-	grep "$@" $CACHE_FILE | first
+	if [ -a $CACHE_FILE ]; then
+		grep "$@" $CACHE_FILE
+	else
+		echo 'none'
+	fi
 }
 
+# udpates the cache file
 update-cache () {
 	rm $CACHE_FILE # disable
 	dir-sum packages/@okta/i18n >> $CACHE_FILE
 	dir-sum src/types >> $CACHE_FILE
 }
 
-if [ $(get-sum src/types) != $(dir-sum src/types | first) ]; then
+if [ $(get-sum src/types | first) != $(dir-sum src/types | first) ]; then
 	echo '[codegen]: changes detected in src/types'
 	yarn build:types
-	# update-cache types
 else
 	echo '[codegen]: no changes detected in src/types'
 fi
 
-if [ $(get-sum packages/@okta/i18n) != $(dir-sum packages/@okta/i18n | first) ]; then
+if [ $(get-sum packages/@okta/i18n | first) != $(dir-sum packages/@okta/i18n | first) ]; then
 	echo '[codegen]: changes detected in packages/@okta/i18n'
 	yarn grunt propertiesToJSON && \
 	yarn generate-config
-	# update-cache packages/@okta/i18n
 else
 	echo '[codegen]: no changes detected in packages/@okta/i18n'
 fi
 
-update-cache && cat $CACHE_FILE
+update-cache


### PR DESCRIPTION
## Description:

Cache `codegen` to prevent unnecessary code re-generation (when no relevant files are changed)

checks

- `packages/@okta/i18n`
- `src/types`

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-525465](https://oktainc.atlassian.net/browse/OKTA-525465)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



