### PR TITLE
OKTA-521272 : Initial implementation for unlock flow empty identifier bug fix

### DIFF
--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -83,7 +83,6 @@ const AuthenticatorButton: UISchemaElementComponent<{
       borderRadius={Tokens.BorderRadiusBase}
       boxShadow={Tokens.ShadowScale0}
       className={style.authButton}
-      role="button"
       data-se="authenticator-button"
       tabIndex={0}
       onClick={onClick}

--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -37,6 +37,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
     translations,
     focus,
     options: {
+      type,
       key: authenticationKey,
       actionParams,
       description,
@@ -58,7 +59,13 @@ const AuthenticatorButton: UISchemaElementComponent<{
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
 
   const onClick: ClickHandler = async () => {
-    const errorMessages = getValidationMessages(dataSchemaRef.current!, data, actionParams);
+    const dataSchema = dataSchemaRef.current!;
+    const errorMessages = getValidationMessages(
+      dataSchema,
+      dataSchema.fieldsToValidate,
+      data,
+      actionParams,
+    );
     if (errorMessages) {
       onValidationHandler(errorMessages);
       return;
@@ -74,7 +81,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
   return (
     <Box
       component="button"
-      type="button"
+      type={type}
       sx={{ width: 1, backgroundColor: 'inherit' }}
       display="flex"
       padding={2}
@@ -100,23 +107,21 @@ const AuthenticatorButton: UISchemaElementComponent<{
         </Box>
       )}
       <Box className={style.infoSection}>
-        <Box
-          component="h3"
-          textAlign="start"
-          sx={{ fontSize: '1rem', margin: 0 }}
+        <Typography
+          variant="h3"
+          sx={{ fontSize: '1rem', margin: 0, textAlign: 'start' }}
           data-se="authenticator-button-label"
         >
           {label}
-        </Box>
+        </Typography>
         {description && (
-          <Box
-            component="p"
-            textAlign="start"
-            sx={{ fontSize: '.875rem', margin: 0 }}
+          <Typography
+            paragraph
+            sx={{ fontSize: '.875rem', margin: 0, textAlign: 'start' }}
             data-se="authenticator-button-description"
           >
             {description}
-          </Box>
+          </Typography>
         )}
         {usageDescription && (
           <Typography

--- a/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
+++ b/src/v3/src/components/AuthenticatorButton/AuthenticatorButton.tsx
@@ -17,13 +17,13 @@ import classNames from 'classnames';
 import { h } from 'preact';
 
 import { useWidgetContext } from '../../contexts';
-import { useAutoFocus, useOnSubmit } from '../../hooks';
+import { useAutoFocus, useOnSubmit, useOnSubmitValidation } from '../../hooks';
 import {
   AuthenticatorButtonElement,
   ClickHandler,
   UISchemaElementComponent,
 } from '../../types';
-import { getTranslation } from '../../util';
+import { getTranslation, getValidationMessages } from '../../util';
 import AuthCoin from '../AuthCoin/AuthCoin';
 import ArrowRight from './arrow-right.svg';
 import { theme } from './AuthenticatorButton.theme';
@@ -46,25 +46,36 @@ const AuthenticatorButton: UISchemaElementComponent<{
       dataSe,
       iconName,
       iconDescr,
+      step,
+      includeData,
+      includeImmutableData,
     },
   } = uischema;
   const label = getTranslation(translations!, 'label');
-  const { idxTransaction } = useWidgetContext();
+  const { dataSchemaRef, data } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
+  const onValidationHandler = useOnSubmitValidation();
   const focusRef = useAutoFocus<HTMLButtonElement>(focus);
 
   const onClick: ClickHandler = async () => {
-    // TODO: pass step from uischema
-    const { name: step } = idxTransaction!.nextStep!;
+    const errorMessages = getValidationMessages(dataSchemaRef.current!, data, actionParams);
+    if (errorMessages) {
+      onValidationHandler(errorMessages);
+      return;
+    }
     onSubmitHandler({
-      params: actionParams,
-      includeData: true,
       step,
+      params: actionParams,
+      includeData,
+      includeImmutableData,
     });
   };
 
   return (
     <Box
+      component="button"
+      type="button"
+      sx={{ width: 1, backgroundColor: 'inherit' }}
       display="flex"
       padding={2}
       border={1}
@@ -91,14 +102,18 @@ const AuthenticatorButton: UISchemaElementComponent<{
       )}
       <Box className={style.infoSection}>
         <Box
-          className={style.title}
+          component="h3"
+          textAlign="start"
+          sx={{ fontSize: '1rem', margin: 0 }}
           data-se="authenticator-button-label"
         >
           {label}
         </Box>
         {description && (
           <Box
-            className={style.description}
+            component="p"
+            textAlign="start"
+            sx={{ fontSize: '.875rem', margin: 0 }}
             data-se="authenticator-button-description"
           >
             {description}
@@ -106,8 +121,9 @@ const AuthenticatorButton: UISchemaElementComponent<{
         )}
         {usageDescription && (
           <Typography
-            className={style.description}
             variant="caption"
+            textAlign="start"
+            sx={{ fontSize: '.875rem', margin: 0 }}
             data-se="authenticator-button-usage-text"
           >
             {usageDescription}
@@ -119,6 +135,7 @@ const AuthenticatorButton: UISchemaElementComponent<{
         >
           <Box
             component="span"
+            sx={{ fontWeight: 700, fontSize: '.875rem' }}
             data-se="cta-button-label"
           >
             {ctaLabel}

--- a/src/v3/src/components/AuthenticatorButton/styles.module.css
+++ b/src/v3/src/components/AuthenticatorButton/styles.module.css
@@ -14,17 +14,10 @@
 
 .infoSection {
   display: flex;
-  padding: 0 0 0 12px;
   flex-grow: 1;
   flex-direction: column;
-}
-
-.title {
-  font-weight: 500;
-}
-
-.description {
-  margin: 6px 0 6px 0;
+  gap: 6px;
+  padding: 0 0 0 12px;
 }
 
 .actionName {

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -49,7 +49,13 @@ const Form: FunctionComponent<{
     // client side validation - only validate for fields in nextStep
     const { nextStep } = currTransaction!;
     if (!step || step === nextStep!.name) {
-      const messages = getValidationMessages(dataSchemaRef.current!, data, params);
+      const dataSchema = dataSchemaRef.current!;
+      const messages = getValidationMessages(
+        dataSchema,
+        dataSchema.fieldsToValidate,
+        data,
+        params,
+      );
       // update transaction with client validation messages to trigger rerender
       if (messages) {
         onValidationHandler(messages);

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -10,17 +10,16 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage } from '@okta/okta-auth-js';
-import { clone } from 'lodash';
 import { FunctionComponent, h } from 'preact';
 import { useCallback } from 'preact/hooks';
 
 import { useWidgetContext } from '../../contexts';
-import { useOnSubmit } from '../../hooks';
+import { useOnSubmit, useOnSubmitValidation } from '../../hooks';
 import {
-  DataSchema, SubmitEvent, UISchemaLayout,
+  SubmitEvent,
+  UISchemaLayout,
 } from '../../types';
-import { loc, resetMessagesToInputs } from '../../util';
+import { getValidationMessages } from '../../util';
 import Layout from './Layout';
 
 const Form: FunctionComponent<{
@@ -29,12 +28,11 @@ const Form: FunctionComponent<{
   const {
     data,
     idxTransaction: currTransaction,
-    setIdxTransaction,
-    setIsClientTransaction,
     setMessage,
     dataSchemaRef,
   } = useWidgetContext();
   const onSubmitHandler = useOnSubmit();
+  const onValidationHandler = useOnSubmitValidation();
 
   const handleSubmit = useCallback(async (e: SubmitEvent) => {
     e.preventDefault();
@@ -46,39 +44,15 @@ const Form: FunctionComponent<{
         step,
         includeImmutableData,
       },
-      fieldsToValidate,
     } = dataSchemaRef.current!;
 
     // client side validation - only validate for fields in nextStep
     const { nextStep } = currTransaction!;
     if (!step || step === nextStep!.name) {
-      // aggregate field level messages based on validation rules in each field
-      const messages = Object.entries(dataSchemaRef.current!)
-        .reduce((acc: Record<string, (IdxMessage & { name?: string })[]>, curr) => {
-          const name = curr[0];
-          const elementSchema = curr[1] as DataSchema;
-          if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
-            const validationMessages = elementSchema.validate({
-              ...data,
-              ...params,
-            });
-            if (validationMessages?.length) {
-              acc[name] = [...validationMessages];
-            }
-          }
-          return acc;
-        }, {});
+      const messages = getValidationMessages(dataSchemaRef.current!, data, params);
       // update transaction with client validation messages to trigger rerender
-      if (Object.entries(messages).length) {
-        const newTransaction = clone(currTransaction);
-        resetMessagesToInputs(newTransaction!.nextStep!.inputs!, messages);
-        setMessage({
-          message: loc('oform.errorbanner.title', 'login'),
-          class: 'ERROR',
-          i18n: { key: 'oform.errorbanner.title' },
-        } as IdxMessage);
-        setIsClientTransaction(true);
-        setIdxTransaction(newTransaction);
+      if (messages) {
+        onValidationHandler(messages);
         return;
       }
     }
@@ -90,15 +64,7 @@ const Form: FunctionComponent<{
       params,
       step,
     });
-  }, [
-    data,
-    currTransaction,
-    dataSchemaRef,
-    setIdxTransaction,
-    setIsClientTransaction,
-    onSubmitHandler,
-    setMessage,
-  ]);
+  }, [currTransaction, data, dataSchemaRef, onSubmitHandler, onValidationHandler, setMessage]);
 
   return (
     <form

--- a/src/v3/src/hooks/index.ts
+++ b/src/v3/src/hooks/index.ts
@@ -14,5 +14,6 @@ export * from './useAutoFocus';
 export * from './useFormFieldValidation';
 export * from './useOnChange';
 export * from './useOnSubmit';
+export * from './useOnSubmitValidation';
 export * from './usePolling';
 export * from './useValue';

--- a/src/v3/src/hooks/useOnSubmitValidation.ts
+++ b/src/v3/src/hooks/useOnSubmitValidation.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { IdxMessage } from '@okta/okta-auth-js';
+import clone from 'lodash/clone';
+import { useCallback } from 'preact/hooks';
+
+import { useWidgetContext } from '../contexts';
+import { IdxMessageWithName } from '../types';
+import { loc, resetMessagesToInputs } from '../util';
+
+export const useOnSubmitValidation = (): (
+messages: Record<string, IdxMessageWithName[]>) => Promise<void> => {
+  const {
+    setIdxTransaction,
+    setIsClientTransaction,
+    setMessage,
+    idxTransaction: currentTransaction,
+  } = useWidgetContext();
+
+  return useCallback(async (messages: Record<string, IdxMessageWithName[]>) => {
+    const newTransaction = clone(currentTransaction);
+    resetMessagesToInputs(newTransaction!.nextStep!.inputs!, messages);
+    setMessage({
+      message: loc('oform.errorbanner.title', 'login'),
+      class: 'ERROR',
+      i18n: { key: 'oform.errorbanner.title' },
+    } as IdxMessage);
+    setIsClientTransaction(true);
+    setIdxTransaction(newTransaction);
+  }, [currentTransaction, setIdxTransaction, setIsClientTransaction, setMessage]);
+};

--- a/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
+++ b/src/v3/src/transformer/i18n/transformAuthenticatorButton.ts
@@ -44,10 +44,10 @@ export const transformAuthenticatorButton: TransformStepFnWithOptions = ({
         return;
       }
 
+      const authenticatorButtonEle = (element as AuthenticatorButtonElement);
       // try get i18nKey with methodType
-      const methodType = (
-        element as AuthenticatorButtonElement
-      ).options.authenticator?.methods?.[0]?.type;
+      const methodType = authenticatorButtonEle.options.authenticator?.methods?.[0]?.type
+        || authenticatorButtonEle.options.actionParams?.['authenticator.methodType'];
       i18nKey = getI18nKey(`${stepName}.authenticator.${(element as AuthenticatorButtonElement).options.key}.${methodType}`);
       if (i18nKey) {
         addTranslation({

--- a/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
+++ b/src/v3/src/transformer/password/transformEnrollPasswordAuthenticator.ts
@@ -10,12 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage } from '@okta/okta-auth-js';
-
 import { PASSWORD_REQUIREMENT_VALIDATION_DELAY_MS } from '../../constants';
 import {
   FieldElement,
   FormBag,
+  IdxMessageWithName,
   IdxStepTransformer,
   PasswordRequirementsElement,
   PasswordSettings,
@@ -80,7 +79,7 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
     // @ts-ignore expose type from auth-js
     const errorMessages = passwordElement.options.inputMeta.messages.value;
     // @ts-ignore expose type from auth-js
-    const newPasswordErrors = errorMessages.filter((message: IdxMessage & { name?: string }) => {
+    const newPasswordErrors = errorMessages.filter((message: IdxMessageWithName) => {
       const { name: newPwName } = passwordElement.options.inputMeta;
       return message.name === newPwName || message.name === undefined;
     });
@@ -93,7 +92,7 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
     }
 
     // @ts-ignore expose type from auth-js
-    const confirmPasswordError = errorMessages.find((message: IdxMessage & { name?: string }) => {
+    const confirmPasswordError = errorMessages.find((message: IdxMessageWithName) => {
       const { name: confirmPwName } = confirmPasswordElement.options.inputMeta;
       return message.name === confirmPwName;
     });
@@ -137,7 +136,7 @@ export const transformEnrollPasswordAuthenticator: IdxStepTransformer = ({
     validate: (data: FormBag['data']) => {
       const newPw = data[passwordFieldName];
       const confirmPw = data.confirmPassword;
-      const errorMessages: (IdxMessage & { name?: string })[] = [];
+      const errorMessages: IdxMessageWithName[] = [];
       if (!newPw) {
         errorMessages.push({
           name: passwordFieldName,

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorEnroll.ts
@@ -38,10 +38,13 @@ export const transformSelectAuthenticatorEnroll: IdxStepTransformer = ({
 }) => {
   const { uischema } = formBag;
   const { brandName } = widgetProps;
-  const { nextStep: { inputs } = {} as NextStep, availableSteps } = transaction;
+  const { nextStep: { inputs, name: stepName } = {} as NextStep, availableSteps } = transaction;
 
   const authenticator = inputs?.find(({ name }) => name === 'authenticator');
-  const authenticatorButtons = getAuthenticatorEnrollButtonElements(authenticator!.options!);
+  const authenticatorButtons = getAuthenticatorEnrollButtonElements(
+    authenticator!.options!,
+    stepName,
+  );
   const skipStep = availableSteps?.find(({ name }) => name === 'skip');
 
   const title: TitleElement = {

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorUnlockVerify.ts
@@ -25,11 +25,14 @@ export const transformSelectAuthenticatorUnlockVerify: IdxStepTransformer = ({
   transaction,
   formBag,
 }) => {
-  const { nextStep: { inputs } = {} as NextStep } = transaction;
+  const { nextStep: { inputs, name: stepName } = {} as NextStep } = transaction;
   const { uischema } = formBag;
 
   const authenticator = inputs?.find(({ name }) => name === 'authenticator');
-  const authenticatorButtons = getAuthenticatorVerifyButtonElements(authenticator!.options!);
+  const authenticatorButtons = getAuthenticatorVerifyButtonElements(
+    authenticator!.options!,
+    stepName,
+  );
 
   const title: TitleElement = {
     type: 'Title',

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectAuthenticatorVerify.ts
@@ -44,14 +44,17 @@ export const transformSelectAuthenticatorVerify: IdxStepTransformer = ({
   widgetProps,
 }) => {
   const { brandName } = widgetProps;
-  const { nextStep: { inputs } = {} as NextStep } = transaction;
+  const { nextStep: { inputs, name: stepName } = {} as NextStep } = transaction;
   const authenticator = inputs?.find(({ name }) => name === 'authenticator');
   if (!authenticator?.options) {
     return formBag;
   }
 
   const { uischema } = formBag;
-  const authenticatorButtonElements = getAuthenticatorVerifyButtonElements(authenticator.options);
+  const authenticatorButtonElements = getAuthenticatorVerifyButtonElements(
+    authenticator.options,
+    stepName,
+  );
   uischema.elements = removeUIElementWithName(
     'authenticator',
     uischema.elements as UISchemaElement[],

--- a/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
+++ b/src/v3/src/transformer/selectAuthenticator/transformSelectOVMethodVerify.ts
@@ -10,7 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { Input } from '@okta/okta-auth-js';
+import { Input, NextStep } from '@okta/okta-auth-js';
 
 import {
   ButtonElement,
@@ -26,7 +26,7 @@ import { getUIElementWithName, removeUIElementWithName } from '../utils';
 import { getOVMethodTypeAuthenticatorButtonElements, isOnlyPushWithAutoChallenge } from './utils';
 
 export const transformSelectOVMethodVerify: IdxStepTransformer = ({ transaction, formBag }) => {
-  const { nextStep: { inputs } = {} } = transaction;
+  const { nextStep: { inputs, name: stepName } = {} as NextStep } = transaction;
   const authenticator = inputs?.find(({ name }) => name === 'authenticator') as Input;
   if (!authenticator) {
     return formBag;
@@ -58,7 +58,7 @@ export const transformSelectOVMethodVerify: IdxStepTransformer = ({ transaction,
       label: loc('oie.okta_verify.sendPushButton', 'login'),
       options: {
         type: ButtonType.SUBMIT,
-        step: transaction.nextStep!.name,
+        step: stepName,
       },
     };
     uischema.elements.push(sendPushButton);
@@ -68,7 +68,10 @@ export const transformSelectOVMethodVerify: IdxStepTransformer = ({ transaction,
       return formBag;
     }
 
-    const buttonElements = getOVMethodTypeAuthenticatorButtonElements(methodType.options);
+    const buttonElements = getOVMethodTypeAuthenticatorButtonElements(
+      methodType.options,
+      stepName,
+    );
     uischema.elements = removeUIElementWithName(
       'authenticator.methodType',
       uischema.elements as UISchemaElement[],

--- a/src/v3/src/transformer/selectAuthenticator/utils.test.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.test.ts
@@ -12,7 +12,7 @@
 
 import { Input } from '@okta/okta-auth-js';
 import { IdxOption } from '@okta/okta-auth-js/lib/idx/types/idx-js';
-import { AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP, AUTHENTICATOR_KEY } from 'src/constants';
+import { AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP, AUTHENTICATOR_KEY, IDX_STEP } from 'src/constants';
 
 import {
   getAuthenticatorEnrollButtonElements,
@@ -22,9 +22,10 @@ import {
 } from './utils';
 
 describe('Select Authenticator Utility Tests', () => {
+  const stepName = IDX_STEP.SELECT_AUTHENTICATOR_ENROLL;
   describe('getOVMethodTypeAuthenticatorButtonElements Tests', () => {
     it('should return an empty array when an empty array of options is provided', () => {
-      expect(getOVMethodTypeAuthenticatorButtonElements([])).toEqual([]);
+      expect(getOVMethodTypeAuthenticatorButtonElements([], stepName)).toEqual([]);
     });
 
     it('should return formatted Authenticator Option Values '
@@ -33,7 +34,7 @@ describe('Select Authenticator Utility Tests', () => {
         { label: 'Enter a code', value: 'totp' } as IdxOption,
         { label: 'Get a push notification', value: 'push' } as IdxOption,
       ];
-      expect(getOVMethodTypeAuthenticatorButtonElements(options)).toEqual([
+      expect(getOVMethodTypeAuthenticatorButtonElements(options, stepName)).toEqual([
         {
           type: 'AuthenticatorButton',
           label: options[0].label,
@@ -112,7 +113,7 @@ describe('Select Authenticator Utility Tests', () => {
 
   describe('getAuthenticatorVerifyButtonElements Tests', () => {
     it('should return empty array when no authenticator options are provided', () => {
-      expect(getAuthenticatorVerifyButtonElements([])).toEqual([]);
+      expect(getAuthenticatorVerifyButtonElements([], stepName)).toEqual([]);
     });
 
     it('should return formatted authenticator options when raw options are provided', () => {
@@ -138,7 +139,7 @@ describe('Select Authenticator Utility Tests', () => {
           }
           return option;
         });
-      const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options);
+      const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(14);
       options.forEach((option) => {
@@ -176,7 +177,7 @@ describe('Select Authenticator Utility Tests', () => {
         },
       }];
 
-      const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options);
+      const authenticatorOptionValues = getAuthenticatorVerifyButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(2);
       expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);
@@ -192,7 +193,7 @@ describe('Select Authenticator Utility Tests', () => {
 
   describe('getAuthenticatorEnrollButtonElements Tests', () => {
     it('should return empty array when no authenticator options are provided', () => {
-      expect(getAuthenticatorEnrollButtonElements([])).toEqual([]);
+      expect(getAuthenticatorEnrollButtonElements([], stepName)).toEqual([]);
     });
 
     it('should return formatted authenticator options when raw options are provided', () => {
@@ -218,7 +219,7 @@ describe('Select Authenticator Utility Tests', () => {
           }
           return option;
         });
-      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options);
+      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(14);
       options.forEach((option) => {
@@ -246,7 +247,7 @@ describe('Select Authenticator Utility Tests', () => {
           key: AUTHENTICATOR_KEY.ON_PREM,
         },
       }];
-      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options);
+      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(1);
       expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.ON_PREM);
@@ -280,7 +281,7 @@ describe('Select Authenticator Utility Tests', () => {
         },
       }];
 
-      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options);
+      const authenticatorOptionValues = getAuthenticatorEnrollButtonElements(options, stepName);
 
       expect(authenticatorOptionValues.length).toBe(2);
       expect(authenticatorOptionValues[0].options.key).toBe(AUTHENTICATOR_KEY.OV);

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -45,6 +45,7 @@ const getAuthenticatorDataSeVal = (authenticatorKey: string, methodType?: string
 
 const buildOktaVerifyOptions = (
   options: IdxOption[],
+  step: string,
   isEnroll?: boolean,
 ): AuthenticatorButtonElement[] => {
   const ovRemediation = getAuthenticatorOption(options, AUTHENTICATOR_KEY.OV);
@@ -70,6 +71,9 @@ const buildOktaVerifyOptions = (
           'authenticator.methodType': option.value,
           'authenticator.id': id,
         } as ActionParams,
+        step,
+        includeData: true,
+        includeImmutableData: false,
         dataSe: getAuthenticatorDataSeVal(AUTHENTICATOR_KEY.OV, option.value as string),
         iconName: option.value === 'totp' ? 'oktaVerify' : 'oktaVerifyPush',
         iconDescr: option.value === 'totp'
@@ -184,6 +188,7 @@ const getUsageDescription = (option: IdxOption): string | undefined => {
 
 const formatAuthenticatorOptions = (
   options: IdxOption[],
+  step: string,
   isEnroll?: boolean,
 ): AuthenticatorButtonElement[] => (
   options.map((option: IdxOption, index: number) => {
@@ -221,6 +226,9 @@ const formatAuthenticatorOptions = (
             : undefined,
           'authenticator.enrollmentId': enrollmentId,
         },
+        step,
+        includeData: true,
+        includeImmutableData: false,
         dataSe: getAuthenticatorDataSeVal(
           authenticatorKey,
           AUTHENTICATORS_WITH_METHOD_TYPE.includes(authenticatorKey) && typeof methodType === 'string'
@@ -235,12 +243,13 @@ const formatAuthenticatorOptions = (
 
 const getAuthenticatorButtonElements = (
   options: IdxOption[],
+  step: string,
   isEnroll?: boolean,
 ): AuthenticatorButtonElement[] => {
-  const formattedOptions = formatAuthenticatorOptions(options, isEnroll);
+  const formattedOptions = formatAuthenticatorOptions(options, step, isEnroll);
 
   // appending OV options back to its original spot
-  const ovOptions = buildOktaVerifyOptions(options, isEnroll);
+  const ovOptions = buildOktaVerifyOptions(options, step, isEnroll);
   if (ovOptions.length && options?.length) {
     const ovIndex = options.findIndex(({ relatesTo }) => relatesTo?.key === AUTHENTICATOR_KEY.OV);
     formattedOptions.splice(ovIndex, 1, ...ovOptions);
@@ -251,6 +260,7 @@ const getAuthenticatorButtonElements = (
 
 export const getOVMethodTypeAuthenticatorButtonElements = (
   options: IdxOption[],
+  step: string,
 ): AuthenticatorButtonElement[] => {
   if (!options.length) {
     return [];
@@ -265,6 +275,9 @@ export const getOVMethodTypeAuthenticatorButtonElements = (
       actionParams: {
         'authenticator.methodType': (option.value as string),
       },
+      step,
+      includeData: true,
+      includeImmutableData: false,
     },
   })) as AuthenticatorButtonElement[];
 };
@@ -282,13 +295,17 @@ export const isOnlyPushWithAutoChallenge = (
 
 export const getAuthenticatorVerifyButtonElements = (
   authenticatorOptions: IdxOption[],
+  step: string,
 ):AuthenticatorButtonElement[] => getAuthenticatorButtonElements(
   authenticatorOptions,
+  step,
 );
 
 export const getAuthenticatorEnrollButtonElements = (
   authenticatorOptions: IdxOption[],
+  step: string,
 ): AuthenticatorButtonElement[] => getAuthenticatorButtonElements(
   authenticatorOptions,
+  step,
   true,
 );

--- a/src/v3/src/transformer/selectAuthenticator/utils.ts
+++ b/src/v3/src/transformer/selectAuthenticator/utils.ts
@@ -18,7 +18,7 @@ import {
   AUTHENTICATOR_ENROLLMENT_DESCR_KEY_MAP,
   AUTHENTICATOR_KEY,
 } from '../../constants';
-import { ActionParams, AuthenticatorButtonElement } from '../../types';
+import { ActionParams, AuthenticatorButtonElement, ButtonType } from '../../types';
 import { loc } from '../../util';
 
 const getAuthenticatorOption = (
@@ -60,6 +60,7 @@ const buildOktaVerifyOptions = (
       type: 'AuthenticatorButton',
       label: option.label,
       options: {
+        type: ButtonType.BUTTON,
         key: AUTHENTICATOR_KEY.OV,
         ctaLabel: isEnroll
           ? loc('oie.enroll.authenticator.button.text', 'login')
@@ -206,6 +207,7 @@ const formatAuthenticatorOptions = (
       type: 'AuthenticatorButton',
       label: option.label,
       options: {
+        type: ButtonType.BUTTON,
         key: authenticatorKey,
         authenticator,
         ctaLabel: isEnroll
@@ -270,6 +272,7 @@ export const getOVMethodTypeAuthenticatorButtonElements = (
     type: 'AuthenticatorButton',
     label: option.label,
     options: {
+      type: ButtonType.BUTTON,
       key: AUTHENTICATOR_KEY.OV,
       ctaLabel: loc('oie.verify.authenticator.button.text', 'login'),
       actionParams: {

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -39,6 +39,8 @@ export type FormBag = {
   }
 };
 
+export type IdxMessageWithName = IdxMessage & { name?: string | undefined; };
+
 export type AutoCompleteValue = 'username'
 | 'current-password'
 | 'one-time-code'
@@ -174,7 +176,7 @@ export interface ButtonElement extends UISchemaElement {
 export interface AuthenticatorButtonElement {
   type: 'AuthenticatorButton';
   label: string;
-  options: Omit<ButtonElement['options'], 'type' | 'step'> & {
+  options: Omit<ButtonElement['options'], 'type'> & {
     key: string;
     authenticator?: IdxAuthenticator;
     ctaLabel: string;

--- a/src/v3/src/types/schema.ts
+++ b/src/v3/src/types/schema.ts
@@ -39,7 +39,7 @@ export type FormBag = {
   }
 };
 
-export type IdxMessageWithName = IdxMessage & { name?: string | undefined; };
+export type IdxMessageWithName = IdxMessage & { name?: string; };
 
 export type AutoCompleteValue = 'username'
 | 'current-password'
@@ -173,10 +173,10 @@ export interface ButtonElement extends UISchemaElement {
   };
 }
 
-export interface AuthenticatorButtonElement {
+export interface AuthenticatorButtonElement extends UISchemaElement {
   type: 'AuthenticatorButton';
   label: string;
-  options: Omit<ButtonElement['options'], 'type'> & {
+  options: ButtonElement['options'] & {
     key: string;
     authenticator?: IdxAuthenticator;
     ctaLabel: string;
@@ -362,7 +362,7 @@ export interface RedirectElement extends UISchemaElement {
   options: { url: string; },
 }
 
-type ValidateFunction = (data: FormBag['data']) => (IdxMessage & { name?: string })[] | undefined;
+type ValidateFunction = (data: FormBag['data']) => IdxMessageWithName[] | undefined;
 
 export interface DataSchema {
   validate?: ValidateFunction;

--- a/src/v3/src/util/getValidationMessages.ts
+++ b/src/v3/src/util/getValidationMessages.ts
@@ -28,6 +28,9 @@ export const getValidationMessages = (
     .reduce((acc: Record<string, IdxMessageWithName[]>, [name, elementSchema]) => {
       if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
         const validationMessages = elementSchema.validate({
+          // data & params are passed here for validation in case a required field
+          // does not translate to user input, we rely on the transformer to populate
+          // actionParams to pass the required validation check.
           ...data,
           ...params,
         });

--- a/src/v3/src/util/getValidationMessages.ts
+++ b/src/v3/src/util/getValidationMessages.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import {
+  ActionOptions,
+  ActionParams,
+  DataSchema,
+  FormBag,
+  IdxMessageWithName,
+} from '../types';
+
+export const getValidationMessages = (
+  dataSchema: Record<string, DataSchema> & {
+    submit: ActionOptions;
+    fieldsToValidate: string[];
+    fieldsToExclude: (data: FormBag['data']) => string[];
+  },
+  data: FormBag['data'],
+  params: ActionParams | undefined,
+): Record<string, IdxMessageWithName[]> | undefined => {
+  const { fieldsToValidate } = dataSchema;
+  // aggregate field level messages based on validation rules in each field
+  const messages = Object.entries(dataSchema)
+    .reduce((acc: Record<string, IdxMessageWithName[]>, curr) => {
+      const name = curr[0];
+      const elementSchema = curr[1] as DataSchema;
+      if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
+        const validationMessages = elementSchema.validate({
+          ...data,
+          ...params,
+        });
+        if (validationMessages?.length) {
+          acc[name] = [...validationMessages];
+        }
+      }
+      return acc;
+    }, {});
+
+  return Object.keys(messages)?.length ? messages : undefined;
+};

--- a/src/v3/src/util/getValidationMessages.ts
+++ b/src/v3/src/util/getValidationMessages.ts
@@ -11,7 +11,6 @@
  */
 
 import {
-  ActionOptions,
   ActionParams,
   DataSchema,
   FormBag,
@@ -19,31 +18,25 @@ import {
 } from '../types';
 
 export const getValidationMessages = (
-  dataSchema: Record<string, DataSchema> & {
-    submit: ActionOptions;
-    fieldsToValidate: string[];
-    fieldsToExclude: (data: FormBag['data']) => string[];
-  },
+  dataSchema: Record<string, DataSchema>,
+  fieldsToValidate: string[],
   data: FormBag['data'],
-  params: ActionParams | undefined,
+  params?: ActionParams,
 ): Record<string, IdxMessageWithName[]> | undefined => {
-  const { fieldsToValidate } = dataSchema;
   // aggregate field level messages based on validation rules in each field
   const messages = Object.entries(dataSchema)
-    .reduce((acc: Record<string, IdxMessageWithName[]>, curr) => {
-      const name = curr[0];
-      const elementSchema = curr[1] as DataSchema;
+    .reduce((acc: Record<string, IdxMessageWithName[]>, [name, elementSchema]) => {
       if (fieldsToValidate.includes(name) && typeof elementSchema.validate === 'function') {
         const validationMessages = elementSchema.validate({
           ...data,
           ...params,
         });
         if (validationMessages?.length) {
-          acc[name] = [...validationMessages];
+          acc[name] = validationMessages;
         }
       }
       return acc;
     }, {});
 
-  return Object.keys(messages)?.length ? messages : undefined;
+  return Object.keys(messages).length ? messages : undefined;
 };

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -18,6 +18,7 @@ export * from './formUtils';
 export * from './getAuthenticatorKey';
 export * from './getImmutableData';
 export * from './getTranslation';
+export * from './getValidationMessages';
 export * from './idxUtils';
 export * from './isInteractiveElement';
 export * from './isPasswordRecovery';

--- a/src/v3/src/util/resetMessagesToInputs.ts
+++ b/src/v3/src/util/resetMessagesToInputs.ts
@@ -10,11 +10,13 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { IdxMessage, Input } from '@okta/okta-auth-js';
+import { Input } from '@okta/okta-auth-js';
+
+import { IdxMessageWithName } from '../types';
 
 export function resetMessagesToInputs(
   inputs: Input[],
-  messagesByField: Record<string, (IdxMessage & { name?: string })[]>,
+  messagesByField: Record<string, IdxMessageWithName[]>,
 ): void {
   const fn = (items: Input[], namePrefix: string) => {
     items.forEach((input) => {

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -111,11 +111,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -161,24 +161,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Password
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a password for your account
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_password"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -186,16 +186,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -251,24 +251,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Phone
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify with a code sent to your phone
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="phone_number"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -276,16 +276,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -351,24 +351,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Use a security key or a biometric authenticator to sign in
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="webauthn"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -376,7 +376,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -162,13 +162,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Password
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a password for your account
@@ -252,13 +252,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Phone
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify with a code sent to your phone
@@ -352,13 +352,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Use a security key or a biometric authenticator to sign in

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -111,11 +111,11 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -161,24 +161,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Password
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a password for your account
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_password"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -186,16 +186,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -251,24 +251,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Phone
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify with a code sent to your phone
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="phone_number"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -276,16 +276,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -351,24 +351,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Use a security key or a biometric authenticator to sign in
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="webauthn"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -376,16 +376,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -431,24 +431,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Question
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a security question and answer that will be used for signing in
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="security_question"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -456,16 +456,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -508,24 +508,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Okta Verify
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Okta Verify is an authenticator app, installed on your phone, used to prove your identity
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_verify"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -533,16 +533,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -660,24 +660,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Google Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Enter a temporary code generated from the Google Authenticator app.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="google_otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -685,16 +685,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -740,24 +740,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom On-prem
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a code generated by Atko Custom On-prem.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="onprem_mfa-otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -765,16 +765,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -814,24 +814,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         RSA SecurID
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a code generated by RSA SecurID
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="rsa_token-otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -839,16 +839,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -890,24 +890,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Duo Security
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify your identity using Duo Security.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="duo"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -915,16 +915,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -975,24 +975,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         IDP Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Redirect to verify with IDP Authenticator.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="external_idp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -1000,16 +1000,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1060,24 +1060,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom OTP Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Enter a temporary code generated from an authenticator device.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="custom_otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -1085,16 +1085,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1142,24 +1142,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Symantec VIP
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a temporary code from the Symantec VIP app.
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="symantec_vip"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -1167,16 +1167,16 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-20"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1224,24 +1224,24 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-24"
                         data-se="authenticator-button-label"
                       >
                         YubiKey Authenticator
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify your identity using YubiKey
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="yubikey_token"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-27"
                           data-se="cta-button-label"
                         >
                           Set up
@@ -1249,7 +1249,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -162,13 +162,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Password
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a password for your account
@@ -252,13 +252,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Phone
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify with a code sent to your phone
@@ -352,13 +352,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Use a security key or a biometric authenticator to sign in
@@ -432,13 +432,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Security Question
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Choose a security question and answer that will be used for signing in
@@ -509,13 +509,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Okta Verify
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Okta Verify is an authenticator app, installed on your phone, used to prove your identity
@@ -661,13 +661,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Google Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Enter a temporary code generated from the Google Authenticator app.
@@ -741,13 +741,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom On-prem
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a code generated by Atko Custom On-prem.
@@ -815,13 +815,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         RSA SecurID
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a code generated by RSA SecurID
@@ -891,13 +891,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Duo Security
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify your identity using Duo Security.
@@ -976,13 +976,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         IDP Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Redirect to verify with IDP Authenticator.
@@ -1061,13 +1061,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom OTP Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Enter a temporary code generated from an authenticator device.
@@ -1143,13 +1143,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         Symantec VIP
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify by entering a temporary code from the Symantec VIP app.
@@ -1225,13 +1225,13 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-24"
+                        class="MuiTypography-root MuiTypography-h3 emotion-24"
                         data-se="authenticator-button-label"
                       >
                         YubiKey Authenticator
                       </h3>
                       <p
-                        class="MuiBox-root emotion-25"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-25"
                         data-se="authenticator-button-description"
                       >
                         Verify your identity using YubiKey

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Password
@@ -242,7 +242,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
@@ -336,7 +336,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
@@ -410,7 +410,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Email
@@ -494,13 +494,13 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone
                       </h3>
                       <p
-                        class="MuiBox-root emotion-54"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
                         data-se="authenticator-button-description"
                       >
                         +1 XXX-XXX-5309
@@ -584,13 +584,13 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone
                       </h3>
                       <p
-                        class="MuiBox-root emotion-54"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
                         data-se="authenticator-button-description"
                       >
                         +1 XXX-XXX-5309
@@ -664,7 +664,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Question
@@ -735,13 +735,13 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Use Okta FastPass
                       </h3>
                       <p
-                        class="MuiBox-root emotion-54"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
                         data-se="authenticator-button-description"
                       >
                         Okta Verify
@@ -887,7 +887,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Google Authenticator
@@ -961,7 +961,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom On-prem
@@ -1029,7 +1029,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         RSA SecurID
@@ -1099,7 +1099,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Duo Security
@@ -1178,7 +1178,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         IDP Authenticator
@@ -1257,7 +1257,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom OTP Authenticator
@@ -1333,7 +1333,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Symantec VIP
@@ -1409,7 +1409,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         YubiKey Authenticator
@@ -1456,13 +1456,13 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                       class="infoSection MuiBox-root emotion-7"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Get a push notification
                       </h3>
                       <p
-                        class="MuiBox-root emotion-54"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-54"
                         data-se="authenticator-button-description"
                       >
                         Custom Push App

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -97,11 +97,11 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -147,18 +147,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Password
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_password"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -166,16 +166,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -241,18 +241,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="webauthn"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -260,16 +260,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -335,18 +335,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Key or Biometric Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="webauthn"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -354,16 +354,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -409,18 +409,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Email
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_email"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -428,16 +428,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -493,24 +493,24 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-54"
                         data-se="authenticator-button-description"
                       >
                         +1 XXX-XXX-5309
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="phone_number"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -518,16 +518,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -583,24 +583,24 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-54"
                         data-se="authenticator-button-description"
                       >
                         +1 XXX-XXX-5309
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="phone_number"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -608,16 +608,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -663,18 +663,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Security Question
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="security_question"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -682,16 +682,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -734,24 +734,24 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Use Okta FastPass
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-54"
                         data-se="authenticator-button-description"
                       >
                         Okta Verify
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="okta_verify"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -759,16 +759,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -886,18 +886,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Google Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="google_otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -905,16 +905,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -960,18 +960,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom On-prem
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="onprem_mfa"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -979,16 +979,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1028,18 +1028,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         RSA SecurID
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="rsa_token"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1047,16 +1047,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1098,18 +1098,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Duo Security
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="duo"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1117,16 +1117,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1177,18 +1177,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         IDP Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="external_idp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1196,16 +1196,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1256,18 +1256,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Atko Custom OTP Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="custom_otp"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1275,16 +1275,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1332,18 +1332,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Symantec VIP
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="symantec_vip"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1351,16 +1351,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1408,18 +1408,18 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         YubiKey Authenticator
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="yubikey_token"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1427,16 +1427,16 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-7"
@@ -1455,24 +1455,24 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-7"
                     >
-                      <div
-                        class="title MuiBox-root emotion-7"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Get a push notification
-                      </div>
-                      <div
-                        class="description MuiBox-root emotion-7"
+                      </h3>
+                      <p
+                        class="MuiBox-root emotion-54"
                         data-se="authenticator-button-description"
                       >
                         Custom Push App
-                      </div>
+                      </p>
                       <div
                         class="cta-button actionName MuiBox-root emotion-7"
                         data-se="custom_app"
                       >
                         <span
-                          class="MuiBox-root emotion-7"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -1480,7 +1480,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`user-unlock-account renders form 1`] = `
                       class="infoSection MuiBox-root emotion-10"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Email
@@ -227,7 +227,7 @@ exports[`user-unlock-account renders form 1`] = `
                       class="infoSection MuiBox-root emotion-10"
                     >
                       <h3
-                        class="MuiBox-root emotion-21"
+                        class="MuiTypography-root MuiTypography-h3 emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -92,11 +92,11 @@ exports[`user-unlock-account renders form 1`] = `
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-10"
@@ -142,18 +142,18 @@ exports[`user-unlock-account renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-10"
                     >
-                      <div
-                        class="title MuiBox-root emotion-10"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Email
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-10"
                         data-se="okta_email"
                       >
                         <span
-                          class="MuiBox-root emotion-10"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -161,16 +161,16 @@ exports[`user-unlock-account renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-6"
                 >
-                  <div
+                  <button
                     class="authButton MuiBox-root emotion-17"
                     data-se="authenticator-button"
-                    role="button"
                     tabindex="0"
+                    type="button"
                   >
                     <div
                       class="MuiBox-root emotion-10"
@@ -226,18 +226,18 @@ exports[`user-unlock-account renders form 1`] = `
                     <div
                       class="infoSection MuiBox-root emotion-10"
                     >
-                      <div
-                        class="title MuiBox-root emotion-10"
+                      <h3
+                        class="MuiBox-root emotion-21"
                         data-se="authenticator-button-label"
                       >
                         Phone
-                      </div>
+                      </h3>
                       <div
                         class="cta-button actionName MuiBox-root emotion-10"
                         data-se="phone_number"
                       >
                         <span
-                          class="MuiBox-root emotion-10"
+                          class="MuiBox-root emotion-23"
                           data-se="cta-button-label"
                         >
                           Select
@@ -245,7 +245,7 @@ exports[`user-unlock-account renders form 1`] = `
                         <mocksvgicon />
                       </div>
                     </div>
-                  </div>
+                  </button>
                 </div>
                 <div
                   class="MuiBox-root emotion-6"


### PR DESCRIPTION
## Description:
The purpose of this PR is to disallow the unlock flow from proceeding if the user has not entered their username/identifier.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521272](https://oktainc.atlassian.net/browse/OKTA-521272)

### Reviewers:

### Screenshot/Video:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/97472729/186276101-9b1ce94d-51e4-4b63-93b5-8f64e8aab8d3.png">


### Downstream Monolith Build:



