### PR TITLE
OKTA-521282 : Remove server side password validations

### DIFF
--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -98,6 +98,5 @@ export const getAgeItems = (age?: AgeRequirements): ListItem[] => {
 };
 
 export const buildPasswordRequirementListItems = (data: PasswordSettings): ListItem[] => {
-  const complexityItems = getComplexityItems(data.complexity);
-  return [...complexityItems];
+  return getComplexityItems(data.complexity);
 };

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -97,6 +97,7 @@ export const getAgeItems = (age?: AgeRequirements): ListItem[] => {
   return items;
 };
 
+// eslint-disable-next-line arrow-body-style
 export const buildPasswordRequirementListItems = (data: PasswordSettings): ListItem[] => {
   return getComplexityItems(data.complexity);
 };

--- a/src/v3/src/transformer/password/passwordSettingsUtils.ts
+++ b/src/v3/src/transformer/password/passwordSettingsUtils.ts
@@ -99,6 +99,5 @@ export const getAgeItems = (age?: AgeRequirements): ListItem[] => {
 
 export const buildPasswordRequirementListItems = (data: PasswordSettings): ListItem[] => {
   const complexityItems = getComplexityItems(data.complexity);
-  const ageItems = getAgeItems(data.age);
-  return [...complexityItems, ...ageItems];
+  return [...complexityItems];
 };

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -321,43 +321,6 @@ exports[`authenticator-expired-password should render form 1`] = `
                           </span>
                         </div>
                       </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        <div
-                          class="MuiBox-root emotion-4"
-                        >
-                          <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-18"
-                          >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <title
-                                id="generated"
-                              >
-                                info
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="MuiBox-root emotion-4"
-                          >
-                            Your password cannot be any of your last 4 passwords
-                          </span>
-                        </div>
-                      </li>
                     </ul>
                   </div>
                 </div>
@@ -371,36 +334,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -413,10 +376,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -439,36 +402,36 @@ exports[`authenticator-expired-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -481,10 +444,10 @@ exports[`authenticator-expired-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -501,7 +464,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -513,7 +476,7 @@ exports[`authenticator-expired-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -446,43 +446,6 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                           </span>
                         </div>
                       </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        <div
-                          class="MuiBox-root emotion-4"
-                        >
-                          <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-21"
-                          >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <title
-                                id="generated"
-                              >
-                                info
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="MuiBox-root emotion-4"
-                          >
-                            Your password cannot be any of your last 4 passwords
-                          </span>
-                        </div>
-                      </li>
                     </ul>
                   </div>
                 </div>
@@ -496,36 +459,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-50"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-51"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-52"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-53"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-54"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-55"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -538,10 +501,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-56"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-57"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -564,36 +527,36 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-50"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-47"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-51"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-48"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-52"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-49"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-53"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-50"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-54"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-51"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-55"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -606,10 +569,10 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-56"
+                          class="MuiOutlinedInput-notchedOutline emotion-53"
                         >
                           <legend
-                            class="emotion-57"
+                            class="emotion-54"
                           >
                             <span
                               class="notranslate"
@@ -626,7 +589,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-70"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-67"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -638,7 +601,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-72"
+                    class="MuiButton-root MuiButton-floating MuiButton-floatingPrimary MuiButton-sizeMedium MuiButton-floatingSizeMedium MuiButton-disableElevation MuiButtonBase-root  emotion-69"
                     tabindex="0"
                     type="button"
                   >
@@ -649,7 +612,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-74"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-71"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -321,43 +321,6 @@ exports[`authenticator-reset-password should render form 1`] = `
                           </span>
                         </div>
                       </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        <div
-                          class="MuiBox-root emotion-4"
-                        >
-                          <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-18"
-                          >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <title
-                                id="generated"
-                              >
-                                info
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="MuiBox-root emotion-4"
-                          >
-                            Your password cannot be any of your last 4 passwords
-                          </span>
-                        </div>
-                      </li>
                     </ul>
                   </div>
                 </div>
@@ -371,36 +334,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -413,10 +376,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -439,36 +402,36 @@ exports[`authenticator-reset-password should render form 1`] = `
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -481,10 +444,10 @@ exports[`authenticator-reset-password should render form 1`] = `
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -501,7 +464,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -513,7 +476,7 @@ exports[`authenticator-reset-password should render form 1`] = `
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >
@@ -851,43 +814,6 @@ exports[`authenticator-reset-password should render form with custom brand name 
                           </span>
                         </div>
                       </li>
-                      <li
-                        class="ods-5vIIsH"
-                      >
-                        <div
-                          class="MuiBox-root emotion-4"
-                        >
-                          <div
-                            class="passwordRequirementIcon info MuiBox-root emotion-18"
-                          >
-                            <svg
-                              aria-labelledby="generated"
-                              class="ods-2icygl"
-                              fill="none"
-                              role="img"
-                              viewBox="0 0 16 16"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <title
-                                id="generated"
-                              >
-                                info
-                              </title>
-                              <path
-                                clip-rule="evenodd"
-                                d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM8 5.5C8.14834 5.5 8.29334 5.45601 8.41668 5.3736C8.54001 5.29119 8.63614 5.17406 8.69291 5.03701C8.74968 4.89997 8.76453 4.74917 8.73559 4.60368C8.70665 4.4582 8.63522 4.32456 8.53033 4.21967C8.42544 4.11478 8.2918 4.04335 8.14632 4.01441C8.00083 3.98547 7.85003 4.00033 7.71299 4.05709C7.57594 4.11386 7.45881 4.20999 7.3764 4.33332C7.29399 4.45666 7.25 4.60166 7.25 4.75C7.25 4.94891 7.32902 5.13968 7.46967 5.28033C7.61032 5.42098 7.80109 5.5 8 5.5ZM8 7C8.27614 7 8.5 7.22386 8.5 7.5V12H7.5V7.5C7.5 7.22386 7.72386 7 8 7Z"
-                                fill="currentColor"
-                                fill-rule="evenodd"
-                              />
-                            </svg>
-                          </div>
-                          <span
-                            class="MuiBox-root emotion-4"
-                          >
-                            Your password cannot be any of your last 4 passwords
-                          </span>
-                        </div>
-                      </li>
                     </ul>
                   </div>
                 </div>
@@ -901,36 +827,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="credentials.passcode"
                       >
                         New password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="credentials.passcode"
                           id="generated"
                           name="credentials.passcode"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -943,10 +869,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -969,36 +895,36 @@ exports[`authenticator-reset-password should render form with custom brand name 
                       class="MuiBox-root emotion-4"
                     >
                       <label
-                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-38"
+                        class="MuiInputLabel-root MuiFormLabel-root MuiFormLabel-colorPrimary emotion-35"
                         for="confirmPassword"
                       >
                         Re-enter password
                       </label>
                       <div
-                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-39"
+                        class="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-adornedEnd emotion-36"
                       >
                         <input
                           aria-invalid="false"
                           autocomplete="new-password"
-                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-40"
+                          class="MuiOutlinedInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd emotion-37"
                           data-se="confirmPassword"
                           id="generated"
                           name="confirmPassword"
                           type="password"
                         />
                         <div
-                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-41"
+                          class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined emotion-38"
                         >
                           <button
                             aria-label="toggle password visibility"
-                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-42"
+                            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium emotion-39"
                             data-mui-internal-clone-element="true"
                             tabindex="0"
                             type="button"
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-43"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-40"
                               data-testid="VisibilityIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -1011,10 +937,10 @@ exports[`authenticator-reset-password should render form with custom brand name 
                         </div>
                         <fieldset
                           aria-hidden="true"
-                          class="MuiOutlinedInput-notchedOutline emotion-44"
+                          class="MuiOutlinedInput-notchedOutline emotion-41"
                         >
                           <legend
-                            class="emotion-45"
+                            class="emotion-42"
                           >
                             <span
                               class="notranslate"
@@ -1031,7 +957,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <button
-                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-58"
+                    class="MuiButton-root MuiButton-primary MuiButton-primaryPrimary MuiButton-sizeMedium MuiButton-primarySizeMedium MuiButton-disableElevation MuiButton-fullWidth MuiButtonBase-root  emotion-55"
                     data-type="save"
                     tabindex="0"
                     type="submit"
@@ -1043,7 +969,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
                   class="MuiBox-root emotion-11"
                 >
                   <a
-                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-60"
+                    class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways emotion-57"
                     data-se="cancel"
                     href="javascript:void(0)"
                   >


### PR DESCRIPTION
## Description:

This PR removes server side password validation items from the password requirements list in the enroll password flow.  

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [ ] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [ ] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-521282](https://oktainc.atlassian.net/browse/OKTA-521282)

### Reviewers:

### Screenshot/Video:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/107433508/188747567-f814f26d-7365-4b55-ae4e-77814b0b6de4.png">

### Downstream Monolith Build:



