### PR TITLE
OKTA-529389 : Preserve user provided data during error scenarios

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -183,8 +183,8 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     dataSchemaRef.current = formBag.dataSchema;
     if (isClientTransaction) {
       setData((prev) => ({
-        ...prev,
         ...formBag.data,
+        ...prev,
       }));
     } else {
       setData(formBag.data);

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -162,7 +162,6 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
       prevTransaction: prevIdxTransactionRef.current,
       step,
       widgetProps,
-      isClientTransaction,
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/v3/src/transformer/identify/transformIdentify.ts
+++ b/src/v3/src/transformer/identify/transformIdentify.ts
@@ -25,7 +25,6 @@ export const transformIdentify: IdxStepTransformer = ({
   formBag,
   widgetProps,
   transaction,
-  isClientTransaction,
 }) => {
   const { features, username } = widgetProps;
   const { uischema, data } = formBag;
@@ -34,7 +33,7 @@ export const transformIdentify: IdxStepTransformer = ({
     'identifier',
     uischema.elements as UISchemaElement[],
   ) as FieldElement;
-  if (identifierElement && !isClientTransaction) {
+  if (identifierElement) {
     // add username/identifier from config if provided
     if (username) {
       data.identifier = username;

--- a/src/v3/src/transformer/layout/transform.ts
+++ b/src/v3/src/transformer/layout/transform.ts
@@ -21,7 +21,6 @@ export const transformLayout: TransformStepFnWithOptions = (options) => (formBag
     transaction,
     prevTransaction,
     step,
-    isClientTransaction,
   } = options;
 
   const authenticatorKey = getAuthenticatorKey(transaction) ?? AUTHENTICATOR_KEY.DEFAULT;
@@ -31,7 +30,6 @@ export const transformLayout: TransformStepFnWithOptions = (options) => (formBag
     prevTransaction,
     formBag,
     widgetProps,
-    isClientTransaction,
   }) ?? formBag;
 
   return updatedFormBag;

--- a/src/v3/src/types/stepTransformer.ts
+++ b/src/v3/src/types/stepTransformer.ts
@@ -20,7 +20,6 @@ type IdxStepTransformerOptions = {
   prevTransaction?: IdxTransaction;
   formBag: FormBag;
   widgetProps: WidgetProps;
-  isClientTransaction?: boolean;
 };
 
 // TODO: remove
@@ -31,7 +30,6 @@ export type TransformationOptions = {
   transaction: IdxTransaction;
   prevTransaction?: IdxTransaction;
   step: string;
-  isClientTransaction?: boolean;
 };
 
 export type TransformStepFn = (formbag: FormBag) => FormBag;


### PR DESCRIPTION
## Description:

Purpose of this PR is to preserve user entered data when there are error scenarios. This prevents the widget from prompting for user data when the field already has information in the input fields (during error scenarios).

I did not add an automation test here because we already had one that covered this exact scenario from another ticket, see: https://github.com/okta/okta-signin-widget/blob/0.0/src/v3/test/integration/identify-with-password-error-flow.test.tsx#L52

This change covers all scenarios instead of just the username/identifier scenario.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-529389](https://oktainc.atlassian.net/browse/OKTA-529389)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



