### PR TITLE
OKTA-525393 display v3 version

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v3",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Okta Sign In Widget Next",
   "homepage": "https://github.com/okta/okta-signin-widget",

--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -18,6 +18,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import { omit } from 'lodash';
 import GitRevisionPlugin from 'git-revision-webpack-plugin';
 import playgroundConfig from '../../webpack.playground.config';
+import { version } from './package.json';
 
 const gitRevisionPlugin = new GitRevisionPlugin();
 
@@ -52,16 +53,14 @@ export default {
       (plugin) => !(plugin instanceof MiniCssExtractPlugin),
     );
 
-    config.plugins.push(
-      new DefinePlugin({
-        // for OktaSignIn.__version, AuthContainer[data-version]
-        VERSION: JSON.stringify(gitRevisionPlugin.version()),
-        // for OktaSignIn.__commit, AuthContainer[data-commit]
-        COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
-        // for v2/util/Logger file
-        DEBUG: env !== 'production',
-      }),
-    );
+    config.plugins.push(new DefinePlugin({
+      // for OktaSignIn.__version, AuthContainer[data-version]
+      VERSION: JSON.stringify(version),
+      // for OktaSignIn.__commit, AuthContainer[data-commit]
+      COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
+      // for v2/util/Logger file
+      DEBUG: env !== 'production',
+    }));
 
     // use odyssey babel configs
     config.module.rules.push({

--- a/src/v3/src/components/AuthContent/AuthContent.tsx
+++ b/src/v3/src/components/AuthContent/AuthContent.tsx
@@ -19,10 +19,21 @@ const AuthContent: FunctionComponent = ({ children }) => (
     flexDirection="column"
     justifyContent="flex-start"
     flexWrap="wrap"
-    padding={7}
+    paddingX={7}
+    paddingTop={7}
+    paddingBottom={0}
     maxWidth={1}
+    marginBottom={3}
   >
-    {children}
+    { children }
+    {
+      process.env.NODE_ENV !== 'test' && (
+        <code aria-hidden>
+          { VERSION }
+          { COMMITHASH.substring(0, 8) }
+        </code>
+      )
+    }
   </Box>
 );
 


### PR DESCRIPTION
## Description:

Display v3 version in widget footer.

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-525393](https://oktainc.atlassian.net/browse/OKTA-525393)

### Reviewers:

### Screenshot/Video:

![Screen Shot 2022-08-18 at 4 24 45 PM](https://user-images.githubusercontent.com/77294605/185488068-269239de-f752-4f48-9bcc-551d060aaf0a.png)

### Downstream Monolith Build:



