### PR TITLE
OKTA-521292 : Webauthn title fix

### DIFF
--- a/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
+++ b/src/v3/src/transformer/webauthn/transformWebAuthNAuthenticator.ts
@@ -61,11 +61,14 @@ const generateUISchemaElementAndInformationLabelFor = (
 
 export const transformWebAuthNAuthenticator: IdxStepTransformer = ({ transaction, formBag }) => {
   const { uischema } = formBag;
+  const { nextStep: { name } = {} } = transaction;
 
   const titleElement: TitleElement = {
     type: 'Title',
     options: {
-      content: loc('oie.enroll.webauthn.title', 'login'),
+      content: name === IDX_STEP.ENROLL_AUTHENTICATOR
+        ? loc('oie.enroll.webauthn.title', 'login')
+        : loc('oie.verify.webauth.title', 'login'),
     },
   };
   const informationalTextElement: DescriptionElement = {

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
                       class="MuiTypography-root MuiTypography-h3 emotion-13"
                       data-se="o-form-head"
                     >
-                      Set up security key or biometric authenticator
+                      Verify with Security Key or Biometric Authenticator
                     </h2>
                   </div>
                 </div>
@@ -212,7 +212,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
                       class="MuiTypography-root MuiTypography-h3 emotion-13"
                       data-se="o-form-head"
                     >
-                      Set up security key or biometric authenticator
+                      Verify with Security Key or Biometric Authenticator
                     </h2>
                   </div>
                 </div>

--- a/src/v3/test/integration/authenticator-verification-webauthn.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-webauthn.test.tsx
@@ -26,7 +26,7 @@ describe('authenticator-verification-webauthn', () => {
       } as unknown as Navigator,
     );
     const { container, findByText } = await setup({ mockResponse });
-    await findByText(/Set up security key or biometric authenticator/);
+    await findByText(/Verify with Security Key or Biometric Authenticator/);
     await findByText(/You will be prompted to use a security key or biometric verification/);
     expect(container).toMatchSnapshot();
   });
@@ -39,7 +39,7 @@ describe('authenticator-verification-webauthn', () => {
       } as unknown as Navigator,
     );
     const { container, findByText } = await setup({ mockResponse });
-    await findByText(/Set up security key or biometric authenticator/);
+    await findByText(/Verify with Security Key or Biometric Authenticator/);
     await findByText(/Security key or biometric authenticator is not supported on this browser./);
     expect(container).toMatchSnapshot();
   });


### PR DESCRIPTION
## Description:

This PR fixes the issue of having the wrong title when verifying with Webauthn.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521292](https://oktainc.atlassian.net/browse/OKTA-521292)

### Reviewers:

### Screenshot/Video:
<img width="563" alt="image" src="https://user-images.githubusercontent.com/107433508/186322853-896c098b-b3ce-4ca0-9c19-0de0be9c419a.png">
<img width="550" alt="image" src="https://user-images.githubusercontent.com/107433508/186323074-f9726a3f-35f3-4c5d-96b9-aaed8aeb25db.png">
### Downstream Monolith Build:



