### PR TITLE
OKTA-525579 : ok-pl content overflow fix

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -106,6 +106,7 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
+      style={{ maxWidth: '100%' }}
     >
       <Layout uischema={uischema} />
     </form>

--- a/src/v3/src/components/StepperButton/StepperButton.tsx
+++ b/src/v3/src/components/StepperButton/StepperButton.tsx
@@ -43,6 +43,9 @@ const StepperButton: UISchemaElementComponent<{
       type="button"
       fullWidth
       ref={focusRef}
+      sx={{
+        whiteSpace: 'normal'
+      }}
     >
       {label}
     </Button>

--- a/src/v3/src/components/StepperButton/StepperButton.tsx
+++ b/src/v3/src/components/StepperButton/StepperButton.tsx
@@ -44,7 +44,7 @@ const StepperButton: UISchemaElementComponent<{
       fullWidth
       ref={focusRef}
       sx={{
-        whiteSpace: 'normal'
+        whiteSpace: 'normal',
       }}
     >
       {label}

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1626,6 +1627,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -235,6 +236,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -422,6 +424,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -581,6 +584,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -444,6 +445,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -787,6 +789,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-expired-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-reset-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -564,6 +565,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -203,6 +204,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -380,6 +382,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -559,6 +562,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -718,6 +722,7 @@ exports[`authenticator-verification-email renders correct form should render ses
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -196,6 +197,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`email-challenge-consent should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`enroll-profile-new should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-400-unauthorized-client should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-account-creation should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-feature-not-enabled should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-recovery-token-invalid should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`error-session-expired should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -238,6 +239,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -495,6 +497,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -698,6 +701,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -899,6 +903,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1136,6 +1141,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1308,6 +1314,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1480,6 +1487,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1737,6 +1745,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3209,6 +3218,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3410,6 +3420,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`identify-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -360,6 +361,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -662,6 +664,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -935,6 +938,7 @@ exports[`identify-with-password renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`terminal-return-email-error should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-email renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -66,6 +66,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`unlock-account-success renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`user-unlock-account renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`webauthn-enroll should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -214,6 +215,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               class="o-form"
               data-se="form"
               novalidate=""
+              style="max-width: 100%;"
             >
               <div
                 class="MuiBox-root emotion-10"


### PR DESCRIPTION
## Description:

Fixes the issue of content overflowing outside of the container with ok-pl language in the authenticator-verification-email flow.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-525579](https://oktainc.atlassian.net/browse/OKTA-525579)

### Reviewers:

### Screenshot/Video:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/107433508/186304409-ea0ecf09-757f-411f-b0b9-341efa38cb72.png">
### Downstream Monolith Build:



