### PR TITLE
fix: prefix data-version attr for d16t

### DIFF
--- a/src/v3/preact.config.js
+++ b/src/v3/preact.config.js
@@ -55,7 +55,7 @@ export default {
 
     config.plugins.push(new DefinePlugin({
       // for OktaSignIn.__version, AuthContainer[data-version]
-      VERSION: JSON.stringify(version),
+      VERSION: JSON.stringify(`okta-signin-widget-${version}`),
       // for OktaSignIn.__commit, AuthContainer[data-commit]
       COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
       // for v2/util/Logger file

--- a/src/v3/src/components/AuthContent/AuthContent.tsx
+++ b/src/v3/src/components/AuthContent/AuthContent.tsx
@@ -30,7 +30,6 @@ const AuthContent: FunctionComponent = ({ children }) => (
       process.env.NODE_ENV !== 'test' && (
         <code aria-hidden>
           { VERSION }
-          { COMMITHASH.substring(0, 8) }
         </code>
       )
     }


### PR DESCRIPTION
## Description:

fix okta-core failures caused by #2724 which swapped out the `gitRevisionPlugin.version()` with `version` from `package.json`. See https://github.com/okta/okta-core/blob/master/components/web/selenium/pages/client-test/src/main/java/com/okta/selenium3/webdriver/enduser/ui/pages/NewLoginOIEPageObject.java#L824

```java
private static final String SIW_NEXT_SELECTOR_VERSION = "[data-version^='okta-signin-widget']";
```

Arguably, the selector could be updated in `okta-core` instead, but this is faster and easier to verify.


![Screen Shot 2022-08-19 at 2 27 02 PM](https://user-images.githubusercontent.com/77294605/185684413-3a6e2369-251b-4d5f-bf2a-eb17a9191ea0.png)

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-XXXXXX](https://oktainc.atlassian.net/browse/OKTA-XXXXXX)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



