### PR TITLE
OKTA-527587 : display short commit sha on widget footer

### DIFF
--- a/src/v3/package.json
+++ b/src/v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v3",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "description": "Okta Sign In Widget Next",
   "homepage": "https://github.com/okta/okta-signin-widget",

--- a/src/v3/src/components/AuthContent/AuthContent.tsx
+++ b/src/v3/src/components/AuthContent/AuthContent.tsx
@@ -13,6 +13,8 @@
 import { Box } from '@mui/material';
 import { FunctionComponent, h } from 'preact';
 
+const version = `${VERSION}-g${COMMITHASH.substring(0, 7)}`;
+
 const AuthContent: FunctionComponent = ({ children }) => (
   <Box
     display="flex"
@@ -29,7 +31,7 @@ const AuthContent: FunctionComponent = ({ children }) => (
     {
       process.env.NODE_ENV !== 'test' && (
         <code aria-hidden>
-          { VERSION }
+          { version }
         </code>
       )
     }


### PR DESCRIPTION
## Description:

display short commit sha on widget footer for easier debugging on demo cell

## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-527587](https://oktainc.atlassian.net/browse/OKTA-527587)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



