### PR TITLE
OKTA-516695 : Implementation to fix OV push notification autoChallenge

### DIFF
--- a/src/v3/src/hooks/usePolling.test.tsx
+++ b/src/v3/src/hooks/usePolling.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { IdxTransaction, NextStep, OktaAuth } from '@okta/okta-auth-js';
-import { waitFor } from '@testing-library/preact';
+import { cleanup, waitFor } from '@testing-library/preact';
 import { renderHook } from '@testing-library/preact-hooks';
 import { WidgetProps } from 'src/types';
 
@@ -41,6 +41,7 @@ describe('usePolling', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    cleanup();
   });
 
   describe('idxTransaction does not include polling step - returns undefined and no timer', () => {
@@ -126,7 +127,6 @@ describe('usePolling', () => {
 
       // expect to call action function when timeout
       jest.advanceTimersByTime(4000);
-      // expect(mockProceedFn).toHaveBeenCalled();
       expect(mockProceedFn).toHaveBeenCalledWith({
         stateHandle: undefined,
         autoChallenge: false,
@@ -161,7 +161,6 @@ describe('usePolling', () => {
 
       // expect to call action function when timeout
       jest.advanceTimersByTime(4000);
-      // expect(mockProceedFn).toHaveBeenCalled();
       expect(mockProceedFn).toHaveBeenCalledWith({
         stateHandle: undefined,
         autoChallenge: true,
@@ -197,7 +196,6 @@ describe('usePolling', () => {
 
       // expect to call action function when timeout
       jest.advanceTimersByTime(4000);
-      // expect(mockProceedFn).toHaveBeenCalled();
       expect(mockProceedFn).toHaveBeenCalledWith({
         stateHandle: undefined,
         autoChallenge: true,

--- a/src/v3/src/hooks/usePolling.test.tsx
+++ b/src/v3/src/hooks/usePolling.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { IdxTransaction, NextStep, OktaAuth } from '@okta/okta-auth-js';
-import { cleanup, waitFor } from '@testing-library/preact';
+import { waitFor } from '@testing-library/preact';
 import { renderHook } from '@testing-library/preact-hooks';
 import { WidgetProps } from 'src/types';
 
@@ -41,7 +41,6 @@ describe('usePolling', () => {
 
   afterEach(() => {
     jest.useRealTimers();
-    cleanup();
   });
 
   describe('idxTransaction does not include polling step - returns undefined and no timer', () => {

--- a/src/v3/src/hooks/usePolling.test.tsx
+++ b/src/v3/src/hooks/usePolling.test.tsx
@@ -109,6 +109,112 @@ describe('usePolling', () => {
       expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 5000);
     });
 
+    it('should trigger poll request with autoChallenge=false when transaction contains input value', async () => {
+      // @ts-ignore remove after adding refresh to nextStep in auth-js
+      const idxTransaction = {
+        nextStep: {
+          name: 'challenge-poll',
+          refresh: 4000,
+          inputs: [{ name: 'autoChallenge', value: false }],
+        },
+      } as IdxTransaction;
+      const { result } = renderHook(() => usePolling(idxTransaction, mockProps, mockData));
+
+      // expect to setup timer
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 4000);
+
+      // expect to call action function when timeout
+      jest.advanceTimersByTime(4000);
+      // expect(mockProceedFn).toHaveBeenCalled();
+      expect(mockProceedFn).toHaveBeenCalledWith({
+        stateHandle: undefined,
+        autoChallenge: false,
+        step: 'challenge-poll',
+      });
+
+      // expect to return new polling transaction
+      await waitFor(() => {
+        expect(result.current).toMatchObject({
+          nextStep: {
+            name: 'challenge-poll',
+            refresh: 4000,
+          },
+        });
+      });
+    });
+
+    it('should trigger poll request with autoChallenge=true when data contains user selected value', async () => {
+      // @ts-ignore remove after adding refresh to nextStep in auth-js
+      const idxTransaction = {
+        nextStep: {
+          name: 'challenge-poll',
+          refresh: 4000,
+        },
+      } as IdxTransaction;
+      mockData.autoChallenge = true;
+      const { result } = renderHook(() => usePolling(idxTransaction, mockProps, mockData));
+
+      // expect to setup timer
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 4000);
+
+      // expect to call action function when timeout
+      jest.advanceTimersByTime(4000);
+      // expect(mockProceedFn).toHaveBeenCalled();
+      expect(mockProceedFn).toHaveBeenCalledWith({
+        stateHandle: undefined,
+        autoChallenge: true,
+        step: 'challenge-poll',
+      });
+
+      // expect to return new polling transaction
+      await waitFor(() => {
+        expect(result.current).toMatchObject({
+          nextStep: {
+            name: 'challenge-poll',
+            refresh: 4000,
+          },
+        });
+      });
+    });
+
+    it('should trigger poll request with autoChallenge=true when data contains user selected value and transaction contains different value', async () => {
+      // @ts-ignore remove after adding refresh to nextStep in auth-js
+      const idxTransaction = {
+        nextStep: {
+          name: 'challenge-poll',
+          refresh: 4000,
+          inputs: [{ name: 'autoChallenge', value: false }],
+        },
+      } as IdxTransaction;
+      mockData.autoChallenge = true;
+      const { result } = renderHook(() => usePolling(idxTransaction, mockProps, mockData));
+
+      // expect to setup timer
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 4000);
+
+      // expect to call action function when timeout
+      jest.advanceTimersByTime(4000);
+      // expect(mockProceedFn).toHaveBeenCalled();
+      expect(mockProceedFn).toHaveBeenCalledWith({
+        stateHandle: undefined,
+        autoChallenge: true,
+        step: 'challenge-poll',
+      });
+
+      // expect to return new polling transaction
+      await waitFor(() => {
+        expect(result.current).toMatchObject({
+          nextStep: {
+            name: 'challenge-poll',
+            refresh: 4000,
+          },
+        });
+      });
+    });
+
     it('uses default timeout when no refresh is found from transaction', () => {
       const mockAction = jest.fn().mockResolvedValue({});
       const idxTransaction = {

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -15,16 +15,10 @@ import {
   useEffect, useMemo, useRef, useState,
 } from 'preact/hooks';
 
-import { IDX_STEP } from '../constants';
 import { FormBag, WidgetOptions } from '../types';
+import { isPollingStep } from '../util';
 
 const DEFAULT_TIMEOUT = 4000;
-const POLL_STEPS = [
-  IDX_STEP.CHALLENGE_POLL,
-  IDX_STEP.DEVICE_CHALLENGE_POLL,
-  IDX_STEP.ENROLL_POLL,
-  IDX_STEP.POLL,
-];
 
 const getPollingStep = (
   transaction: IdxTransaction | undefined,
@@ -96,7 +90,7 @@ export const usePolling = (
         payload.autoChallenge = autoChallenge;
       }
       // POLL_STEPS are not an action, so must treat as such
-      if (POLL_STEPS.includes(name)) {
+      if (isPollingStep(name)) {
         payload.step = name;
       } else {
         payload = { actions: [{ name, params: payload }] };

--- a/src/v3/src/hooks/usePolling.ts
+++ b/src/v3/src/hooks/usePolling.ts
@@ -80,9 +80,7 @@ export const usePolling = (
   // start polling timer when internal polling transaction changes
   useEffect(() => {
     if (!pollingStep) {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
+      clearTimeout(timerRef.current);
       setTransaction(undefined);
       return undefined;
     }

--- a/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
+++ b/src/v3/src/transformer/oktaVerify/transformOktaVerifyChallengePoll.ts
@@ -15,6 +15,7 @@ import { NextStep } from '@okta/okta-auth-js';
 import PhoneSvg from '../../img/phone-icon.svg';
 import {
   DescriptionElement,
+  FieldElement,
   IdxStepTransformer,
   ImageWithTextElement,
   ReminderElement,
@@ -22,16 +23,21 @@ import {
   TitleElement,
 } from '../../types';
 import { loc } from '../../util';
+import { getUIElementWithName } from '../utils';
 
 export const transformOktaVerifyChallengePoll: IdxStepTransformer = ({ transaction, formBag }) => {
   const { nextStep = {} as NextStep, availableSteps } = transaction;
   const { relatesTo } = nextStep;
-  const { uischema } = formBag;
+  const { uischema, data } = formBag;
 
   const [selectedMethod] = relatesTo?.value?.methods || [];
   if (!selectedMethod) {
     return formBag;
   }
+
+  // Need to initialize autoChallenge checkbox if it is set otherwise it will not display in UI
+  const autoChallenge = getUIElementWithName('autoChallenge', uischema.elements) as FieldElement;
+  data.autoChallenge = autoChallenge?.options?.inputMeta?.value;
 
   // @ts-ignore OKTA-496373 correctAnswer is missing from interface
   const correctAnswer = relatesTo?.value?.contextualData?.correctAnswer;

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -20,6 +20,7 @@ export * from './getImmutableData';
 export * from './getTranslation';
 export * from './idxUtils';
 export * from './isPasswordRecovery';
+export * from './isPollingStep';
 export * from './languageUtils';
 export * from './locUtil';
 export * from './passwordUtils';

--- a/src/v3/src/util/isPollingStep.ts
+++ b/src/v3/src/util/isPollingStep.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IDX_STEP } from '../constants';
+
+const POLL_STEPS = new Set<string>([
+  IDX_STEP.CHALLENGE_POLL,
+  IDX_STEP.DEVICE_CHALLENGE_POLL,
+  IDX_STEP.ENROLL_POLL,
+  IDX_STEP.POLL,
+]);
+
+export const isPollingStep = (stepName: string): boolean => POLL_STEPS.has(stepName);


### PR DESCRIPTION
## Description:
Purpose of this PR is to fix the autoChallenge input value from being excluded from OV Push notification poll requests.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516695](https://oktainc.atlassian.net/browse/OKTA-516695)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



