### PR TITLE
OKTA-525579 : Fixing content overflow issue

### DIFF
--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -78,7 +78,7 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
-      style={{ maxWidth: '100%', overflowWrap: 'anywhere' }}
+      style={{ maxWidth: '100%', wordBreak: 'break-word' }}
     >
       <Layout uischema={uischema} />
     </form>

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -78,7 +78,7 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
-      style={{ maxWidth: '100%' }}
+      style={{ maxWidth: '100%', wordBreak: 'break-word' }}
     >
       <Layout uischema={uischema} />
     </form>

--- a/src/v3/src/components/Form/Form.tsx
+++ b/src/v3/src/components/Form/Form.tsx
@@ -78,7 +78,7 @@ const Form: FunctionComponent<{
       onSubmit={handleSubmit}
       className="o-form" // FIXME update page objects using .o-form selectors
       data-se="form"
-      style={{ maxWidth: '100%', wordBreak: 'break-word' }}
+      style={{ maxWidth: '100%', overflowWrap: 'anywhere' }}
     >
       <Layout uischema={uischema} />
     </form>

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-email-verification-data.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-email-verification-data should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1709,7 +1709,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1709,7 +1709,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-data-phone.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-data-phone should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1709,7 +1709,7 @@ exports[`authenticator-enroll-data-phone should send correct payload when select
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -442,7 +442,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -733,7 +733,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -996,7 +996,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -442,7 +442,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -733,7 +733,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -996,7 +996,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders QR code 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -442,7 +442,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders challeng
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -733,7 +733,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -996,7 +996,7 @@ exports[`authenticator-enroll-google-authenticator renders form renders secret k
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-phone-voice.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-enroll-phone-voice should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -510,7 +510,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1298,7 +1298,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -510,7 +510,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1298,7 +1298,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`authenticator-enroll-security-question custom question fails client sid
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -510,7 +510,7 @@ exports[`authenticator-enroll-security-question custom question renders correct 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1298,7 +1298,7 @@ exports[`authenticator-enroll-security-question predefined question renders corr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-security-question.test.tsx.snap
@@ -914,7 +914,7 @@ exports[`authenticator-enroll-security-question custom question should show fiel
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -1810,7 +1810,7 @@ exports[`authenticator-enroll-security-question predefined question should send 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -2302,7 +2302,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -2823,7 +2823,7 @@ exports[`authenticator-enroll-security-question predefined question should show 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator-with-skip.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-enroll-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-enroll-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-no-complexity.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-no-complexity should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password-with-enrollment-authenticator.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password-with-enrollment-authenticator should ren
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expired-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expired-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-expiry-warning-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-expiry-warning-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-reset-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -590,7 +590,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-reset-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -590,7 +590,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-reset-password.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-reset-password should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -590,7 +590,7 @@ exports[`authenticator-reset-password should render form with custom brand name 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-data-phone-sms-only.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-data-phone-sms-only should render form 1`] =
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -975,7 +975,7 @@ exports[`authenticator-verification-email renders correct form should display re
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -266,7 +266,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -475,7 +475,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -715,7 +715,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -1178,7 +1178,7 @@ exports[`authenticator-verification-email renders correct form should render ses
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -266,7 +266,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -475,7 +475,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -715,7 +715,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -1178,7 +1178,7 @@ exports[`authenticator-verification-email renders correct form should render ses
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -266,7 +266,7 @@ exports[`authenticator-verification-email renders correct form renders the initi
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -475,7 +475,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -715,7 +715,7 @@ exports[`authenticator-verification-email renders correct form renders the otp c
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-15"
@@ -1178,7 +1178,7 @@ exports[`authenticator-verification-email renders correct form should render ses
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-google-authenticator.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`authenticator-verification-google-authenticator should render form 1`] 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-code.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push-code should render form 1`]
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push-poll.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render polling form 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-push.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-push should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-okta-verify-totp.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`authenticator-verification-okta-verify-totp should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-phone-sms.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`authenticator-verification-phone-sms should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-security-question.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`authenticator-verification-security-question renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-select-authenticator.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`authenticator-verification-select-authenticator renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -299,7 +299,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -299,7 +299,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/authenticator-verification-webauthn.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn not support
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -299,7 +299,7 @@ exports[`authenticator-verification-webauthn renders form - webauthn supported 1
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`email-challenge-consent should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`email-challenge-consent should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/email-challenge-consent.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`email-challenge-consent should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`enroll-profile-new should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`enroll-profile-new should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/enroll-profile-new.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`enroll-profile-new should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-400-unauthorized-client should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-400-unauthorized-client should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-400-unauthorized-client.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-400-unauthorized-client should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-account-creation should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-account-creation should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-account-creation.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-account-creation should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-authenticator-enrollment-not-allowed.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`error-authenticator-enrollment-not-allowed should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-feature-not-enabled should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-feature-not-enabled should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-feature-not-enabled.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-feature-not-enabled should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-recovery-token-invalid should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-recovery-token-invalid should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-recovery-token-invalid.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-recovery-token-invalid should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-session-expired should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-session-expired should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/error-session-expired.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`error-session-expired should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -295,7 +295,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -581,7 +581,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -813,7 +813,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1043,7 +1043,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1309,7 +1309,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1510,7 +1510,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1711,7 +1711,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1997,7 +1997,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3498,7 +3498,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3728,7 +3728,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -295,7 +295,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -581,7 +581,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -813,7 +813,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1043,7 +1043,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1309,7 +1309,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1510,7 +1510,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1711,7 +1711,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1997,7 +1997,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3498,7 +3498,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3728,7 +3728,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-okta-verify-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -295,7 +295,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -581,7 +581,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -813,7 +813,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1043,7 +1043,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1309,7 +1309,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1510,7 +1510,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1711,7 +1711,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -1997,7 +1997,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3498,7 +3498,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -3728,7 +3728,7 @@ exports[`flow-okta-verify-enrollment qr polling -> channel selection -> data enr
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/flow-unlock-account-email-polling-to-mfa-authenticator.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`flow-unlock-account-email-polling-to-mfa-challenge-authenticator should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`identify-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`identify-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-recovery.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`identify-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -367,7 +367,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -676,7 +676,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -956,7 +956,7 @@ exports[`identify-with-password renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -367,7 +367,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -676,7 +676,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -956,7 +956,7 @@ exports[`identify-with-password renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/identify-with-password.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`identify-with-password Client-side field change validation tests fails 
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -367,7 +367,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -676,7 +676,7 @@ exports[`identify-with-password Client-side field change validation tests should
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -956,7 +956,7 @@ exports[`identify-with-password renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-email-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-email-channel-enrollment should render email channel form a
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-enrollment-version-upgrade.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-enrollment-version-upgrade should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/okta-verify-sms-channel-enrollment.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`okta-verify-sms-channel-enrollment should render sms channel form and s
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`terminal-return-email-error should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`terminal-return-email-error should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email-error.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`terminal-return-email-error should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-6"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-email renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-email renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-email.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-email renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-enrollment.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-enrollment renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-recovery.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-recovery renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location-unlock.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location-unlock renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-full-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-full-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-no-location.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-no-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/terminal-return-otp-only-partial-location..test.tsx.snap
@@ -97,7 +97,7 @@ exports[`terminal-return-otp-only-partial-location renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`unlock-account-success renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`unlock-account-success renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/unlock-account-success.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`unlock-account-success renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-9"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`user-unlock-account renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`user-unlock-account renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/user-unlock-account.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`user-unlock-account renders form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-5"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`webauthn-enroll should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -317,7 +317,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`webauthn-enroll should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -317,7 +317,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; overflow-wrap: anywhere;"
+              style="max-width: 100%; word-break: break-word;"
             >
               <div
                 class="MuiBox-root emotion-10"

--- a/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
+++ b/src/v3/test/integration/__snapshots__/webauthn-enroll.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`webauthn-enroll should render form 1`] = `
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"
@@ -317,7 +317,7 @@ exports[`webauthn-enroll should render form when Credentials API is not availabl
               class="o-form"
               data-se="form"
               novalidate=""
-              style="max-width: 100%; word-break: break-word;"
+              style="max-width: 100%; overflow-wrap: anywhere;"
             >
               <div
                 class="MuiBox-root emotion-10"


### PR DESCRIPTION
## Description:

Purpose of this PR is to fix the content overflow issue that is caused by text that has no breaks which can cause the content to overflow beyond the widget's container. 

## PR Checklist

- [x] Have you verified the basic functionality for this change?
- [ ] Did you add tests, as appropriate, following our [Automated Test guidelines](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/2676497890/Automated+Testing+in+the+Signin+Widget)?
- [x] Did you follow our [Security Best Practices](https://oktawiki.atlassian.net/wiki/display/eng/Security+Best+practices)?
- [ ] Did you verify the change by running [downstream monolith artifact](https://oktawiki.atlassian.net/wiki/spaces/eng/pages/102897979/Sign-in+Widget+Development#Sign-inWidgetDevelopment-Instructionstocreateandrunthedownstreamartifact(d16t))? (Provide link to build below)
- [x] Does this PR include noticeable changes to the UI? (If yes, attach screenshots/video below)

### Issue:

- [OKTA-525579](https://oktainc.atlassian.net/browse/OKTA-525579)

### Reviewers:

### Screenshot/Video:
Before: 
<img width="885" alt="image" src="https://user-images.githubusercontent.com/97472729/188918468-a42c5c31-c130-418c-8e85-dc463afdccb8.png">


After: 
<img width="750" alt="image" src="https://user-images.githubusercontent.com/97472729/188918378-b79edb2d-d80b-4d44-a61d-dca5c5b9bee1.png">


### Downstream Monolith Build:



