### PR TITLE
chore: fix CI verify-package

### DIFF
--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -35,7 +35,25 @@ mv node_modules node_modules2
 
 # Verify minimum supported version of node
 
-if ! setup_service node v12.22.0; then
+EXPECTED_NODE_VERSION=12.22.0
+
+function install_node() {
+    nvm install ${EXPECTED_NODE_VERSION}
+    nvm use ${EXPECTED_NODE_VERSION}
+    nvm unalias default
+    nvm alias "default" "${EXPECTED_NODE_VERSION}"
+    npm config set prefix=/root/.nvm/versions/node/v${EXPECTED_NODE_VERSION}/bin
+    export PATH=$(echo ${PATH} | sed "s/node\/v[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\/bin/node\/v${EXPECTED_NODE_VERSION}\/bin/")
+
+  node -v
+    if [[ "$(node -v)" != "v${EXPECTED_NODE_VERSION}" ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+if ! install_node; then
   echo "setup_service returned non-zero exit code";
   node --version
 fi

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -34,29 +34,8 @@ fi
 mv node_modules node_modules2
 
 # Verify minimum supported version of node
-
-EXPECTED_NODE_VERSION=12.22.0
-
-function install_node() {
-    nvm install ${EXPECTED_NODE_VERSION}
-    nvm use ${EXPECTED_NODE_VERSION}
-    nvm unalias default
-    nvm alias "default" "${EXPECTED_NODE_VERSION}"
-    npm config set prefix=/root/.nvm/versions/node/v${EXPECTED_NODE_VERSION}/bin
-    export PATH=$(echo ${PATH} | sed "s/node\/v[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\/bin/node\/v${EXPECTED_NODE_VERSION}\/bin/")
-
-  node -v
-    if [[ "$(node -v)" != "v${EXPECTED_NODE_VERSION}" ]]; then
-        return 1
-    else
-        return 0
-    fi
-}
-
-if ! install_node; then
-  echo "setup_service returned non-zero exit code";
-  node --version
-fi
+nvm uninstall current
+setup_service node v12.22.0
 
 # Verify minimum supported version of yarn
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -34,7 +34,11 @@ fi
 mv node_modules node_modules2
 
 # Verify minimum supported version of node
-setup_service node v12.22.0
+
+if ! setup_service node v12.22.0; then
+  echo "setup_service returned non-zero exit code";
+  node --version
+fi
 
 # Verify minimum supported version of yarn
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ORIGINAL_PATH=$PATH
+
 source $OKTA_HOME/$REPO/scripts/setup.sh
 
 export PATH="${PATH}:$(yarn global bin)"
@@ -34,12 +36,13 @@ fi
 mv node_modules node_modules2
 
 # Verify minimum supported version of node
-nvm uninstall current
+export PATH=$ORIGINAL_PATH
 setup_service node v12.22.0
 
 # Verify minimum supported version of yarn
 # Use the cacert bundled with centos as okta root CA is self-signed and cause issues downloading from yarn
 setup_service yarn 1.7.0 /etc/pki/tls/certs/ca-bundle.crt
+export PATH="${PATH}:$(yarn global bin)"
 
 pushd test/package/tsc
 if ! (yarn && yarn test); then


### PR DESCRIPTION
## Description:
Fix issue that is breaking verify-package

When a node version is installed the PATH is modified. The way this logic is currently implemented causes an error on subsequent node installs.  Workaround by saving ORIGINAL_PATH


## PR Checklist

- [ ] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-529523](https://oktainc.atlassian.net/browse/OKTA-529523)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



