### PR TITLE
OKTA-516622 : Global error message implementation

### DIFF
--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -224,11 +224,16 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
      * i.e. unlocking an account and immeidiately being challenged with a different authenticator
      * when that is the case, we need to check the authenticator key to
      * determine if they are the same (as you shouldn't be challenged with the same authenticator)
+     * But if for some reason the keys are the same between them, we perform a last ditch check
+     * against the current authenticator's ID, which should always be unique between challenges
     */
     const pollingTxAuthKey = getAuthenticatorKey(pollingTransaction);
     const currentTxAuthKey = getAuthenticatorKey(idxTransaction);
+    const pollingTxAuthId = pollingTransaction.context.currentAuthenticator?.value?.id;
+    const currentTxAuthId = idxTransaction.context.currentAuthenticator?.value?.id;
     if (pollingTransaction.nextStep?.name !== idxTransaction.nextStep?.name
-        || pollingTxAuthKey !== currentTxAuthKey) {
+        || pollingTxAuthKey !== currentTxAuthKey
+        || pollingTxAuthId !== currentTxAuthId) {
       setIdxTransaction(pollingTransaction);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/v3/src/components/Widget/index.tsx
+++ b/src/v3/src/components/Widget/index.tsx
@@ -20,7 +20,6 @@ import {
   IdxStatus,
   IdxTransaction,
 } from '@okta/okta-auth-js';
-import isEqual from 'lodash/isEqual';
 import { FunctionComponent, h } from 'preact';
 import {
   useCallback,
@@ -223,19 +222,12 @@ export const Widget: FunctionComponent<WidgetProps> = (widgetProps) => {
     /**
      * polling transaction name can sometimes be the same as the current transaction's name
      * i.e. unlocking an account and immeidiately being challenged with a different authenticator
-     * when that is the case, we need to compare inputs to determine if it is the same transaction
-     * lastly, inputs could also be the same (i.e. email otp to password) in that case we finally
-     * check the authenticator key to determine if they are the same
-     * (as you shouldnt be challenged with the same authenticator)
+     * when that is the case, we need to check the authenticator key to
+     * determine if they are the same (as you shouldn't be challenged with the same authenticator)
     */
-    const pollingTxAndCurrentTxInputsDiffer = !isEqual(
-      pollingTransaction.nextStep?.inputs,
-      idxTransaction.nextStep?.inputs,
-    );
     const pollingTxAuthKey = getAuthenticatorKey(pollingTransaction);
     const currentTxAuthKey = getAuthenticatorKey(idxTransaction);
     if (pollingTransaction.nextStep?.name !== idxTransaction.nextStep?.name
-        || pollingTxAndCurrentTxInputsDiffer
         || pollingTxAuthKey !== currentTxAuthKey) {
       setIdxTransaction(pollingTransaction);
     }

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -10,13 +10,14 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import { AuthApiError, IdxActionParams } from '@okta/okta-auth-js';
+import { AuthApiError, IdxActionParams, IdxMessage } from '@okta/okta-auth-js';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
 import { useCallback } from 'preact/hooks';
 
+import { IDX_STEP } from '../constants';
 import { useWidgetContext } from '../contexts';
-import { getImmutableData, toNestedObject } from '../util';
+import { getImmutableData, loc, toNestedObject } from '../util';
 
 type OnSubmitHandlerOptions = {
   includeData?: boolean;
@@ -100,8 +101,21 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     try {
       const newTransaction = await fn(payload);
       setIdxTransaction(newTransaction);
-      const isClientTransaction = newTransaction.nextStep?.name === currTransaction?.nextStep?.name;
+      const isClientTransaction = !(newTransaction.requestDidSucceed ?? true);
       setIsClientTransaction(isClientTransaction);
+      if (isClientTransaction
+          && !newTransaction.messages?.length
+          // TODO: OKTA-521014 below logic only needed because of this bug, remove once fixed
+          && newTransaction.nextStep?.name
+          && ![IDX_STEP.SELECT_AUTHENTICATOR_ENROLL,
+            IDX_STEP.SELECT_AUTHENTICATOR_AUTHENTICATE,
+          ].includes(newTransaction.nextStep.name)) {
+        setMessage({
+          message: loc('oform.errorbanner.title', 'login'),
+          class: 'ERROR',
+          i18n: { key: 'oform.errorbanner.title' },
+        } as IdxMessage);
+      }
       setStepToRender(stepToRender);
     } catch (error) {
       handleError(error);

--- a/src/v3/src/hooks/useOnSubmit.ts
+++ b/src/v3/src/hooks/useOnSubmit.ts
@@ -101,7 +101,7 @@ export const useOnSubmit = (): (options: OnSubmitHandlerOptions) => Promise<void
     try {
       const newTransaction = await fn(payload);
       setIdxTransaction(newTransaction);
-      const isClientTransaction = !(newTransaction.requestDidSucceed ?? true);
+      const isClientTransaction = !newTransaction.requestDidSucceed;
       setIsClientTransaction(isClientTransaction);
       if (isClientTransaction
           && !newTransaction.messages?.length

--- a/src/v3/src/mocks/scenario/securityquestion-enroll-mfa.ts
+++ b/src/v3/src/mocks/scenario/securityquestion-enroll-mfa.ts
@@ -61,13 +61,15 @@ scenario('securityquestion-enroll-mfa', (rest) => ([
     const request = req.body as Record<string, any>;
     const answer = request.credentials?.answer;
     let response = null;
+    let responseStatus = 200;
     if (answer?.length < 4) {
       response = (await import('../response/idp/idx/challenge/answer/enroll-security-question-with-character-limit-error.json')).default;
+      responseStatus = 400;
     } else {
       response = (await import('../response/oauth2/default/v1/token/default.json')).default;
     }
     return res(
-      ctx.status(200),
+      ctx.status(responseStatus),
       ctx.json(response),
     );
   }),

--- a/src/v3/src/mocks/scenario/securityquestion-enroll-mfa.ts
+++ b/src/v3/src/mocks/scenario/securityquestion-enroll-mfa.ts
@@ -60,18 +60,17 @@ scenario('securityquestion-enroll-mfa', (rest) => ([
   rest.post('*/idp/idx/challenge/answer', async (req, res, ctx) => {
     const request = req.body as Record<string, any>;
     const answer = request.credentials?.answer;
-    let response = null;
-    let responseStatus = 200;
     if (answer?.length < 4) {
-      response = (await import('../response/idp/idx/challenge/answer/enroll-security-question-with-character-limit-error.json')).default;
-      responseStatus = 400;
+      return res(
+        ctx.status(400),
+        ctx.json((await import('../response/idp/idx/challenge/answer/enroll-security-question-with-character-limit-error.json')).default),
+      );
     } else {
-      response = (await import('../response/oauth2/default/v1/token/default.json')).default;
+      return res(
+        ctx.status(200),
+        ctx.json((await import('../response/oauth2/default/v1/token/default.json')).default),
+      );
     }
-    return res(
-      ctx.status(responseStatus),
-      ctx.json(response),
-    );
   }),
 
   // get oauth2 token

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -17,7 +17,7 @@ import {
   TransformStepFnWithOptions,
   UISchemaElement,
 } from '../../types';
-import { isInteractiveType } from '../../util';
+import { generateUUID, isInteractiveType } from '../../util';
 import { traverseLayout } from '../util';
 
 const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
@@ -26,8 +26,16 @@ const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formba
     predicate: (element) => !!element.type,
     callback: (element) => {
       const { nextStep: { name } = {} } = transaction;
-      // eslint-disable-next-line no-param-reassign
-      element.key = element.key ? `${name}_${element.key}` : name;
+      // We need Reminder Elements to unmount from view when new transaction
+      // is set, this prevents this alert and error alerts from both displaying
+      // at the same time
+      if (element.type === 'Reminder') {
+        // eslint-disable-next-line no-param-reassign
+        element.key = `${name}_${generateUUID()}`;
+      } else {
+        // eslint-disable-next-line no-param-reassign
+        element.key = element.key ? `${name}_${element.key}` : name;
+      }
     },
   });
   return formbag;

--- a/src/v3/src/transformer/uischema/transform.ts
+++ b/src/v3/src/transformer/uischema/transform.ts
@@ -17,7 +17,7 @@ import {
   TransformStepFnWithOptions,
   UISchemaElement,
 } from '../../types';
-import { generateUUID, isInteractiveType } from '../../util';
+import { generateRandomString, isInteractiveType } from '../../util';
 import { traverseLayout } from '../util';
 
 const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formbag) => {
@@ -31,7 +31,7 @@ const addKeyToElement: TransformStepFnWithOptions = ({ transaction }) => (formba
       // at the same time
       if (element.type === 'Reminder') {
         // eslint-disable-next-line no-param-reassign
-        element.key = `${name}_${generateUUID()}`;
+        element.key = `${name}_${generateRandomString()}`;
       } else {
         // eslint-disable-next-line no-param-reassign
         element.key = element.key ? `${name}_${element.key}` : name;

--- a/src/v3/src/util/generateRandomString.ts
+++ b/src/v3/src/util/generateRandomString.ts
@@ -10,6 +10,5 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-// eslint-disable-next-line max-len
-export const generateUUID = (): string => Date.now().toString(36)
+export const generateRandomString = (): string => Date.now().toString(36)
   + Math.random().toString(36).substring(2);

--- a/src/v3/src/util/generateUUID.ts
+++ b/src/v3/src/util/generateUUID.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+// eslint-disable-next-line max-len
+export const generateUUID = (): string => Date.now().toString(36)
+  + Math.random().toString(36).substring(2);

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -15,7 +15,7 @@ export * from './cookieUtils';
 export * from './environmentUtils';
 export * from './flattenInputs';
 export * from './formUtils';
-export * from './generateUUID';
+export * from './generateRandomString';
 export * from './getAuthenticatorKey';
 export * from './getImmutableData';
 export * from './getTranslation';

--- a/src/v3/src/util/index.ts
+++ b/src/v3/src/util/index.ts
@@ -15,6 +15,7 @@ export * from './cookieUtils';
 export * from './environmentUtils';
 export * from './flattenInputs';
 export * from './formUtils';
+export * from './generateUUID';
 export * from './getAuthenticatorKey';
 export * from './getImmutableData';
 export * from './getTranslation';

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -502,7 +502,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                   class="identifier identifierSpan MuiBox-root emotion-4"
                   data-se="identifier"
                 >
-                  tester35@test.com
+                  tester14@test.com
                 </span>
               </div>
             </div>
@@ -772,6 +772,419 @@ exports[`authenticator-enroll-security-question custom question renders correct 
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-53"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-enroll-security-question custom question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinSecurityQuestionAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinSecurityQuestionAuthenticator"
+                >
+                  Security Question
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester35@test.com
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-10"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-11"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-12"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-14"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%;"
+            >
+              <div
+                class="MuiBox-root emotion-15"
+              >
+                <div
+                  class="MuiBox-root emotion-15"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-19"
+                        data-se="o-form-head"
+                      >
+                        Set up security question
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root emotion-21"
+                    >
+                      
+                      <div
+                        class="MuiFormGroup-root emotion-22"
+                        role="radiogroup"
+                      >
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-28"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-35"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
+                        for="credentials.question"
+                      >
+                        Create my own security question
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth emotion-40"
+                      >
+                        <input
+                          aria-invalid="false"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-41"
+                          data-se="credentials.question"
+                          id="credentials.question"
+                          name="credentials.question"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-42"
+                        >
+                          <legend
+                            class="emotion-43"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-39"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
+                        >
+                          <input
+                            aria-describedby="credentials.answer-error"
+                            aria-invalid="true"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-42"
+                          >
+                            <legend
+                              class="emotion-43"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-55"
+                        data-se="credentials.answer-error"
+                        id="credentials.answer-error"
+                        role="alert"
+                      >
+                        The security question answer must be at least 4 characters in length
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-57"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-59"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -1255,6 +1668,1540 @@ exports[`authenticator-enroll-security-question predefined question renders corr
                 >
                   <a
                     class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-48"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-enroll-security-question predefined question should send correct payload when toggling between question types and submitted form with incorrect number of characters 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinSecurityQuestionAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinSecurityQuestionAuthenticator"
+                >
+                  Security Question
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester35@test.com
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-10"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-11"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-12"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-14"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%;"
+            >
+              <div
+                class="MuiBox-root emotion-15"
+              >
+                <div
+                  class="MuiBox-root emotion-15"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-19"
+                        data-se="o-form-head"
+                      >
+                        Set up security question
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root emotion-21"
+                    >
+                      
+                      <div
+                        class="MuiFormGroup-root emotion-22"
+                        role="radiogroup"
+                      >
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-28"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-35"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      >
+                        <label
+                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                          for="credentials.questionKey"
+                        >
+                          <span
+                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <div
+                          class="ods-mUkyrD"
+                        >
+                          <select
+                            class="ods-1B2Zfy"
+                            id="credentials.questionKey"
+                            name="credentials.questionKey"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              value="disliked_food"
+                            >
+                              What is the food you least liked as a child?
+                            </option>
+                            <option
+                              value="name_of_first_plush_toy"
+                            >
+                              What is the name of your first stuffed animal?
+                            </option>
+                            <option
+                              value="first_award"
+                            >
+                              What did you earn your first medal or award for?
+                            </option>
+                            <option
+                              value="favorite_security_question"
+                            >
+                              What is your favorite security question?
+                            </option>
+                            <option
+                              value="favorite_toy"
+                            >
+                              What is the toy/stuffed animal you liked the most as a kid?
+                            </option>
+                            <option
+                              value="first_computer_game"
+                            >
+                              What was the first computer game you played?
+                            </option>
+                            <option
+                              value="favorite_movie_quote"
+                            >
+                              What is your favorite movie quote?
+                            </option>
+                            <option
+                              value="first_sports_team_mascot"
+                            >
+                              What was the mascot of the first sports team you played on?
+                            </option>
+                            <option
+                              value="first_music_purchase"
+                            >
+                              What music album or song did you first purchase?
+                            </option>
+                            <option
+                              value="favorite_art_piece"
+                            >
+                              What is your favorite piece of art?
+                            </option>
+                            <option
+                              value="grandmother_favorite_desert"
+                            >
+                              What was your grandmother's favorite dessert?
+                            </option>
+                            <option
+                              value="first_thing_cooked"
+                            >
+                              What was the first thing you learned to cook?
+                            </option>
+                            <option
+                              value="childhood_dream_job"
+                            >
+                              What was your dream job as a child?
+                            </option>
+                            <option
+                              value="place_where_significant_other_was_met"
+                            >
+                              Where did you meet your spouse/significant other?
+                            </option>
+                            <option
+                              value="favorite_vacation_location"
+                            >
+                              Where did you go for your favorite vacation?
+                            </option>
+                            <option
+                              value="new_years_two_thousand"
+                            >
+                              Where were you on New Year's Eve in the year 2000?
+                            </option>
+                            <option
+                              value="favorite_speaker_actor"
+                            >
+                              Who is your favorite speaker/orator?
+                            </option>
+                            <option
+                              value="favorite_book_movie_character"
+                            >
+                              Who is your favorite book/movie character?
+                            </option>
+                            <option
+                              value="favorite_sports_player"
+                            >
+                              Who is your favorite sports player?
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
+                          >
+                            <svg
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-42"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                        >
+                          <input
+                            aria-describedby="credentials.answer-error"
+                            aria-invalid="true"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-46"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-47"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-48"
+                          >
+                            <legend
+                              class="emotion-49"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-50"
+                        data-se="credentials.answer-error"
+                        id="credentials.answer-error"
+                        role="alert"
+                      >
+                        The security question answer must be at least 4 characters in length
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-52"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-enroll-security-question predefined question should show field level character count error message on multiple attempts to submit with invalid character count 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinSecurityQuestionAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinSecurityQuestionAuthenticator"
+                >
+                  Security Question
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester35@test.com
+                </span>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%;"
+            >
+              <div
+                class="MuiBox-root emotion-10"
+              >
+                <div
+                  class="MuiBox-root emotion-10"
+                >
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-13"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-14"
+                        data-se="o-form-head"
+                      >
+                        Set up security question
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root emotion-16"
+                    >
+                      
+                      <div
+                        class="MuiFormGroup-root emotion-17"
+                        role="radiogroup"
+                      >
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-19"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
+                            />
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-23"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-18"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-19"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-20"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-21"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-22"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-30"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-24"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      >
+                        <label
+                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                          for="credentials.questionKey"
+                        >
+                          <span
+                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <div
+                          class="ods-mUkyrD"
+                        >
+                          <select
+                            class="ods-1B2Zfy"
+                            id="credentials.questionKey"
+                            name="credentials.questionKey"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              value="disliked_food"
+                            >
+                              What is the food you least liked as a child?
+                            </option>
+                            <option
+                              value="name_of_first_plush_toy"
+                            >
+                              What is the name of your first stuffed animal?
+                            </option>
+                            <option
+                              value="first_award"
+                            >
+                              What did you earn your first medal or award for?
+                            </option>
+                            <option
+                              value="favorite_security_question"
+                            >
+                              What is your favorite security question?
+                            </option>
+                            <option
+                              value="favorite_toy"
+                            >
+                              What is the toy/stuffed animal you liked the most as a kid?
+                            </option>
+                            <option
+                              value="first_computer_game"
+                            >
+                              What was the first computer game you played?
+                            </option>
+                            <option
+                              value="favorite_movie_quote"
+                            >
+                              What is your favorite movie quote?
+                            </option>
+                            <option
+                              value="first_sports_team_mascot"
+                            >
+                              What was the mascot of the first sports team you played on?
+                            </option>
+                            <option
+                              value="first_music_purchase"
+                            >
+                              What music album or song did you first purchase?
+                            </option>
+                            <option
+                              value="favorite_art_piece"
+                            >
+                              What is your favorite piece of art?
+                            </option>
+                            <option
+                              value="grandmother_favorite_desert"
+                            >
+                              What was your grandmother's favorite dessert?
+                            </option>
+                            <option
+                              value="first_thing_cooked"
+                            >
+                              What was the first thing you learned to cook?
+                            </option>
+                            <option
+                              value="childhood_dream_job"
+                            >
+                              What was your dream job as a child?
+                            </option>
+                            <option
+                              value="place_where_significant_other_was_met"
+                            >
+                              Where did you meet your spouse/significant other?
+                            </option>
+                            <option
+                              value="favorite_vacation_location"
+                            >
+                              Where did you go for your favorite vacation?
+                            </option>
+                            <option
+                              value="new_years_two_thousand"
+                            >
+                              Where were you on New Year's Eve in the year 2000?
+                            </option>
+                            <option
+                              value="favorite_speaker_actor"
+                            >
+                              Who is your favorite speaker/orator?
+                            </option>
+                            <option
+                              value="favorite_book_movie_character"
+                            >
+                              Who is your favorite book/movie character?
+                            </option>
+                            <option
+                              value="favorite_sports_player"
+                            >
+                              Who is your favorite sports player?
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
+                          >
+                            <svg
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-37"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-38"
+                        >
+                          <input
+                            aria-describedby="credentials.answer-error"
+                            aria-invalid="true"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-39"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-40"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-41"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-42"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-43"
+                          >
+                            <legend
+                              class="emotion-44"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-45"
+                        data-se="credentials.answer-error"
+                        id="credentials.answer-error"
+                        role="alert"
+                      >
+                        The security question answer must be at least 4 characters in length
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-12"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-47"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-12"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-49"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`authenticator-enroll-security-question predefined question should show field level character count error message when invalid number of characters are sent and field should retain characters 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-security-question authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinSecurityQuestionAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinSecurityQuestionAuthenticator"
+                >
+                  Security Question
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="m24.25 39.123-4.615-3.433a21.799 21.799 0 0 1-8.827-16.259l-.329-5.738 12.84-4.534a2.818 2.818 0 0 1 1.862 0l12.84 4.534-.329 5.738a21.8 21.8 0 0 1-8.827 16.259l-4.615 3.433ZM11.521 14.387l.285 4.987a20.811 20.811 0 0 0 8.425 15.514l4.019 2.989 4.019-2.989a20.81 20.81 0 0 0 8.425-15.514l.285-4.987L24.848 10.1a1.792 1.792 0 0 0-1.2 0l-12.127 4.287Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M29.44 19.729a5.007 5.007 0 0 0-8.846-2.356 4.484 4.484 0 0 0-.827 4.385l.929-.367A3.48 3.48 0 0 1 21.369 18a4.027 4.027 0 1 1 5.244 5.972C25 25 23.5 26.252 23.5 28.528h1c0-1.691 1.058-2.7 2.646-3.707a5.067 5.067 0 0 0 2.294-5.092Zm-5.454 12.246a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  tester35@test.com
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-10"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-11"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-12"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-14"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%;"
+            >
+              <div
+                class="MuiBox-root emotion-15"
+              >
+                <div
+                  class="MuiBox-root emotion-15"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-18"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-19"
+                        data-se="o-form-head"
+                      >
+                        Set up security question
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <fieldset
+                      class="MuiFormControl-root emotion-21"
+                    >
+                      
+                      <div
+                        class="MuiFormGroup-root emotion-22"
+                        role="radiogroup"
+                      >
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root Mui-checked emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="predefined"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-28"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <label
+                          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-23"
+                        >
+                          <span
+                            class="MuiRadio-root MuiRadio-colorPrimary MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root emotion-24"
+                          >
+                            <input
+                              class="PrivateSwitchBase-input emotion-25"
+                              name="questionType"
+                              type="radio"
+                              value="custom"
+                            />
+                            <span
+                              class="emotion-26"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-27"
+                                data-testid="RadioButtonUncheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                                />
+                              </svg>
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-35"
+                                data-testid="RadioButtonCheckedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          <span
+                            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-29"
+                          >
+                            Create my own security question
+                          </span>
+                        </label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="ods-4o5zYQ ods-76eppy ods-2Se4oq ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-4zKnH2"
+                      >
+                        <label
+                          class="ods-4o5zYQ ods-76eppy ods-5VQ9Rl ods-7KS5Kt ods-2oc5SK ods-4XAbls ods-2NLKpK ods-1ll9ky ods-4IdjLs ods-g8inGu"
+                          for="credentials.questionKey"
+                        >
+                          <span
+                            class="ods-4o5zYQ ods-nqMobL ods-5fvoER ods-6rDd3P ods-7KlglL ods-6MIfC2 ods-14pjkk ods-5IIKpe ods-6iOjmZ"
+                          >
+                            Choose a security question
+                          </span>
+                        </label>
+                        <div
+                          class="ods-mUkyrD"
+                        >
+                          <select
+                            class="ods-1B2Zfy"
+                            id="credentials.questionKey"
+                            name="credentials.questionKey"
+                          >
+                            <option
+                              value=""
+                            />
+                            <option
+                              value="disliked_food"
+                            >
+                              What is the food you least liked as a child?
+                            </option>
+                            <option
+                              value="name_of_first_plush_toy"
+                            >
+                              What is the name of your first stuffed animal?
+                            </option>
+                            <option
+                              value="first_award"
+                            >
+                              What did you earn your first medal or award for?
+                            </option>
+                            <option
+                              value="favorite_security_question"
+                            >
+                              What is your favorite security question?
+                            </option>
+                            <option
+                              value="favorite_toy"
+                            >
+                              What is the toy/stuffed animal you liked the most as a kid?
+                            </option>
+                            <option
+                              value="first_computer_game"
+                            >
+                              What was the first computer game you played?
+                            </option>
+                            <option
+                              value="favorite_movie_quote"
+                            >
+                              What is your favorite movie quote?
+                            </option>
+                            <option
+                              value="first_sports_team_mascot"
+                            >
+                              What was the mascot of the first sports team you played on?
+                            </option>
+                            <option
+                              value="first_music_purchase"
+                            >
+                              What music album or song did you first purchase?
+                            </option>
+                            <option
+                              value="favorite_art_piece"
+                            >
+                              What is your favorite piece of art?
+                            </option>
+                            <option
+                              value="grandmother_favorite_desert"
+                            >
+                              What was your grandmother's favorite dessert?
+                            </option>
+                            <option
+                              value="first_thing_cooked"
+                            >
+                              What was the first thing you learned to cook?
+                            </option>
+                            <option
+                              value="childhood_dream_job"
+                            >
+                              What was your dream job as a child?
+                            </option>
+                            <option
+                              value="place_where_significant_other_was_met"
+                            >
+                              Where did you meet your spouse/significant other?
+                            </option>
+                            <option
+                              value="favorite_vacation_location"
+                            >
+                              Where did you go for your favorite vacation?
+                            </option>
+                            <option
+                              value="new_years_two_thousand"
+                            >
+                              Where were you on New Year's Eve in the year 2000?
+                            </option>
+                            <option
+                              value="favorite_speaker_actor"
+                            >
+                              Who is your favorite speaker/orator?
+                            </option>
+                            <option
+                              value="favorite_book_movie_character"
+                            >
+                              Who is your favorite book/movie character?
+                            </option>
+                            <option
+                              value="favorite_sports_player"
+                            >
+                              Who is your favorite sports player?
+                            </option>
+                          </select>
+                          <span
+                            class="ods-7mdg51"
+                          >
+                            <svg
+                              class="ods-2icygl"
+                              fill="none"
+                              role="presentation"
+                              viewBox="0 0 16 16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                clip-rule="evenodd"
+                                d="M8 10.2929L12.6464 5.64645L13.3536 6.35355L8.35355 11.3536C8.15829 11.5488 7.84171 11.5488 7.64645 11.3536L2.64645 6.35355L3.35355 5.64645L8 10.2929Z"
+                                fill="currentColor"
+                                fill-rule="evenodd"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <div
+                        class="MuiBox-root emotion-4"
+                      >
+                        <label
+                          class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-42"
+                          for="credentials.answer"
+                        >
+                          Answer
+                        </label>
+                        <div
+                          class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-43"
+                        >
+                          <input
+                            aria-describedby="credentials.answer-error"
+                            aria-invalid="true"
+                            class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-44"
+                            data-se="credentials.answer"
+                            id="credentials.answer"
+                            name="credentials.answer"
+                            type="password"
+                          />
+                          <div
+                            class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-45"
+                          >
+                            <button
+                              aria-label="toggle password visibility"
+                              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-46"
+                              data-mui-internal-clone-element="true"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-47"
+                                data-testid="VisibilityIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                                />
+                              </svg>
+                            </button>
+                          </div>
+                          <fieldset
+                            aria-hidden="true"
+                            class="MuiOutlinedInput-notchedOutline emotion-48"
+                          >
+                            <legend
+                              class="emotion-49"
+                            >
+                              <span
+                                class="notranslate"
+                              >
+                                ​
+                              </span>
+                            </legend>
+                          </fieldset>
+                        </div>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-50"
+                        data-se="credentials.answer-error"
+                        id="credentials.answer-error"
+                        role="alert"
+                      >
+                        The security question answer must be at least 4 characters in length
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-52"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Return to authenticator list
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-54"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -682,6 +682,35 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                 </span>
               </div>
             </div>
+            <div
+              class="MuiBox-root emotion-10"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-11"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-12"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-14"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
             <form
               class="o-form"
               data-se="form"
@@ -689,22 +718,22 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               style="max-width: 100%;"
             >
               <div
-                class="MuiBox-root emotion-10"
+                class="MuiBox-root emotion-15"
               >
                 <div
-                  class="MuiBox-root emotion-10"
+                  class="MuiBox-root emotion-15"
                 >
                   <div
-                    class="MuiBox-root emotion-12"
+                    class="MuiBox-root emotion-17"
                   />
                   <div
-                    class="MuiBox-root emotion-12"
+                    class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-19"
                     >
                       <h2
-                        class="MuiTypography-root MuiTypography-h3 emotion-15"
+                        class="MuiTypography-root MuiTypography-h3 emotion-20"
                         data-se="o-form-head"
                       >
                         Verify with your email
@@ -712,13 +741,13 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-12"
+                    class="MuiBox-root emotion-17"
                   >
                     <div
-                      class="MuiBox-root emotion-14"
+                      class="MuiBox-root emotion-19"
                     >
                       <p
-                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-18"
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-23"
                         data-se="o-form-explain"
                       >
                         We sent an email to t***t@idx.com. Click the verification link in your email to continue or enter the code below.
@@ -726,25 +755,25 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-12"
+                    class="MuiBox-root emotion-17"
                   >
                     <div
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-21"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-26"
                         for="credentials.passcode"
                       >
                         Enter Code
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-22"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-27"
                       >
                         <input
                           aria-describedby="credentials.passcode-error"
                           aria-invalid="true"
                           autocomplete="one-time-code"
-                          class="MuiOutlinedInput-input MuiInputBase-input emotion-23"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-28"
                           data-se="credentials.passcode"
                           id="credentials.passcode"
                           name="credentials.passcode"
@@ -752,10 +781,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                         />
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-24"
+                          class="MuiOutlinedInput-notchedOutline emotion-29"
                         >
                           <legend
-                            class="emotion-25"
+                            class="emotion-30"
                           >
                             <span
                               class="notranslate"
@@ -766,7 +795,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                         </fieldset>
                       </div>
                       <p
-                        class="MuiFormHelperText-root Mui-error emotion-26"
+                        class="MuiFormHelperText-root Mui-error emotion-31"
                         data-se="credentials.passcode-error"
                         id="credentials.passcode-error"
                         role="alert"
@@ -776,10 +805,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                     </div>
                   </div>
                   <div
-                    class="MuiBox-root emotion-12"
+                    class="MuiBox-root emotion-17"
                   >
                     <button
-                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-28"
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-33"
                       data-type="save"
                       tabindex="0"
                       type="submit"
@@ -789,10 +818,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                     data-se="switchAuthenticator"
                     href="javascript:void(0)"
                   >
@@ -800,10 +829,10 @@ exports[`authenticator-verification-email renders correct form renders the otp c
                   </a>
                 </div>
                 <div
-                  class="MuiBox-root emotion-12"
+                  class="MuiBox-root emotion-17"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-30"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-35"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -849,6 +849,306 @@ exports[`authenticator-verification-email renders correct form renders the otp c
 </div>
 `;
 
+exports[`authenticator-verification-email renders correct form should display reminder prompt, then global error after invalid entry and finally display reminder again with global error 1`] = `
+<div>
+  <div
+    class="MuiScopedCssBaseline-root emotion-0"
+  >
+    <span>
+      <main
+        class="auth-container main-container mainViewContainer MuiBox-root emotion-1"
+        data-commit="b9bbc0140703c3fbf0e2e58920362e70"
+        data-version="0.0.0"
+        id="okta-sign-in"
+      >
+        <div
+          class="siwContainer MuiBox-root emotion-2"
+        >
+          <div
+            class="okta-sign-in-header auth-header siwHeader authCoinSpacing"
+          >
+            <h1
+              class="MuiTypography-root MuiTypography-h1 emotion-3"
+            />
+            <div
+              class="iconContainer mfa-okta-email authCoinOverlay MuiBox-root emotion-4"
+            >
+              <svg
+                aria-labelledby="authCoinEmailAuthenticator"
+                fill="none"
+                height="48"
+                role="img"
+                viewBox="0 0 48 48"
+                width="48"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title
+                  id="authCoinEmailAuthenticator"
+                >
+                  Email Authentication
+                </title>
+                <circle
+                  class="siwFillBg"
+                  cx="24"
+                  cy="24"
+                  fill="#F5F5F6"
+                  r="24"
+                />
+                <path
+                  class="siwFillSecondary"
+                  d="M32 18v1h5.3L32 24.29v1.42l6-6.01v12.8a1.5 1.5 0 0 1-1.5 1.5h-17a1.5 1.5 0 0 1-1.5-1.5V31h-1v1.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V18h-7Z"
+                  fill="#A7B5EC"
+                />
+                <path
+                  class="siwFillPrimary"
+                  d="M9 13v14.5a2.5 2.5 0 0 0 2.5 2.5h17a2.5 2.5 0 0 0 2.5-2.5V13H9Zm20.293 1-8.81 8.81L10.794 14h18.499ZM28.5 29h-17a1.5 1.5 0 0 1-1.5-1.5V14.63l10.517 9.56L30 14.707V27.5a1.5 1.5 0 0 1-1.5 1.5Z"
+                  fill="#00297A"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root emotion-5"
+          >
+            <div
+              class="identifier-container MuiBox-root emotion-6"
+            >
+              <div
+                class="identifierContainer MuiBox-root emotion-7"
+              >
+                <span
+                  class="userIconContainer MuiBox-root emotion-4"
+                >
+                  <svg
+                    class="ods-2icygl"
+                    fill="none"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      clip-rule="evenodd"
+                      d="M10 3V5C10 6.10457 9.10457 7 8 7C6.89543 7 6 6.10457 6 5V3C6 1.89543 6.89543 1 8 1C9.10457 1 10 1.89543 10 3ZM5 3C5 1.34315 6.34315 0 8 0C9.65685 0 11 1.34315 11 3V5C11 6.65685 9.65685 8 8 8C6.34315 8 5 6.65685 5 5V3ZM4.1305 10.0742C4.26803 10.0181 4.459 10 5.41376 10H10.5862C11.541 10 11.732 10.0181 11.8695 10.0742C12.0299 10.1398 12.1706 10.2459 12.2777 10.3821C12.3695 10.4989 12.4393 10.6776 12.7016 11.5956L13.6743 15H2.32573L3.29841 11.5956C3.5607 10.6776 3.63054 10.4989 3.72233 10.3821C3.82941 10.2459 3.97006 10.1398 4.1305 10.0742ZM13.6631 11.3209L14.7143 15L15 16H13.96H2.04002H1L1.28571 15L2.33689 11.3209C2.57458 10.489 2.69343 10.073 2.93606 9.76423C3.15022 9.49171 3.43152 9.27953 3.75239 9.14848C4.11592 9 4.54854 9 5.41376 9H10.5862C11.4515 9 11.8841 9 12.2476 9.14848C12.5685 9.27953 12.8498 9.49171 13.0639 9.76423C13.3066 10.073 13.4254 10.489 13.6631 11.3209Z"
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="identifier identifierSpan MuiBox-root emotion-4"
+                  data-se="identifier"
+                >
+                  testUser@okta.com
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root emotion-10"
+            >
+              <div
+                class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxError MuiAlert-infobox emotion-11"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon emotion-12"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message emotion-14"
+                >
+                  We found some errors. Please review the form and make corrections.
+                </div>
+              </div>
+            </div>
+            <form
+              class="o-form"
+              data-se="form"
+              novalidate=""
+              style="max-width: 100%;"
+            >
+              <div
+                class="MuiBox-root emotion-15"
+              >
+                <div
+                  class="MuiBox-root emotion-15"
+                >
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-17"
+                    >
+                      <div
+                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-infoboxWarning MuiAlert-infobox emotion-19"
+                        role="alert"
+                      >
+                        <div
+                          class="MuiAlert-icon emotion-20"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit emotion-13"
+                            data-testid="ReportProblemOutlinedIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z"
+                            />
+                          </svg>
+                        </div>
+                        <div
+                          class="MuiAlert-message emotion-14"
+                        >
+                          <div
+                            class="MuiBox-root emotion-23"
+                          >
+                            Haven't received an email?
+                          </div>
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                            href="javascript:void(0);"
+                          >
+                            Send again
+                          </a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-26"
+                    >
+                      <h2
+                        class="MuiTypography-root MuiTypography-h3 emotion-27"
+                        data-se="o-form-head"
+                      >
+                        Verify with your email
+                      </h2>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-26"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 MuiTypography-paragraph emotion-30"
+                        data-se="o-form-explain"
+                      >
+                        We sent an email to t***t@idx.com. Click the verification link in your email to continue or enter the code below.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <div
+                      class="MuiBox-root emotion-4"
+                    >
+                      <label
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-33"
+                        for="credentials.passcode"
+                      >
+                        Enter Code
+                      </label>
+                      <div
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary Mui-error MuiInputBase-fullWidth emotion-34"
+                      >
+                        <input
+                          aria-describedby="credentials.passcode-error"
+                          aria-invalid="true"
+                          autocomplete="one-time-code"
+                          class="MuiOutlinedInput-input MuiInputBase-input emotion-35"
+                          data-se="credentials.passcode"
+                          id="credentials.passcode"
+                          name="credentials.passcode"
+                          type="text"
+                        />
+                        <fieldset
+                          aria-hidden="true"
+                          class="MuiOutlinedInput-notchedOutline emotion-36"
+                        >
+                          <legend
+                            class="emotion-37"
+                          >
+                            <span
+                              class="notranslate"
+                            >
+                              ​
+                            </span>
+                          </legend>
+                        </fieldset>
+                      </div>
+                      <p
+                        class="MuiFormHelperText-root Mui-error emotion-38"
+                        data-se="credentials.passcode-error"
+                        id="credentials.passcode-error"
+                        role="alert"
+                      >
+                        Invalid code. Try again.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root emotion-17"
+                  >
+                    <button
+                      class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-40"
+                      data-type="save"
+                      tabindex="0"
+                      type="submit"
+                    >
+                      Verify
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="switchAuthenticator"
+                    href="javascript:void(0)"
+                  >
+                    Verify with something else
+                  </a>
+                </div>
+                <div
+                  class="MuiBox-root emotion-17"
+                >
+                  <a
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-24"
+                    data-se="cancel"
+                    href="javascript:void(0)"
+                  >
+                    Back to sign in
+                  </a>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`authenticator-verification-email renders correct form should render session expired terminal view when polling results in expired session 1`] = `
 <div>
   <div

--- a/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
+++ b/src/v3/test/integration/authenticator-enroll-security-question.test.tsx
@@ -39,16 +39,19 @@ describe('authenticator-enroll-security-question', () => {
       }
 
       if (url.endsWith('/idp/idx/challenge/answer')) {
-        let response;
         const { data } = options;
         const answer = JSON.parse(data).credentials?.answer;
         if (answer?.length < 4) {
-          response = responseWithCharacterLimitError;
-        } else {
-          response = {};
+          // eslint-disable-next-line prefer-promise-reject-errors
+          return Promise.reject({
+            responseText: JSON.stringify(responseWithCharacterLimitError),
+            status: 401,
+            headers: {},
+          });
         }
         return Promise.resolve({
-          responseText: JSON.stringify(response),
+          responseText: JSON.stringify({}),
+          status: 200,
         });
       }
 
@@ -148,7 +151,7 @@ describe('authenticator-enroll-security-question', () => {
 
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
-        user, authClient, findByText, findByTestId,
+        user, authClient, container, findByText, findByTestId,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       await findByText(/Set up security question/);
@@ -183,11 +186,12 @@ describe('authenticator-enroll-security-question', () => {
       // Previously entered characters should remain in the field
       expect((await findByTestId('credentials.answer') as HTMLInputElement).value).toBe(answer);
       expect(answerEleError.innerHTML).toEqual('The security question answer must be at least 4 characters in length');
+      expect(container).toMatchSnapshot();
     });
 
     it('should show field level character count error message on multiple attempts to submit with invalid character count', async () => {
       const {
-        user, authClient, findByText, findByTestId,
+        user, authClient, container, findByText, findByTestId,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       await findByText(/Set up security question/);
@@ -244,11 +248,12 @@ describe('authenticator-enroll-security-question', () => {
       );
       expect((await findByTestId('credentials.answer-error')).innerHTML)
         .toEqual('The security question answer must be at least 4 characters in length');
+      expect(container).toMatchSnapshot();
     });
 
     it('should send correct payload when toggling between question types and submitted form with incorrect number of characters', async () => {
       const {
-        user, authClient, findByText, findByTestId, findByLabelText,
+        user, authClient, container, findByText, findByTestId, findByLabelText,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       await findByText(/Set up security question/);
@@ -352,6 +357,7 @@ describe('authenticator-enroll-security-question', () => {
       expect((await findByTestId('credentials.answer') as HTMLInputElement).value).toBe(answer);
       expect((await findByTestId('credentials.answer-error')).innerHTML)
         .toEqual('The security question answer must be at least 4 characters in length');
+      expect(container).toMatchSnapshot();
       await user.click(await findByText('Verify', { selector: 'button' }));
       expect(authClient.options.httpRequestClient).toHaveBeenCalledWith(
         'POST',
@@ -564,7 +570,7 @@ describe('authenticator-enroll-security-question', () => {
 
     it('should show field level character count error message when invalid number of characters are sent and field should retain characters', async () => {
       const {
-        user, authClient, findByText, findByTestId, findByLabelText,
+        user, authClient, container, findByText, findByTestId, findByLabelText,
       } = await setup({ mockRequestClient: mockRequestClientWithError });
 
       await findByText(/Set up security question/);
@@ -609,6 +615,7 @@ describe('authenticator-enroll-security-question', () => {
       // Previously entered characters should remain in the field
       expect((await findByTestId('credentials.answer') as HTMLInputElement).value).toBe(answer);
       expect(answerEleError.innerHTML).toEqual('The security question answer must be at least 4 characters in length');
+      expect(container).toMatchSnapshot();
     });
   });
 });

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -81,6 +81,7 @@ describe('authenticator-verification-email', () => {
         user,
         findByText,
         findByTestId,
+        queryByText,
       } = await setup({
         mockResponses: {
           '/introspect': {
@@ -124,6 +125,10 @@ describe('authenticator-verification-email', () => {
         },
       );
 
+      act(() => {
+        jest.advanceTimersByTime(31_000);
+      });
+      await findByText(/Haven't received an email?/);
       // render invalid otp message
       const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
       const submitButton = await findByText('Verify', { selector: 'button' });
@@ -131,6 +136,9 @@ describe('authenticator-verification-email', () => {
       await user.type(codeEle, verificationCode);
       await user.click(submitButton);
       await findByText('Invalid code. Try again.');
+      // After an error, verify that the Reminder prompt is removed in lieu of the global error
+      expect(queryByText(/Haven't received an email?/)).toBeNull();
+      await findByText(/We found some errors./);
       expect(container).toMatchSnapshot();
 
       // allow polling request to be triggered

--- a/src/v3/test/integration/authenticator-verification-email.test.tsx
+++ b/src/v3/test/integration/authenticator-verification-email.test.tsx
@@ -74,6 +74,57 @@ describe('authenticator-verification-email', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('should display reminder prompt, then global error after invalid entry and finally display reminder again with global error', async () => {
+      const {
+        container,
+        user,
+        findByText,
+        findByTestId,
+        queryByText,
+      } = await setup({
+        mockResponses: {
+          '/introspect': {
+            data: authenticatorVerificationEmail,
+            status: 200,
+          },
+          '/challenge/poll': {
+            data: authenticatorVerificationEmail,
+            status: 200,
+          },
+          '/challenge/answer': {
+            data: authenticatorVerificationEmailInvalidOtp,
+            status: 401,
+          },
+        },
+      });
+      await findByText(/Verify with your email/);
+      await user.click(await findByText(/Enter a code from the email instead/));
+      await findByText(/Enter Code/);
+
+      act(() => {
+        jest.advanceTimersByTime(31_000);
+      });
+      await findByText(/Haven't received an email?/);
+
+      const codeEle = await findByTestId('credentials.passcode') as HTMLInputElement;
+      const submitButton = await findByText('Verify', { selector: 'button' });
+      const verificationCode = '123456';
+      await user.type(codeEle, verificationCode);
+      await user.click(submitButton);
+      await findByText('Invalid code. Try again.');
+      // After an error, verify that the Reminder prompt is removed in lieu of the global error
+      expect(queryByText(/Haven't received an email?/)).toBeNull();
+      await findByText(/We found some errors./);
+
+      act(() => {
+        jest.advanceTimersByTime(31_000);
+      });
+      // after delay, reminder should be displayed as well as global error
+      await findByText(/We found some errors./);
+      await findByText(/Haven't received an email?/);
+      expect(container).toMatchSnapshot();
+    });
+
     it('renders the otp challenge form', async () => {
       const {
         authClient,

--- a/src/v3/test/integration/identify-with-password-error-flow.test.tsx
+++ b/src/v3/test/integration/identify-with-password-error-flow.test.tsx
@@ -33,7 +33,7 @@ describe('identify-with-password-error-flow', () => {
         },
         '/idp/idx/identify': {
           data: wrongPasswordMockresponse,
-          status: 200,
+          status: 401,
         },
       },
       widgetOptions: { features: { rememberMyUsernameOnOIE: true } },


### PR DESCRIPTION
## Description:

This PR is to implement the global error message to be displayed when there are transaction errors. Additionally, this makes the reminder prompt unmount when there are transaction errors (to prevent the global error and reminder prompt from being displayed at the same time).


## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [x] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-516622](https://oktainc.atlassian.net/browse/OKTA-516622)

### Reviewers:

### Screenshot/Video:


https://user-images.githubusercontent.com/97472729/188007637-df5c14da-0b22-472d-8254-841c48783b2d.mov


### Downstream Monolith Build:



