### PR TITLE
OKTA-527591 : Username field auto populate fix 

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -129,7 +129,9 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       prevTransaction: prevIdxTransactionRef.current,
       step,
       widgetProps,
+      isClientTransaction,
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     idxTransaction,
     authApiError,

--- a/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
@@ -159,7 +159,7 @@
   "user": {
     "type": "object",
     "value": {
-      "identifier": "lee.mchale@okta.com"
+      "identifier": "tester@okta1.com"
     }
   },
   "cancel": {

--- a/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
@@ -1,0 +1,200 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+  "expiresAt": "2022-08-30T20:13:10.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "identify",
+        "href": "https://oie-4695462.oktapreview.com/idp/idx/identify",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "identifier",
+            "label": "Username",
+            "required": true
+          },
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Password",
+                  "secret": true
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "rememberMe",
+            "type": "boolean",
+            "label": "Remember this device"
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "launch-authenticator",
+        "relatesTo": [
+          "authenticatorChallenge"
+        ],
+        "href": "https://oie-4695462.oktapreview.com/idp/idx/authenticators/okta-verify/launch",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-enroll-profile",
+        "href": "https://oie-4695462.oktapreview.com/idp/idx/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "unlock-account",
+        "href": "https://oie-4695462.oktapreview.com/idp/idx/unlock-account",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "messages": {
+    "type": "array",
+    "value": [
+      {
+        "message": "Authentication failed",
+        "i18n": {
+          "key": "errors.E0000004"
+        },
+        "class": "ERROR"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "recover": {
+        "rel": [
+          "create-form"
+        ],
+        "name": "recover",
+        "href": "https://oie-4695462.oktapreview.com/idp/idx/recover",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      "type": "password",
+      "key": "okta_password",
+      "id": "aut2h3ffszv3me6O31d7",
+      "displayName": "Password",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ]
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "identifier": "lee.mchale@okta.com"
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "https://oie-4695462.oktapreview.com/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02.id.nlOnqLKIOjvGxhynCvDYhDcY9ylph5rF32L8T3rR",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "SIW Next",
+      "id": "0oa2h3j3ysoR3eHN11d7"
+    }
+  },
+  "authenticatorChallenge": {
+    "type": "object",
+    "value": {
+      "challengeMethod": "CUSTOM_URI",
+      "href": "com-okta-authenticator:/deviceChallenge?challengeRequest=eyJraWQiOiJNd2lINFJ2SFpSa0pvUFJVWkZwcWZzdzU4dWdqNjdaYWlGLW9DNFpuT2VzIiwidHlwIjoib2t0YS1kZXZpY2ViaW5kK2p3dCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL29pZS00Njk1NDYyLm9rdGFwcmV2aWV3LmNvbSIsImF1ZCI6Im9rdGEuNjNjMDgxZGItMWYxMy01MDg0LTg4MmYtZTc5ZTFlNWUyZGE3IiwiZXhwIjoxNjYxODgyNTQ5LCJpYXQiOjE2NjE4ODIyNDksImp0aSI6ImZ0SjJGa2lCSEpqTkotUjZiOGJwdGkwSnR3ZFJHd3l6NXMiLCJub25jZSI6IkFVR0VnYkpjbHJTdDVZd25GUVhiIiwidHJhbnNhY3Rpb25JZCI6ImZ0SjJGa2lCSEpqTkotUjZiOGJwdGkwSnR3ZFJHd3l6NXMiLCJzaWduYWxzIjpbImlkIiwiZGlzcGxheU5hbWUiLCJwbGF0Zm9ybSIsIm1hbnVmYWN0dXJlciIsIm1vZGVsIiwib3NWZXJzaW9uIiwic2VyaWFsTnVtYmVyIiwidWRpZCIsInNpZCIsImltZWkiLCJtZWlkIiwidHBtUHVibGljS2V5SGFzaCIsInNlY3VyZUhhcmR3YXJlUHJlc2VudCIsImRldmljZUF0dGVzdGF0aW9uIiwiZGV2aWNlSW50ZWdyaXR5Iiwic2NyZWVuTG9ja1R5cGUiLCJkaXNrRW5jcnlwdGlvblR5cGUiLCJjbGllbnRJbnN0YW5jZUJ1bmRsZUlkIiwiY2xpZW50SW5zdGFuY2VEZXZpY2VTZGtWZXJzaW9uIiwiY2xpZW50SW5zdGFuY2VJZCIsImNsaWVudEluc3RhbmNlVmVyc2lvbiJdLCJ2ZXJpZmljYXRpb25VcmkiOiJodHRwczovL29pZS00Njk1NDYyLm9rdGFwcmV2aWV3LmNvbS9pZHAvYXV0aGVudGljYXRvcnMvYXV0MmgzZmZ0NHk5cERQQ1MxZDcvdHJhbnNhY3Rpb25zL2Z0SjJGa2lCSEpqTkotUjZiOGJwdGkwSnR3ZFJHd3l6NXMvdmVyaWZ5IiwiY2FTdWJqZWN0TmFtZXMiOltdLCJtZG1BdHRlc3RhdGlvbklzc3VlcnMiOltdLCJrZXlUeXBlIjoicHJvb2ZPZlBvc3Nlc3Npb24iLCJrZXlUeXBlcyI6WyJ1c2VyVmVyaWZpY2F0aW9uIiwicHJvb2ZPZlBvc3Nlc3Npb24iXSwiZmFjdG9yVHlwZSI6InNpZ25lZF9ub25jZSIsIm9yZ0lkIjoiMDBvMmgzZmZvYVR3S1cwRU0xZDciLCJhcHBJbnN0YW5jZU5hbWUiOiJTSVcgTmV4dCIsIm1ldGhvZCI6InNpZ25lZF9ub25jZSIsInJlcXVlc3RSZWZlcnJlciI6Imh0dHBzOi8vb2llLTQ2OTU0NjIub2t0YXByZXZpZXcuY29tIiwidXNlck1lZGlhdGlvbiI6IlJFUVVJUkVEIiwidXNlclZlcmlmaWNhdGlvbiI6IlBSRUZFUlJFRCIsInZlciI6MH0.snDlFeNbASMC7duz1mrdteWqZVkJtEkzDEzRdjbFmdOkwslN76L9Iz4OlwSnKDOhnBy_1DTTxBl04vy4TgyUyKXDiv1ESeAJIV6_61DnwNskAa8mGXLZmQiojC7SfRTNHV9-eGcFewkvLBmBKBa9xgFOQJeG0FRZMjABG4qFUoPixbpiUxF7rf3nz1ptZPf0HUaTkgpAyyEOqzSCx8tbZjhJlEjtuueYMimkx0QAmGG1l-78_CN9H7Wt6qG3yU__hN_cPB56XiS5XsAOM-rnxuSQEuSz-rCb1JKrWgxWA6kX-rQuOOQRe5aRMwGP_WLTdohfXn2VXOoxQH-AZliZpQ",
+      "downloadHref": "https://apps.apple.com/us/app/okta-verify/id490179405"
+    }
+  }
+}

--- a/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
+++ b/src/v3/src/mocks/response/idp/idx/identify/error-wrong-password.json
@@ -11,7 +11,7 @@
           "create-form"
         ],
         "name": "identify",
-        "href": "https://oie-4695462.oktapreview.com/idp/idx/identify",
+        "href": "http://localhost:3000/idp/idx/identify",
         "method": "POST",
         "produces": "application/ion+json; okta-version=1.0.0",
         "value": [
@@ -57,7 +57,7 @@
         "relatesTo": [
           "authenticatorChallenge"
         ],
-        "href": "https://oie-4695462.oktapreview.com/idp/idx/authenticators/okta-verify/launch",
+        "href": "http://localhost:3000/idp/idx/authenticators/okta-verify/launch",
         "method": "POST",
         "produces": "application/ion+json; okta-version=1.0.0",
         "value": [
@@ -76,7 +76,7 @@
           "create-form"
         ],
         "name": "select-enroll-profile",
-        "href": "https://oie-4695462.oktapreview.com/idp/idx/enroll",
+        "href": "http://localhost:3000/idp/idx/enroll",
         "method": "POST",
         "produces": "application/ion+json; okta-version=1.0.0",
         "value": [
@@ -95,7 +95,7 @@
           "create-form"
         ],
         "name": "unlock-account",
-        "href": "https://oie-4695462.oktapreview.com/idp/idx/unlock-account",
+        "href": "http://localhost:3000/idp/idx/unlock-account",
         "method": "POST",
         "produces": "application/ion+json; okta-version=1.0.0",
         "value": [
@@ -131,7 +131,7 @@
           "create-form"
         ],
         "name": "recover",
-        "href": "https://oie-4695462.oktapreview.com/idp/idx/recover",
+        "href": "http://localhost:3000/idp/idx/recover",
         "method": "POST",
         "produces": "application/ion+json; okta-version=1.0.0",
         "value": [
@@ -167,7 +167,7 @@
       "create-form"
     ],
     "name": "cancel",
-    "href": "https://oie-4695462.oktapreview.com/idp/idx/cancel",
+    "href": "http://localhost:3000/idp/idx/cancel",
     "method": "POST",
     "produces": "application/ion+json; okta-version=1.0.0",
     "value": [

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -21,7 +21,12 @@ import {
 import { getUsernameCookie, loc } from '../../util';
 import { getUIElementWithName, removeUIElementWithName } from '../utils';
 
-export const transformIdentify: IdxStepTransformer = ({ formBag, widgetProps, transaction }) => {
+export const transformIdentify: IdxStepTransformer = ({
+  formBag,
+  widgetProps,
+  transaction,
+  isClientTransaction,
+}) => {
   const { features, username } = widgetProps;
   const { uischema, data } = formBag;
 
@@ -36,8 +41,10 @@ export const transformIdentify: IdxStepTransformer = ({ formBag, widgetProps, tr
     // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
     // (i.e. rememberMe is default = true in v2)
     } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {
-      const usernameCookie = getUsernameCookie();
-      data.identifier = usernameCookie;
+      if (!isClientTransaction) {
+        const usernameCookie = getUsernameCookie();
+        data.identifier = usernameCookie;
+      }
     }
   }
 

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -35,13 +35,13 @@ export const transformIdentify: IdxStepTransformer = ({
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
   if (identifierElement) {
-    // add username/identifier from config if provided
-    if (username) {
-      data.identifier = username;
-    // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
-    // (i.e. rememberMe is default = true in v2)
-    } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {
-      if (!isClientTransaction) {
+    if (!isClientTransaction) {
+      // add username/identifier from config if provided
+      if (username) {
+        data.identifier = username;
+      // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
+      // (i.e. rememberMe is default = true in v2)
+      } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {
         const usernameCookie = getUsernameCookie();
         data.identifier = usernameCookie;
       }

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -34,17 +34,15 @@ export const transformIdentify: IdxStepTransformer = ({
     'identifier',
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
-  if (identifierElement) {
-    if (!isClientTransaction) {
-      // add username/identifier from config if provided
-      if (username) {
-        data.identifier = username;
-      // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
-      // (i.e. rememberMe is default = true in v2)
-      } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {
-        const usernameCookie = getUsernameCookie();
-        data.identifier = usernameCookie;
-      }
+  if (identifierElement && !isClientTransaction) {
+    // add username/identifier from config if provided
+    if (username) {
+      data.identifier = username;
+    // TODO: OKTA-508744 - to use rememberMe in features once Default values are added widgetProps.
+    // (i.e. rememberMe is default = true in v2)
+    } else if (features?.rememberMe !== false && features?.rememberMyUsernameOnOIE) {
+      const usernameCookie = getUsernameCookie();
+      data.identifier = usernameCookie;
     }
   }
 

--- a/src/v3/src/transformer/layout/transform.ts
+++ b/src/v3/src/transformer/layout/transform.ts
@@ -17,7 +17,11 @@ import TransformerMap from './idxTransformerMapping';
 
 export const transformLayout: TransformStepFnWithOptions = (options) => (formBag) => {
   const {
-    widgetProps, transaction, prevTransaction, step,
+    widgetProps,
+    transaction,
+    prevTransaction,
+    step,
+    isClientTransaction,
   } = options;
 
   const authenticatorKey = getAuthenticatorKey(transaction) ?? AUTHENTICATOR_KEY.DEFAULT;
@@ -27,6 +31,7 @@ export const transformLayout: TransformStepFnWithOptions = (options) => (formBag
     prevTransaction,
     formBag,
     widgetProps,
+    isClientTransaction,
   }) ?? formBag;
 
   return updatedFormBag;

--- a/src/v3/src/types/stepTransformer.ts
+++ b/src/v3/src/types/stepTransformer.ts
@@ -20,6 +20,7 @@ type IdxStepTransformerOptions = {
   prevTransaction?: IdxTransaction;
   formBag: FormBag;
   widgetProps: WidgetProps;
+  isClientTransaction?: boolean;
 };
 
 // TODO: remove
@@ -30,6 +31,7 @@ export type TransformationOptions = {
   transaction: IdxTransaction;
   prevTransaction?: IdxTransaction;
   step: string;
+  isClientTransaction?: boolean;
 };
 
 export type TransformStepFn = (formbag: FormBag) => FormBag;

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+import { setup } from './util';
+
+import * as cookieUtils from '../../src/util/cookieUtils';
+import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
+import wrongPasswordMockresponse from '../../src/mocks/response/idp/idx/identify/error-wrong-password.json';
+
+describe('identify-with-password-error-flow', () => {
+  it('should not pre-populate username into identifier field when set in cookie after an error', async () => {
+    const mockUsername = 'testuser@okta1.com';
+    jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
+    const {
+      user,
+      findByTestId,
+      findByText,
+    } = await setup({
+      mockResponses: {
+        '/introspect': {
+          data: mockResponse,
+          status: 200,
+        },
+        '/idp/idx/identify': {
+          data: wrongPasswordMockresponse,
+          status: 200,
+        },
+      },
+      widgetOptions: { features: { rememberMyUsernameOnOIE: true } },
+    });
+    
+    const submitButton = await findByText('Sign in', { selector: 'button' });
+    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
+
+    await user.clear(usernameEl);
+    await user.type(usernameEl, 'bad_user@bad.com');
+    await user.type(passwordEl, 'wrongPassword1234');
+    await user.click(submitButton);
+
+    await findByText('Unable to sign in');
+    expect((await findByTestId('identifier') as HTMLInputElement).value).not.toBe(mockUsername);
+  });
+});

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+
 import { setup } from './util';
 
 import * as cookieUtils from '../../src/util/cookieUtils';
@@ -36,7 +37,7 @@ describe('identify-with-password-error-flow', () => {
       },
       widgetOptions: { features: { rememberMyUsernameOnOIE: true } },
     });
-    
+
     const submitButton = await findByText('Sign in', { selector: 'button' });
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -19,6 +19,7 @@ import wrongPasswordMockresponse from '../../src/mocks/response/idp/idx/identify
 describe('identify-with-password-error-flow', () => {
   it('should not pre-populate username into identifier field when set in cookie after an error', async () => {
     const mockUsername = 'testuser@okta1.com';
+    const badUsername = 'bad_user@bad.com';
     jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
     const {
       user,
@@ -43,11 +44,11 @@ describe('identify-with-password-error-flow', () => {
     const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     await user.clear(usernameEl);
-    await user.type(usernameEl, 'bad_user@bad.com');
+    await user.type(usernameEl, badUsername);
     await user.type(passwordEl, 'wrongPassword1234');
     await user.click(submitButton);
 
     await findByText('Unable to sign in');
-    expect((await findByTestId('identifier') as HTMLInputElement).value).not.toBe(mockUsername);
+    expect((await findByTestId('identifier') as HTMLInputElement).value).toBe(badUsername);
   });
 });

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -15,6 +15,7 @@ import { setup } from './util';
 
 import * as cookieUtils from '../../src/util/cookieUtils';
 import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
+import wrongPasswordMockresponse from '../../src/mocks/response/idp/idx/identify/error-wrong-password.json';
 
 describe('identify-with-password', () => {
   it('renders the loading state first', async () => {
@@ -259,13 +260,26 @@ describe('identify-with-password', () => {
       findByTestId,
       findByText,
     } = await setup({
-      mockResponse,
+      //mockResponse,
+      mockResponses: {
+        '/introspect': {
+          data: mockResponse,
+          status: 200,
+        },
+        '/idx/challenge/answer': {
+          data: wrongPasswordMockresponse,
+          status: 200,
+        },
+      },
       widgetOptions: { features: { rememberMyUsernameOnOIE: true } },
     });
     const submitButton = await findByText('Sign in', { selector: 'button' });
     const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
 
     await user.clear(usernameEl);
+    await user.type(usernameEl, 'bad_user@bad.com');
+    await user.type(passwordEl, 'wrongPassword1234');
     await user.click(submitButton);
 
     expect(usernameEl.value).not.toBe(mockUsername);

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -15,7 +15,6 @@ import { setup } from './util';
 
 import * as cookieUtils from '../../src/util/cookieUtils';
 import mockResponse from '../../src/mocks/response/idp/idx/introspect/default.json';
-import wrongPasswordMockresponse from '../../src/mocks/response/idp/idx/identify/error-wrong-password.json';
 
 describe('identify-with-password', () => {
   it('renders the loading state first', async () => {
@@ -250,39 +249,6 @@ describe('identify-with-password', () => {
         expect(passwordError).toBeNull();
       });
     });
-  });
-
-  it('should not pre-populate username into identifier field when set in cookie after an error', async () => {
-    const mockUsername = 'testuser@okta1.com';
-    jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
-    const {
-      user,
-      findByTestId,
-      findByText,
-    } = await setup({
-      //mockResponse,
-      mockResponses: {
-        '/introspect': {
-          data: mockResponse,
-          status: 200,
-        },
-        '/idx/challenge/answer': {
-          data: wrongPasswordMockresponse,
-          status: 200,
-        },
-      },
-      widgetOptions: { features: { rememberMyUsernameOnOIE: true } },
-    });
-    const submitButton = await findByText('Sign in', { selector: 'button' });
-    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
-    const passwordEl = await findByTestId('credentials.passcode') as HTMLInputElement;
-
-    await user.clear(usernameEl);
-    await user.type(usernameEl, 'bad_user@bad.com');
-    await user.type(passwordEl, 'wrongPassword1234');
-    await user.click(submitButton);
-
-    expect(usernameEl.value).not.toBe(mockUsername);
   });
 
   describe('sends correct payload', () => {

--- a/src/v3/test/integration/identify-with-password.test.tsx
+++ b/src/v3/test/integration/identify-with-password.test.tsx
@@ -251,6 +251,26 @@ describe('identify-with-password', () => {
     });
   });
 
+  it('should not pre-populate username into identifier field when set in cookie after an error', async () => {
+    const mockUsername = 'testuser@okta1.com';
+    jest.spyOn(cookieUtils, 'getUsernameCookie').mockReturnValue(mockUsername);
+    const {
+      user,
+      findByTestId,
+      findByText,
+    } = await setup({
+      mockResponse,
+      widgetOptions: { features: { rememberMyUsernameOnOIE: true } },
+    });
+    const submitButton = await findByText('Sign in', { selector: 'button' });
+    const usernameEl = await findByTestId('identifier') as HTMLInputElement;
+
+    await user.clear(usernameEl);
+    await user.click(submitButton);
+
+    expect(usernameEl.value).not.toBe(mockUsername);
+  });
+
   describe('sends correct payload', () => {
     it('with all required fields', async () => {
       const {


### PR DESCRIPTION
## Description:

This PR fixes the issue of the Username field auto populates when another bad user tries to login.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-527591](https://oktainc.atlassian.net/browse/OKTA-527591)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



