### PR TITLE
OKTA-528694 - Adding aria attributes to error messages for screen readers

### DIFF
--- a/src/v3/src/components/InputPassword/InputPassword.tsx
+++ b/src/v3/src/components/InputPassword/InputPassword.tsx
@@ -66,12 +66,15 @@ const InputPassword: UISchemaElementComponent<UISchemaElementComponentWithValida
         fullWidth
         inputProps={{
           'data-se': name,
+          'aria-describedby': error && `${name}-error`,
           ...attributes,
         }}
         ref={focusRef}
       />
       {error && (
         <FormHelperText
+          id={`${name}-error`}
+          role="alert"
           data-se={`${name}-error`}
           error
         >

--- a/src/v3/src/components/InputText/InputText.tsx
+++ b/src/v3/src/components/InputText/InputText.tsx
@@ -69,12 +69,15 @@ const InputText: UISchemaElementComponent<UISchemaElementComponentWithValidation
         fullWidth
         inputProps={{
           'data-se': dataSe,
+          'aria-describedby': error && `${name}-error`,
           ...attributes,
         }}
         inputRef={focusRef}
       />
       {error && (
         <FormHelperText
+          id={`${name}-error`}
+          role="alert"
           data-se={`${dataSe}-error`}
           error
         >

--- a/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
+++ b/src/v3/src/components/PhoneAuthenticator/PhoneAuthenticator.tsx
@@ -190,11 +190,14 @@ const PhoneAuthenticator: UISchemaElementComponent<UISchemaElementComponentWithV
             fullWidth
             inputProps={{
               'data-se': fieldName,
+              'aria-describedby': error && `${fieldName}-error`,
               ...attributes,
             }}
           />
           {!!error && (
             <FormHelperText
+              id={`${fieldName}-error`}
+              role="alert"
               data-se={`${fieldName}-error`}
               error
             >

--- a/src/v3/src/components/Radio/Radio.tsx
+++ b/src/v3/src/components/Radio/Radio.tsx
@@ -59,6 +59,7 @@ const Radio: UISchemaElementComponent<{
       <RadioGroup
         name={name}
         id={name}
+        aria-describedby={error && `${name}-error`}
         value={value as string ?? ''}
         onChange={handleChange}
       >
@@ -76,7 +77,14 @@ const Radio: UISchemaElementComponent<{
         }
       </RadioGroup>
       {error && (
-        <FormHelperText>{error}</FormHelperText>
+        <FormHelperText
+          id={`${name}-error`}
+          role="alert"
+          data-se={`${name}-error`}
+          error
+        >
+          {error}
+        </FormHelperText>
       )}
     </FormControl>
   );

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -3132,6 +3132,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                               </p>
                             </span>
                             <input
+                              aria-describedby="authenticator.phoneNumber-error"
                               aria-invalid="true"
                               autocomplete="tel-national"
                               class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedStart emotion-44"
@@ -3158,6 +3159,8 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
                           <p
                             class="MuiFormHelperText-root Mui-error emotion-47"
                             data-se="authenticator.phoneNumber-error"
+                            id="authenticator.phoneNumber-error"
+                            role="alert"
                           >
                             This field cannot be left blank
                           </p>

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -268,6 +268,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                         class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-40"
                       >
                         <input
+                          aria-describedby="credentials.question-error"
                           aria-invalid="true"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-41"
                           data-se="credentials.question"
@@ -293,6 +294,8 @@ exports[`authenticator-enroll-security-question custom question fails client sid
                       <p
                         class="MuiFormHelperText-root Mui-error emotion-44"
                         data-se="credentials.question-error"
+                        id="credentials.question-error"
+                        role="alert"
                       >
                         This field cannot be left blank
                       </p>

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -741,6 +741,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                         class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
                       >
                         <input
+                          aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="one-time-code"
                           class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
@@ -767,6 +768,8 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                       <p
                         class="MuiFormHelperText-root Mui-error emotion-26"
                         data-se="credentials.passcode-error"
+                        id="credentials.passcode-error"
+                        role="alert"
                       >
                         Invalid code. Try again.
                       </p>

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -93,6 +93,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                       class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-17"
                     >
                       <input
+                        aria-describedby="identifier-error"
                         aria-invalid="true"
                         autocomplete="username"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
@@ -119,6 +120,8 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="identifier-error"
+                      id="identifier-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>
@@ -143,6 +146,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
                         class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-26"
                       >
                         <input
+                          aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="current-password"
                           class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
@@ -193,6 +197,8 @@ exports[`identify-with-password Client-side field change validation tests fails 
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>
@@ -396,6 +402,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-17"
                     >
                       <input
+                        aria-describedby="identifier-error"
                         aria-invalid="true"
                         autocomplete="username"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
@@ -422,6 +429,8 @@ exports[`identify-with-password Client-side field change validation tests should
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="identifier-error"
+                      id="identifier-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>
@@ -446,6 +455,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-26"
                       >
                         <input
+                          aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="current-password"
                           class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
@@ -496,6 +506,8 @@ exports[`identify-with-password Client-side field change validation tests should
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>
@@ -699,6 +711,7 @@ exports[`identify-with-password Client-side field change validation tests should
                       class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth Mui-focused emotion-17"
                     >
                       <input
+                        aria-describedby="identifier-error"
                         aria-invalid="true"
                         autocomplete="username"
                         class="MuiOutlinedInput-input MuiInputBase-input emotion-18"
@@ -725,6 +738,8 @@ exports[`identify-with-password Client-side field change validation tests should
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="identifier-error"
+                      id="identifier-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>
@@ -749,6 +764,7 @@ exports[`identify-with-password Client-side field change validation tests should
                         class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-26"
                       >
                         <input
+                          aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="current-password"
                           class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-27"
@@ -799,6 +815,8 @@ exports[`identify-with-password Client-side field change validation tests should
                     <p
                       class="MuiFormHelperText-root Mui-error emotion-21"
                       data-se="credentials.passcode-error"
+                      id="credentials.passcode-error"
+                      role="alert"
                     >
                       This field cannot be left blank
                     </p>

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -119,8 +119,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findAllByRole('alert');
-      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const [globalError] = await findAllByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -139,8 +139,8 @@ describe('authenticator-enroll-security-question', () => {
 
       // assert no error message
       await waitFor(() => {
-        const globalError = queryAllByRole('alert');
-        expect(globalError).toEqual([]);
+        const [globalError] = queryAllByRole('alert');
+        expect(globalError).toBeUndefined();
         const answerFieldError = queryByTestId('credentials.answer-error');
         expect(answerFieldError).toBeNull();
       });
@@ -464,8 +464,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findAllByRole('alert');
-      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const [globalError] = await findAllByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const questionFieldError = await findByTestId('credentials.question-error');
       expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -501,8 +501,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findAllByRole('alert');
-      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const [globalError] = await findAllByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -530,8 +530,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findAllByRole('alert');
-      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const [globalError] = await findAllByRole('alert');
+      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const questionFieldError = await findByTestId('credentials.question-error');
       expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -553,8 +553,8 @@ describe('authenticator-enroll-security-question', () => {
 
       // assert no error message
       await waitFor(() => {
-        const globalError = queryAllByRole('alert');
-        expect(globalError).toEqual([]);
+        const [globalError] = queryAllByRole('alert');
+        expect(globalError).toBeUndefined();
         const questionFieldError = queryByTestId('credentials.question-error');
         expect(questionFieldError).toBeNull();
         const answerFieldError = queryByTestId('credentials.answer-error');

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -106,7 +106,7 @@ describe('authenticator-enroll-security-question', () => {
 
     it('fails client side validation when answer is missing', async () => {
       const {
-        authClient, user, findByRole, findByTestId, findByText,
+        authClient, user, findAllByRole, findByTestId, findByText,
       } = await setup({ mockResponse });
 
       await findByText(/Set up security question/);
@@ -119,8 +119,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findByRole('alert');
-      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const globalError = await findAllByRole('alert');
+      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -128,7 +128,7 @@ describe('authenticator-enroll-security-question', () => {
 
     it('clears messages when switch to custom question form', async () => {
       const {
-        user, queryByRole, queryByTestId, findByText, findByLabelText,
+        user, queryAllByRole, findByText, findByLabelText, queryByTestId,
       } = await setup({ mockResponse });
 
       await findByText(/Set up security question/);
@@ -139,8 +139,8 @@ describe('authenticator-enroll-security-question', () => {
 
       // assert no error message
       await waitFor(() => {
-        const globalError = queryByRole('alert');
-        expect(globalError).toBeNull();
+        const globalError = queryAllByRole('alert');
+        expect(globalError).toEqual([]);
         const answerFieldError = queryByTestId('credentials.answer-error');
         expect(answerFieldError).toBeNull();
       });
@@ -442,7 +442,7 @@ describe('authenticator-enroll-security-question', () => {
         findByTestId,
         findByText,
         findByLabelText,
-        findByRole,
+        findAllByRole,
         queryByTestId,
       } = await setup({ mockResponse });
 
@@ -464,8 +464,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findByRole('alert');
-      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const globalError = await findAllByRole('alert');
+      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const questionFieldError = await findByTestId('credentials.question-error');
       expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -481,7 +481,7 @@ describe('authenticator-enroll-security-question', () => {
         findByTestId,
         findByText,
         findByLabelText,
-        findByRole,
+        findAllByRole,
         queryByTestId,
       } = await setup({ mockResponse });
 
@@ -501,8 +501,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findByRole('alert');
-      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const globalError = await findAllByRole('alert');
+      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const answerFieldError = await findByTestId('credentials.answer-error');
       expect(answerFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -517,7 +517,7 @@ describe('authenticator-enroll-security-question', () => {
         findByTestId,
         findByText,
         findByLabelText,
-        findByRole,
+        findAllByRole,
       } = await setup({ mockResponse });
 
       // switch to custom question form
@@ -530,8 +530,8 @@ describe('authenticator-enroll-security-question', () => {
         expect.anything(),
       );
       // assert global alert
-      const globalError = await findByRole('alert');
-      expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+      const globalError = await findAllByRole('alert');
+      expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
       // assert field level error
       const questionFieldError = await findByTestId('credentials.question-error');
       expect(questionFieldError.innerHTML).toEqual('This field cannot be left blank');
@@ -541,7 +541,7 @@ describe('authenticator-enroll-security-question', () => {
 
     it('clears messages when switch to predefined question form', async () => {
       const {
-        user, queryByRole, queryByTestId, findByText, findByLabelText,
+        user, queryAllByRole, queryByTestId, findByText, findByLabelText,
       } = await setup({ mockResponse });
 
       // switch to custom question form
@@ -553,8 +553,8 @@ describe('authenticator-enroll-security-question', () => {
 
       // assert no error message
       await waitFor(() => {
-        const globalError = queryByRole('alert');
-        expect(globalError).toBeNull();
+        const globalError = queryAllByRole('alert');
+        expect(globalError).toEqual([]);
         const questionFieldError = queryByTestId('credentials.question-error');
         expect(questionFieldError).toBeNull();
         const answerFieldError = queryByTestId('credentials.answer-error');

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -26,12 +26,12 @@ describe('identify-recovery', () => {
       user,
       findByTestId,
       findByText,
-      findByRole,
+      findAllByRole,
     } = await setup({ mockResponse });
 
     await user.click(await findByText('Next', { selector: 'button' }));
-    const globalError = await findByRole('alert');
-    expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+    const globalError = await findAllByRole('alert');
+    expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
     const identifierError = await findByTestId('identifier-error');
     expect(identifierError.textContent).toEqual('This field cannot be left blank');
   });

--- a/src/v3/test/integration/identify-recovery.test.tsx
+++ b/src/v3/test/integration/identify-recovery.test.tsx
@@ -30,8 +30,8 @@ describe('identify-recovery', () => {
     } = await setup({ mockResponse });
 
     await user.click(await findByText('Next', { selector: 'button' }));
-    const globalError = await findAllByRole('alert');
-    expect(globalError[0].innerHTML).toContain('We found some errors. Please review the form and make corrections.');
+    const [globalError] = await findAllByRole('alert');
+    expect(globalError.innerHTML).toContain('We found some errors. Please review the form and make corrections.');
     const identifierError = await findByTestId('identifier-error');
     expect(identifierError.textContent).toEqual('This field cannot be left blank');
   });

--- a/src/v3/test/integration/user-unlock-account.test.tsx
+++ b/src/v3/test/integration/user-unlock-account.test.tsx
@@ -25,7 +25,7 @@ describe('user-unlock-account', () => {
 
   it('should display client-side validation errors when trying to submit the flow without a username', async () => {
     const {
-      authClient, user, findByTestId, findByRole,
+      authClient, user, findByTestId, findAllByRole,
     } = await setup({ mockResponse });
 
     await findByTestId('identifier') as HTMLInputElement;
@@ -37,8 +37,8 @@ describe('user-unlock-account', () => {
       'https://oie-4695462.oktapreview.com/idp/idx/challenge',
       expect.anything(),
     );
-    const alertBox = await findByRole('alert');
-    within(alertBox).findByText(/We found some errors/);
+    const alertBox = await findAllByRole('alert');
+    within(alertBox[0]).findByText(/We found some errors/);
     const identifierError = await findByTestId('identifier-error');
     expect(identifierError.textContent).toEqual('This field cannot be left blank');
   });

--- a/src/v3/test/integration/user-unlock-account.test.tsx
+++ b/src/v3/test/integration/user-unlock-account.test.tsx
@@ -37,8 +37,8 @@ describe('user-unlock-account', () => {
       'https://oie-4695462.oktapreview.com/idp/idx/challenge',
       expect.anything(),
     );
-    const alertBox = await findAllByRole('alert');
-    within(alertBox[0]).findByText(/We found some errors/);
+    const [alertBox] = await findAllByRole('alert');
+    within(alertBox).findByText(/We found some errors/);
     const identifierError = await findByTestId('identifier-error');
     expect(identifierError.textContent).toEqual('This field cannot be left blank');
   });


### PR DESCRIPTION
## Description:
The purpose of this PR is to add the missing aria attributes that allows screen readers to read out field level error messages.


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-528694](https://oktainc.atlassian.net/browse/OKTA-528694)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



