### PR TITLE
OKTA-527227 : Implementation to fix back to sign in link on account unlock success page

### DIFF
--- a/src/v3/src/mocks/response/idp/idx/challenge/answer/unlock-account-success.json
+++ b/src/v3/src/mocks/response/idp/idx/challenge/answer/unlock-account-success.json
@@ -20,10 +20,10 @@
     "type": "object",
     "value": {
       "id": "00u2kk7x4ni8vYvuO1d7",
-      "identifier": "glen.fannin@okta.com",
+      "identifier": "tester@okta1.com",
       "profile": {
-        "firstName": "Okta Glen",
-        "lastName": "Fannin (Okta)",
+        "firstName": "Okta Tester",
+        "lastName": "McTesterson",
         "timeZone": "America/Los_Angeles",
         "locale": "en_US"
       }
@@ -34,7 +34,7 @@
       "create-form"
     ],
     "name": "cancel",
-    "href": "https://oie-4695462.oktapreview.com/idp/idx/cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
     "method": "POST",
     "produces": "application/ion+json; okta-version=1.0.0",
     "value": [

--- a/src/v3/src/transformer/button/getButtonControls.ts
+++ b/src/v3/src/transformer/button/getButtonControls.ts
@@ -21,10 +21,11 @@ import {
   ButtonType,
   DescriptionElement,
   LinkElement,
+  OktaWidgetFeatures,
   UISchemaElement,
   UISchemaLayoutType,
 } from '../../types';
-import { loc } from '../../util';
+import { loc, shouldShowCancelLink } from '../../util';
 
 interface GetButtonControls {
   elements: UISchemaElement[];
@@ -39,6 +40,7 @@ interface GetButtonControlsArgs {
   stepWithUnlockAccount?: boolean;
   verifyWithOther?: boolean;
   backToAuthList?: boolean;
+  features?: OktaWidgetFeatures;
 }
 
 export const getButtonControls = (
@@ -170,7 +172,7 @@ export const getButtonControls = (
   }
 
   const cancelStep = getButtonStep('cancel');
-  if (config.stepWithCancel && cancelStep) {
+  if (config.stepWithCancel && cancelStep && shouldShowCancelLink(config.features)) {
     const { name: step } = cancelStep;
     const cancel: LinkElement = {
       type: 'Link',

--- a/src/v3/src/transformer/button/transform.ts
+++ b/src/v3/src/transformer/button/transform.ts
@@ -19,7 +19,7 @@ import TransformerMap from '../layout/idxTransformerMapping';
 import { getButtonControls } from './getButtonControls';
 
 export const transformButtons: TransformStepFnWithOptions = (options) => (formbag) => {
-  const { transaction, step } = options;
+  const { transaction, step, widgetProps: { features } } = options;
   const { availableSteps, enabledFeatures } = transaction;
 
   const hasIdentityStep = availableSteps?.some((s) => s.name === IDX_STEP.IDENTIFY);
@@ -50,6 +50,7 @@ export const transformButtons: TransformStepFnWithOptions = (options) => (formba
       stepWithUnlockAccount,
       backToAuthList,
       verifyWithOther,
+      features,
     },
   );
 

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -42,6 +42,7 @@ import {
   loc,
   removeUsernameCookie,
   setUsernameCookie,
+  shouldShowCancelLink,
 } from '../../util';
 import { redirectTransformer } from '../redirect';
 import { createForm } from '../utils';
@@ -77,13 +78,15 @@ const appendViewLinks = (
   uischema: UISchemaLayout,
   widgetProps: WidgetProps,
 ): void => {
-  const { baseUrl } = widgetProps;
+  const { baseUrl, features } = widgetProps;
+  const isCancelAvailable = shouldShowCancelLink(features);
   const cancelStep = transaction?.availableSteps?.find(({ name }) => name === 'cancel');
   const cancelLink: LinkElement = {
     type: 'Link',
     options: {
       label: loc('goback', 'login'),
       step: 'cancel',
+      isActionStep: true,
       href: cancelStep ? undefined : (baseUrl || '/'),
     },
   };
@@ -95,17 +98,19 @@ const appendViewLinks = (
         type: 'Button',
         label: loc('oie.enroll.skip.setup', 'login'),
         options: {
-          type: ButtonType.SUBMIT,
+          type: ButtonType.BUTTON,
           step: skipStep.name,
         },
       };
       uischema.elements.push(skipElement);
     }
-  } else if (containsOneOfMessageKeys(DEVICE_CODE_ERROR_KEYS, transaction.messages)) {
+  } else if (containsOneOfMessageKeys(DEVICE_CODE_ERROR_KEYS, transaction.messages)
+      && isCancelAvailable) {
     cancelLink.options.label = loc('oie.try.again', 'login');
     uischema.elements.push(cancelLink);
-  } else if (transaction.actions?.cancel
-    || !containsOneOfMessageKeys(TERMINAL_KEYS_WITHOUT_CANCEL, transaction.messages)) {
+  } else if ((transaction.actions?.cancel
+    || !containsOneOfMessageKeys(TERMINAL_KEYS_WITHOUT_CANCEL, transaction.messages))
+    && isCancelAvailable) {
     uischema.elements.push(cancelLink);
   }
 };

--- a/src/v3/src/types/widget.ts
+++ b/src/v3/src/types/widget.ts
@@ -194,6 +194,7 @@ export type OktaWidgetFeatures = {
   useDeviceFingerprintForSecurityImage?: boolean;
   trackTypingPattern?: boolean;
   hideSignOutLinkInMFA?: boolean;
+  mfaOnlyFlow?: boolean;
   hideBackToSignInForReset?: boolean;
   rememberMyUsernameOnOIE?: boolean;
   engFastpassMultipleAccounts?: boolean;

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -28,5 +28,6 @@ export * from './passwordUtils';
 export * from './removeFieldLevelMessages';
 export * from './resetMessagesToInputs';
 export * from './settingsUtils';
+export * from './shouldShowCancelLink';
 export * from './toNestedObject';
 export * from './webauthnUtils';

--- a/src/v3/src/util/shouldShowCancelLink.ts
+++ b/src/v3/src/util/shouldShowCancelLink.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { OktaWidgetFeatures } from '../types';
+
+export const shouldShowCancelLink = (features?: OktaWidgetFeatures): boolean => {
+  const { hideSignOutLinkInMFA, mfaOnlyFlow } = features || {};
+
+  return !(hideSignOutLinkInMFA || mfaOnlyFlow);
+};

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`unlock-account-success renders form 1`] = `
                   class="identifier identifierSpan MuiBox-root emotion-7"
                   data-se="identifier"
                 >
-                  glen.fannin@okta.com
+                  tester@okta1.com
                 </span>
               </div>
             </div>

--- a/src/v3/test/integration/unlock-account-success.test.tsx
+++ b/src/v3/test/integration/unlock-account-success.test.tsx
@@ -20,4 +20,31 @@ describe('unlock-account-success', () => {
     await findByText(/Account successfully unlocked!/);
     expect(container).toMatchSnapshot();
   });
+
+  it('should send correct payload when clicking "Back to sign in" link', async () => {
+    const {
+      authClient,
+      user,
+      findByText,
+    } = await setup({ mockResponse });
+
+    const backToSigninLink = await findByText(/Back to sign in/);
+
+    await user.click(backToSigninLink);
+    expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
+      'POST',
+      'http://localhost:3000/idp/idx/cancel',
+      {
+        data: JSON.stringify({
+          stateHandle: 'fake-stateHandle',
+        }),
+        headers: {
+          Accept: 'application/json; okta-version=1.0.0',
+          'Content-Type': 'application/json',
+          'X-Okta-User-Agent-Extended': 'okta-auth-js/9.9.9',
+        },
+        withCredentials: true,
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Description:

This PR fixes the back to sign in link on account unlock page as well as all Terminal pages that contains the link. The `cancel` link is an action and has to be treated as such when sending the request to auth-js, otherwise we will receive an error and the navigation will not happen. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-527227](https://oktainc.atlassian.net/browse/OKTA-527227)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



