### PR TITLE
Escapes regular expressions passed to password validators

### DIFF
--- a/src/v3/src/util/passwordUtils.test.ts
+++ b/src/v3/src/util/passwordUtils.test.ts
@@ -201,6 +201,21 @@ describe('PasswordUtils Tests', () => {
       .toEqual(true);
     expect(validatePassword('testpass', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
       .toEqual(true);
+
+    userInfo = { identifier: 'tester.user+123@okta.com' };
+
+    expect(validatePassword('tester.user', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
+      .toEqual(true);
+    expect(validatePassword('tester.user@okta.com', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
+      .toEqual(true);
+    expect(validatePassword('tester.user+123@okta.com', userInfo, { complexity: { excludeUsername: true } })?.excludeUsername)
+      .toEqual(false);
+    expect(validatePassword('tester.user', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
+      .toEqual(true);
+    expect(validatePassword('tester.user@okta.com', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
+      .toEqual(true);
+    expect(validatePassword('tester.user+123@okta.com', userInfo, { complexity: { excludeUsername: false } })?.excludeUsername)
+      .toEqual(true);
   });
 
   it('should validate excludeFirstName', () => {

--- a/src/v3/src/util/passwordUtils.ts
+++ b/src/v3/src/util/passwordUtils.ts
@@ -48,13 +48,20 @@ const minSymbolValidator = (password: string, limit: unknown): boolean => (
   !(limit as number) || (password.match(/["!#$%&'()*+,-./\\:;<=>?@[\]^_`{|}~]/)?.length || 0) >= (limit as number)
 );
 
+/**
+ * The MDN recommended expression for escaping all special characters in RegExp
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ */
+
+const escapeRegExp = (input: string): string => input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const excludeAttributeValidator = (
   password: string,
   ruleEnabled: boolean,
   attributeVal: string,
 ): boolean => {
   if (ruleEnabled) {
-    return password ? !new RegExp(attributeVal, 'i').test(password) : false;
+    return password ? !new RegExp(escapeRegExp(attributeVal), 'i').test(password) : false;
   }
   return true;
 };


### PR DESCRIPTION
## Description:

Escape regular expression strings before passing them to the `RegExp` constructor so that special characters in the attribute to be checked against do not get treated as regular expression special tokens.

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [x] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521321](https://oktainc.atlassian.net/browse/OKTA-521321)

### Reviewers:

### Screenshot/Video:


### Downstream Monolith Build:



