### PR TITLE
OKTA-521660 : Email/SMS magic link polling session expired

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -60,7 +60,7 @@
     "@okta/odyssey-react": "^0.14.5",
     "@okta/odyssey-react-mui": "^0.14.5",
     "@okta/odyssey-react-theme": "^0.14.5",
-    "@okta/okta-auth-js": "6.7.3",
+    "@okta/okta-auth-js": "6.7.6",
     "ajv": "^8.6.1",
     "ajv-errors": "^3.0.0",
     "babel-jest": "^27.3.1",

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -689,3 +689,91 @@ exports[`authenticator-verification-email renders correct form renders the otp c
   </div>
 </div>
 `;
+
+exports[`authenticator-verification-email renders correct form should render session expired terminal view when polling results in expired session 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+          </div>
+          <div
+            class="MuiBox-root emotion-4"
+          >
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+            >
+              <div
+                class="MuiBox-root emotion-5"
+              >
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <div
+                    class="MuiBox-root emotion-7"
+                    data-se="message"
+                  >
+                    <div
+                      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-8"
+                      data-se="infobox-error"
+                      role="alert"
+                    >
+                      <div
+                        class="MuiAlert-icon emotion-9"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-10"
+                          data-testid="ErrorOutlineIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                          />
+                        </svg>
+                      </div>
+                      <div
+                        class="MuiAlert-message emotion-11"
+                      >
+                        You have been logged out due to inactivity. Refresh or return to the sign in screen.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-6"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-13"
+                    href="/"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -15,6 +15,8 @@ import { setup } from './util';
 
 import authenticatorVerificationEmail from '../../src/mocks/response/idp/idx/challenge/default.json';
 import authenticatorVerificationEmailInvalidOtp from '../../src/mocks/response/idp/idx/challenge/error-401-invalid-otp-passcode.json';
+import sessionExpiredResponse from '../../src/mocks/response/idp/idx/identify/error-session-expired.json';
+import { within } from '@testing-library/preact';
 
 describe('authenticator-verification-email', () => {
   describe('renders correct form', () => {
@@ -149,6 +151,34 @@ describe('authenticator-verification-email', () => {
           withCredentials: true,
         },
       );
+    });
+
+    it('should render session expired terminal view when polling results in expired session', async () => {
+      const {
+        container,
+        findByText,
+        findByTestId,
+      } = await setup({
+        mockResponses: {
+          '/introspect': {
+            data: authenticatorVerificationEmail,
+            status: 200,
+          },
+          '/challenge/poll': {
+            data: sessionExpiredResponse,
+            status: 401,
+          },
+        },
+      });
+      await findByText(/Verify with your email/);
+
+      // allow polling request to be triggered
+      jest.advanceTimersByTime(5000 /* refresh: 4000 */);
+
+      const errorAlert = await findByTestId('infobox-error');
+      await within(errorAlert).findByText(/You have been logged out due to inactivity/);
+
+      expect(container).toMatchSnapshot();
     });
   });
 

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -11,12 +11,12 @@
  */
 
 import { act } from 'preact/test-utils';
+import { within } from '@testing-library/preact';
 import { setup } from './util';
 
 import authenticatorVerificationEmail from '../../src/mocks/response/idp/idx/challenge/default.json';
 import authenticatorVerificationEmailInvalidOtp from '../../src/mocks/response/idp/idx/challenge/error-401-invalid-otp-passcode.json';
 import sessionExpiredResponse from '../../src/mocks/response/idp/idx/identify/error-session-expired.json';
-import { within } from '@testing-library/preact';
 
 describe('authenticator-verification-email', () => {
   describe('renders correct form', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4963,17 +4963,17 @@
     "@react-aria/focus" "3.5.0"
     choices.js "^9.0.1"
 
-"@okta/okta-auth-js@6.7.3":
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.7.3.tgz#f3f3be4cc7d210595955fc6c0889c41f058e32c4"
-  integrity sha512-SasHFbvIbYKtqWBK6KpeKO6zdZJpHGmXl3m17kebsnA5ZoMHSFGF2CAeyWtm2YMn3UNCX2p5m02wOSRkGSro0g==
+"@okta/okta-auth-js@6.7.6":
+  version "6.7.6"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-6.7.6.tgz#31745df22f31e981d18bd0ec1fe85fcb9aa1b4c7"
+  integrity sha512-HUhy0+cccTPRRvlswDkeRt205cAPm+Z+51Xm8nTsnKn5+tWVDZ86Rq8w7JDsr+HjUQGZpdUxRP3Er+vEcoVcgg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.17.0"
     "@peculiar/webcrypto" "^1.4.0"
     Base64 "1.1.0"
     atob "^2.1.2"
-    broadcast-channel "^4.13.0"
+    broadcast-channel "4.13.0"
     btoa "^1.2.1"
     core-js "^3.6.5"
     cross-fetch "^3.1.5"
@@ -8314,6 +8314,19 @@ braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+broadcast-channel@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
+  integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
+  dependencies:
+    "@babel/runtime" "^7.16.0"
+    detect-node "^2.1.0"
+    microtime "3.0.0"
+    oblivious-set "1.1.1"
+    p-queue "6.6.2"
+    rimraf "3.0.2"
+    unload "2.3.1"
+
 broadcast-channel@^4.10.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.11.0.tgz#b9ebc7ce1326120088e61d2197477496908a1a9e"
@@ -8323,19 +8336,6 @@ broadcast-channel@^4.10.0:
     detect-node "^2.1.0"
     microtime "3.0.0"
     oblivious-set "1.0.0"
-    p-queue "6.6.2"
-    rimraf "3.0.2"
-    unload "2.3.1"
-
-broadcast-channel@^4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-4.13.0.tgz#21387b2602b9e9ec3b97b03bd8a8d2c198352ff6"
-  integrity sha512-fcDr8QNJ4SOb6jyjUNZatVNmcHtSWfW4PFcs4xIEFZAtorKCIFoEYtjIjaQ4c0jrbr/Bl8NIwOWiLSyspoAnEQ==
-  dependencies:
-    "@babel/runtime" "^7.16.0"
-    detect-node "^2.1.0"
-    microtime "3.0.0"
-    oblivious-set "1.1.1"
     p-queue "6.6.2"
     rimraf "3.0.2"
     unload "2.3.1"


### PR DESCRIPTION
## Description:
The purpose of this PR is to fix the bug that causes the widget not to respond when the session has expired while in a polling state. 

i.e. When polling for an Email magic link, if the user sits on the page long enough for the session to expire, the poll response fails appropriately but auth-js did not send that error message as a response to the proceed function causing the widget to break. This PR bumps the auth-js version which resolves this issue and adds an integration test to ensure the scenario is covered.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521660](https://oktainc.atlassian.net/browse/OKTA-521660)

### Reviewers:

### Screenshot/Video:

https://user-images.githubusercontent.com/97472729/185667533-47921666-7565-4f19-8af4-ab383b3db535.mov



### Downstream Monolith Build:



