### PR TITLE
OKTA-527004 : Error link focus fix 

### DIFF
--- a/src/v3/src/components/Form/Layout.tsx
+++ b/src/v3/src/components/Form/Layout.tsx
@@ -21,7 +21,7 @@ import {
   UISchemaLayout,
   UISchemaLayoutType,
 } from '../../types';
-import { isDevelopmentEnvironment, isInteractiveType, isTestEnvironment } from '../../util';
+import { isDevelopmentEnvironment, isTestEnvironment } from '../../util';
 import renderers from './renderers';
 // eslint-disable-next-line import/no-cycle
 import Stepper from './Stepper';
@@ -42,7 +42,6 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
 
   const isHorizontalLayout = type === UISchemaLayoutType.HORIZONTAL;
   const flexDirection = isHorizontalLayout ? 'row' : 'column';
-  let firstFieldFound = false;
   return (
     <Box
       display="flex"
@@ -85,11 +84,6 @@ const Layout: FunctionComponent<LayoutProps> = ({ uischema }) => {
           }
 
           const uischemaElement = (element as UISchemaElement);
-          if (isInteractiveType(uischemaElement.type) && !firstFieldFound) {
-            uischemaElement.focus = true;
-            firstFieldFound = true;
-          }
-
           const Component = renderer.renderer as UISchemaElementComponent;
           return (
             <Box

--- a/src/v3/src/components/Link/Link.tsx
+++ b/src/v3/src/components/Link/Link.tsx
@@ -13,7 +13,7 @@
 import { Link as LinkMui } from '@mui/material';
 import { h } from 'preact';
 
-import { useOnSubmit } from '../../hooks';
+import { useAutoFocus, useOnSubmit } from '../../hooks';
 import { ClickHandler, LinkElement, UISchemaElementComponent } from '../../types';
 
 const Link: UISchemaElementComponent<{
@@ -29,10 +29,10 @@ const Link: UISchemaElementComponent<{
       step,
       onClick: onClickHandler,
     },
+    focus,
   } = uischema;
   const onSubmitHandler = useOnSubmit();
-  // TO DO: https://oktainc.atlassian.net/browse/OKTA-527004
-  // const focusRef = useAutoFocus<HTMLAnchorElement>(focus);
+  const focusRef = useAutoFocus<HTMLAnchorElement>(focus);
 
   const onClick: ClickHandler = async (e) => {
     e.preventDefault();
@@ -52,7 +52,7 @@ const Link: UISchemaElementComponent<{
         href="javascript:void(0)"
         onClick={onClickHandler || onClick}
         onMouseDown={onMouseDown}
-        // ref={focusRef}
+        ref={focusRef}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...(dataSe && { 'data-se': dataSe } )}
       >
@@ -63,7 +63,7 @@ const Link: UISchemaElementComponent<{
         <LinkMui
           href={href}
           onMouseDown={onMouseDown}
-          // ref={focusRef}
+          ref={focusRef}
         >
           {label}
         </LinkMui>

--- a/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
+++ b/src/v3/src/transformer/layout/email/emailChallengeTransformer.ts
@@ -53,6 +53,9 @@ export const transformEmailChallenge: IdxStepTransformer = ({ transaction, formB
     'credentials.passcode',
     uischema.elements as UISchemaElement[],
   );
+  if (passcodeElement) {
+    passcodeElement.focus = true;
+  }
 
   const redactedEmailAddress = nextStep.relatesTo?.value?.profile?.email;
   const maginLinkText = redactedEmailAddress

--- a/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
+++ b/src/v3/src/transformer/terminal/transformTerminalTransaction.ts
@@ -44,6 +44,7 @@ import {
   setUsernameCookie,
 } from '../../util';
 import { redirectTransformer } from '../redirect';
+import { setFocusOnFirstElement } from '../uischema';
 import { createForm } from '../utils';
 import { transformTerminalMessages } from './transformTerminalMessages';
 
@@ -257,6 +258,8 @@ export const transformTerminalTransaction = (
   transformTerminalMessages(transaction, formBag);
 
   appendViewLinks(transaction, formBag.uischema, widgetProps, bootstrapFn);
+
+  setFocusOnFirstElement(formBag);
 
   return formBag;
 };

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -10,9 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { flow } from 'lodash';
+
 import {
+  TransformStepFn,
   TransformStepFnWithOptions,
+  UISchemaElement,
 } from '../../types';
+import { isInteractiveType } from '../../util';
 import { traverseLayout } from '../util';
 
 const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
@@ -28,6 +33,23 @@ const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formba
   return formbag;
 };
 
+export const setFocusOnFirstElement: TransformStepFn = (formbag) => {
+  let firstFieldFound = false;
+  traverseLayout({
+    layout: formbag.uischema,
+    predicate: (el) => (!firstFieldFound && isInteractiveType(el.type)),
+    callback: (el) => {
+      const uischemaElement = (el as UISchemaElement);
+      uischemaElement.focus = true;
+      firstFieldFound = true;
+    },
+  });
+  return formbag;
+};
+
 export const transformUISchema: TransformStepFnWithOptions = (
   options,
-) => (formbag) => addKeyToElement(options)(formbag);
+) => (formbag) => flow(
+  addKeyToElement(options),
+  setFocusOnFirstElement,
+)(formbag);

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -491,7 +491,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
                         Enter code
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-21"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
                       >
                         <input
                           aria-invalid="false"
@@ -1045,7 +1045,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
                         Enter code
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused emotion-21"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-21"
                       >
                         <input
                           aria-invalid="false"

--- a/src/v3/test/integration/error-session-expired.test.tsx
+++ b/src/v3/test/integration/error-session-expired.test.tsx
@@ -14,6 +14,7 @@ import { setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/error-session-expired.json';
 import identifyWithPassword from '../../src/mocks/response/idp/idx/introspect/default.json';
+import { waitFor } from '@testing-library/preact';
 
 describe('error-session-expired', () => {
   it('should render form', async () => {
@@ -58,5 +59,12 @@ describe('error-session-expired', () => {
         withCredentials: true,
       },
     );
+  });
+
+  it('should have focus on "Back to sign in" link', async () => {
+    const { findByText } = await setup({ mockResponse });
+    await findByText(/You have been logged out due to inactivity. Refresh or return to the sign in screen./);
+    const cancelLink = await findByText(/Back to sign in/);
+    await waitFor(() => expect(cancelLink).toHaveFocus());
   });
 });

--- a/src/v3/test/integration/error-session-expired.test.tsx
+++ b/src/v3/test/integration/error-session-expired.test.tsx
@@ -10,11 +10,11 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+import { waitFor } from '@testing-library/preact';
 import { setup } from './util';
 
 import mockResponse from '../../src/mocks/response/idp/idx/identify/error-session-expired.json';
 import identifyWithPassword from '../../src/mocks/response/idp/idx/introspect/default.json';
-import { waitFor } from '@testing-library/preact';
 
 describe('error-session-expired', () => {
   it('should render form', async () => {


### PR DESCRIPTION
## Description:

This PR fixes the issue of the `Back to sign in` link being not in focus when the session expired error appears.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-527004](https://oktainc.atlassian.net/browse/OKTA-527004)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



